### PR TITLE
feat(hooks): Add security hook suite for Claude Code sessions (Closes #43)

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -27,6 +27,46 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": {
+          "tool_name": "Bash"
+        },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/hook-validate-command.sh",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": {
+          "tool_name": "Bash"
+        },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/hook-mask-output.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "tool_name": "Read"
+        },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/hook-mask-output.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -36,6 +76,13 @@
             "timeout": 1000
           }
         ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "type": "command",
+        "command": "~/.claude/scripts/session-register.sh end 2>/dev/null || true",
+        "timeout": 2000
       }
     ]
   }

--- a/scripts/hook-mask-output.sh
+++ b/scripts/hook-mask-output.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# hook-mask-output.sh - PostToolUse hook to mask secrets in tool output
+#
+# This hook receives tool output on stdin and masks sensitive data
+# before it's shown to Claude, preventing secrets from entering context.
+#
+# Usage (called by Claude Code hooks system):
+#   echo '{"tool_output": "password=secret123"}' | hook-mask-output.sh
+#
+# Input: JSON with tool_name, tool_input, tool_output
+# Output: Modified tool_output (or empty for no change)
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract tool_output from JSON
+# Using Python for reliable JSON parsing
+MASKED_OUTPUT=$(python3 << PYEOF
+import sys
+import json
+import re
+
+input_json = '''$INPUT'''
+
+try:
+    data = json.loads(input_json)
+    output = data.get('tool_output', '')
+
+    if not output:
+        sys.exit(0)
+
+    # Connection strings - mask password
+    output = re.sub(r'(postgresql://[^:]+:)[^@]+(@)', r'\1****\2', output)
+    output = re.sub(r'(postgres://[^:]+:)[^@]+(@)', r'\1****\2', output)
+    output = re.sub(r'(mysql://[^:]+:)[^@]+(@)', r'\1****\2', output)
+    output = re.sub(r'(mongodb://[^:]+:)[^@]+(@)', r'\1****\2', output)
+    output = re.sub(r'(redis://[^:]+:)[^@]+(@)', r'\1****\2', output)
+
+    # API Keys with known prefixes
+    output = re.sub(r'(sk-)[A-Za-z0-9]{20,}', r'\1**********', output)
+    output = re.sub(r'(AIza)[A-Za-z0-9_-]{35}', r'\1**********', output)
+    output = re.sub(r'(ghp_)[A-Za-z0-9]{36,}', r'\1**********', output)
+    output = re.sub(r'(github_pat_)[A-Za-z0-9]{22,}', r'\1**********', output)
+    output = re.sub(r'(glpat-)[A-Za-z0-9_-]{20,}', r'\1**********', output)
+    output = re.sub(r'(gho_)[A-Za-z0-9]{36,}', r'\1**********', output)
+
+    # AWS keys
+    output = re.sub(r'(AKIA)[A-Z0-9]{16}', r'\1**********', output)
+    output = re.sub(r'(ASIA)[A-Z0-9]{16}', r'\1**********', output)
+
+    # Slack tokens
+    output = re.sub(r'(xox[baprs]-)[A-Za-z0-9-]+', r'\1**********', output)
+
+    # Stripe keys
+    output = re.sub(r'(sk_live_)[A-Za-z0-9]{24,}', r'\1**********', output)
+    output = re.sub(r'(sk_test_)[A-Za-z0-9]{24,}', r'\1**********', output)
+
+    # Anthropic API keys
+    output = re.sub(r'(sk-ant-)[A-Za-z0-9_-]{20,}', r'\1**********', output)
+
+    # NPM tokens
+    output = re.sub(r'(npm_)[A-Za-z0-9]{36}', r'\1**********', output)
+
+    # PyPI tokens
+    output = re.sub(r'(pypi-)[A-Za-z0-9_-]{20,}', r'\1**********', output)
+
+    # Sendgrid API keys
+    output = re.sub(r'(SG\.)[A-Za-z0-9_-]{22,}', r'\1**********', output)
+
+    # Generic key=value patterns (case insensitive)
+    output = re.sub(r'(password\s*[=:]\s*)[^\s}{,"\x27]+', r'\1****', output, flags=re.IGNORECASE)
+    output = re.sub(r'(passwd\s*[=:]\s*)[^\s}{,"\x27]+', r'\1****', output, flags=re.IGNORECASE)
+    output = re.sub(r'(secret\s*[=:]\s*)[^\s}{,"\x27]+', r'\1****', output, flags=re.IGNORECASE)
+    output = re.sub(r'(api[_-]?key\s*[=:]\s*)[^\s}{,"\x27]+', r'\1****', output, flags=re.IGNORECASE)
+    output = re.sub(r'(auth[_-]?token\s*[=:]\s*)[^\s}{,"\x27]+', r'\1****', output, flags=re.IGNORECASE)
+    output = re.sub(r'(access[_-]?token\s*[=:]\s*)[^\s}{,"\x27]+', r'\1****', output, flags=re.IGNORECASE)
+    output = re.sub(r'(bearer\s+)[A-Za-z0-9._-]+', r'\1****', output, flags=re.IGNORECASE)
+
+    # .env file patterns
+    output = re.sub(r'^(DB_PASSWORD\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^(DATABASE_PASSWORD\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^(AWS_SECRET_ACCESS_KEY\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^(ANTHROPIC_API_KEY\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^(OPENAI_API_KEY\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^(GEMINI_API_KEY\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^([A-Z_]*SECRET[A-Z_]*\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^([A-Z_]*PASSWORD[A-Z_]*\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^([A-Z_]*TOKEN[A-Z_]*\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+    output = re.sub(r'^([A-Z_]*API_KEY[A-Z_]*\s*=\s*)(.+)$', r'\1****', output, flags=re.MULTILINE)
+
+    print(output)
+except Exception as e:
+    # On error, pass through unchanged
+    print(data.get('tool_output', '') if 'data' in dir() else '', file=sys.stderr)
+    sys.exit(0)
+PYEOF
+)
+
+# Output the masked result
+echo "$MASKED_OUTPUT"

--- a/scripts/hook-validate-command.sh
+++ b/scripts/hook-validate-command.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# hook-validate-command.sh - PreToolUse hook to warn on dangerous commands
+#
+# This hook receives tool input on stdin and checks for dangerous patterns.
+# Returns non-zero exit code with warning message to block the command.
+#
+# Usage (called by Claude Code hooks system):
+#   echo '{"tool_name": "Bash", "tool_input": {"command": "git push --force"}}' | hook-validate-command.sh
+#
+# Exit codes:
+#   0 - Command is safe, proceed
+#   1 - Command is dangerous, block with warning
+#
+
+set -euo pipefail
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Parse and validate command
+python3 << PYEOF
+import sys
+import json
+import re
+
+input_json = '''$INPUT'''
+
+try:
+    data = json.loads(input_json)
+    tool_name = data.get('tool_name', '')
+    tool_input = data.get('tool_input', {})
+
+    # Only check Bash commands
+    if tool_name != 'Bash':
+        sys.exit(0)
+
+    command = tool_input.get('command', '')
+    if not command:
+        sys.exit(0)
+
+    warnings = []
+
+    # Force push to main/master
+    if re.search(r'git\s+push\s+.*--force', command, re.IGNORECASE):
+        if re.search(r'(main|master)', command, re.IGNORECASE):
+            warnings.append("Force push to main/master detected")
+
+    # Hard reset
+    if re.search(r'git\s+reset\s+--hard', command, re.IGNORECASE):
+        warnings.append("git reset --hard will lose uncommitted changes")
+
+    # Dangerous rm commands
+    if re.search(r'rm\s+-[rf]*\s+/', command):
+        if re.search(r'rm\s+-[rf]*\s+/($|\s)', command):
+            warnings.append("rm -rf / is extremely dangerous")
+        elif re.search(r'rm\s+-[rf]*\s+/home', command):
+            warnings.append("rm on /home directory detected")
+
+    # SQL destructive operations without WHERE
+    if re.search(r'DROP\s+(TABLE|DATABASE)', command, re.IGNORECASE):
+        warnings.append("DROP TABLE/DATABASE detected")
+
+    if re.search(r'DELETE\s+FROM\s+\w+\s*;', command, re.IGNORECASE):
+        warnings.append("DELETE without WHERE clause detected")
+
+    if re.search(r'TRUNCATE\s+TABLE', command, re.IGNORECASE):
+        warnings.append("TRUNCATE TABLE detected")
+
+    # chmod/chown on system directories
+    if re.search(r'(chmod|chown)\s+.*\s+/', command):
+        if re.search(r'(chmod|chown)\s+-R\s+.*\s+/(etc|usr|bin|sbin|lib)', command):
+            warnings.append("Recursive permission change on system directory")
+
+    # Format disk
+    if re.search(r'mkfs\.|fdisk|parted', command, re.IGNORECASE):
+        warnings.append("Disk formatting command detected")
+
+    # Kill all processes
+    if re.search(r'kill\s+-9\s+-1', command) or re.search(r'killall\s+-9', command):
+        warnings.append("Kill all processes command detected")
+
+    if warnings:
+        print("⚠️  DANGEROUS COMMAND DETECTED:")
+        for w in warnings:
+            print(f"   - {w}")
+        print(f"\nCommand: {command[:100]}...")
+        print("\nThis command was blocked by hook-validate-command.sh")
+        print("Remove the hook or modify the command to proceed.")
+        sys.exit(1)
+
+    # Command is safe
+    sys.exit(0)
+
+except json.JSONDecodeError:
+    # Can't parse, let it through
+    sys.exit(0)
+except Exception as e:
+    # On error, let command through
+    sys.exit(0)
+PYEOF


### PR DESCRIPTION
## Summary

Implement automatic protection for Claude Code sessions through hooks.

### 1. Secret Masking (PostToolUse)

All Bash and Read tool output is automatically masked:
- Connection strings: `postgresql://user:****@host:5432/db`
- API keys: `sk-ant-**********`, `ghp_**********`
- Environment variables: `DB_PASSWORD=****`, `API_KEY=****`

### 2. Dangerous Command Blocking (PreToolUse)

Blocks destructive commands with warnings:
- `git push --force` to main/master
- `git reset --hard`
- `rm -rf /` or system directories
- `DROP TABLE`, `DELETE FROM` without WHERE

### 3. Session Cleanup (SessionEnd)

On session end:
- Releases all held locks
- Releases issue claims

## Files Changed

| File | Change |
|------|--------|
| `scripts/hook-mask-output.sh` | New - masks secrets in tool output |
| `scripts/hook-validate-command.sh` | New - blocks dangerous commands |
| `.claude/hooks.json` | Added PreToolUse, PostToolUse, SessionEnd hooks |
| `CLAUDE.md` | Added Security Hooks documentation section |

## Test Plan

- [x] Test mask output hook with passwords
- [x] Test mask output hook with connection strings
- [x] Test mask output hook with API keys
- [x] Test validate command hook blocks force push
- [x] Test validate command hook allows safe commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)