### PR TITLE
feat(cmd): Enhance /project-next with spec awareness (Closes #34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,20 @@ This repository contains five main components:
 - MCP Coordination: port 8082
 - All documentation uses progressive disclosure principles
 
+## Environment Variables
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `CLAUDE_PROJECT` | Default project for `/project-next` when run from `~/Projects` | `claude-power-pack` |
+| `CONDA_ENV_NAME` | Override conda environment detection | `mcp-second-opinion` |
+
+**Setup (add to `~/.bashrc`):**
+```bash
+export CLAUDE_PROJECT="claude-power-pack"  # Default project
+```
+
+This allows running `/project-next` from `~/Projects` without being in a specific project directory.
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
## Summary

- Add `CLAUDE_PROJECT` environment variable for running `/project-next` from `~/Projects`
- Add spec-driven development detection and display in project-next output
- Link worktrees to spec features via issue labels
- Add spec sync to priority recommendations

## Changes

### project-next.md
- **Step 2.1**: Added `CLAUDE_PROJECT` env var support for project selection from parent directories
- **Step 2.4**: New section for spec-driven development detection using `lib/spec_bridge`
- **Step 5.1**: Issue-to-spec mapping for linking worktrees to spec features
- **Step 6 Priority 3b**: Pending spec sync as a priority action
- **Step 7 Output**: Added Spec Features table with status indicators (✓/○/✗)
- **Step 7 Worktree Table**: Added "Spec Feature" column
- **Step 8**: Added spec-related follow-up options (sync, status)

### CLAUDE.md
- Added new "Environment Variables" section documenting `CLAUDE_PROJECT` and `CONDA_ENV_NAME`

## Test plan

- [ ] Run `/project-next` in a project with `.specify/` directory - verify spec features table appears
- [ ] Run `/project-next` in a project without `.specify/` - verify graceful skip
- [ ] Set `CLAUDE_PROJECT=claude-power-pack` and run `/project-next` from `~/Projects` - verify correct project detected
- [ ] Verify worktree table shows Spec Feature column with linked features

🤖 Generated with [Claude Code](https://claude.com/claude-code)