### PR TITLE
Fix hardcoded absolute paths in commands and skills

### DIFF
--- a/.claude/commands/load-best-practices.md
+++ b/.claude/commands/load-best-practices.md
@@ -3,7 +3,7 @@ description: Load full Claude Code best practices documentation (25K tokens)
 ---
 
 Read and summarize the key points from:
-`/home/cooneycw/Projects/claude-power-pack/docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md`
+`docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md`
 
 **Note:** For context efficiency, consider using topic-specific skills instead:
 - `context-efficiency` - Token optimization

--- a/.claude/commands/load-mcp-docs.md
+++ b/.claude/commands/load-mcp-docs.md
@@ -4,8 +4,8 @@ description: Load MCP Second Opinion server documentation
 
 Read the MCP Second Opinion documentation and summarize the available tools and usage patterns:
 
-1. Read: `/home/cooneycw/Projects/claude-power-pack/README.md` (MCP Second Opinion section)
-2. Read: `/home/cooneycw/Projects/claude-power-pack/mcp-second-opinion/src/server.py` (tool definitions)
+1. Read: `README.md` (MCP Second Opinion section)
+2. Read: `mcp-second-opinion/src/server.py` (tool definitions)
 
 Provide an overview of:
 - The 10 available tools and their purposes

--- a/.claude/skills/claude-md-config.md
+++ b/.claude/skills/claude-md-config.md
@@ -8,7 +8,7 @@ trigger: CLAUDE.md, configuration, project setup, conventions
 
 When the user asks about CLAUDE.md structure, configuration, or project setup:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/claude-md-config.md`
+1. Read `docs/skills/claude-md-config.md`
 2. Provide the CLAUDE.md template
 3. Explain structure hierarchy (user, parent, project)
 4. Share optimization tips (+5-10% on SWE Bench)

--- a/.claude/skills/code-quality.md
+++ b/.claude/skills/code-quality.md
@@ -8,7 +8,7 @@ trigger: code review, quality, testing, production ready, best practices
 
 When the user asks about code quality, review patterns, or production readiness:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/code-quality.md`
+1. Read `docs/skills/code-quality.md`
 2. Explain the "you are the issue, not the AI" insight
 3. Cover review patterns and workflow strategies
 4. Share the Top 10 Rules and red/green flags

--- a/.claude/skills/context-efficiency.md
+++ b/.claude/skills/context-efficiency.md
@@ -8,7 +8,7 @@ trigger: context, tokens, optimization, token budget, progressive disclosure
 
 When the user asks about context efficiency, token optimization, or progressive disclosure:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/context-efficiency.md`
+1. Read `docs/skills/context-efficiency.md`
 2. Provide guidance based on the content
 3. Reference `PROGRESSIVE_DISCLOSURE_GUIDE.md` for deeper architecture details
 4. Reference `MCP_TOKEN_AUDIT_CHECKLIST.md` for practical checklists

--- a/.claude/skills/hooks-automation.md
+++ b/.claude/skills/hooks-automation.md
@@ -8,7 +8,7 @@ trigger: hooks, automation, hook lifecycle, SessionStart, UserPromptSubmit
 
 When the user asks about hooks, automation, or the hook lifecycle:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/hooks-automation.md`
+1. Read `docs/skills/hooks-automation.md`
 2. Explain the 5 hook types and their uses
 3. Provide examples of common hook configurations
 4. Reference the hooks mastery repository

--- a/.claude/skills/idd-workflow.md
+++ b/.claude/skills/idd-workflow.md
@@ -8,7 +8,7 @@ trigger: issue driven, worktree, IDD, parallel development, git worktree
 
 When the user asks about issue-driven development, worktrees, or parallel development:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/idd-workflow.md`
+1. Read `docs/skills/idd-workflow.md`
 2. Explain the Phase → Wave → Micro-issue hierarchy
 3. Provide worktree commands and naming conventions
 4. Reference `ISSUE_DRIVEN_DEVELOPMENT.md` for the complete guide

--- a/.claude/skills/mcp-optimization.md
+++ b/.claude/skills/mcp-optimization.md
@@ -8,7 +8,7 @@ trigger: MCP, token consumption, tool optimization, code-mode
 
 When the user asks about MCP optimization, tool selection, or Code-Mode:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/mcp-optimization.md`
+1. Read `docs/skills/mcp-optimization.md`
 2. Provide guidance on MCP selection and optimization
 3. Explain Code-Mode benefits (60% token savings)
 4. Reference `MCP_TOKEN_AUDIT_CHECKLIST.md` for practical steps

--- a/.claude/skills/session-management.md
+++ b/.claude/skills/session-management.md
@@ -8,7 +8,7 @@ trigger: session, reset, plan mode, context degradation, compacting
 
 When the user asks about session management, when to reset, or plan mode:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/session-management.md`
+1. Read `docs/skills/session-management.md`
 2. Provide guidance on session resets and context degradation
 3. Explain plan mode benefits and usage
 4. Include the "single most useful line" tip

--- a/.claude/skills/skills-patterns.md
+++ b/.claude/skills/skills-patterns.md
@@ -8,7 +8,7 @@ trigger: skill activation, skill design, skills patterns, prompt injection
 
 When the user asks about skill design, activation patterns, or improving skill activation rates:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/skills-patterns.md`
+1. Read `docs/skills/skills-patterns.md`
 2. Explain the 20% to 84% activation improvement techniques
 3. Cover skills = prompt injection + hooks + pattern matching
 4. Warn about security considerations for third-party skills

--- a/.claude/skills/spec-driven-dev.md
+++ b/.claude/skills/spec-driven-dev.md
@@ -8,7 +8,7 @@ trigger: spec driven, specification, SDD, planning, requirements
 
 When the user asks about spec-driven development, planning, or requirements:
 
-1. Read `/home/cooneycw/Projects/claude-power-pack/docs/skills/spec-driven-dev.md`
+1. Read `docs/skills/spec-driven-dev.md`
 2. Explain the SDD workflow (Spec → Sandbox → Production)
 3. Provide the spec template
 4. Reference GitHub Spec Kit for tooling


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `/home/cooneycw/Projects/claude-power-pack/` paths with relative paths
- Affects 11 files across commands and skills

## Files Changed

| File | Change |
|------|--------|
| `.claude/commands/load-best-practices.md` | Use relative path to docs |
| `.claude/commands/load-mcp-docs.md` | Use relative paths to MCP docs |
| `.claude/skills/*.md` (9 files) | Use relative paths to docs/skills |

## Test plan

- [x] Verify no hardcoded paths remain: `grep -r "/home/cooneycw" .claude/`
- [ ] Test `/load-best-practices` command works with relative path
- [ ] Test skill loading works with relative paths

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)