### PR TITLE
fix(session): Handle REPO_INFO env var in claim command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,13 @@ Prevent conflicts between concurrent Claude Code sessions.
 - No visibility into active work
 - Worktree cleanup conflicts
 
+### Prerequisites
+```bash
+# Install jq (JSON processor - required for session coordination)
+sudo apt install jq   # Debian/Ubuntu
+# or: brew install jq  # macOS
+```
+
 ### Setup
 ```bash
 # Symlink scripts

--- a/scripts/session-register.sh
+++ b/scripts/session-register.sh
@@ -699,13 +699,22 @@ main() {
             ;;
         claim)
             # claim OWNER/REPO NUM [TITLE] [PREFIX]
+            # Note: repo_spec can come from $2 or REPO_INFO env var
+            # This handles the common pattern: REPO_INFO="owner/repo" script claim "$REPO_INFO" ...
+            # where $REPO_INFO expands empty due to shell evaluation order
             local repo_spec="${2:-}"
             local issue_num="${3:-}"
             local title="${4:-}"
             local prefix="${5:-}"
 
+            # Fallback to REPO_INFO env var if repo_spec is empty
+            if [[ -z "$repo_spec" ]] && [[ -n "${REPO_INFO:-}" ]]; then
+                repo_spec="$REPO_INFO"
+            fi
+
             if [[ -z "$repo_spec" ]] || [[ -z "$issue_num" ]]; then
                 echo -e "${RED}Usage: session-register.sh claim OWNER/REPO ISSUE_NUM [TITLE] [PREFIX]${NC}" >&2
+                echo -e "${YELLOW}Hint: Set REPO_INFO env var or pass repo as first argument${NC}" >&2
                 exit 1
             fi
 


### PR DESCRIPTION
## Summary

- Fix claim command failing when using `REPO_INFO="owner/repo" script claim "$REPO_INFO" ...` pattern
- Shell expands `$REPO_INFO` before the assignment takes effect, resulting in empty argument
- Added fallback to `REPO_INFO` environment variable when positional argument is empty
- Documented `jq` as a prerequisite for session coordination

Closes #63

## Test plan

- [x] Tested with `REPO_INFO="owner/repo" script claim "$REPO_INFO" ...` pattern
- [x] Tested with direct `script claim "owner/repo" ...` pattern
- [x] Both patterns work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)