### PR TITLE
fix(scripts): Fix cleanup command exiting after first session

### DIFF
--- a/scripts/session-register.sh
+++ b/scripts/session-register.sh
@@ -615,7 +615,7 @@ cleanup_sessions() {
             # Remove session files
             rm -f "$session_file" "$HEARTBEAT_DIR/${session_id}.heartbeat"
             echo -e "  ${RED}Removed stale session:${NC} $session_id"
-            ((cleaned++))
+            cleaned=$((cleaned + 1))
         fi
     done
 


### PR DESCRIPTION
## Summary

- Fixes `session-register.sh cleanup` command that was exiting after removing only one stale session
- Root cause: `((cleaned++))` with `set -e` causes exit on first iteration (bash returns 1 for zero arithmetic result)
- Solution: Use `cleaned=$((cleaned + 1))` assignment instead

## Test plan

- [x] Run `session-register.sh cleanup` with multiple stale sessions
- [x] Verify all stale sessions are removed (was 5, now 0 stale)
- [x] Confirm no regression in other commands

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)