### PR TITLE
fix(mcp-second-opinion): Add User/Group directives to systemd service (Closes #75)

### DIFF
--- a/mcp-second-opinion/deploy/mcp-second-opinion.service
+++ b/mcp-second-opinion/deploy/mcp-second-opinion.service
@@ -5,6 +5,8 @@ Documentation=https://github.com/cooneycw/claude-power-pack
 
 [Service]
 Type=simple
+User=cooneycw
+Group=cooneycw
 WorkingDirectory=/home/cooneycw/Projects/claude-power-pack/mcp-second-opinion
 
 # Load environment variables from .env file


### PR DESCRIPTION
## Summary
- Add `User=cooneycw` and `Group=cooneycw` directives to systemd service file
- Without these, the service runs as root and fails when uv tries to write to `/root/.cache/uv` (blocked by `ProtectHome=read-only`)

## Test plan
- [ ] Copy updated service file: `sudo cp mcp-second-opinion/deploy/mcp-second-opinion.service /etc/systemd/system/`
- [ ] Reload systemd: `sudo systemctl daemon-reload`
- [ ] Start service: `sudo systemctl start mcp-second-opinion`
- [ ] Verify running: `systemctl status mcp-second-opinion`

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)