### PR TITLE
fix(mcp-second-opinion): Wrap FunctionDeclarations in Tool object for Gemini 3 Pro

### DIFF
--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -634,12 +634,13 @@ async def get_agentic_response(
 
     try:
         # Configure generation parameters
+        # Wrap FunctionDeclarations in a Tool object - required for Gemini 3 Pro
         config = types.GenerateContentConfig(
             max_output_tokens=Config.MAX_TOKENS,
             temperature=Config.TEMPERATURE,
             top_p=Config.TOP_P,
             top_k=Config.TOP_K,
-            tools=enabled_declarations,
+            tools=[types.Tool(function_declarations=enabled_declarations)],
         )
 
         logger.info(f"Starting agentic request to {model_name} with tools: {tools_enabled}")


### PR DESCRIPTION
## Summary

- Fixes session tool-calling (web_search, fetch_url) not functioning with Gemini 3 Pro

## Root Cause

The google-genai SDK requires `FunctionDeclaration` objects to be wrapped in a `types.Tool` object before passing to `GenerateContentConfig.tools`. The previous code passed declarations directly:

```python
# Before (broken)
tools=enabled_declarations  # List[FunctionDeclaration]
```

The fix wraps them properly:

```python
# After (working)
tools=[types.Tool(function_declarations=enabled_declarations)]
```

Without this wrapping, Gemini 3 Pro silently ignores the tool declarations.

## Test plan

- [x] Verified `types.Tool(function_declarations=[...])` creates valid config
- [x] Verified server imports successfully
- [ ] Manual test: Create session with tools_enabled, call consult with tool-invoking prompt

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/claude-code)