### PR TITLE
refactor(hooks): Remove session/heartbeat overhead (Closes #90)

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -4,22 +4,6 @@
       {
         "type": "command",
         "command": "bash -c 'git fetch origin --quiet 2>/dev/null && BEHIND=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo 0) && if [ \"$BEHIND\" -gt 0 ]; then echo \"⚠️  claude-power-pack has $BEHIND new commit(s). Run: git pull\"; else echo \"✓ claude-power-pack is current\"; fi'"
-      },
-      {
-        "type": "command",
-        "command": "~/.claude/scripts/session-register.sh start 2>/dev/null || true",
-        "timeout": 5000
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/scripts/session-heartbeat.sh touch 2>/dev/null || true",
-            "timeout": 500
-          }
-        ]
       }
     ],
     "PreToolUse": [
@@ -60,24 +44,6 @@
             "timeout": 5000
           }
         ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/scripts/session-register.sh pause 2>/dev/null || true",
-            "timeout": 1000
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "type": "command",
-        "command": "~/.claude/scripts/session-register.sh end 2>/dev/null || true",
-        "timeout": 2000
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Removes 4 session coordination hooks that added overhead without proportional value
- Keeps 3 high-value security/awareness hooks
- Reduces hooks.json from 84 lines to 50 lines (40% reduction)

## What was removed

| Hook Event | Action | Why removed |
|------------|--------|-------------|
| SessionStart | `session-register.sh start` | Session tracking not needed for stateless /flow workflow |
| UserPromptSubmit | `session-heartbeat.sh touch` | Heartbeat tracking adds latency to every prompt |
| Stop | `session-register.sh pause` | Session pause tracking unnecessary |
| SessionEnd | `session-register.sh end` | Session end tracking unnecessary |

## What was kept

| Hook Event | Action | Why kept |
|------------|--------|----------|
| SessionStart | `git fetch` + behind check | Useful for detecting upstream changes |
| PreToolUse (Bash) | `hook-validate-command.sh` | Blocks dangerous commands (security) |
| PostToolUse (Bash/Read) | `hook-mask-output.sh` | Masks secrets in output (security) |

## Test plan

- [ ] Verify SessionStart still reports upstream changes
- [ ] Verify PreToolUse still blocks dangerous commands
- [ ] Verify PostToolUse still masks secrets
- [ ] Verify no errors from removed hooks (clean startup/shutdown)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)