### PR TITLE
feat(mcp-second-opinion): Add GPT-5.3-Codex and GPT-5.2-Codex (Closes #85)

### DIFF
--- a/mcp-second-opinion/.env.example
+++ b/mcp-second-opinion/.env.example
@@ -22,8 +22,10 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Available models:
 #   - gpt-4o, gpt-4o-mini: Fast multimodal models
 #   - gpt-4-turbo: Complex reasoning
-#   - gpt-5.1-codex-max: Most capable for complex coding (Responses API)
+#   - gpt-5.3-codex: Most capable agentic coding model (Responses API)
+#   - gpt-5.2-codex: Default Codex model (Responses API)
 #   - gpt-5.1-codex-mini: Cost-effective coding (Responses API)
+#   - gpt-5.2, gpt-5.2-mini: Latest GPT models
 #   - o3: Advanced reasoning (Responses API)
 #   - o1, o1-mini: Reasoning models
 

--- a/mcp-second-opinion/README.md
+++ b/mcp-second-opinion/README.md
@@ -5,7 +5,7 @@ Gemini-powered code review MCP server for Claude Code.
 ## Features
 
 - **Code Review**: Get AI-powered second opinions on code issues
-- **Multi-Model Support**: Consult multiple LLMs (Gemini, OpenAI Codex, GPT-5.2)
+- **Multi-Model Support**: Consult multiple LLMs (Gemini, GPT-5.3 Codex, GPT-5.2)
 - **Session-Based**: Interactive multi-turn conversations for deeper analysis
 - **Visual Analysis**: Support for screenshot/image analysis (Playwright integration)
 

--- a/mcp-second-opinion/src/config.py
+++ b/mcp-second-opinion/src/config.py
@@ -118,13 +118,13 @@ class Config:
     # GPT-4 Turbo (best for complex reasoning)
     OPENAI_MODEL_GPT4_TURBO: str = "gpt-4-turbo"
 
-    # Codex models (use Responses API) - Updated Dec 2025
-    # gpt-5.1-codex-max: Most capable for complex coding
+    # Codex models (use Responses API) - Updated Feb 2026
+    # gpt-5.3-codex: Most capable agentic coding model (API access may be gated)
+    # gpt-5.2-codex: Current default Codex model
     # gpt-5.1-codex-mini: Cost-effective coding model
-    # gpt-5-codex: Base codex model
     # o3: Full Codex reasoning agent
-    OPENAI_MODEL_CODEX: str = "gpt-5-codex"
-    OPENAI_MODEL_CODEX_MAX: str = "gpt-5.1-codex-max"
+    OPENAI_MODEL_CODEX: str = "gpt-5.2-codex"
+    OPENAI_MODEL_CODEX_MAX: str = "gpt-5.3-codex"
     OPENAI_MODEL_CODEX_MINI: str = "gpt-5.1-codex-mini"
     OPENAI_MODEL_O3: str = "o3"
 
@@ -142,15 +142,15 @@ class Config:
     # Fallback
     OPENAI_MODEL_FALLBACK: str = "gpt-4o-mini"
 
-    # OpenAI API Pricing (per million tokens) - Updated 2025-12
+    # OpenAI API Pricing (per million tokens) - Updated 2026-02
     OPENAI_PRICING: Dict[str, Dict[str, float]] = {
         "gpt-4o": {"input": 2.50, "output": 10.00},
         "gpt-4o-mini": {"input": 0.15, "output": 0.60},
         "gpt-4-turbo": {"input": 10.00, "output": 30.00},
         # Codex models (use Responses API)
-        "gpt-5.1-codex-max": {"input": 5.00, "output": 20.00},
+        "gpt-5.3-codex": {"input": 5.00, "output": 20.00},
+        "gpt-5.2-codex": {"input": 3.50, "output": 14.00},
         "gpt-5.1-codex-mini": {"input": 1.50, "output": 6.00},
-        "gpt-5-codex": {"input": 3.00, "output": 12.00},
         "o3": {"input": 10.00, "output": 40.00},
         # Reasoning models
         "o1": {"input": 15.00, "output": 60.00},
@@ -199,11 +199,17 @@ class Config:
             "description": "Best for complex reasoning tasks",
         },
         # OpenAI Codex models (uses Responses API)
+        "codex": {
+            "provider": "openai",
+            "model_id": "gpt-5.2-codex",
+            "display_name": "GPT-5.2 Codex",
+            "description": "Default Codex model for coding tasks",
+        },
         "codex-max": {
             "provider": "openai",
-            "model_id": "gpt-5.1-codex-max",
-            "display_name": "Codex Max",
-            "description": "Most capable for complex, long-horizon coding",
+            "model_id": "gpt-5.3-codex",
+            "display_name": "GPT-5.3 Codex",
+            "description": "Most capable agentic coding model",
         },
         "codex-mini": {
             "provider": "openai",
@@ -229,13 +235,6 @@ class Config:
             "model_id": "o1-mini",
             "display_name": "o1 Mini",
             "description": "Faster reasoning model",
-        },
-        # Base Codex model
-        "codex": {
-            "provider": "openai",
-            "model_id": "gpt-5-codex",
-            "display_name": "Codex",
-            "description": "Base Codex model for coding tasks",
         },
         # GPT-5.2 models
         "gpt-5.2": {
@@ -287,7 +286,7 @@ class Config:
 
     # Server Configuration
     SERVER_NAME: str = "second-opinion-server"
-    SERVER_VERSION: str = "1.7.0"  # In-depth analysis, code_files, verbosity-driven token limits
+    SERVER_VERSION: str = "1.8.0"  # Add GPT-5.3-Codex and GPT-5.2-Codex, retire older models
 
     # HTTP/SSE Transport Configuration (with safe parsing)
     SERVER_HOST: str = os.getenv("MCP_SERVER_HOST", "127.0.0.1")

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -280,7 +280,7 @@ async def get_openai_streaming_response(
 
     Args:
         prompt: The prompt to send to OpenAI
-        model_name: The model to use (e.g., gpt-5-codex, gpt-5.2)
+        model_name: The model to use (e.g., gpt-5.2-codex, gpt-5.2)
         max_tokens: Maximum output tokens
 
     Returns:


### PR DESCRIPTION
## Summary
- Update `codex` model key to `gpt-5.2-codex` (API available now)
- Update `codex-max` model key to `gpt-5.3-codex` (most capable agentic coding model)
- Retire `gpt-5-codex` and `gpt-5.1-codex-max` (replaced by newer versions)
- Add pricing entries for new models, remove old ones
- Update `.env.example` and `README.md` with new model references
- Bump server version to 1.8.0

## Test plan
- [ ] Verify `list_available_models` shows updated model IDs
- [ ] Test `get_multi_model_second_opinion` with `codex` key routes to `gpt-5.2-codex`
- [ ] Test `codex-max` routes to `gpt-5.3-codex` via Responses API
- [ ] Verify `codex-mini` still works unchanged (`gpt-5.1-codex-mini`)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)