### PR TITLE
feat(docs): Modernize package recommendations for uv compatibility (Closes #97)

### DIFF
--- a/.claude/commands/project-lite.md
+++ b/.claude/commands/project-lite.md
@@ -90,7 +90,7 @@ Generate this compact summary:
 ### Conventions
 {extracted from CLAUDE.md or inferred:}
 - **Language:** {Python 3.x / TypeScript / etc.}
-- **Package Manager:** {conda / pip / npm / etc.}
+- **Package Manager:** {uv / npm / etc.}
 - **Quality Checks:** {pre-commit hooks / CI / etc.}
 
 ### Worktrees

--- a/INSTALLATION_ISSUES.md
+++ b/INSTALLATION_ISSUES.md
@@ -67,4 +67,4 @@ redis-cli ping  # Should return PONG
 ---
 
 *Generated: 2025-12-20*
-*Updated: 2026-01-04 - Migrated from conda to uv*
+*Updated: 2026-02-16 - Modernized for uv-first workflow*

--- a/README.md
+++ b/README.md
@@ -463,6 +463,33 @@ cd mcp-second-opinion
 uv run python src/server.py
 ```
 
+### Recommended Python Stack (uv-compatible)
+
+| Category | Recommended | Avoid |
+|----------|------------|-------|
+| Package mgmt | `uv` | pip, poetry, conda |
+| HTTP client | `httpx>=0.27` | requests (unless needed) |
+| Validation | `pydantic>=2.6` | marshmallow, attrs |
+| CLI | `typer>=0.12` or `click>=8.1` | argparse (for complex CLIs) |
+| Web (API) | `fastapi>=0.115` | Flask (for API-only) |
+| Web (full) | `django>=5.1` | Django <5.0 (uv conflicts) |
+| Linting | `ruff>=0.8` | flake8, pylint, isort, black |
+| Type checking | `mypy>=1.13` or `pyright` | — |
+| Testing | `pytest>=8.3` | unittest |
+| Build | `hatchling` or `setuptools>=75` | poetry-core |
+| Task runner | `make` + `uv run` prefix | invoke, nox |
+
+All commands should run through `uv run`:
+```makefile
+test:
+	uv run pytest
+
+lint:
+	uv run ruff check .
+```
+
+Always commit `uv.lock` for reproducibility. Use `uv lock` to generate/update.
+
 ### Project Structure
 
 Each Python component has its own `pyproject.toml`:
@@ -912,9 +939,6 @@ claude mcp add coordination --transport sse --url http://127.0.0.1:8082/sse
 ```bash
 # Linux/macOS
 curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Or with pip
-pip install uv
 
 # Verify installation
 uv --version

--- a/mcp-second-opinion/deploy/Dockerfile
+++ b/mcp-second-opinion/deploy/Dockerfile
@@ -1,42 +1,26 @@
 # Second Opinion MCP Server - Dockerfile
-# Multi-stage build for optimized image size
+# Multi-stage build using uv for dependency management
 
 FROM python:3.11-slim AS builder
 
-# Install build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    gcc \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Set working directory
 WORKDIR /app
 
 # Copy dependency files
-COPY environment.yml* requirements.txt* ./
+COPY pyproject.toml uv.lock ./
 
-# Install Python dependencies
-# If requirements.txt doesn't exist, create it from environment.yml
-RUN if [ -f environment.yml ]; then \
-    pip install --no-cache-dir \
-        'mcp[cli]>=1.2.0' \
-        'fastmcp>=1.0' \
-        'google-generativeai>=0.3.0' \
-        'tenacity>=8.0.0' \
-        'pydantic>=2.0.0' \
-        'httpx>=0.24.0'; \
-    elif [ -f requirements.txt ]; then \
-    pip install --no-cache-dir -r requirements.txt; \
-    fi
+# Install dependencies into a virtual environment
+RUN uv sync --frozen --no-dev --no-install-project
 
 # Final stage
 FROM python:3.11-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1
+    PYTHONDONTWRITEBYTECODE=1
 
 # Create non-root user
 RUN useradd -m -u 1000 mcpuser && \
@@ -45,15 +29,17 @@ RUN useradd -m -u 1000 mcpuser && \
 
 WORKDIR /app
 
-# Copy Python packages from builder
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
 
-# Copy application code (from src/ directory)
+# Copy application code
 COPY --chown=mcpuser:mcpuser src/config.py src/prompts.py src/server.py ./
 
 # Switch to non-root user
 USER mcpuser
+
+# Use the virtual environment
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/mcp-second-opinion/pyproject.toml
+++ b/mcp-second-opinion/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "google-genai>=1.0.0",
     "openai>=1.50.0",
     "tenacity>=8.0.0",
-    "pydantic>=2.0.0",
-    "httpx>=0.24.0",
+    "pydantic>=2.6.0",
+    "httpx>=0.27.0",
 ]
 
 [build-system]
@@ -25,5 +25,5 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 
-[tool.uv]
-dev-dependencies = []
+[dependency-groups]
+dev = []

--- a/mcp-second-opinion/uv.lock
+++ b/mcp-second-opinion/uv.lock
@@ -711,10 +711,10 @@ dependencies = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=1.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
-    { name = "httpx", specifier = ">=0.24.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
     { name = "openai", specifier = ">=1.50.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic", specifier = ">=2.6.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Add recommended Python stack table to README with uv-compatible packages and version guidance
- Rewrite `mcp-second-opinion/deploy/Dockerfile` to use uv instead of pip (multi-stage build with `ghcr.io/astral-sh/uv`)
- Bump minimum dependency versions: pydantic >=2.6, httpx >=0.27
- Migrate deprecated `tool.uv.dev-dependencies` to `dependency-groups.dev` format
- Remove outdated `pip install uv` option from installation docs
- Update `/project-lite` template to reference uv as primary package manager

## Test plan

- [ ] Verify `uv lock` resolves cleanly in `mcp-second-opinion/` (confirmed)
- [ ] Verify README package table renders correctly on GitHub
- [ ] Verify Dockerfile builds: `docker build -f mcp-second-opinion/deploy/Dockerfile mcp-second-opinion/`

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)