### PR TITLE
refactor(cpp): Update /cpp:init tiers for simplified architecture (Closes #95)

### DIFF
--- a/.claude/commands/cpp/help.md
+++ b/.claude/commands/cpp/help.md
@@ -21,8 +21,8 @@ CPP uses a tiered installation model:
 | Tier | Name | What's Included |
 |------|------|-----------------|
 | 1 | **Minimal** | Commands + Skills symlinks |
-| 2 | **Standard** | + Scripts, hooks, shell prompt, coordination |
-| 3 | **Full** | + MCP servers (uv, Redis, API keys, systemd) |
+| 2 | **Standard** | + Scripts, hooks, shell prompt |
+| 3 | **Full** | + MCP servers (uv, API keys) |
 
 ## Quick Start
 
@@ -37,19 +37,21 @@ CPP uses a tiered installation model:
 ## Components
 
 ### Tier 1 - Minimal
-- **Commands**: `/project-next`, `/spec:*`, `/github:*`, `/coordination:*`
+- **Commands**: `/project-next`, `/flow:*`, `/spec:*`, `/github:*`
 - **Skills**: Best practices loaders, secrets management
 
 ### Tier 2 - Standard
-- **Scripts**: Session coordination, secret masking
-- **Hooks**: Session tracking, security
+- **Scripts**: Secret masking, worktree cleanup, shell prompt context
+- **Hooks**: Security (command validation, output masking)
 - **Shell prompt**: Worktree context display (`[CPP #42]`)
 
 ### Tier 3 - Full
 - **MCP Second Opinion** (port 8080): Gemini/OpenAI code review
 - **MCP Playwright** (port 8081): Persistent browser automation
-- **MCP Coordination** (port 8082): Redis-backed distributed locking
 - **Systemd services**: Auto-start on boot (optional)
+
+### Optional Add-on
+- **Redis Coordination** (`extras/`): Distributed locking for team/multi-session use
 
 ## Related Documentation
 

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive setup wizard for Claude Power Pack
-allowed-tools: Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(cp:*), Bash(uv:*), Bash(claude mcp list:*), Bash(claude mcp add:*), Bash(redis-cli:*), Bash(sudo apt install:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*)
+allowed-tools: Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(cp:*), Bash(uv:*), Bash(claude mcp list:*), Bash(claude mcp add:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*)
 ---
 
 # Claude Power Pack Setup Wizard
@@ -51,21 +51,18 @@ HOOKS_EXIST=false
 [ -f ".claude/hooks.json" ] && HOOKS_EXIST=true
 
 # Tier 3 checks
-REDIS_RUNNING=false
-redis-cli ping 2>/dev/null | grep -q PONG && REDIS_RUNNING=true
-
 UV_INSTALLED=false
 command -v uv &>/dev/null && UV_INSTALLED=true
 
 # Check for pyproject.toml in each MCP server
 MCP_PROJECTS=""
-for server in mcp-second-opinion mcp-coordination mcp-playwright-persistent; do
+for server in mcp-second-opinion mcp-playwright-persistent; do
   [ -f "$CPP_DIR/$server/pyproject.toml" ] && MCP_PROJECTS="$MCP_PROJECTS $server"
 done
 
 MCP_SERVERS=""
 MCP_LIST=$(claude mcp list 2>/dev/null || echo "")
-for server in second-opinion coordination playwright-persistent; do
+for server in second-opinion playwright-persistent; do
   echo "$MCP_LIST" | grep -q "$server" && MCP_SERVERS="$MCP_SERVERS $server"
 done
 ```
@@ -83,10 +80,10 @@ Ask the user which tier they want to install using the AskUserQuestion tool:
 | Tier | Name | Description |
 |------|------|-------------|
 | 1 | **Minimal** | Commands + Skills symlinks only |
-| 2 | **Standard** | + Scripts, hooks, shell prompt, session coordination |
-| 3 | **Full** | + MCP servers (Redis, uv, API keys) |
+| 2 | **Standard** | + Scripts, hooks, shell prompt |
+| 3 | **Full** | + MCP servers (uv, API keys) |
 
-Default recommendation: **Standard** for most users, **Full** for multi-session workflows.
+Default recommendation: **Standard** for most users, **Full** for MCP-powered workflows.
 
 ---
 
@@ -156,7 +153,7 @@ Ask the user which permission profile they want using AskUserQuestion:
       "Bash(curl:*)", "Bash(wget:*)",
       "WebFetch", "WebSearch",
       "Skill(*)",
-      "mcp__second-opinion__*", "mcp__coordination__*", "mcp__playwright-persistent__*"
+      "mcp__second-opinion__*", "mcp__playwright-persistent__*"
     ],
     "deny": [
       "Bash(rm -rf /:*)", "Bash(rm -rf ~:*)", "Bash(rm -rf /home:*)",
@@ -228,23 +225,15 @@ This will make the following changes:
     • .claude/skills → {CPP_DIR}/.claude/skills
 
   [Tier 2 - Scripts] (~/.claude/scripts/)
-    • prompt-context.sh      - Shell prompt worktree context
-    • session-register.sh    - Session lifecycle management
-    • session-lock.sh        - Distributed locking (file-based)
-    • session-heartbeat.sh   - Activity tracking
-    • pytest-locked.sh       - Coordinated test execution
-    • secrets-mask.sh        - Output masking filter
-    • hook-mask-output.sh    - PostToolUse secret masking
+    • prompt-context.sh       - Shell prompt worktree context
+    • worktree-remove.sh      - Safe worktree cleanup
+    • secrets-mask.sh         - Output masking filter
+    • hook-mask-output.sh     - PostToolUse secret masking
     • hook-validate-command.sh - PreToolUse safety checks
-    • worktree-remove.sh     - Safe worktree cleanup
 
   [Tier 2 - Hooks] (.claude/hooks.json)
-    • SessionStart: Session registration
-    • UserPromptSubmit: heartbeat update
     • PreToolUse: block dangerous commands
     • PostToolUse: mask secrets in output
-    • Stop: pause session
-    • SessionEnd: cleanup and release locks
 
   [Tier 2 - Shell Prompt] (optional)
     • Add worktree context to PS1: [CPP #42] ~/project $
@@ -270,13 +259,8 @@ This will make the following changes:
   [Tier 1 + 2 - All Standard components]
     (see above)
 
-  [Tier 3 - System Packages] (requires sudo)
-    • redis-server (~2 MB installed)
-    • Auto-enabled to start on boot
-
-  [Tier 3 - Python Virtual Environments (uv)] (~200 MB total)
+  [Tier 3 - Python Virtual Environments (uv)] (~150 MB total)
     • mcp-second-opinion/.venv  - Gemini/OpenAI code review (~80 MB)
-    • mcp-coordination/.venv    - Redis-backed locking (~50 MB)
     • mcp-playwright-persistent/.venv - Browser automation (~70 MB)
 
   [Tier 3 - Playwright Browsers]
@@ -287,25 +271,20 @@ This will make the following changes:
     • OPENAI_API_KEY - Optional, for multi-model comparison
 
   [Tier 3 - MCP Servers] (added to Claude Code)
-    • second-opinion      - port 8080
-    • coordination        - port 8082
+    • second-opinion        - port 8080
     • playwright-persistent - port 8081
 
   [Tier 3 - Configuration Files]
     • mcp-second-opinion/.env
-    • mcp-coordination/.env
 
-  Disk usage: ~350 MB (venvs) + 150 MB (Chromium)
-  Ports used: 8080, 8081, 8082
+  Disk usage: ~150 MB (venvs) + 150 MB (Chromium)
+  Ports used: 8080, 8081
 
   To undo:
     # Tier 1+2 cleanup (see above)
-    sudo apt remove redis-server
     rm -rf {CPP_DIR}/mcp-second-opinion/.venv
-    rm -rf {CPP_DIR}/mcp-coordination/.venv
     rm -rf {CPP_DIR}/mcp-playwright-persistent/.venv
     claude mcp remove second-opinion
-    claude mcp remove coordination
     claude mcp remove playwright-persistent
 
 Proceed? [y/N]
@@ -469,28 +448,7 @@ echo "→ Happy CLI installation skipped"
 
 ### Tier 3 Execution
 
-#### 3a. Redis Installation
-
-```bash
-# Check if Redis is running
-if redis-cli ping 2>/dev/null | grep -q PONG; then
-  echo "→ Redis already running (skipped)"
-else
-  echo "Installing Redis..."
-  sudo apt install -y redis-server
-  sudo systemctl enable redis-server
-  sudo systemctl start redis-server
-
-  # Verify
-  if redis-cli ping | grep -q PONG; then
-    echo "✓ Redis installed and running"
-  else
-    echo "⚠ Redis installed but failed to start"
-  fi
-fi
-```
-
-#### 3b. Install uv and Sync Dependencies
+#### 3a. Install uv and Sync Dependencies
 
 ```bash
 # Check if uv is installed
@@ -504,7 +462,7 @@ else
 fi
 
 # Sync dependencies for each MCP server
-for server in mcp-second-opinion mcp-coordination mcp-playwright-persistent; do
+for server in mcp-second-opinion mcp-playwright-persistent; do
   if [ ! -d "$CPP_DIR/$server/.venv" ]; then
     echo "Creating virtual environment for $server..."
     cd "$CPP_DIR/$server"
@@ -516,7 +474,7 @@ for server in mcp-second-opinion mcp-coordination mcp-playwright-persistent; do
 done
 ```
 
-#### 3c. Playwright Browser
+#### 3b. Playwright Browser
 
 ```bash
 # Install Chromium for Playwright
@@ -526,7 +484,7 @@ uv run playwright install chromium
 echo "✓ Chromium browser installed"
 ```
 
-#### 3d. API Key Configuration
+#### 3c. API Key Configuration
 
 Prompt the user for API keys:
 
@@ -555,20 +513,7 @@ echo "✓ mcp-second-opinion/.env configured"
 
 Optional: Ask for OPENAI_API_KEY for multi-model comparison.
 
-Create .env for coordination:
-```bash
-cd "$CPP_DIR/mcp-coordination"
-cat > .env << EOF
-REDIS_URL=redis://localhost:6379/0
-SERVER_PORT=8082
-LOG_LEVEL=INFO
-DEFAULT_LOCK_TIMEOUT=300
-HEARTBEAT_TTL=300
-EOF
-echo "✓ mcp-coordination/.env configured"
-```
-
-#### 3e. Register MCP Servers
+#### 3d. Register MCP Servers
 
 ```bash
 # Add MCP servers to Claude Code
@@ -579,13 +524,6 @@ if ! echo "$MCP_LIST" | grep -q "second-opinion"; then
   echo "✓ second-opinion MCP registered"
 else
   echo "→ second-opinion MCP already registered (skipped)"
-fi
-
-if ! echo "$MCP_LIST" | grep -q "coordination"; then
-  claude mcp add coordination --transport sse --url http://127.0.0.1:8082/sse
-  echo "✓ coordination MCP registered"
-else
-  echo "→ coordination MCP already registered (skipped)"
 fi
 
 if ! echo "$MCP_LIST" | grep -q "playwright-persistent"; then
@@ -609,11 +547,10 @@ Would you like to install systemd services for auto-start on boot?
 
 This will:
   • Create /etc/systemd/system/mcp-second-opinion.service
-  • Create /etc/systemd/system/mcp-coordination.service
-  • Enable services to start automatically on boot
+  • Enable service to start automatically on boot
 
 Note: You'll need to manually start MCP servers until reboot,
-or run: sudo systemctl start mcp-second-opinion mcp-coordination
+or run: sudo systemctl start mcp-second-opinion
 
 Install systemd services? [y/N]
 ```
@@ -622,21 +559,19 @@ If yes:
 ```bash
 # Copy service files
 sudo cp "$CPP_DIR/mcp-second-opinion/deploy/mcp-second-opinion.service" /etc/systemd/system/
-sudo cp "$CPP_DIR/mcp-coordination/deploy/mcp-coordination.service" /etc/systemd/system/
 
 # Update paths in service files (replace placeholder user)
 CURRENT_USER=$(whoami)
 sudo sed -i "s/cooneycw/$CURRENT_USER/g" /etc/systemd/system/mcp-second-opinion.service
-sudo sed -i "s/cooneycw/$CURRENT_USER/g" /etc/systemd/system/mcp-coordination.service
 
 # Reload and enable
 sudo systemctl daemon-reload
-sudo systemctl enable mcp-second-opinion mcp-coordination
+sudo systemctl enable mcp-second-opinion
 
 echo "✓ Systemd services installed and enabled"
 echo ""
-echo "To start now: sudo systemctl start mcp-second-opinion mcp-coordination"
-echo "To check status: systemctl status mcp-second-opinion mcp-coordination"
+echo "To start now: sudo systemctl start mcp-second-opinion"
+echo "To check status: systemctl status mcp-second-opinion"
 ```
 
 ---
@@ -651,7 +586,7 @@ CPP Installation Complete!
 Installed:
   ✓ Tier 1: Commands + Skills symlinked
   ✓ Tier 2: Scripts, hooks, shell prompt
-  ✓ Tier 3: Redis, MCP servers, API keys
+  ✓ Tier 3: uv, MCP servers, API keys
 
 Permission Profile: {PROFILE_NAME}
   Auto-approved: {AUTO_APPROVE_SUMMARY}
@@ -659,14 +594,12 @@ Permission Profile: {PROFILE_NAME}
   Settings: .claude/settings.local.json
 
 MCP Servers:
-  • second-opinion (port 8080) - Gemini code review
-  • coordination (port 8082) - Distributed locking
+  • second-opinion (port 8080) - Gemini/OpenAI code review
   • playwright-persistent (port 8081) - Browser automation
 
 Next Steps:
   1. Start MCP servers (if not using systemd):
      cd {CPP_DIR}/mcp-second-opinion && ./start-server.sh &
-     cd {CPP_DIR}/mcp-coordination && ./start-server.sh &
      cd {CPP_DIR}/mcp-playwright-persistent && ./start-server.sh &
 
   2. Restart your shell to apply prompt changes:
@@ -710,16 +643,6 @@ If automatic installation fails:
 Skip Tier 3 components? [Y/n]
 ```
 
-### Redis Installation Fails
-```
-⚠ Redis installation failed.
-
-The coordination MCP server can still work with file-based locking,
-but Redis provides better performance for multi-session coordination.
-
-Continue without Redis? [Y/n]
-```
-
 ### API Key Not Provided
 ```
 ⚠ No GEMINI_API_KEY provided.
@@ -728,6 +651,67 @@ MCP Second Opinion will not work without an API key.
 You can configure it later by editing: {CPP_DIR}/mcp-second-opinion/.env
 
 Continue? [Y/n]
+```
+
+---
+
+## Step 8: Optional — Redis Coordination (Teams Only)
+
+After the main installation completes, offer this add-on:
+
+```
+=== Optional: Redis Coordination ===
+
+Do you run multiple concurrent Claude Code sessions that need to coordinate?
+(e.g., team development, parallel issue work with shared resources)
+
+Most users do NOT need this — the /flow workflow is stateless and conflict-free.
+
+Install Redis Coordination? [y/N]
+```
+
+If yes, install from `extras/redis-coordination/`:
+
+```bash
+# Install Redis
+if ! redis-cli ping 2>/dev/null | grep -q PONG; then
+  echo "Installing Redis..."
+  sudo apt install -y redis-server
+  sudo systemctl enable redis-server
+  sudo systemctl start redis-server
+fi
+
+# Symlink coordination scripts
+for script in "$CPP_DIR"/extras/redis-coordination/scripts/*.sh; do
+  name=$(basename "$script")
+  ln -sf "$script" ~/.claude/scripts/"$name"
+  echo "✓ $name installed"
+done
+
+# Setup MCP Coordination server
+cd "$CPP_DIR/extras/redis-coordination/mcp-server"
+uv sync
+
+# Create .env
+cat > .env << EOF
+REDIS_URL=redis://localhost:6379/0
+SERVER_PORT=8082
+LOG_LEVEL=INFO
+DEFAULT_LOCK_TIMEOUT=300
+HEARTBEAT_TTL=300
+EOF
+
+# Register MCP server
+claude mcp add coordination --transport sse --url http://127.0.0.1:8082/sse
+
+echo "✓ Redis Coordination installed"
+echo "  Start: cd $CPP_DIR/extras/redis-coordination/mcp-server && ./start-server.sh"
+echo "  Docs:  $CPP_DIR/extras/redis-coordination/README.md"
+```
+
+If no:
+```bash
+echo "→ Redis Coordination skipped (not needed for solo development)"
 ```
 
 ---

--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -1,6 +1,6 @@
 ---
 description: Check Claude Power Pack installation state
-allowed-tools: Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(uv:*), Bash(claude mcp list:*), Bash(systemctl:*), Bash(redis-cli:*)
+allowed-tools: Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(uv:*), Bash(claude mcp list:*), Bash(systemctl:*)
 ---
 
 # CPP Installation Status
@@ -61,7 +61,7 @@ Check scripts, hooks, and shell prompt:
 # Check scripts
 SCRIPTS_INSTALLED=0
 SCRIPTS_TOTAL=0
-for script in prompt-context.sh session-register.sh session-lock.sh session-heartbeat.sh pytest-locked.sh secrets-mask.sh hook-mask-output.sh hook-validate-command.sh worktree-remove.sh; do
+for script in prompt-context.sh worktree-remove.sh secrets-mask.sh hook-mask-output.sh hook-validate-command.sh; do
   SCRIPTS_TOTAL=$((SCRIPTS_TOTAL + 1))
   if [ -f ~/.claude/scripts/$script ] || [ -L ~/.claude/scripts/$script ]; then
     SCRIPTS_INSTALLED=$((SCRIPTS_INSTALLED + 1))
@@ -138,19 +138,10 @@ else
   echo "[ ] uv: not installed"
 fi
 
-# Check Redis
-if command -v redis-cli &>/dev/null && redis-cli ping 2>/dev/null | grep -q PONG; then
-  echo "[x] Redis: running"
-elif command -v redis-cli &>/dev/null; then
-  echo "[~] Redis: installed but not running"
-else
-  echo "[ ] Redis: not installed"
-fi
-
 # Check MCP server pyproject.toml files
 echo ""
 echo "MCP Server Projects:"
-for server in mcp-second-opinion mcp-coordination mcp-playwright-persistent; do
+for server in mcp-second-opinion mcp-playwright-persistent; do
   if [ -f "$CPP_DIR/$server/pyproject.toml" ]; then
     echo "  [x] $server: pyproject.toml found"
   else
@@ -162,7 +153,7 @@ done
 echo ""
 echo "MCP Servers (Claude Code):"
 MCP_LIST=$(claude mcp list 2>/dev/null || echo "")
-for server in second-opinion coordination playwright-persistent; do
+for server in second-opinion playwright-persistent; do
   if echo "$MCP_LIST" | grep -q "$server"; then
     echo "  [x] $server"
   else
@@ -173,7 +164,7 @@ done
 # Check systemd services
 echo ""
 echo "Systemd Services:"
-for service in mcp-second-opinion mcp-coordination mcp-playwright; do
+for service in mcp-second-opinion mcp-playwright-persistent; do
   if systemctl is-enabled $service &>/dev/null; then
     if systemctl is-active $service &>/dev/null; then
       echo "  [x] $service: enabled, running"
@@ -207,8 +198,8 @@ Tier 1 (Minimal):
   Status: Complete
 
 Tier 2 (Standard):
-  [x] Scripts: 9/9 installed
-  [x] Hooks: 5 hooks configured
+  [x] Scripts: 5/5 installed
+  [x] Hooks: 2 hooks configured
   [x] Permission profile: Standard
       Auto-approve rules: ~22
   [ ] Shell prompt: not configured
@@ -216,16 +207,14 @@ Tier 2 (Standard):
 
 Tier 3 (Full):
   [x] uv: 0.5.x
-  [x] Redis: running
   [x] mcp-second-opinion: pyproject.toml + registered
-  [ ] mcp-coordination: not registered
-  [ ] mcp-playwright: not configured
+  [ ] mcp-playwright-persistent: not configured
   [ ] Systemd: not installed
   Status: Partial
 
 ---------------------------------
 Current Level: Tier 2 (Standard)
-Missing: Shell prompt, mcp-coordination, mcp-playwright, systemd
+Missing: Shell prompt, mcp-playwright-persistent, systemd
 
 Run /cpp:init to complete setup
 =================================


### PR DESCRIPTION
## Summary
- Tier 2 simplified: 5 core scripts (removed session-register, session-lock, session-heartbeat, pytest-locked), 2 hooks (PreToolUse + PostToolUse only)
- Tier 3 simplified: removed Redis installation and MCP Coordination server setup — only uv, MCP Second Opinion, and MCP Playwright remain
- Added Step 8: Optional Redis Coordination add-on (from `extras/redis-coordination/`) for team environments
- Updated `/cpp:status` to reflect new 5-script, 2-server expectations
- Updated `/cpp:help` with revised tier descriptions and optional add-on section

## Test plan
- [ ] Run `/cpp:status` — verify script count shows X/5 (not X/9)
- [ ] Run `/cpp:init` — verify Tier 2 no longer mentions session coordination
- [ ] Verify Tier 3 disclosure shows no Redis or coordination references
- [ ] Verify optional Redis add-on prompt appears after main installation

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)