### PR TITLE
feat(security): Add /security scan command for novice-friendly vulnerability detection (Closes #99)

### DIFF
--- a/.claude/commands/flow/deploy.md
+++ b/.claude/commands/flow/deploy.md
@@ -62,6 +62,18 @@ targets:
 - If `requires_confirmation: true`, ask the user to confirm before proceeding
 - If no deploy.yaml, proceed without extra confirmation
 
+### Step 4b: Run Security Check
+
+Run security scan before deploying:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate flow_deploy
+```
+
+- If the gate **fails** (critical or high findings): **stop and report**. Show findings.
+- If the gate produces **warnings** (medium findings): display them but proceed.
+- If `lib/security` is not available, skip this step.
+
 ### Step 5: Run Deploy
 
 ```bash

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -43,6 +43,18 @@ fi
 - If tests or lint fail, **stop and report**. Do not proceed to PR creation.
 - If no Makefile exists, skip quality gates (warn the user).
 
+### Step 2b: Run Security Quick Scan
+
+Run the native security scanner as a quality gate:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate flow_finish
+```
+
+- If the gate **fails** (critical findings): **stop and report**. Show findings and remediation.
+- If the gate produces **warnings** (high findings): display them but proceed.
+- If `lib/security` is not available, skip this step (warn the user).
+
 ### Step 3: Check for Changes
 
 ```bash
@@ -97,6 +109,7 @@ Closes #ISSUE_NUM"
 Quality gates passed:
   ✅ make lint
   ✅ make test
+  ✅ security scan (quick)
 
 Branch pushed: issue-42-fix-login → origin
 

--- a/.claude/commands/security/deep.md
+++ b/.claude/commands/security/deep.md
@@ -1,0 +1,33 @@
+---
+description: Deep security scan (includes git history)
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Read(*.py), Read(*.yml)
+---
+
+# Security Deep Scan
+
+Thorough security scan including git history analysis. Runs all native and external scanners.
+
+## Arguments
+
+- `--json` - Output as JSON
+- `--verbose` - Show additional details
+
+## What's Checked
+
+Everything from `/security:scan` plus:
+- **Git history scanning** via gitleaks (if installed)
+- Secrets that may have been committed and later removed
+
+## Important
+
+If secrets are found in git history:
+- The secret is **compromised** regardless of current file state
+- **Rotate the credential immediately**
+- Consider using `git filter-repo` to clean history (advanced)
+- Never auto-fix git history — too dangerous for novices
+
+## Run Command
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security deep
+```

--- a/.claude/commands/security/explain.md
+++ b/.claude/commands/security/explain.md
@@ -1,0 +1,40 @@
+---
+description: Explain a security finding in detail
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*)
+---
+
+# Security Explain
+
+Get a detailed explanation of a specific security finding type.
+
+## Arguments
+
+- `FINDING_ID` (required) — The finding identifier (e.g., `HARDCODED_PASSWORD`)
+
+## Available Finding IDs
+
+| ID | Description |
+|----|-------------|
+| `GITIGNORE_MISSING` | No .gitignore file found |
+| `GITIGNORE_GAP` | Sensitive pattern missing from .gitignore |
+| `FILE_PERMISSIONS` | Sensitive file is world-readable |
+| `AWS_ACCESS_KEY` | AWS access key in source code |
+| `OPENAI_API_KEY` | OpenAI API key in source code |
+| `ANTHROPIC_API_KEY` | Anthropic API key in source code |
+| `GITHUB_PAT` | GitHub personal access token in source |
+| `HARDCODED_PASSWORD` | Password hardcoded in source |
+| `HARDCODED_SECRET` | Secret/token hardcoded in source |
+| `ENV_TRACKED` | .env file tracked by git |
+| `DEBUG_FLAG` | Debug mode enabled in config |
+
+## Example
+
+```
+/security:explain HARDCODED_PASSWORD
+```
+
+## Run Command
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security explain "$@"
+```

--- a/.claude/commands/security/help.md
+++ b/.claude/commands/security/help.md
@@ -1,0 +1,62 @@
+# Security Commands
+
+Novice-friendly security scanning for Claude Code projects.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/security:scan` | Full scan: native checks + available external tools |
+| `/security:quick` | Fast scan: native checks only (zero deps) |
+| `/security:deep` | Deep scan: includes git history analysis |
+| `/security:explain <ID>` | Detailed explanation of a finding type |
+| `/security:help` | This help page |
+
+## Scan Modes
+
+| Mode | Speed | What's Checked |
+|------|-------|---------------|
+| **quick** | ~1 sec | .gitignore, permissions, secrets, .env tracking, debug flags |
+| **scan** | ~5 sec | Quick + gitleaks, pip-audit, npm audit (if installed) |
+| **deep** | ~30 sec | Scan + git history analysis |
+
+## Severity Levels
+
+| Level | Icon | Behavior in /flow |
+|-------|------|-------------------|
+| CRITICAL | Red circle | Blocks `/flow:finish` and `/flow:deploy` |
+| HIGH | Yellow circle | Warning displayed, prompts to proceed |
+| MEDIUM | Orange circle | Warning displayed, proceeds |
+| LOW | White circle | Info only |
+
+## External Tools (auto-detected)
+
+| Tool | What it scans | Install |
+|------|--------------|---------|
+| `gitleaks` | Secrets in code + git history | `brew install gitleaks` |
+| `pip-audit` | Python dependency CVEs | `uv pip install pip-audit` |
+| `npm audit` | Node dependency CVEs | Built into npm |
+
+## /flow Integration
+
+- `/flow:finish` runs `/security:quick` before creating PR
+- `/flow:deploy` runs `/security:quick` before deploying
+- Configure gating in `.claude/security.yml`
+
+## Configuration
+
+Create `.claude/security.yml` to customize:
+
+```yaml
+gates:
+  flow_finish:
+    block_on: [critical]
+    warn_on: [high]
+  flow_deploy:
+    block_on: [critical, high]
+    warn_on: [medium]
+suppressions:
+  - id: HARDCODED_SECRET
+    path: tests/fixtures/.*
+    reason: "Test fixtures with fake credentials"
+```

--- a/.claude/commands/security/quick.md
+++ b/.claude/commands/security/quick.md
@@ -1,0 +1,33 @@
+---
+description: Quick security scan (native only, fast)
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Read(*.py), Read(*.yml)
+---
+
+# Security Quick Scan
+
+Fast security scan using only built-in native scanners. No external tools required.
+
+## Arguments
+
+- `--json` - Output as JSON
+- `--verbose` - Show additional details
+
+## What's Checked
+
+- `.gitignore` coverage for sensitive file patterns
+- File permissions on secrets/keys
+- High-confidence secret patterns in source code
+- `.env` files tracked by git
+- Debug flags in production configs
+
+## When to Use
+
+- Before creating a PR (run automatically by `/flow:finish`)
+- Quick check during development
+- CI environments without external tools
+
+## Run Command
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security quick
+```

--- a/.claude/commands/security/scan.md
+++ b/.claude/commands/security/scan.md
@@ -1,0 +1,40 @@
+---
+description: Run full security scan (native + external tools)
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Read(*.py), Read(*.yml)
+---
+
+# Security Scan
+
+Run a full security scan using native checks plus any available external tools.
+
+## Arguments
+
+- `--json` - Output as JSON (machine-readable)
+- `--verbose` - Show matched patterns and additional details
+- `--path <dir>` - Scan a specific directory (default: current project)
+
+## What's Checked
+
+### Native (always available)
+- `.gitignore` coverage for sensitive file patterns
+- File permissions on secrets/keys
+- High-confidence secret patterns (AWS keys, GitHub tokens, API keys)
+- `.env` files tracked by git
+- Debug flags in production configs
+
+### External (auto-detected)
+- **gitleaks** — secret detection in working tree
+- **pip-audit** — Python dependency CVEs
+- **npm audit** — Node.js dependency CVEs
+
+## Process
+
+1. Run the security scanner on the current project
+2. Display novice-friendly results with Why/Fix/Cmd for each finding
+3. Exit code 0 if no critical issues, 1 if critical issues found
+
+## Run Command
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security scan
+```

--- a/lib/security/__init__.py
+++ b/lib/security/__init__.py
@@ -1,0 +1,41 @@
+"""Security scanning for Claude Code projects.
+
+Provides novice-friendly vulnerability detection with:
+- Native scanners: gitignore, permissions, secrets, env files, debug flags
+- External tool adapters: gitleaks, pip-audit, npm audit
+- Configurable suppression via .claude/security.yml
+- /flow integration as quality gates
+
+Quick Start:
+    from lib.security import scan_quick, scan_full, scan_deep
+
+    # Fast native-only scan
+    result = scan_quick("/path/to/project")
+    print(result.summary_line())
+
+    # Full scan with external tools
+    result = scan_full("/path/to/project")
+
+    # Check flow gate
+    from lib.security import check_gate
+    passed, messages = check_gate(result, "flow_finish")
+"""
+
+from .config import SecurityConfig
+from .models import Finding, ScanResult, Severity, Suppression
+from .orchestrator import check_gate, scan_deep, scan_full, scan_quick
+
+__all__ = [
+    # Models
+    "Finding",
+    "ScanResult",
+    "Severity",
+    "Suppression",
+    # Config
+    "SecurityConfig",
+    # Orchestrator
+    "scan_quick",
+    "scan_full",
+    "scan_deep",
+    "check_gate",
+]

--- a/lib/security/__main__.py
+++ b/lib/security/__main__.py
@@ -1,0 +1,20 @@
+"""Enable python -m lib.security invocation.
+
+Usage:
+    python -m lib.security scan [OPTIONS]
+    python -m lib.security quick [OPTIONS]
+    python -m lib.security deep [OPTIONS]
+    python -m lib.security explain <FINDING_ID>
+    python -m lib.security gate <GATE_NAME>
+
+Examples:
+    python -m lib.security scan
+    python -m lib.security quick --json
+    python -m lib.security explain HARDCODED_PASSWORD
+    python -m lib.security gate flow_finish
+"""
+
+from .cli import run
+
+if __name__ == "__main__":
+    run()

--- a/lib/security/cli.py
+++ b/lib/security/cli.py
@@ -1,0 +1,206 @@
+"""Command-line interface for security scanning.
+
+Usage:
+    python -m lib.security scan [OPTIONS]
+    python -m lib.security quick [OPTIONS]
+    python -m lib.security deep [OPTIONS]
+    python -m lib.security explain <FINDING_ID>
+
+Examples:
+    python -m lib.security scan
+    python -m lib.security quick --json
+    python -m lib.security deep --path /my/project
+    python -m lib.security explain HARDCODED_PASSWORD
+    python -m lib.security gate flow_finish
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import NoReturn
+
+from .config import SecurityConfig
+from .explain import get_explanation, list_finding_ids
+from .models import ScanResult
+from .orchestrator import check_gate, scan_deep, scan_full, scan_quick
+from .output.json_output import format_results as format_json
+from .output.novice import format_results as format_novice
+
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    """Run full security scan."""
+    config = SecurityConfig.load(args.path)
+    result = scan_full(args.path, config)
+    _print_results(result, args)
+    return 1 if result.has_blockers else 0
+
+
+def cmd_quick(args: argparse.Namespace) -> int:
+    """Run quick (native-only) security scan."""
+    config = SecurityConfig.load(args.path)
+    result = scan_quick(args.path, config)
+    _print_results(result, args)
+    return 1 if result.has_blockers else 0
+
+
+def cmd_deep(args: argparse.Namespace) -> int:
+    """Run deep security scan including git history."""
+    config = SecurityConfig.load(args.path)
+    result = scan_deep(args.path, config)
+    _print_results(result, args)
+    return 1 if result.has_blockers else 0
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    """Show detailed explanation for a finding."""
+    explanation = get_explanation(args.finding_id)
+    if explanation:
+        print(explanation.strip())
+        return 0
+
+    print(f"Unknown finding ID: {args.finding_id}", file=sys.stderr)
+    print(f"\nAvailable finding IDs:", file=sys.stderr)
+    for fid in list_finding_ids():
+        print(f"  - {fid}", file=sys.stderr)
+    return 1
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    """Check if scan results pass a flow gate."""
+    config = SecurityConfig.load(args.path)
+    result = scan_quick(args.path, config)
+    passed, messages = check_gate(result, args.gate_name, config)
+
+    for msg in messages:
+        print(msg)
+
+    if passed:
+        if not messages:
+            print("Security gate passed.")
+        return 0
+    else:
+        print(f"\nSecurity gate '{args.gate_name}' FAILED. Fix critical issues before proceeding.")
+        return 1
+
+
+def _print_results(result: ScanResult, args: argparse.Namespace) -> None:
+    """Print results in the chosen format."""
+    if args.json:
+        print(format_json(result))
+    else:
+        print(format_novice(result, verbose=args.verbose))
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments to a parser."""
+    parser.add_argument(
+        "--path",
+        "-p",
+        default=os.getcwd(),
+        help="Project root directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--json",
+        "-j",
+        action="store_true",
+        help="Output as JSON",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show additional details (matched patterns, etc.)",
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="python -m lib.security",
+        description="Security scanning for Claude Code projects",
+    )
+    _add_common_args(parser)
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # 'scan' subcommand
+    scan_parser = subparsers.add_parser(
+        "scan",
+        help="Full scan: native + available external tools",
+    )
+    _add_common_args(scan_parser)
+
+    # 'quick' subcommand
+    quick_parser = subparsers.add_parser(
+        "quick",
+        help="Quick scan: native scanners only (fast, zero deps)",
+    )
+    _add_common_args(quick_parser)
+
+    # 'deep' subcommand
+    deep_parser = subparsers.add_parser(
+        "deep",
+        help="Deep scan: includes git history analysis",
+    )
+    _add_common_args(deep_parser)
+
+    # 'explain' subcommand
+    explain_parser = subparsers.add_parser(
+        "explain",
+        help="Detailed explanation of a finding",
+    )
+    explain_parser.add_argument(
+        "finding_id",
+        help="Finding ID to explain (e.g., HARDCODED_PASSWORD)",
+    )
+
+    # 'gate' subcommand
+    gate_parser = subparsers.add_parser(
+        "gate",
+        help="Check if scan passes a flow gate",
+    )
+    gate_parser.add_argument(
+        "gate_name",
+        choices=["flow_finish", "flow_deploy"],
+        help="Gate to check",
+    )
+    _add_common_args(gate_parser)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for the CLI."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        # Default to full scan
+        args.command = "scan"
+        return cmd_scan(args)
+
+    commands = {
+        "scan": cmd_scan,
+        "quick": cmd_quick,
+        "deep": cmd_deep,
+        "explain": cmd_explain,
+        "gate": cmd_gate,
+    }
+
+    handler = commands.get(args.command)
+    if handler:
+        return handler(args)
+
+    parser.print_help()
+    return 1
+
+
+def run() -> NoReturn:
+    """Entry point that exits with the return code."""
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/lib/security/config.py
+++ b/lib/security/config.py
@@ -1,0 +1,96 @@
+"""Security scan configuration.
+
+Loads configuration from .claude/security.yml if present,
+otherwise uses sensible defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .models import Severity, Suppression
+
+
+@dataclass
+class GatePolicy:
+    """Policy for a specific flow gate (finish or deploy)."""
+
+    block_on: list[Severity] = field(default_factory=lambda: [Severity.CRITICAL])
+    warn_on: list[Severity] = field(default_factory=lambda: [Severity.HIGH])
+
+
+@dataclass
+class SecurityConfig:
+    """Configuration for security scanning."""
+
+    gates: dict[str, GatePolicy] = field(default_factory=dict)
+    suppressions: list[Suppression] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, project_root: Optional[str] = None) -> SecurityConfig:
+        """Load config from .claude/security.yml or use defaults."""
+        if project_root is None:
+            project_root = os.getcwd()
+
+        config_path = Path(project_root) / ".claude" / "security.yml"
+        if config_path.exists():
+            return cls._from_yaml(config_path)
+
+        return cls._defaults()
+
+    @classmethod
+    def _defaults(cls) -> SecurityConfig:
+        return cls(
+            gates={
+                "flow_finish": GatePolicy(
+                    block_on=[Severity.CRITICAL],
+                    warn_on=[Severity.HIGH],
+                ),
+                "flow_deploy": GatePolicy(
+                    block_on=[Severity.CRITICAL, Severity.HIGH],
+                    warn_on=[Severity.MEDIUM],
+                ),
+            },
+            suppressions=[],
+        )
+
+    @classmethod
+    def _from_yaml(cls, path: Path) -> SecurityConfig:
+        """Parse YAML config file."""
+        try:
+            import yaml
+        except ImportError:
+            # If PyYAML not installed, use defaults
+            return cls._defaults()
+
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+        config = cls._defaults()
+
+        # Parse gates
+        gates_data = data.get("gates", {})
+        for gate_name, gate_cfg in gates_data.items():
+            block = [_parse_severity(s) for s in gate_cfg.get("block_on", [])]
+            warn = [_parse_severity(s) for s in gate_cfg.get("warn_on", [])]
+            config.gates[gate_name] = GatePolicy(block_on=block, warn_on=warn)
+
+        # Parse suppressions
+        for supp in data.get("suppressions", []):
+            config.suppressions.append(
+                Suppression(
+                    id=supp["id"],
+                    path=supp.get("path"),
+                    reason=supp.get("reason", ""),
+                )
+            )
+
+        return config
+
+
+def _parse_severity(name: str) -> Severity:
+    """Parse severity name string to enum."""
+    return Severity[name.upper()]

--- a/lib/security/explain.py
+++ b/lib/security/explain.py
@@ -1,0 +1,233 @@
+"""Detailed explanations for security findings.
+
+Provides in-depth rationale for each finding type,
+aimed at developers who want to understand the "why" deeply.
+"""
+
+from __future__ import annotations
+
+# Finding ID -> detailed explanation
+EXPLANATIONS: dict[str, str] = {
+    "GITIGNORE_MISSING": """
+## .gitignore Missing
+
+Your project has no .gitignore file. This means `git add .` or `git add -A`
+will stage EVERY file in your project, including:
+
+- `.env` files with database passwords and API keys
+- Private keys (*.pem, *.key) used for TLS or SSH
+- IDE configuration that may contain tokens
+- Build artifacts and dependencies
+
+### What to do
+
+1. Create a .gitignore immediately
+2. Use a generator for your language: https://www.toptal.com/developers/gitignore
+3. Always add `.env`, `*.pem`, `*.key` at minimum
+
+### If you already committed secrets
+
+Secrets in git history remain accessible even after deletion.
+You must rotate (change) any exposed credentials immediately.
+""",
+    "GITIGNORE_GAP": """
+## .gitignore Gap
+
+Your .gitignore exists but is missing coverage for a sensitive file pattern.
+This creates a risk window where `git add .` could include secrets.
+
+### Common patterns to include
+
+```gitignore
+# Environment files
+.env
+.env.*
+
+# Private keys
+*.pem
+*.key
+*.p12
+
+# Secrets
+secrets.*
+
+# IDE/editor
+.idea/
+.vscode/settings.json
+```
+
+### Best practice
+
+Use language-specific gitignore templates as a starting point,
+then add project-specific patterns.
+""",
+    "FILE_PERMISSIONS": """
+## Sensitive File Permissions
+
+Unix file permissions control who can read, write, and execute files.
+Sensitive files should be readable only by the owner (mode 600).
+
+### Permission breakdown
+
+- `600` (rw-------): Owner can read/write. Nobody else can access. GOOD.
+- `644` (rw-r--r--): Owner can read/write. Everyone can read. BAD for secrets.
+- `755` (rwxr-xr-x): Everyone can read and execute. BAD for secrets.
+
+### Why this matters
+
+On shared systems (servers, CI), other users/processes may be able to
+read world-readable files. This includes other containers on the same host.
+
+### Fix
+
+```bash
+chmod 600 path/to/sensitive/file
+```
+""",
+    "AWS_ACCESS_KEY": """
+## AWS Access Key in Source Code
+
+AWS access keys (starting with AKIA) provide direct access to your AWS account.
+If committed to a public repository, automated bots scan for these within minutes
+and can spin up resources at your expense.
+
+### Immediate actions
+
+1. **Rotate the key immediately** in AWS IAM Console
+2. Remove from source code
+3. Check CloudTrail for unauthorized usage
+
+### Best practice
+
+Use IAM roles (for EC2/Lambda) or environment variables (for local dev).
+Never put AWS keys in source code.
+""",
+    "OPENAI_API_KEY": """
+## OpenAI API Key in Source Code
+
+OpenAI API keys (starting with sk-proj-) provide access to your OpenAI
+account and can incur charges. If exposed, anyone can make API calls
+billed to your account.
+
+### Fix
+
+1. Rotate the key in the OpenAI dashboard
+2. Store in .env file (not tracked by git)
+3. Load via `os.environ["OPENAI_API_KEY"]`
+""",
+    "ANTHROPIC_API_KEY": """
+## Anthropic API Key in Source Code
+
+Anthropic API keys (starting with sk-ant-) provide access to Claude
+and other Anthropic APIs. Exposure means unauthorized access to your account.
+
+### Fix
+
+1. Rotate the key in the Anthropic console
+2. Store in environment variable or secrets manager
+3. Never commit to source control
+""",
+    "GITHUB_PAT": """
+## GitHub Personal Access Token in Source Code
+
+GitHub PATs (starting with ghp_) provide authenticated access to your
+GitHub account. Depending on scopes, this could allow reading private repos,
+pushing code, or managing settings.
+
+### Fix
+
+1. Revoke the token in GitHub Settings > Developer Settings > Personal Access Tokens
+2. Create a new token with minimal required scopes
+3. Store in environment variable
+""",
+    "HARDCODED_PASSWORD": """
+## Hardcoded Password
+
+A password was found directly in source code. This means:
+- The password is visible to anyone with repo access
+- It cannot be rotated without a code change and deployment
+- It's stored in git history even after removal
+
+### Best practice
+
+Use environment variables or a secrets manager:
+
+```python
+# Bad
+password = "my_secret_password"
+
+# Good
+password = os.environ["DB_PASSWORD"]
+```
+""",
+    "HARDCODED_SECRET": """
+## Hardcoded Secret/Token
+
+A secret or token was found assigned to a variable in source code.
+Hard-coded secrets create security and operational risks.
+
+### Fix
+
+1. Move to .env file or secrets manager
+2. Load via environment variable
+3. Rotate the exposed credential
+""",
+    "ENV_TRACKED": """
+## .env File Tracked by Git
+
+Your .env file is being tracked by git version control. This means:
+- The file (with all secrets) exists in your repository history
+- Anyone who clones or forks the repo gets your secrets
+- Even if you delete it later, the history retains the content
+
+### Fix
+
+```bash
+# Remove from git tracking (keeps the local file)
+git rm --cached .env
+
+# Prevent future tracking
+echo ".env" >> .gitignore
+
+# Commit the changes
+git add .gitignore
+git commit -m "Remove .env from tracking"
+```
+
+### If your repo is public
+
+All secrets in the .env file should be considered compromised.
+Rotate every credential immediately.
+""",
+    "DEBUG_FLAG": """
+## Debug Flag in Configuration
+
+Debug mode was found enabled in a configuration file. In production:
+- Stack traces may be shown to users, revealing code structure
+- Debug endpoints may be exposed
+- Verbose logging may include sensitive data
+- Performance is typically degraded
+
+### Fix
+
+Ensure debug is disabled for production:
+
+```python
+# Django
+DEBUG = os.environ.get("DJANGO_DEBUG", "False") == "True"
+
+# Flask
+app.config["DEBUG"] = os.environ.get("FLASK_DEBUG", "0") == "1"
+```
+""",
+}
+
+
+def get_explanation(finding_id: str) -> str | None:
+    """Get detailed explanation for a finding ID."""
+    return EXPLANATIONS.get(finding_id)
+
+
+def list_finding_ids() -> list[str]:
+    """List all finding IDs that have explanations."""
+    return sorted(EXPLANATIONS.keys())

--- a/lib/security/models.py
+++ b/lib/security/models.py
@@ -1,0 +1,142 @@
+"""Data models for security scanning.
+
+Provides:
+- Severity: Enum for finding severity levels
+- Finding: A single security issue detected by a scanner
+- ScanResult: Aggregated results from all scanners
+- Suppression: Configuration to suppress known findings
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional
+
+
+class Severity(IntEnum):
+    """Severity levels for security findings, ordered by importance."""
+
+    CRITICAL = 4
+    HIGH = 3
+    MEDIUM = 2
+    LOW = 1
+
+    @property
+    def icon(self) -> str:
+        icons = {
+            Severity.CRITICAL: "\U0001f534",  # red circle
+            Severity.HIGH: "\U0001f7e1",  # yellow circle
+            Severity.MEDIUM: "\U0001f7e0",  # orange circle
+            Severity.LOW: "\u26aa",  # white circle
+        }
+        return icons[self]
+
+    @property
+    def label(self) -> str:
+        return self.name
+
+
+@dataclass
+class Finding:
+    """A single security issue detected by a scanner module."""
+
+    id: str
+    severity: Severity
+    title: str
+    file_path: Optional[str] = None
+    line_number: Optional[int] = None
+    why: str = ""
+    fix: str = ""
+    command: Optional[str] = None
+    time_estimate: Optional[str] = None
+    scanner: str = "native"
+    raw_match: Optional[str] = None
+
+    @property
+    def location(self) -> str:
+        if self.file_path and self.line_number:
+            return f"{self.file_path}:{self.line_number}"
+        if self.file_path:
+            return self.file_path
+        return ""
+
+    def mask_secret(self, value: str) -> str:
+        """Mask a secret value, showing only a prefix."""
+        if len(value) <= 4:
+            return "****"
+        return value[:4] + "*" * min(16, len(value) - 4)
+
+
+@dataclass
+class Suppression:
+    """A suppression rule for known/accepted findings."""
+
+    id: str
+    path: Optional[str] = None
+    reason: str = ""
+
+    def matches(self, finding: Finding) -> bool:
+        if finding.id != self.id:
+            return False
+        if self.path and finding.file_path:
+            return bool(re.match(self.path, finding.file_path))
+        if self.path:
+            return False
+        return True
+
+
+@dataclass
+class ScanResult:
+    """Aggregated results from all scanner modules."""
+
+    findings: list[Finding] = field(default_factory=list)
+    passed: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.CRITICAL)
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.HIGH)
+
+    @property
+    def medium_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.MEDIUM)
+
+    @property
+    def low_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.LOW)
+
+    @property
+    def has_blockers(self) -> bool:
+        return self.critical_count > 0
+
+    @property
+    def has_warnings(self) -> bool:
+        return self.high_count > 0
+
+    def summary_line(self) -> str:
+        parts = []
+        if self.critical_count:
+            parts.append(f"{self.critical_count} critical")
+        if self.high_count:
+            parts.append(f"{self.high_count} high")
+        if self.medium_count:
+            parts.append(f"{self.medium_count} medium")
+        if self.low_count:
+            parts.append(f"{self.low_count} low")
+        if not parts:
+            return "No issues found"
+        return ", ".join(parts)
+
+    def merge(self, other: ScanResult) -> None:
+        self.findings.extend(other.findings)
+        self.passed.extend(other.passed)
+        self.skipped.extend(other.skipped)
+        self.errors.extend(other.errors)

--- a/lib/security/modules/__init__.py
+++ b/lib/security/modules/__init__.py
@@ -1,0 +1,4 @@
+"""Scanner modules for security checks.
+
+Each module implements a scan() function that returns a ScanResult.
+"""

--- a/lib/security/modules/debug_flags.py
+++ b/lib/security/modules/debug_flags.py
@@ -1,0 +1,86 @@
+"""Detect debug flags left in production configuration.
+
+Checks for DEBUG=True and similar patterns in configuration files
+that could expose sensitive information in production.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+# Patterns that indicate debug mode enabled
+DEBUG_PATTERNS = [
+    (r"DEBUG\s*=\s*True", "Python DEBUG=True"),
+    (r'"debug"\s*:\s*true', "JSON debug: true"),
+    (r"debug:\s*true", "YAML debug: true"),
+    (r"DEBUG\s*=\s*1", "DEBUG=1"),
+    (r"FLASK_DEBUG\s*=\s*1", "Flask debug mode"),
+    (r"DJANGO_DEBUG\s*=\s*True", "Django debug mode"),
+]
+
+# Only check config-like files
+CONFIG_EXTENSIONS = {
+    ".py", ".yml", ".yaml", ".toml", ".cfg", ".conf", ".ini", ".json",
+}
+
+CONFIG_NAMES = {
+    "settings.py", "config.py", "production.py", "prod.py",
+    "docker-compose.yml", "docker-compose.yaml",
+    "config.yml", "config.yaml", "config.json",
+}
+
+SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv",
+    "test", "tests", "fixtures", "mocks",
+    "security",  # skip the security scanner module itself
+}
+
+
+def scan(project_root: str) -> ScanResult:
+    """Check for debug flags in configuration files."""
+    result = ScanResult()
+    root = Path(project_root)
+    files_checked = 0
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(skip in path.parts for skip in SKIP_DIRS):
+            continue
+        if path.suffix not in CONFIG_EXTENSIONS and path.name not in CONFIG_NAMES:
+            continue
+
+        files_checked += 1
+        try:
+            content = path.read_text(errors="ignore")
+        except OSError:
+            continue
+
+        rel_path = str(path.relative_to(root))
+
+        for pattern, description in DEBUG_PATTERNS:
+            for match in re.finditer(pattern, content, re.IGNORECASE):
+                line_num = content[: match.start()].count("\n") + 1
+                result.findings.append(
+                    Finding(
+                        id="DEBUG_FLAG",
+                        severity=Severity.MEDIUM,
+                        title=f"Debug flag enabled: {description}",
+                        file_path=rel_path,
+                        line_number=line_num,
+                        why="Debug mode can expose stack traces, internal paths, "
+                        "and sensitive data to users. Should be disabled in production.",
+                        fix="Set debug to False for production configurations.",
+                        time_estimate="~1 minute",
+                    )
+                )
+
+    if files_checked and not result.findings:
+        result.passed.append("No debug flags found in configuration files")
+    elif not files_checked:
+        result.skipped.append("No configuration files found to check")
+
+    return result

--- a/lib/security/modules/env_files.py
+++ b/lib/security/modules/env_files.py
@@ -1,0 +1,87 @@
+"""Detect .env files tracked by git.
+
+.env files should never be committed to version control as they
+typically contain secrets. This module checks for .env files that
+are tracked by git (not just present on disk).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+
+def scan(project_root: str) -> ScanResult:
+    """Check if any .env files are tracked by git."""
+    result = ScanResult()
+    root = Path(project_root)
+
+    # Check if this is a git repo
+    git_dir = root / ".git"
+    if not git_dir.exists():
+        result.skipped.append(".env tracking check (not a git repository)")
+        return result
+
+    # Get list of tracked files matching .env patterns
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "--", "*.env", ".env", ".env.*"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+            timeout=10,
+        )
+        tracked_env_files = [
+            f.strip() for f in proc.stdout.strip().splitlines() if f.strip()
+        ]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        result.errors.append("Could not check git-tracked .env files")
+        return result
+
+    # Also check for common env file names not caught by the glob
+    try:
+        proc2 = subprocess.run(
+            ["git", "ls-files"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+            timeout=10,
+        )
+        all_tracked = proc2.stdout.strip().splitlines()
+        for f in all_tracked:
+            name = Path(f).name
+            if name.startswith(".env") and f not in tracked_env_files:
+                tracked_env_files.append(f)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    # Filter out safe files like .env.example
+    safe_suffixes = {".example", ".sample", ".template", ".dist"}
+    unsafe_files = [
+        f
+        for f in tracked_env_files
+        if not any(f.endswith(suffix) for suffix in safe_suffixes)
+    ]
+
+    for env_file in unsafe_files:
+        result.findings.append(
+            Finding(
+                id="ENV_TRACKED",
+                severity=Severity.CRITICAL,
+                title=f".env file tracked by git: {env_file}",
+                file_path=env_file,
+                why="Your .env file contains secrets. Since it's tracked by git, "
+                "those secrets are in your repository history. Anyone with "
+                "access to the repo can see them.",
+                fix="Remove from tracking (keeps the file locally) and add to .gitignore.",
+                command=f'git rm --cached {env_file} && echo "{env_file}" >> .gitignore',
+                time_estimate="~2 minutes",
+            )
+        )
+
+    if not unsafe_files:
+        result.passed.append("No .env files tracked by git")
+
+    return result

--- a/lib/security/modules/gitignore.py
+++ b/lib/security/modules/gitignore.py
@@ -1,0 +1,100 @@
+"""Check .gitignore covers sensitive file patterns.
+
+Verifies that common sensitive files (.env, *.pem, *.key, secrets.*)
+are listed in .gitignore to prevent accidental commits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+# Patterns that should be in .gitignore
+REQUIRED_PATTERNS = [
+    (".env", "Environment variables file containing secrets"),
+    (".env.*", "Environment-specific files (.env.local, .env.production)"),
+    ("*.pem", "TLS/SSH private key files"),
+    ("*.key", "Private key files"),
+    ("secrets.*", "Secrets configuration files"),
+    ("*.p12", "PKCS#12 certificate files"),
+    (".claude/security.yml", "Security scan suppressions (may contain path info)"),
+]
+
+
+def scan(project_root: str) -> ScanResult:
+    """Check .gitignore for required sensitive file patterns."""
+    result = ScanResult()
+    gitignore_path = Path(project_root) / ".gitignore"
+
+    if not gitignore_path.exists():
+        result.findings.append(
+            Finding(
+                id="GITIGNORE_MISSING",
+                severity=Severity.HIGH,
+                title="No .gitignore file found",
+                file_path=".gitignore",
+                why="Without a .gitignore, `git add .` will stage all files "
+                "including secrets, keys, and environment files.",
+                fix="Create a .gitignore with standard exclusions.",
+                command='curl -sL https://www.toptal.com/developers/gitignore/api/python > .gitignore && echo ".env" >> .gitignore',
+                time_estimate="~2 minutes",
+            )
+        )
+        return result
+
+    gitignore_content = gitignore_path.read_text()
+    gitignore_lines = [
+        line.strip()
+        for line in gitignore_content.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    missing = []
+    for pattern, description in REQUIRED_PATTERNS:
+        if not _pattern_covered(pattern, gitignore_lines):
+            missing.append((pattern, description))
+
+    if missing:
+        for pattern, description in missing:
+            result.findings.append(
+                Finding(
+                    id="GITIGNORE_GAP",
+                    severity=Severity.CRITICAL if pattern == ".env" else Severity.HIGH,
+                    title=f"`{pattern}` not in .gitignore",
+                    file_path=".gitignore",
+                    why=f"{description}. Without gitignore coverage, "
+                    "`git add .` will include it in your next commit.",
+                    fix=f"Add `{pattern}` to .gitignore.",
+                    command=f'echo "{pattern}" >> .gitignore',
+                    time_estimate="~1 minute",
+                )
+            )
+    else:
+        result.passed.append("All sensitive file patterns covered in .gitignore")
+
+    return result
+
+
+def _pattern_covered(pattern: str, gitignore_lines: list[str]) -> bool:
+    """Check if a pattern is covered by any gitignore line."""
+    # Direct match
+    if pattern in gitignore_lines:
+        return True
+
+    # Check for broader patterns that cover ours
+    # e.g., "*.pem" covers "server.pem"
+    for line in gitignore_lines:
+        # .env is covered by .env or .env*
+        if pattern == ".env" and line in (".env", ".env*", ".env.*"):
+            return True
+        if pattern == ".env.*" and line in (".env*", ".env.*"):
+            return True
+        # Wildcard patterns
+        if line == pattern:
+            return True
+        # e.g., gitignore has "*.key" which covers our "*.key"
+        if "*" in line and pattern.endswith(line.replace("*", "")):
+            return True
+
+    return False

--- a/lib/security/modules/gitleaks.py
+++ b/lib/security/modules/gitleaks.py
@@ -1,0 +1,93 @@
+"""External tool adapter: gitleaks.
+
+Runs gitleaks for deep secret detection in code and git history.
+Auto-detected: only runs if gitleaks is installed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+
+def is_available() -> bool:
+    """Check if gitleaks is installed."""
+    return shutil.which("gitleaks") is not None
+
+
+def scan(project_root: str, include_history: bool = False) -> ScanResult:
+    """Run gitleaks on the project."""
+    result = ScanResult()
+
+    if not is_available():
+        result.skipped.append("gitleaks not installed (run `brew install gitleaks` or see https://github.com/gitleaks/gitleaks)")
+        return result
+
+    cmd = ["gitleaks", "detect", "--source", project_root, "--report-format", "json", "--report-path", "/dev/stdout", "--no-banner"]
+
+    if not include_history:
+        cmd.append("--no-git")
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        result.errors.append("gitleaks timed out after 120 seconds")
+        return result
+    except FileNotFoundError:
+        result.skipped.append("gitleaks not found")
+        return result
+
+    # gitleaks returns exit code 1 when findings exist, 0 when clean
+    if proc.returncode == 0:
+        label = "code and git history" if include_history else "working tree"
+        result.passed.append(f"No secrets found by gitleaks ({label})")
+        return result
+
+    # Parse JSON output
+    try:
+        findings = json.loads(proc.stdout) if proc.stdout.strip() else []
+    except json.JSONDecodeError:
+        if proc.returncode == 1:
+            # gitleaks found issues but output isn't parseable
+            result.findings.append(
+                Finding(
+                    id="GITLEAKS_FINDING",
+                    severity=Severity.CRITICAL,
+                    title="gitleaks detected secrets (could not parse details)",
+                    why="gitleaks found secrets but the output format was unexpected.",
+                    fix="Run `gitleaks detect` manually for details.",
+                )
+            )
+        return result
+
+    for item in findings:
+        secret_val = item.get("Secret", "")
+        masked = secret_val[:4] + "****" if len(secret_val) > 4 else "****"
+
+        result.findings.append(
+            Finding(
+                id="GITLEAKS_" + item.get("RuleID", "UNKNOWN").upper(),
+                severity=Severity.CRITICAL,
+                title=f"Secret detected: {item.get('Description', 'Unknown')}",
+                file_path=item.get("File", ""),
+                line_number=item.get("StartLine"),
+                why="This secret was detected by gitleaks pattern matching. "
+                "If committed, it may be visible in your repository history.",
+                fix="Remove the secret from source, rotate the credential, "
+                "and load from environment variables.",
+                time_estimate="~5 minutes",
+                scanner="gitleaks",
+                raw_match=masked,
+            )
+        )
+
+    return result

--- a/lib/security/modules/npm_audit.py
+++ b/lib/security/modules/npm_audit.py
@@ -1,0 +1,99 @@
+"""External tool adapter: npm audit.
+
+Checks Node.js dependencies for known vulnerabilities.
+Auto-detected: only runs if package.json exists and npm is installed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+# Map npm severity to our severity model
+NPM_SEVERITY_MAP = {
+    "critical": Severity.CRITICAL,
+    "high": Severity.HIGH,
+    "moderate": Severity.MEDIUM,
+    "low": Severity.LOW,
+    "info": Severity.LOW,
+}
+
+
+def is_available() -> bool:
+    """Check if npm is installed."""
+    return shutil.which("npm") is not None
+
+
+def _is_node_project(project_root: str) -> bool:
+    """Check if this is a Node.js project."""
+    return (Path(project_root) / "package.json").exists()
+
+
+def scan(project_root: str) -> ScanResult:
+    """Run npm audit on the project."""
+    result = ScanResult()
+
+    if not _is_node_project(project_root):
+        result.skipped.append("npm audit (not a Node.js project)")
+        return result
+
+    if not is_available():
+        result.skipped.append("npm not installed")
+        return result
+
+    # Check for package-lock.json (required for npm audit)
+    if not (Path(project_root) / "package-lock.json").exists():
+        result.skipped.append("npm audit (no package-lock.json — run `npm install` first)")
+        return result
+
+    try:
+        proc = subprocess.run(
+            ["npm", "audit", "--json"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        result.errors.append("npm audit timed out after 60 seconds")
+        return result
+    except FileNotFoundError:
+        result.skipped.append("npm not found")
+        return result
+
+    try:
+        data = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    except json.JSONDecodeError:
+        result.errors.append("npm audit output was not valid JSON")
+        return result
+
+    vulnerabilities = data.get("vulnerabilities", {})
+    if not vulnerabilities:
+        result.passed.append("No dependency vulnerabilities found (npm audit)")
+        return result
+
+    for pkg_name, vuln_info in vulnerabilities.items():
+        severity_str = vuln_info.get("severity", "low")
+        severity = NPM_SEVERITY_MAP.get(severity_str, Severity.LOW)
+        fix_available = vuln_info.get("fixAvailable", False)
+
+        result.findings.append(
+            Finding(
+                id="NPM_AUDIT_" + pkg_name.upper().replace("-", "_").replace("/", "_"),
+                severity=severity,
+                title=f"Vulnerable dependency: {pkg_name} ({severity_str})",
+                file_path="package.json",
+                why=f"Known {severity_str} vulnerability in {pkg_name}. "
+                f"Range: {vuln_info.get('range', 'unknown')}",
+                fix="Run npm audit fix" if fix_available else "Manual upgrade required",
+                command="npm audit fix" if fix_available else None,
+                time_estimate="~5 minutes",
+                scanner="npm-audit",
+            )
+        )
+
+    return result

--- a/lib/security/modules/permissions.py
+++ b/lib/security/modules/permissions.py
@@ -1,0 +1,92 @@
+"""Check file permissions on sensitive files.
+
+Ensures that files containing secrets (*.pem, *.key, .env, etc.)
+are not world-readable (chmod 600 or stricter).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+# File patterns to check permissions on (actual secret storage files only)
+SENSITIVE_PATTERNS = [
+    "*.pem",
+    "*.key",
+    "*.p12",
+    ".env",
+    ".env.local",
+    ".env.production",
+]
+
+# Directories to skip
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", ".tox", ".mypy_cache"}
+
+# File extensions that are source code, not secrets (skip even if name matches)
+SOURCE_EXTENSIONS = {".py", ".js", ".ts", ".md", ".sh", ".rb", ".go", ".rs", ".java", ".php"}
+
+# File suffixes that indicate templates/examples (not actual secrets)
+SAFE_SUFFIXES = {".example", ".sample", ".template", ".dist"}
+
+
+def scan(project_root: str) -> ScanResult:
+    """Check file permissions on sensitive files."""
+    result = ScanResult()
+    root = Path(project_root)
+    found_any = False
+
+    for path in _find_sensitive_files(root):
+        found_any = True
+        try:
+            file_stat = path.stat()
+            mode = file_stat.st_mode
+            # Check if group or others have read access
+            if mode & (stat.S_IRGRP | stat.S_IROTH):
+                perms = stat.filemode(mode)
+                result.findings.append(
+                    Finding(
+                        id="FILE_PERMISSIONS",
+                        severity=Severity.HIGH,
+                        title=f"Sensitive file is world-readable: {path.relative_to(root)}",
+                        file_path=str(path.relative_to(root)),
+                        why="Other users on this system can read this file. "
+                        "If it contains secrets, they could be exposed.",
+                        fix="Restrict to owner-only access.",
+                        command=f"chmod 600 {path.relative_to(root)}",
+                        time_estimate="~1 minute",
+                        raw_match=f"current permissions: {perms}",
+                    )
+                )
+        except OSError:
+            continue
+
+    if found_any and not result.findings:
+        result.passed.append("All sensitive files have restricted permissions")
+    elif not found_any:
+        result.passed.append("No sensitive files found to check permissions on")
+
+    return result
+
+
+def _find_sensitive_files(root: Path) -> list[Path]:
+    """Find files matching sensitive patterns."""
+    files = []
+    seen = set()
+    for pattern in SENSITIVE_PATTERNS:
+        for f in root.rglob(pattern):
+            if f in seen:
+                continue
+            seen.add(f)
+            if any(skip in f.parts for skip in SKIP_DIRS):
+                continue
+            # Skip source code files (they contain code about secrets, not secrets themselves)
+            if f.suffix in SOURCE_EXTENSIONS:
+                continue
+            # Skip example/template files
+            if any(f.name.endswith(suffix) for suffix in SAFE_SUFFIXES):
+                continue
+            files.append(f)
+    return files

--- a/lib/security/modules/pip_audit.py
+++ b/lib/security/modules/pip_audit.py
@@ -1,0 +1,101 @@
+"""External tool adapter: pip-audit.
+
+Checks Python dependencies for known vulnerabilities (CVEs).
+Auto-detected: only runs if pip-audit is installed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+
+def is_available() -> bool:
+    """Check if pip-audit is installed."""
+    return shutil.which("pip-audit") is not None
+
+
+def _is_python_project(project_root: str) -> bool:
+    """Check if this is a Python project."""
+    root = Path(project_root)
+    return any(
+        (root / f).exists()
+        for f in ("pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile")
+    )
+
+
+def scan(project_root: str) -> ScanResult:
+    """Run pip-audit on the project."""
+    result = ScanResult()
+
+    if not _is_python_project(project_root):
+        result.skipped.append("pip-audit (not a Python project)")
+        return result
+
+    if not is_available():
+        result.skipped.append("pip-audit not installed (run `uv pip install pip-audit` for Python dependency CVE scanning)")
+        return result
+
+    cmd = ["pip-audit", "--format", "json", "--progress-spinner", "off"]
+
+    # Use requirements file if available
+    root = Path(project_root)
+    req_file = root / "requirements.txt"
+    if req_file.exists():
+        cmd.extend(["--requirement", str(req_file)])
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        result.errors.append("pip-audit timed out after 120 seconds")
+        return result
+    except FileNotFoundError:
+        result.skipped.append("pip-audit not found")
+        return result
+
+    # Parse JSON output
+    try:
+        data = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    except json.JSONDecodeError:
+        if proc.returncode != 0:
+            result.errors.append(f"pip-audit failed: {proc.stderr[:200]}")
+        return result
+
+    vulns = data.get("dependencies", [])
+    vuln_count = 0
+
+    for dep in vulns:
+        for vuln in dep.get("vulns", []):
+            vuln_count += 1
+            vuln_id = vuln.get("id", "UNKNOWN")
+            fix_version = vuln.get("fix_versions", [])
+            fix_str = f"Upgrade to {', '.join(fix_version)}" if fix_version else "No fix available yet"
+
+            result.findings.append(
+                Finding(
+                    id="PIP_AUDIT_" + vuln_id.replace("-", "_"),
+                    severity=Severity.HIGH,
+                    title=f"Vulnerable dependency: {dep['name']} ({vuln_id})",
+                    file_path="requirements.txt" if req_file.exists() else "pyproject.toml",
+                    why=f"{vuln.get('description', 'Known vulnerability in this package version.')}",
+                    fix=fix_str,
+                    command=f"uv pip install --upgrade {dep['name']}" if fix_version else None,
+                    time_estimate="~5 minutes",
+                    scanner="pip-audit",
+                )
+            )
+
+    if not vuln_count:
+        result.passed.append("No dependency vulnerabilities found (pip-audit)")
+
+    return result

--- a/lib/security/modules/secrets.py
+++ b/lib/security/modules/secrets.py
@@ -1,0 +1,191 @@
+"""Native high-confidence secret detection in source files.
+
+Detects well-known secret patterns with low false-positive rates:
+- AWS access keys (AKIA...)
+- OpenAI API keys (sk-proj-...)
+- GitHub tokens (ghp_..., gho_..., ghs_...)
+- Google API keys (AIza...)
+- Anthropic keys (sk-ant-...)
+- Generic high-entropy strings assigned to secret-like variables
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import Finding, ScanResult, Severity
+
+# High-confidence secret patterns (low false-positive rate)
+SECRET_PATTERNS = [
+    (
+        r"AKIA[0-9A-Z]{16}",
+        "AWS_ACCESS_KEY",
+        "AWS Access Key detected",
+        "This key grants access to your AWS account. "
+        "If committed, anyone who sees the repo can use your account.",
+    ),
+    (
+        r"sk-proj-[A-Za-z0-9_-]{20,}",
+        "OPENAI_API_KEY",
+        "OpenAI API key detected",
+        "This key provides access to your OpenAI account and billing.",
+    ),
+    (
+        r"sk-ant-[A-Za-z0-9_-]{20,}",
+        "ANTHROPIC_API_KEY",
+        "Anthropic API key detected",
+        "This key provides access to your Anthropic account and billing.",
+    ),
+    (
+        r"ghp_[A-Za-z0-9]{36,}",
+        "GITHUB_PAT",
+        "GitHub personal access token detected",
+        "This token grants access to your GitHub repos and account.",
+    ),
+    (
+        r"gho_[A-Za-z0-9]{36,}",
+        "GITHUB_OAUTH",
+        "GitHub OAuth token detected",
+        "This token provides GitHub OAuth access.",
+    ),
+    (
+        r"ghs_[A-Za-z0-9]{36,}",
+        "GITHUB_APP_TOKEN",
+        "GitHub App installation token detected",
+        "This token provides GitHub App access to repositories.",
+    ),
+    (
+        r"AIza[A-Za-z0-9_-]{35}",
+        "GOOGLE_API_KEY",
+        "Google API key detected",
+        "This key provides access to Google Cloud services.",
+    ),
+    (
+        r"glpat-[A-Za-z0-9_-]{20,}",
+        "GITLAB_PAT",
+        "GitLab personal access token detected",
+        "This token grants access to your GitLab account.",
+    ),
+    (
+        r"xox[bpsar]-[A-Za-z0-9-]{10,}",
+        "SLACK_TOKEN",
+        "Slack token detected",
+        "This token provides access to your Slack workspace.",
+    ),
+]
+
+# Variable assignment patterns that suggest hardcoded secrets
+ASSIGNMENT_PATTERNS = [
+    (
+        r"""(?:password|passwd|pwd)\s*[=:]\s*["'][^"']{8,}["']""",
+        "HARDCODED_PASSWORD",
+        "Hardcoded password in source code",
+        "Passwords should never be hardcoded. Use environment variables or a secrets manager.",
+    ),
+    (
+        r"""(?:secret|api_?key|auth_?token|access_?token)\s*[=:]\s*["'][A-Za-z0-9+/=_-]{16,}["']""",
+        "HARDCODED_SECRET",
+        "Hardcoded secret/token in source code",
+        "Secrets and tokens should be loaded from environment variables or a secrets manager.",
+    ),
+]
+
+# File extensions to scan
+SCAN_EXTENSIONS = {
+    ".py", ".js", ".ts", ".jsx", ".tsx", ".rb", ".go", ".java",
+    ".rs", ".php", ".sh", ".bash", ".zsh", ".yml", ".yaml",
+    ".toml", ".cfg", ".conf", ".ini", ".json", ".xml", ".tf",
+    ".tfvars", ".env.example", ".env.sample",
+}
+
+# Directories and files to skip
+SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv", ".tox",
+    ".mypy_cache", ".pytest_cache", "dist", "build", ".eggs",
+}
+
+SKIP_FILES = {"package-lock.json", "yarn.lock", "uv.lock", "poetry.lock"}
+
+# Files that contain patterns/regex for masking/detection (not actual secrets)
+SKIP_PATTERN_FILES = {
+    "secrets-mask.sh", "hook-mask-output.sh", "masking.py",
+    "explain.py", "secrets.py",  # the scanner itself and explanation docs
+}
+
+
+def scan(project_root: str) -> ScanResult:
+    """Scan source files for high-confidence secret patterns."""
+    result = ScanResult()
+    root = Path(project_root)
+    files_scanned = 0
+
+    for file_path in _find_source_files(root):
+        files_scanned += 1
+        try:
+            content = file_path.read_text(errors="ignore")
+        except OSError:
+            continue
+
+        rel_path = str(file_path.relative_to(root))
+
+        # Check high-confidence patterns
+        for pattern, finding_id, title, why in SECRET_PATTERNS:
+            for match in re.finditer(pattern, content):
+                line_num = content[: match.start()].count("\n") + 1
+                matched = match.group()
+                masked = matched[:4] + "*" * min(16, len(matched) - 4)
+                result.findings.append(
+                    Finding(
+                        id=finding_id,
+                        severity=Severity.CRITICAL,
+                        title=title,
+                        file_path=rel_path,
+                        line_number=line_num,
+                        why=why,
+                        fix="Move the key to your secrets store and load from environment.",
+                        command="# Remove from source, add to .env, load via os.environ",
+                        time_estimate="~5 minutes",
+                        raw_match=masked,
+                    )
+                )
+
+        # Check assignment patterns
+        for pattern, finding_id, title, why in ASSIGNMENT_PATTERNS:
+            for match in re.finditer(pattern, content, re.IGNORECASE):
+                line_num = content[: match.start()].count("\n") + 1
+                result.findings.append(
+                    Finding(
+                        id=finding_id,
+                        severity=Severity.HIGH,
+                        title=title,
+                        file_path=rel_path,
+                        line_number=line_num,
+                        why=why,
+                        fix="Move to environment variable or secrets manager.",
+                        time_estimate="~5 minutes",
+                    )
+                )
+
+    if files_scanned and not result.findings:
+        result.passed.append(f"No secrets found in {files_scanned} source files")
+    elif not files_scanned:
+        result.skipped.append("No source files found to scan")
+
+    return result
+
+
+def _find_source_files(root: Path) -> list[Path]:
+    """Find source files to scan, respecting skip lists."""
+    files = []
+    for path in root.rglob("*"):
+        if path.is_file():
+            if any(skip in path.parts for skip in SKIP_DIRS):
+                continue
+            if path.name in SKIP_FILES:
+                continue
+            if path.name in SKIP_PATTERN_FILES:
+                continue
+            if path.suffix in SCAN_EXTENSIONS or path.name in (".env.example", ".env.sample"):
+                files.append(path)
+    return files

--- a/lib/security/orchestrator.py
+++ b/lib/security/orchestrator.py
@@ -1,0 +1,140 @@
+"""Security scan orchestrator.
+
+Runs scanner modules, aggregates results, and applies suppressions.
+Provides quick, standard, and deep scan modes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import SecurityConfig
+from .models import ScanResult
+from .modules import debug_flags, env_files, gitignore, gitleaks, npm_audit, permissions, pip_audit, secrets
+
+
+def scan_quick(project_root: str, config: SecurityConfig | None = None) -> ScanResult:
+    """Quick scan: native scanners only, working tree only.
+
+    Fast, zero-dependency scan suitable for /flow:finish gate.
+    """
+    if config is None:
+        config = SecurityConfig.load(project_root)
+
+    result = ScanResult()
+
+    # Run native modules
+    result.merge(gitignore.scan(project_root))
+    result.merge(permissions.scan(project_root))
+    result.merge(secrets.scan(project_root))
+    result.merge(env_files.scan(project_root))
+    result.merge(debug_flags.scan(project_root))
+
+    # Apply suppressions
+    _apply_suppressions(result, config)
+
+    return result
+
+
+def scan_full(project_root: str, config: SecurityConfig | None = None) -> ScanResult:
+    """Full scan: native + available external tools, working tree only.
+
+    Default mode for /security:scan.
+    """
+    if config is None:
+        config = SecurityConfig.load(project_root)
+
+    # Start with quick scan
+    result = scan_quick(project_root, config)
+
+    # Add external tool scans (working tree only)
+    result.merge(gitleaks.scan(project_root, include_history=False))
+    result.merge(pip_audit.scan(project_root))
+    result.merge(npm_audit.scan(project_root))
+
+    # Re-apply suppressions (covers external findings)
+    _apply_suppressions(result, config)
+
+    return result
+
+
+def scan_deep(project_root: str, config: SecurityConfig | None = None) -> ScanResult:
+    """Deep scan: everything + git history scanning.
+
+    For /security:deep — includes git history analysis.
+    """
+    if config is None:
+        config = SecurityConfig.load(project_root)
+
+    result = ScanResult()
+
+    # Native modules
+    result.merge(gitignore.scan(project_root))
+    result.merge(permissions.scan(project_root))
+    result.merge(secrets.scan(project_root))
+    result.merge(env_files.scan(project_root))
+    result.merge(debug_flags.scan(project_root))
+
+    # External tools WITH history
+    result.merge(gitleaks.scan(project_root, include_history=True))
+    result.merge(pip_audit.scan(project_root))
+    result.merge(npm_audit.scan(project_root))
+
+    # Apply suppressions
+    _apply_suppressions(result, config)
+
+    return result
+
+
+def check_gate(result: ScanResult, gate_name: str, config: SecurityConfig | None = None) -> tuple[bool, list[str]]:
+    """Check if scan results pass a flow gate.
+
+    Args:
+        result: Scan results to evaluate.
+        gate_name: Gate to check ("flow_finish" or "flow_deploy").
+        config: Security configuration (loads default if None).
+
+    Returns:
+        Tuple of (passed, messages).
+        passed: True if the gate allows proceeding.
+        messages: Warning or error messages to display.
+    """
+    if config is None:
+        config = SecurityConfig._defaults()
+
+    gate = config.gates.get(gate_name)
+    if gate is None:
+        return True, []
+
+    messages = []
+    blocked = False
+
+    for finding in result.findings:
+        if finding.severity in gate.block_on:
+            messages.append(
+                f"BLOCKED: {finding.severity.icon} {finding.severity.label}: {finding.title}"
+            )
+            blocked = True
+        elif finding.severity in gate.warn_on:
+            messages.append(
+                f"WARNING: {finding.severity.icon} {finding.severity.label}: {finding.title}"
+            )
+
+    return not blocked, messages
+
+
+def _apply_suppressions(result: ScanResult, config: SecurityConfig) -> None:
+    """Remove suppressed findings from results."""
+    if not config.suppressions:
+        return
+
+    original = result.findings[:]
+    result.findings = [
+        f
+        for f in original
+        if not any(s.matches(f) for s in config.suppressions)
+    ]
+
+    suppressed_count = len(original) - len(result.findings)
+    if suppressed_count:
+        result.passed.append(f"{suppressed_count} finding(s) suppressed by configuration")

--- a/lib/security/output/__init__.py
+++ b/lib/security/output/__init__.py
@@ -1,0 +1,1 @@
+"""Output formatters for security scan results."""

--- a/lib/security/output/json_output.py
+++ b/lib/security/output/json_output.py
@@ -1,0 +1,38 @@
+"""JSON output formatter for machine-readable results."""
+
+from __future__ import annotations
+
+import json
+
+from ..models import ScanResult
+
+
+def format_results(result: ScanResult) -> str:
+    """Format scan results as JSON."""
+    data = {
+        "findings": [
+            {
+                "id": f.id,
+                "severity": f.severity.label,
+                "title": f.title,
+                "file": f.file_path,
+                "line": f.line_number,
+                "why": f.why,
+                "fix": f.fix,
+                "command": f.command,
+                "scanner": f.scanner,
+            }
+            for f in sorted(result.findings, key=lambda f: f.severity, reverse=True)
+        ],
+        "passed": result.passed,
+        "skipped": result.skipped,
+        "errors": result.errors,
+        "summary": {
+            "critical": result.critical_count,
+            "high": result.high_count,
+            "medium": result.medium_count,
+            "low": result.low_count,
+            "total": len(result.findings),
+        },
+    }
+    return json.dumps(data, indent=2)

--- a/lib/security/output/novice.py
+++ b/lib/security/output/novice.py
@@ -1,0 +1,88 @@
+"""Novice-friendly output formatter.
+
+Provides detailed explanations with Why/Fix/Command for each finding,
+designed for developers who may not have security expertise.
+"""
+
+from __future__ import annotations
+
+from ..models import ScanResult, Severity
+
+# ANSI color codes
+RED = "\033[0;31m"
+YELLOW = "\033[0;33m"
+ORANGE = "\033[0;33m"  # Terminal orange = yellow
+GREEN = "\033[0;32m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+SEVERITY_COLOR = {
+    Severity.CRITICAL: RED,
+    Severity.HIGH: YELLOW,
+    Severity.MEDIUM: ORANGE,
+    Severity.LOW: DIM,
+}
+
+
+def format_results(result: ScanResult, verbose: bool = False) -> str:
+    """Format scan results for novice-friendly display."""
+    lines = []
+    lines.append(f"{BOLD}## Security Scan Results{NC}")
+    lines.append("")
+
+    # Findings sorted by severity (highest first)
+    sorted_findings = sorted(result.findings, key=lambda f: f.severity, reverse=True)
+
+    for finding in sorted_findings:
+        color = SEVERITY_COLOR.get(finding.severity, NC)
+        lines.append(
+            f"{finding.severity.icon} {color}{BOLD}{finding.severity.label}: "
+            f"{finding.title}{NC}"
+        )
+        if finding.location:
+            lines.append(f"   File: {finding.location}")
+        if finding.why:
+            # Wrap why text with indentation
+            for i, why_line in enumerate(finding.why.split("\n")):
+                prefix = "   Why:  " if i == 0 else "         "
+                lines.append(f"{prefix}{why_line}")
+        if finding.fix:
+            lines.append(f"   Fix:  {finding.fix}")
+        if finding.command:
+            lines.append(f"   Cmd:  {DIM}{finding.command}{NC}")
+        if finding.time_estimate:
+            lines.append(f"   Time: {finding.time_estimate}")
+        if finding.raw_match and verbose:
+            lines.append(f"   Match: {DIM}{finding.raw_match}{NC}")
+        lines.append("")
+
+    # Passed checks
+    for passed in result.passed:
+        lines.append(f"\U0001f7e2 PASS: {passed}")
+
+    # Skipped checks
+    for skipped in result.skipped:
+        lines.append(f"\u26aa SKIP: {skipped}")
+
+    # Errors
+    for error in result.errors:
+        lines.append(f"{RED}ERROR: {error}{NC}")
+
+    lines.append("")
+    lines.append(
+        f"{BOLD}Summary: {result.summary_line()}{NC}"
+    )
+
+    if result.has_blockers:
+        lines.append(
+            f"{RED}Fix the critical issues before creating a PR.{NC}"
+        )
+    elif result.has_warnings:
+        lines.append(
+            f"{YELLOW}Consider fixing high-severity issues before deploying.{NC}"
+        )
+    else:
+        lines.append(f"{GREEN}All clear!{NC}")
+
+    return "\n".join(lines)

--- a/lib/security/pyproject.toml
+++ b/lib/security/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "security"
+version = "0.1.0"
+description = "Security scanning for Claude Code projects"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "cooneycw"}
+]
+dependencies = []
+
+[project.optional-dependencies]
+yaml = ["pyyaml>=6.0"]
+all = ["pyyaml>=6.0"]
+
+[project.scripts]
+security-scan = "security.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv]
+dev-dependencies = []


### PR DESCRIPTION
## Summary

- Add `lib/security/` Python module with native scanners (gitignore, permissions, secrets, env files, debug flags) and external tool adapters (gitleaks, pip-audit, npm audit)
- Add `/security:scan`, `/security:quick`, `/security:deep`, `/security:explain`, `/security:help` commands
- Integrate security scanning as quality gates in `/flow:finish` (Step 2b) and `/flow:deploy` (Step 4b)
- Add configurable severity gating and suppression via `.claude/security.yml`
- Update CLAUDE.md and README.md with security scanning documentation

## Test plan

- [x] `python3 -m lib.security scan` — full scan with novice-friendly output
- [x] `python3 -m lib.security quick --json` — JSON output mode
- [x] `python3 -m lib.security explain HARDCODED_PASSWORD` — explain command
- [x] `python3 -m lib.security gate flow_finish` — gate check (exit 0 = pass)
- [x] False positive reduction verified (masking scripts, source code files, scanner self-detection)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)