### PR TITLE
feat(flow): Add /flow:sync command for cross-machine worktree pickup (Closes #93)

### DIFF
--- a/.claude/commands/flow/help.md
+++ b/.claude/commands/flow/help.md
@@ -11,6 +11,7 @@ Streamlined worktree-based development workflow. No locks, no Redis — just git
 | `/flow:finish` | Run quality gates, commit, push, and create PR |
 | `/flow:merge` | Merge PR, clean up worktree and branch |
 | `/flow:deploy [target]` | Run Makefile deploy target |
+| `/flow:sync` | Push WIP branch to remote for cross-machine pickup |
 | `/flow:auto <issue>` | Full lifecycle: start → analyze → implement → finish → merge → deploy |
 | `/flow:cleanup` | Prune stale worktree references and delete merged branches |
 | `/flow:doctor` | Diagnose workflow environment and readiness |
@@ -27,6 +28,12 @@ Streamlined worktree-based development workflow. No locks, no Redis — just git
 Or step by step:
 ```
 /flow:start 42  →  work  →  /flow:finish  →  /flow:merge  →  /flow:deploy
+```
+
+Cross-machine (optional):
+```
+Machine A: /flow:start 42  →  work  →  /flow:sync
+Machine B: /flow:start 42  →  picks up remote branch  →  continue working
 ```
 
 ## Conventions
@@ -60,6 +67,10 @@ Or step by step:
 # Deploy to production
 /flow:deploy
 # → Runs make deploy
+
+# Sync WIP to remote (for cross-machine work)
+/flow:sync
+# → Auto-commits WIP, pushes branch to origin
 
 # Or do it all in one shot (start to deploy):
 /flow:auto 42

--- a/.claude/commands/flow/sync.md
+++ b/.claude/commands/flow/sync.md
@@ -1,0 +1,77 @@
+# Flow: Sync — Push WIP to Remote for Cross-Machine Pickup
+
+Push the current branch to the remote so you can continue work on another machine. Optional feature — most users won't need this.
+
+## Arguments
+
+None. Operates on the current worktree/branch.
+
+## Instructions
+
+When the user invokes `/flow:sync`, perform these steps:
+
+### Step 1: Validate Context
+
+```bash
+# Ensure we're in a git repo
+git rev-parse --show-toplevel
+
+# Get current branch
+BRANCH=$(git branch --show-current)
+```
+
+- If on `main` or `master`: **STOP**. Report: "Cannot sync main branch. Use `/flow:start <issue>` to create a worktree first."
+- If not on an `issue-*` branch: Warn but allow (user may have custom branch names).
+
+### Step 2: Check for Uncommitted Changes
+
+```bash
+# Check working tree status
+git status --short
+```
+
+- **If clean:** Skip to Step 3.
+- **If dirty (uncommitted changes):** Auto-commit as WIP:
+  ```bash
+  git add -A
+  git commit -m "wip: sync work in progress
+
+  Auto-committed by /flow:sync for cross-machine pickup.
+  This commit will be squash-merged — no need to clean up."
+  ```
+  Report: "Auto-committed WIP changes."
+
+### Step 3: Push to Remote
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+- If push fails (e.g., rejected): Report the error and suggest `git pull --rebase origin "$BRANCH"` to resolve.
+
+### Step 4: Output
+
+```
+Synced branch to remote.
+
+  Branch: issue-42-fix-login-bug
+  Remote: origin
+
+  To continue on another machine:
+    /flow:start 42
+    → Detects remote branch and creates worktree from it
+```
+
+## Error Handling
+
+- **Not in a git repo:** Report error clearly.
+- **On main branch:** Block sync, suggest `/flow:start`.
+- **Push rejected:** Suggest `git pull --rebase` to reconcile.
+- **No remote configured:** Report "No remote 'origin' found."
+
+## Notes
+
+- This command is intentionally simple — just commit WIP + push.
+- `/flow:start` already handles the receiving end (detects remote branches and creates worktrees tracking them).
+- WIP commits are harmless because `/flow:merge` uses squash-merge, collapsing all commits into one clean commit.
+- No configuration required — works with any git remote.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ claude-power-pack/
 │   │   │   ├── finish.md                       # Commit, push, create PR
 │   │   │   ├── merge.md                        # Merge PR, clean up
 │   │   │   ├── deploy.md                       # Run make deploy
+│   │   │   ├── sync.md                         # Push WIP to remote (cross-machine)
 │   │   │   ├── cleanup.md                      # Prune stale worktrees and branches
 │   │   │   ├── auto.md                         # Full lifecycle automation
 │   │   │   ├── doctor.md                       # Diagnose workflow environment


### PR DESCRIPTION
## Summary

- Adds `/flow:sync` command for optional cross-machine worktree state transfer
- Auto-commits WIP changes and pushes branch to remote
- `/flow:start` already detects remote branches — no changes needed there
- Updated `help.md`, `CLAUDE.md`, and `ISSUE_DRIVEN_DEVELOPMENT.md` with cross-machine workflow docs

## Acceptance Criteria from Issue

- [x] `/flow:sync` pushes current WIP branch to remote
- [x] `/flow:start` detects and checks out existing remote branches (already existed)
- [x] Works without any infrastructure (just git remotes)
- [x] Documented as optional feature
- [x] No impact on users who don't use cross-machine workflow

## Test plan

- [ ] Invoke `/flow:sync` from an issue worktree — verify it auto-commits and pushes
- [ ] Invoke `/flow:sync` from main branch — verify it blocks with helpful message
- [ ] Invoke `/flow:start N` when remote branch exists — verify it creates worktree tracking remote
- [ ] Verify `/flow:help` shows sync command in table and examples

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)