### PR TITLE
feat(flow): Add Makefile integration as first-class deployment concept (Closes #89)

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -238,6 +238,10 @@ This will make the following changes:
   [Tier 2 - Shell Prompt] (optional)
     • Add worktree context to PS1: [CPP #42] ~/project $
 
+  [Tier 2 - Makefile] (optional)
+    • Create starter Makefile with lint, test, deploy targets
+    • Used by /flow:finish and /flow:deploy
+
   Disk usage: ~50 KB
 
   To undo:
@@ -406,6 +410,37 @@ echo '' >> ~/.bashrc
 echo '# Claude Power Pack - worktree context in prompt' >> ~/.bashrc
 echo 'export PS1='\''$(~/.claude/scripts/prompt-context.sh)\w $ '\''' >> ~/.bashrc
 echo "✓ Shell prompt configured (restart shell or source ~/.bashrc)"
+```
+
+**Makefile Setup (Optional)**
+
+If no Makefile exists in the project root, offer to create one from the template:
+
+```
+=== Optional: Makefile ===
+
+The /flow commands use Makefile targets for quality gates and deployment:
+  /flow:finish  → runs `make lint` and `make test`
+  /flow:deploy  → runs `make deploy`
+
+Create a starter Makefile? [y/N]
+```
+
+If yes:
+```bash
+if [ ! -f "Makefile" ]; then
+  cp "$CPP_DIR/templates/Makefile.example" Makefile
+  echo "✓ Makefile created from template"
+  echo "  Edit targets to match your project's commands"
+else
+  echo "→ Makefile already exists (skipped)"
+fi
+```
+
+If no:
+```bash
+echo "→ Makefile creation skipped"
+echo "  You can copy it later: cp $CPP_DIR/templates/Makefile.example Makefile"
 ```
 
 **Happy CLI Installation (Optional)**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ claude-power-pack/
 │   ├── issue_sync.py                           # GitHub issue creation
 │   ├── status.py                               # Alignment checking
 │   └── cli.py                                  # Command-line interface
+├── templates/
+│   └── Makefile.example                        # Starter Makefile for flow integration
 ├── scripts/
 │   ├── prompt-context.sh                       # Shell prompt context
 │   ├── worktree-remove.sh                      # Safe worktree removal
@@ -606,6 +608,71 @@ suppressions:
     path: tests/fixtures/.*
     reason: "Test fixtures with fake credentials"
 ```
+
+## Makefile Integration
+
+The `/flow` commands use Makefile targets as the canonical way to run tests, lint, and deploy. This keeps build logic in one place and lets flow commands orchestrate without hardcoding commands.
+
+### How Flow Commands Use Makefile
+
+| Command | Target | Behavior |
+|---------|--------|----------|
+| `/flow:finish` | `lint`, `test` | Auto-discovers and runs if targets exist; skips if no Makefile |
+| `/flow:deploy [target]` | `deploy` (default) | Runs specified target; lists available targets if not found |
+| `/flow:auto` | `deploy` | Runs after merge if target exists; skips otherwise |
+| `/flow:doctor` | all | Reports which standard targets are available |
+
+### Getting Started
+
+Copy the template Makefile to your project:
+
+```bash
+cp ~/Projects/claude-power-pack/templates/Makefile.example Makefile
+```
+
+Or create a minimal one:
+
+```makefile
+.PHONY: test lint deploy
+
+test:
+	uv run pytest
+
+lint:
+	uv run ruff check .
+
+deploy:
+	@echo "Define your deploy steps here"
+```
+
+### Optional Deploy Metadata
+
+Create `.claude/deploy.yaml` for per-target metadata:
+
+```yaml
+targets:
+  deploy:
+    description: Deploy to production
+    requires_confirmation: true
+  deploy-staging:
+    description: Deploy to staging
+```
+
+If `requires_confirmation: true`, `/flow:deploy` will ask for confirmation before running.
+
+### Deploy History
+
+All deployments are logged to `.claude/deploy.log`:
+
+```
+2026-02-16T14:30:00-05:00 | deploy | abc1234 | main | 0
+```
+
+Format: `timestamp | target | commit | branch | exit_code`
+
+### Template
+
+A starter Makefile is available at `templates/Makefile.example`.
 
 ## MCP Coordination Server (Optional)
 

--- a/README.md
+++ b/README.md
@@ -270,8 +270,18 @@ Or step-by-step:
 
 - **Stateless** — All context from git (branches, worktrees, remotes) and GitHub (issues, PRs)
 - **Idempotent** — Running `/flow:start 42` twice detects the existing worktree
-- **Quality gates** — `/flow:finish` runs `make lint` and `make test` if targets exist
+- **Makefile-driven** — Quality gates and deployment use Makefile targets as the single source of truth
 - **Safe cleanup** — `/flow:merge` handles worktree removal safely (avoids cwd-in-worktree issues)
+
+### Makefile Integration
+
+Flow commands auto-discover Makefile targets. Get started with the template:
+
+```bash
+cp ~/Projects/claude-power-pack/templates/Makefile.example Makefile
+```
+
+Or `/cpp:init` will offer to create one for you.
 
 ## 📋 Spec-Driven Development
 
@@ -1173,6 +1183,8 @@ claude-power-pack/
 │   └── spec_bridge/                            # Spec-to-Issue sync
 │       ├── parser.py                           # Parse spec/tasks files
 │       └── issue_sync.py                       # GitHub issue creation
+├── templates/
+│   └── Makefile.example                        # Starter Makefile for flow integration
 ├── scripts/
 │   ├── prompt-context.sh                       # Shell prompt context
 │   ├── hook-mask-output.sh                     # Secret masking

--- a/templates/Makefile.example
+++ b/templates/Makefile.example
@@ -1,0 +1,39 @@
+# Project Makefile — Claude Power Pack Integration
+#
+# The /flow commands auto-discover these targets:
+#   /flow:finish  → runs `make lint` and `make test` (if targets exist)
+#   /flow:deploy  → runs `make deploy` (or any target you specify)
+#   /flow:doctor  → reports which targets are available
+#
+# Copy this file to your project root as "Makefile" and customize.
+# All commands use `uv run` for dependency isolation.
+
+.PHONY: test lint format deploy deploy-staging clean
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	uv run ruff check .
+
+format:
+	uv run ruff format .
+
+test:
+	uv run pytest
+
+## Deployment (used by /flow:deploy)
+
+deploy:
+	@echo "Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  ansible-playbook deploy.yaml"
+	@echo "  ssh prod 'cd /app && git pull && systemctl restart app'"
+	@echo "  docker compose up -d --build"
+
+deploy-staging:
+	@echo "Define your staging deploy steps here"
+
+## Utilities
+
+clean:
+	rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache dist build *.egg-info


### PR DESCRIPTION
## Summary
- Add `templates/Makefile.example` starter template with lint, test, deploy, and clean targets
- Add "Makefile Integration" section to CLAUDE.md documenting how flow commands use Makefile targets
- Update `/cpp:init` wizard to offer Makefile creation from template during Tier 2 setup
- Update README.md with Makefile integration section and templates directory in repo structure

## Test plan
- [ ] Verify `templates/Makefile.example` is a valid Makefile
- [ ] Verify CLAUDE.md Makefile section is accurate
- [ ] Verify `/cpp:init` offers Makefile creation when no Makefile exists
- [ ] Verify README flow section mentions Makefile integration

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)