### PR TITLE
feat(secrets): Enhanced secrets management with tiered providers and FastAPI UI (Closes #98)

### DIFF
--- a/.claude/commands/secrets/help.md
+++ b/.claude/commands/secrets/help.md
@@ -1,0 +1,34 @@
+# Secrets Commands
+
+Overview of all secrets management commands.
+
+## Instructions
+
+Display the following help information:
+
+```
+Secrets Management Commands
+
+  /secrets:get [ID]        Get credentials (masked output)
+  /secrets:set KEY VALUE   Set or update a secret value
+  /secrets:list            List all secret keys (values masked)
+  /secrets:run -- CMD      Run command with secrets injected as env vars
+  /secrets:validate        Validate credential configuration
+  /secrets:ui              Launch web UI for secrets management
+  /secrets:rotate KEY      Rotate a secret value
+  /secrets:help            This help message
+
+Tiered Architecture:
+  Tier 0: .env in global config (~/.config/claude-power-pack/secrets/)
+  Tier 1: Encrypted local store (optional, requires cryptography)
+  Tier 2: AWS Secrets Manager (requires boto3 + AWS credentials)
+
+CLI Usage:
+  PYTHONPATH="$HOME/Projects/claude-power-pack/lib:$PYTHONPATH"
+  python3 -m lib.creds <command> [options]
+
+Configuration:
+  Project-level: .claude/secrets.yml
+  Audit log:     ~/.config/claude-power-pack/audit.log
+  Secret store:  ~/.config/claude-power-pack/secrets/{project_id}/.env
+```

--- a/.claude/commands/secrets/list.md
+++ b/.claude/commands/secrets/list.md
@@ -1,0 +1,22 @@
+# List Secrets
+
+List all secret keys for the current project (values masked).
+
+## Arguments
+
+- `PROJECT` (optional): Override auto-detected project ID
+
+## Instructions
+
+When the user invokes `/secrets:list`, run:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds list
+```
+
+With project override:
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds list --project "$PROJECT"
+```
+
+Report the result showing key names with masked values.

--- a/.claude/commands/secrets/rotate.md
+++ b/.claude/commands/secrets/rotate.md
@@ -1,0 +1,26 @@
+# Rotate a Secret
+
+Update an existing secret with a new value. Logs the rotation action
+to the audit log (never the value).
+
+## Arguments
+
+- `KEY` (required): Secret key to rotate
+- `VALUE` (optional): New value (prompts interactively if not provided)
+
+## Instructions
+
+When the user invokes `/secrets:rotate KEY [VALUE]`, run:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds rotate "$KEY" "$VALUE"
+```
+
+Without value (interactive prompt):
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds rotate "$KEY"
+```
+
+**IMPORTANT:** Never echo or display the secret value in output.
+
+Report the rotation result to the user.

--- a/.claude/commands/secrets/run.md
+++ b/.claude/commands/secrets/run.md
@@ -1,0 +1,28 @@
+# Run with Secrets
+
+Execute a command with project secrets injected as environment variables.
+Secrets never appear in CLI arguments, logs, or output.
+
+## Arguments
+
+- `COMMAND` (required): The command to run (after --)
+
+## Instructions
+
+When the user invokes `/secrets:run -- COMMAND`, run:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds run -- $COMMAND
+```
+
+With provider override:
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds run --provider aws -- $COMMAND
+```
+
+**IMPORTANT:**
+- Never display secret values in output
+- Secrets are injected as environment variables in the subprocess only
+- The parent process environment is not modified
+
+Report the command exit code.

--- a/.claude/commands/secrets/set.md
+++ b/.claude/commands/secrets/set.md
@@ -1,0 +1,25 @@
+# Set a Secret
+
+Set or update a secret value in the project's global config store.
+
+## Arguments
+
+- `KEY` (required): Secret key name (e.g., `DB_PASSWORD`, `API_KEY`)
+- `VALUE` (required): Secret value
+
+## Instructions
+
+When the user invokes `/secrets:set KEY VALUE`, run:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds set "$KEY" "$VALUE"
+```
+
+If `--project` is specified, add it:
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds set "$KEY" "$VALUE" --project "$PROJECT"
+```
+
+**IMPORTANT:** Never echo or display the secret value in output. Only confirm the key name was set.
+
+Report the result to the user.

--- a/.claude/commands/secrets/ui.md
+++ b/.claude/commands/secrets/ui.md
@@ -1,0 +1,36 @@
+# Secrets Web UI
+
+Launch a local web interface for managing project secrets.
+
+## Arguments
+
+- `--port PORT` (optional): Port to bind to (default: 8090)
+- `--project PROJECT` (optional): Override auto-detected project ID
+
+## Instructions
+
+When the user invokes `/secrets:ui`, run:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds ui
+```
+
+With options:
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds ui --port 8090
+```
+
+**Requirements:**
+- FastAPI and uvicorn must be installed: `uv pip install 'creds[ui]'`
+- The server binds to `127.0.0.1` only (no network exposure)
+- A bearer token is generated on startup and printed to the terminal
+- Copy the token to authenticate in the browser
+
+**Features:**
+- View all secret keys (values masked by default)
+- Reveal individual values (click Reveal)
+- Add/update secrets
+- Delete secrets
+- Promote local secrets to AWS Secrets Manager
+
+Report the URL and token to the user.

--- a/.claude/skills/secrets.md
+++ b/.claude/skills/secrets.md
@@ -1,7 +1,7 @@
 ---
 name: Secrets Management
-description: Secure credential access with provider abstraction and masking
-trigger: secrets, credentials, database password, api key, aws secrets, environment variables, .env, get credentials, connection string
+description: Secure credential access with tiered providers, output masking, and web UI
+trigger: secrets, credentials, database password, api key, aws secrets, environment variables, .env, get credentials, connection string, secret management
 ---
 
 # Secrets Management Skill
@@ -16,19 +16,49 @@ When the user asks about accessing secrets, credentials, or database connections
 4. **Validate credentials without exposing them**
 5. **Default to READ_ONLY** database access
 
-## Provider Priority
+## Tiered Architecture
 
-The secrets module auto-detects providers in this order:
+| Tier | Provider | Storage | Use Case |
+|------|----------|---------|----------|
+| **0** | `dotenv-global` | `~/.config/claude-power-pack/secrets/{project_id}/.env` | Local dev (default) |
+| **1** | `env-file` | Environment variables / `.env` in repo | Legacy compat |
+| **2** | `aws-secrets-manager` | AWS Secrets Manager | Production |
 
-1. **Environment variables** (fastest, for local dev)
-   - Looks for `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`
-   - Or `{PREFIX}_*` pattern for other secrets
-   - Always available
+## Project Identity
 
-2. **AWS Secrets Manager** (for production)
-   - Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-   - Or IAM role if running on AWS infrastructure
-   - Secret ID can be name or ARN
+Secrets are scoped per-project using a stable ID derived from the git repo root:
+
+```python
+from lib.creds.project import get_project_id
+project_id = get_project_id()  # e.g., "claude-power-pack"
+```
+
+All worktrees for the same repo share the same project_id and secrets.
+
+## Bundle API (Recommended)
+
+```python
+from lib.creds import get_bundle_provider
+from lib.creds.project import get_project_id
+
+provider = get_bundle_provider()
+bundle = provider.get_bundle(get_project_id())
+print(bundle)  # Keys visible, values masked
+
+# Set a secret
+from lib.creds.base import SecretBundle
+update = SecretBundle(project_id=get_project_id(), secrets={"API_KEY": "value"})
+provider.put_bundle(update, mode="merge")
+```
+
+## Secret Injection
+
+Run commands with secrets as environment variables (never in CLI args):
+
+```bash
+python -m lib.creds run -- make deploy
+python -m lib.creds run -- ansible-playbook deploy.yaml
+```
 
 ## Usage Patterns
 
@@ -37,100 +67,42 @@ The secrets module auto-detects providers in this order:
 ```python
 from lib.creds import get_credentials
 
-# Auto-detect provider and get credentials
-creds = get_credentials()  # Uses DB_* env vars or AWS
-
-# Display is always masked
-print(creds)
-# DatabaseCredentials(host='localhost', port=5432, database='myapp',
-#                     username='appuser', password=SecretValue('****'))
-
-print(creds.connection_string)
-# postgresql://appuser:****@localhost:5432/myapp
-
-# For actual database connection (use sparingly):
-import asyncpg
-conn = await asyncpg.connect(**creds.dsn)  # dsn contains real password
-```
-
-### Using Explicit Provider
-
-```python
-from lib.creds.providers import AWSSecretsProvider, EnvSecretsProvider
-
-# Force AWS
-aws = AWSSecretsProvider(region="us-east-1")
-if aws.is_available():
-    creds = get_credentials("prod/database", provider=aws)
-
-# Force environment
-env = EnvSecretsProvider()
-creds = get_credentials("DB", provider=env)
+creds = get_credentials()  # Auto-detect provider
+print(creds.connection_string)  # postgresql://user:****@host:5432/db
+conn = await asyncpg.connect(**creds.dsn)  # dsn has real password
 ```
 
 ### Masking Output
 
 ```python
-from lib.creds import mask_output, register_secret
-
-# Mask known patterns
+from lib.creds import mask_output
 safe = mask_output("password=secret123")  # "password=****"
-
-# Register custom secrets
-api_key = os.getenv("MY_API_KEY")
-register_secret(api_key)  # Now masked everywhere
-```
-
-## Database Access Levels
-
-| Level | Operations | Use Case |
-|-------|------------|----------|
-| `READ_ONLY` | SELECT only | Development queries (DEFAULT) |
-| `READ_WRITE` | SELECT, INSERT, UPDATE | Data modification |
-| `ADMIN` | All including DELETE/DROP | Schema changes |
-
-### Permission Checking
-
-```python
-from lib.creds import PermissionConfig, AccessLevel, OperationType
-
-# Default: read-only
-config = PermissionConfig()
-
-allowed, reason = config.can_execute(OperationType.SELECT, "users")
-# (True, "Allowed")
-
-allowed, reason = config.can_execute(OperationType.DELETE, "users")
-# (False, "Operation delete requires admin access")
-
-# Upgrade when needed
-config = PermissionConfig(access_level=AccessLevel.READ_WRITE)
-```
-
-## Bash Scripts
-
-For non-Python workflows:
-
-```bash
-# Get credentials (masked output)
-~/.claude/scripts/secrets-get.sh
-
-# Validate configuration
-~/.claude/scripts/secrets-validate.sh --db
-
-# Mask sensitive output
-some_command | ~/.claude/scripts/secrets-mask.sh
 ```
 
 ## Commands
 
-- `/secrets:get [secret_id]` - Get and display credentials (masked)
-- `/secrets:validate` - Test credential configuration
+| Command | Purpose |
+|---------|---------|
+| `/secrets:get [id]` | Get credentials (masked output) |
+| `/secrets:set KEY VALUE` | Set or update a secret |
+| `/secrets:list` | List all secret keys (masked) |
+| `/secrets:run -- CMD` | Run command with secrets injected |
+| `/secrets:validate` | Test credential configuration |
+| `/secrets:ui` | Launch web UI for management |
+| `/secrets:rotate KEY` | Rotate a secret value |
+| `/secrets:help` | Overview of all commands |
+
+## CLI Usage
+
+```bash
+PYTHONPATH="$HOME/Projects/claude-power-pack/lib:$PYTHONPATH"
+python3 -m lib.creds <command> [options]
+```
 
 ## Best Practices
 
-1. **Store secrets in providers, not code** - Use env vars or AWS
+1. **Store secrets in global config, not repo** - Use `creds set`
 2. **Use get_credentials() helper** - Handles provider detection
-3. **Check permissions before writes** - Use PermissionConfig
-4. **Mask all output** - Use connection_string, not connection_string_real
-5. **Clear cache after rotation** - Call `provider.clear_cache()`
+3. **Inject with `creds run`** - Never pass secrets as CLI args
+4. **Launch UI for bulk management** - `creds ui`
+5. **Audit log tracks all actions** - `~/.config/claude-power-pack/audit.log`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,14 +78,23 @@ claude-power-pack/
 │       ├── mcp-server/                         # MCP Coordination server (8 tools)
 │       └── scripts/                            # Session coordination scripts
 ├── lib/creds/                                  # Secrets management
-│   ├── __init__.py                             # Main exports
+│   ├── __init__.py                             # Main exports + get_bundle_provider()
 │   ├── __main__.py                             # python -m lib.creds entry
-│   ├── base.py                                 # SecretValue, SecretsProvider
-│   ├── cli.py                                  # CLI (get, validate commands)
+│   ├── base.py                                 # SecretValue, SecretBundle, BundleProvider
+│   ├── cli.py                                  # CLI (get, set, list, run, ui, rotate)
+│   ├── project.py                              # Project identity (git-based)
+│   ├── config.py                               # SecretsConfig from .claude/secrets.yml
+│   ├── audit.py                                # Audit logging (actions only, never values)
+│   ├── run.py                                  # Secret injection for subprocess exec
 │   ├── credentials.py                          # DatabaseCredentials with masking
 │   ├── masking.py                              # Output masking patterns
 │   ├── permissions.py                          # Access control model
-│   └── providers/                              # AWS, env providers
+│   ├── providers/                              # Secret providers
+│   │   ├── env.py                              # Legacy env var provider
+│   │   ├── dotenv.py                           # Global config .env provider
+│   │   └── aws.py                              # AWS SM with bundle + IAM
+│   └── ui/                                     # FastAPI web UI
+│       └── app.py                              # Local-only CRUD with auth
 ├── lib/security/                               # Security scanning
 │   ├── __init__.py                             # Main exports
 │   ├── __main__.py                             # python -m lib.security entry
@@ -147,7 +156,15 @@ claude-power-pack/
 │   │   │   ├── deep.md                         # Deep scan (+ git history)
 │   │   │   ├── explain.md                      # Explain a finding
 │   │   │   └── help.md                         # Security command overview
-│   │   ├── secrets/                            # Secrets commands
+│   │   ├── secrets/                            # Secrets management commands
+│   │   │   ├── get.md                          # Get credentials (masked)
+│   │   │   ├── set.md                          # Set a secret value
+│   │   │   ├── list.md                         # List secret keys
+│   │   │   ├── run.md                          # Run command with secrets
+│   │   │   ├── validate.md                     # Validate configuration
+│   │   │   ├── ui.md                           # Launch web UI
+│   │   │   ├── rotate.md                       # Rotate a secret
+│   │   │   └── help.md                         # Secrets command overview
 │   │   ├── env/                                # Environment commands
 │   │   ├── project-next.md                     # Next steps orchestrator
 │   │   ├── project-lite.md                     # Quick reference
@@ -677,14 +694,26 @@ See `mcp-playwright-persistent/README.md` for detailed documentation.
 
 ## Secrets Management
 
-Secure credential access with provider abstraction and output masking.
+Tiered secrets management scaling from `.env` files to AWS Secrets Manager, with a FastAPI web UI.
+
+### Tiered Architecture
+
+| Tier | Provider | Storage | Use Case |
+|------|----------|---------|----------|
+| **0** | `dotenv-global` | `~/.config/claude-power-pack/secrets/{project_id}/.env` | Local dev (default) |
+| **1** | `env-file` | Environment variables / `.env` in repo | Legacy compat |
+| **2** | `aws-secrets-manager` | AWS Secrets Manager | Production |
 
 ### Features
 
-- **Provider abstraction**: AWS Secrets Manager + environment variables
+- **Project identity**: Stable ID from git repo root, shared across worktrees
+- **Bundle API**: CRUD operations for project secrets (get, set, delete, list)
+- **Secret injection**: `creds run -- cmd` injects secrets as env vars (never in CLI args)
+- **FastAPI UI**: Local-only web interface with bearer token auth
+- **Audit logging**: Actions logged to `~/.config/claude-power-pack/audit.log` (never values)
+- **IAM isolation**: Per-project AWS roles with scoped policies
 - **Output masking**: Never exposes actual secret values
 - **Permission model**: Read-only by default, writes require explicit permission
-- **Cross-platform CLI**: Python CLI works on Windows/Mac/Linux
 
 ### Setup
 
@@ -699,22 +728,26 @@ ln -sf ~/Projects/claude-power-pack/scripts/secrets-mask.sh ~/.claude/scripts/
 ### CLI Usage
 
 ```bash
-# Get database credentials (auto-detect provider)
+# Set a secret
+python -m lib.creds set DB_PASSWORD my-secret-value
+
+# List all secrets (masked)
+python -m lib.creds list
+
+# Run command with secrets injected
+python -m lib.creds run -- make deploy
+
+# Launch web UI
+python -m lib.creds ui
+
+# Rotate a secret
+python -m lib.creds rotate DB_PASSWORD
+
+# Get database credentials (legacy)
 python -m lib.creds get
-
-# Get specific secret from AWS
-python -m lib.creds get --provider aws prod/database
-
-# Get credentials as JSON (masked)
-python -m lib.creds get --json
 
 # Validate all providers
 python -m lib.creds validate
-
-# Validate specific provider
-python -m lib.creds validate --env
-python -m lib.creds validate --aws
-python -m lib.creds validate --db
 ```
 
 ### Commands
@@ -722,16 +755,45 @@ python -m lib.creds validate --db
 | Command | Purpose |
 |---------|---------|
 | `/secrets:get [id]` | Get credentials (masked output) |
+| `/secrets:set KEY VALUE` | Set or update a secret |
+| `/secrets:list` | List all secret keys (masked) |
+| `/secrets:run -- CMD` | Run command with secrets injected |
 | `/secrets:validate` | Test credential configuration |
+| `/secrets:ui` | Launch web UI for management |
+| `/secrets:rotate KEY` | Rotate a secret value |
+| `/secrets:help` | Overview of all commands |
 
 ### Python Usage
 
 ```python
-from lib.creds import get_credentials
+# Bundle API (recommended)
+from lib.creds import get_bundle_provider
+from lib.creds.project import get_project_id
 
+provider = get_bundle_provider()
+bundle = provider.get_bundle(get_project_id())
+print(bundle)  # Keys visible, values masked
+
+# Legacy credentials API
+from lib.creds import get_credentials
 creds = get_credentials()  # Auto-detects provider
-print(creds)  # Password masked as ****
 conn = await asyncpg.connect(**creds.dsn)  # dsn has real password
+```
+
+### Configuration
+
+Create `.claude/secrets.yml` for project-level settings:
+
+```yaml
+default_provider: auto  # auto, dotenv, aws
+aws:
+  region: us-east-1
+  role_arn: ""  # Optional IAM role for isolation
+ui:
+  host: 127.0.0.1
+  port: 8090
+rotation:
+  warn_days: 90
 ```
 
 ### Masking Pipe Filter

--- a/lib/creds/__main__.py
+++ b/lib/creds/__main__.py
@@ -2,12 +2,20 @@
 
 Usage:
     python -m lib.creds get [OPTIONS] [SECRET_ID]
+    python -m lib.creds set KEY VALUE [--project PROJECT]
+    python -m lib.creds list [--project PROJECT]
+    python -m lib.creds run -- COMMAND [ARGS...]
     python -m lib.creds validate [OPTIONS]
+    python -m lib.creds ui [--port PORT]
+    python -m lib.creds rotate KEY [--project PROJECT]
 
 Examples:
     python -m lib.creds get
-    python -m lib.creds get --json
-    python -m lib.creds validate --db
+    python -m lib.creds set DB_PASSWORD my-secret
+    python -m lib.creds list
+    python -m lib.creds run -- make deploy
+    python -m lib.creds ui
+    python -m lib.creds validate --dotenv
 """
 
 from .cli import run

--- a/lib/creds/audit.py
+++ b/lib/creds/audit.py
@@ -1,0 +1,66 @@
+"""Audit logging for secrets operations.
+
+Logs actions (who, when, what) but NEVER secret values.
+Audit log location: ~/.config/claude-power-pack/audit.log
+
+Usage:
+    from lib.creds.audit import log_action
+
+    log_action("get", project_id="my-app", details="key=DB_PASSWORD")
+    log_action("set", project_id="my-app", details="key=API_KEY")
+    log_action("rotate", project_id="my-app", details="key=DB_PASSWORD")
+"""
+
+from __future__ import annotations
+
+import getpass
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _get_audit_log_path() -> Path:
+    """Get the path to the audit log file."""
+    config_home = os.environ.get(
+        "XDG_CONFIG_HOME", os.path.expanduser("~/.config")
+    )
+    return Path(config_home) / "claude-power-pack" / "audit.log"
+
+
+def log_action(
+    action: str,
+    project_id: str = "",
+    details: str = "",
+) -> None:
+    """Log a secrets action to the audit log.
+
+    NEVER include secret values in the details string.
+
+    Args:
+        action: The action performed (get, set, delete, rotate, run, ui).
+        project_id: The project identifier.
+        details: Additional details (key names, provider, NOT values).
+    """
+    log_path = _get_audit_log_path()
+
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        user = getpass.getuser()
+
+        entry = f"{timestamp} | {action} | {project_id} | {user} | {details}\n"
+
+        with open(log_path, "a") as f:
+            f.write(entry)
+
+        # Enforce permissions on first write
+        if log_path.stat().st_size <= len(entry):
+            log_path.chmod(0o600)
+
+    except Exception as e:
+        # Audit logging should never block operations
+        logger.debug(f"Audit log write failed: {e}")

--- a/lib/creds/config.py
+++ b/lib/creds/config.py
@@ -1,0 +1,84 @@
+"""Secrets management configuration.
+
+Loads configuration from .claude/secrets.yml (if present)
+with sensible defaults for all settings.
+
+Usage:
+    from lib.creds.config import SecretsConfig
+
+    config = SecretsConfig.load()
+    print(config.default_provider)  # "dotenv" or "aws"
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SecretsConfig:
+    """Configuration for the secrets management system."""
+
+    # Default provider: "dotenv", "aws", "auto"
+    default_provider: str = "auto"
+
+    # AWS-specific settings
+    aws_region: str = "us-east-1"
+    aws_role_arn: str = ""
+
+    # UI settings
+    ui_host: str = "127.0.0.1"
+    ui_port: int = 8090
+
+    # Rotation settings
+    rotation_warn_days: int = 90
+
+    @classmethod
+    def load(cls, project_root: str | None = None) -> SecretsConfig:
+        """Load config from .claude/secrets.yml or return defaults.
+
+        Args:
+            project_root: Project root directory. Defaults to cwd.
+
+        Returns:
+            SecretsConfig with loaded or default values.
+        """
+        if project_root is None:
+            project_root = os.getcwd()
+
+        config_path = Path(project_root) / ".claude" / "secrets.yml"
+
+        if config_path.exists():
+            return cls._from_yaml(config_path)
+
+        return cls()
+
+    @classmethod
+    def _from_yaml(cls, path: Path) -> SecretsConfig:
+        """Parse YAML config file."""
+        try:
+            import yaml
+        except ImportError:
+            logger.debug("PyYAML not installed, using defaults")
+            return cls()
+
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except Exception as e:
+            logger.warning(f"Error reading {path}: {e}, using defaults")
+            return cls()
+
+        return cls(
+            default_provider=data.get("default_provider", "auto"),
+            aws_region=data.get("aws", {}).get("region", "us-east-1"),
+            aws_role_arn=data.get("aws", {}).get("role_arn", ""),
+            ui_host=data.get("ui", {}).get("host", "127.0.0.1"),
+            ui_port=data.get("ui", {}).get("port", 8090),
+            rotation_warn_days=data.get("rotation", {}).get("warn_days", 90),
+        )

--- a/lib/creds/project.py
+++ b/lib/creds/project.py
@@ -1,0 +1,142 @@
+"""Project identity for secrets management.
+
+Derives a stable project_id from the git repository root, ensuring
+all worktrees for the same repo share the same identity. This means
+secrets are stored per-project, not per-worktree.
+
+Usage:
+    from lib.creds.project import get_project_id, get_project_root
+
+    project_id = get_project_id()  # e.g., "claude-power-pack"
+    root = get_project_root()      # e.g., "/home/user/Projects/claude-power-pack"
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+
+def get_project_root() -> Path:
+    """Get the root directory of the git repository.
+
+    For worktrees, this returns the main repository root (not the
+    worktree directory), ensuring consistency across all worktrees.
+
+    Returns:
+        Path to the git repository root.
+
+    Raises:
+        RuntimeError: If not inside a git repository.
+    """
+    try:
+        # git rev-parse --show-toplevel gives the worktree root
+        # For the main repo root, we need --git-common-dir
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("Not inside a git repository")
+
+        git_common_dir = Path(result.stdout.strip())
+
+        # If it's a worktree, git_common_dir is like /path/to/main/.git
+        # If it's the main repo, it's just .git
+        if git_common_dir.is_absolute():
+            return git_common_dir.parent
+        else:
+            # Relative path — resolve from cwd
+            toplevel = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if toplevel.returncode != 0:
+                raise RuntimeError("Not inside a git repository")
+
+            worktree_root = Path(toplevel.stdout.strip())
+            resolved = (worktree_root / git_common_dir).resolve()
+
+            # If git_common_dir is ".git", parent is the repo root
+            # If it's "../main-repo/.git", parent is the main repo
+            return resolved.parent
+
+    except FileNotFoundError:
+        raise RuntimeError("git is not installed")
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("git command timed out")
+
+
+def get_project_id(project_root: Path | None = None) -> str:
+    """Get a stable project identifier.
+
+    Uses the repository directory name by default. Falls back to
+    a hash of the absolute path if the name contains unusual characters.
+
+    Args:
+        project_root: Override the auto-detected project root.
+
+    Returns:
+        A filesystem-safe project identifier string.
+    """
+    if project_root is None:
+        project_root = get_project_root()
+
+    name = project_root.name
+
+    # Validate the name is filesystem-safe
+    if name and all(c.isalnum() or c in "-_." for c in name):
+        return name.lower()
+
+    # Fall back to a short hash of the full path
+    path_hash = hashlib.sha256(str(project_root).encode()).hexdigest()[:12]
+    return f"project-{path_hash}"
+
+
+def get_secrets_dir(project_id: str | None = None) -> Path:
+    """Get the directory for storing project secrets.
+
+    Secrets are stored outside the repo to prevent accidental commits
+    and avoid worktree drift.
+
+    Location: ~/.config/claude-power-pack/secrets/{project_id}/
+
+    Args:
+        project_id: Override the auto-detected project ID.
+
+    Returns:
+        Path to the secrets directory (created if needed).
+    """
+    if project_id is None:
+        project_id = get_project_id()
+
+    config_home = os.environ.get(
+        "XDG_CONFIG_HOME", os.path.expanduser("~/.config")
+    )
+    secrets_dir = Path(config_home) / "claude-power-pack" / "secrets" / project_id
+
+    return secrets_dir
+
+
+def ensure_secrets_dir(project_id: str | None = None) -> Path:
+    """Get the secrets directory, creating it with secure permissions.
+
+    Args:
+        project_id: Override the auto-detected project ID.
+
+    Returns:
+        Path to the secrets directory.
+    """
+    secrets_dir = get_secrets_dir(project_id)
+    secrets_dir.mkdir(parents=True, exist_ok=True)
+
+    # Enforce directory permissions: owner-only
+    secrets_dir.chmod(0o700)
+
+    return secrets_dir

--- a/lib/creds/providers/__init__.py
+++ b/lib/creds/providers/__init__.py
@@ -1,24 +1,29 @@
 """Secrets providers for different backends.
 
 Available providers:
-- EnvSecretsProvider: Environment variables and .env files
-- AWSSecretsProvider: AWS Secrets Manager
+- EnvSecretsProvider: Environment variables and .env files (legacy)
+- DotEnvSecretsProvider: Global config .env files with bundle support
+- AWSSecretsProvider: AWS Secrets Manager with bundle support
 
 Usage:
     from lib.creds.providers import EnvSecretsProvider, AWSSecretsProvider
+    from lib.creds.providers import DotEnvSecretsProvider
 
-    # Get credentials from environment
-    env_provider = EnvSecretsProvider()
-    if env_provider.is_available():
-        creds = env_provider.get_secret("DB")  # Looks for DB_* vars
+    # Global config provider (recommended for new code)
+    dotenv = DotEnvSecretsProvider()
+    bundle = dotenv.get_bundle("my-project")
 
-    # Get credentials from AWS
-    aws_provider = AWSSecretsProvider()
-    if aws_provider.is_available():
-        creds = aws_provider.get_secret("prod/database")
+    # Legacy environment provider
+    env = EnvSecretsProvider()
+    creds = env.get_secret("DB")
+
+    # AWS provider with bundle support
+    aws = AWSSecretsProvider()
+    bundle = aws.get_bundle("my-project")
 """
 
 from .env import EnvSecretsProvider
 from .aws import AWSSecretsProvider
+from .dotenv import DotEnvSecretsProvider
 
-__all__ = ["EnvSecretsProvider", "AWSSecretsProvider"]
+__all__ = ["EnvSecretsProvider", "AWSSecretsProvider", "DotEnvSecretsProvider"]

--- a/lib/creds/providers/dotenv.py
+++ b/lib/creds/providers/dotenv.py
@@ -1,0 +1,242 @@
+"""DotEnv secrets provider — global config location.
+
+Stores secrets in ~/.config/claude-power-pack/secrets/{project_id}.env,
+keeping them outside the repo to prevent accidental commits.
+
+File permissions are enforced at 600 (owner read/write only).
+
+Usage:
+    from lib.creds.providers.dotenv import DotEnvSecretsProvider
+    from lib.creds.project import get_project_id
+
+    provider = DotEnvSecretsProvider()
+    bundle = provider.get_bundle(get_project_id())
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Literal
+
+from ..base import (
+    BundleProvider,
+    ProviderCaps,
+    SecretBundle,
+    SecretNotFoundError,
+    SecretsError,
+)
+from ..project import ensure_secrets_dir, get_project_id
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a .env file into key-value pairs.
+
+    Handles:
+    - KEY=value
+    - KEY="quoted value"
+    - KEY='single quoted'
+    - # comments
+    - Empty lines
+    - export KEY=value
+    """
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        # Strip optional 'export ' prefix
+        if line.startswith("export "):
+            line = line[7:]
+
+        if "=" not in line:
+            continue
+
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        # Remove surrounding quotes
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+
+        result[key] = value
+
+    return result
+
+
+def _write_env_file(path: Path, secrets: dict[str, str]) -> None:
+    """Write secrets to a .env file with proper formatting."""
+    lines = [
+        "# Claude Power Pack secrets",
+        f"# Project: {path.parent.name}",
+        f"# Updated: {datetime.now(timezone.utc).isoformat()}",
+        "#",
+        "# DO NOT commit this file. It is stored outside the repo.",
+        "",
+    ]
+
+    for key in sorted(secrets):
+        value = secrets[key]
+        # Quote values that contain spaces, special chars, or are empty
+        if not value or " " in value or any(c in value for c in '#"\'\\$'):
+            value = shlex.quote(value)
+        lines.append(f"{key}={value}")
+
+    lines.append("")  # trailing newline
+
+    path.write_text("\n".join(lines))
+
+    # Enforce file permissions: owner read/write only
+    path.chmod(0o600)
+
+
+class DotEnvSecretsProvider(BundleProvider):
+    """Secrets provider storing .env files in global config directory.
+
+    Secrets are stored at:
+        ~/.config/claude-power-pack/secrets/{project_id}.env
+
+    This keeps secrets outside the repository to prevent accidental
+    commits and avoids worktree drift (all worktrees share the same
+    secrets since project_id is derived from the main repo root).
+    """
+
+    def __init__(self, config_dir: Path | None = None) -> None:
+        """Initialize the DotEnv provider.
+
+        Args:
+            config_dir: Override the default config directory.
+        """
+        self._config_dir = config_dir
+
+    def _get_env_path(self, project_id: str) -> Path:
+        """Get the .env file path for a project."""
+        if self._config_dir:
+            secrets_dir = self._config_dir / project_id
+            secrets_dir.mkdir(parents=True, exist_ok=True)
+            return secrets_dir / ".env"
+        return ensure_secrets_dir(project_id) / ".env"
+
+    @property
+    def name(self) -> str:
+        return "dotenv-global"
+
+    def caps(self) -> ProviderCaps:
+        return ProviderCaps(
+            can_read=True,
+            can_write=True,
+            can_delete=True,
+            can_list=True,
+            can_rotate=False,
+            supports_versions=False,
+        )
+
+    def is_available(self) -> bool:
+        """DotEnv provider is always available."""
+        return True
+
+    def get_secret(self, secret_id: str) -> Dict[str, Any]:
+        """Get secrets as a flat dict (legacy interface).
+
+        For DotEnv provider, secret_id is the project_id.
+        """
+        try:
+            bundle = self.get_bundle(secret_id)
+            return dict(bundle.secrets)
+        except SecretNotFoundError:
+            raise
+        except Exception as e:
+            raise SecretsError(f"Error reading secrets: {e}") from e
+
+    def get_bundle(
+        self, project_id: str, version: str | None = None
+    ) -> SecretBundle:
+        """Get all secrets for a project."""
+        path = self._get_env_path(project_id)
+
+        if not path.exists():
+            return SecretBundle(
+                project_id=project_id,
+                secrets={},
+                provider=self.name,
+            )
+
+        # Check file permissions
+        stat = path.stat()
+        mode = stat.st_mode & 0o777
+        if mode != 0o600:
+            logger.warning(
+                f"Secret file {path} has permissions {oct(mode)}, "
+                "fixing to 600"
+            )
+            path.chmod(0o600)
+
+        secrets = _parse_env_file(path)
+
+        return SecretBundle(
+            project_id=project_id,
+            secrets=secrets,
+            updated_at=datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            ),
+            provider=self.name,
+        )
+
+    def put_bundle(
+        self,
+        bundle: SecretBundle,
+        mode: Literal["merge", "replace"] = "merge",
+    ) -> SecretBundle:
+        """Write secrets for a project."""
+        path = self._get_env_path(bundle.project_id)
+
+        if mode == "merge" and path.exists():
+            existing = _parse_env_file(path)
+            existing.update(bundle.secrets)
+            merged = existing
+        else:
+            merged = dict(bundle.secrets)
+
+        _write_env_file(path, merged)
+
+        return SecretBundle(
+            project_id=bundle.project_id,
+            secrets=merged,
+            updated_at=datetime.now(timezone.utc),
+            provider=self.name,
+        )
+
+    def delete_key(self, project_id: str, key: str) -> None:
+        """Delete a single secret key."""
+        path = self._get_env_path(project_id)
+
+        if not path.exists():
+            raise SecretNotFoundError(f"No secrets found for project '{project_id}'")
+
+        secrets = _parse_env_file(path)
+        if key not in secrets:
+            raise SecretNotFoundError(f"Key '{key}' not found in project '{project_id}'")
+
+        del secrets[key]
+        _write_env_file(path, secrets)
+
+    def list_keys(self, project_id: str) -> list[str]:
+        """List all secret key names for a project."""
+        path = self._get_env_path(project_id)
+
+        if not path.exists():
+            return []
+
+        secrets = _parse_env_file(path)
+        return sorted(secrets.keys())

--- a/lib/creds/pyproject.toml
+++ b/lib/creds/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "creds"
-version = "0.1.0"
-description = "Secrets management with provider abstraction and output masking"
+version = "0.2.0"
+description = "Secrets management with provider abstraction, output masking, and web UI"
 requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
@@ -12,7 +12,17 @@ dependencies = []
 [project.optional-dependencies]
 dotenv = ["python-dotenv>=1.0.0"]
 aws = ["boto3>=1.26.0"]
-all = ["python-dotenv>=1.0.0", "boto3>=1.26.0"]
+ui = ["fastapi>=0.115", "uvicorn>=0.34"]
+crypto = ["cryptography>=44.0"]
+yaml = ["pyyaml>=6.0"]
+all = [
+    "python-dotenv>=1.0.0",
+    "boto3>=1.26.0",
+    "fastapi>=0.115",
+    "uvicorn>=0.34",
+    "cryptography>=44.0",
+    "pyyaml>=6.0",
+]
 
 [project.scripts]
 creds = "creds.cli:main"

--- a/lib/creds/run.py
+++ b/lib/creds/run.py
@@ -1,0 +1,112 @@
+"""Secret injection for subprocess execution.
+
+Loads secrets into environment variables and executes a command,
+ensuring secrets never appear in CLI arguments or logs.
+
+Usage:
+    from lib.creds.run import run_with_secrets
+
+    exit_code = run_with_secrets(
+        ["make", "deploy"],
+        project_id="my-app",
+    )
+
+CLI:
+    python -m lib.creds run -- make deploy
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import sys
+from typing import Optional
+
+from .audit import log_action
+from .base import SecretsError
+from .project import get_project_id
+
+logger = logging.getLogger(__name__)
+
+
+def _get_bundle_provider(provider_name: str | None = None):
+    """Get a bundle-capable provider."""
+    from .providers.dotenv import DotEnvSecretsProvider
+    from .providers.aws import AWSSecretsProvider
+
+    if provider_name == "aws":
+        return AWSSecretsProvider()
+    elif provider_name == "dotenv":
+        return DotEnvSecretsProvider()
+    else:
+        # Auto-detect: try AWS first, fall back to dotenv
+        aws = AWSSecretsProvider()
+        if aws.is_available():
+            return aws
+        return DotEnvSecretsProvider()
+
+
+def run_with_secrets(
+    command: list[str],
+    project_id: str | None = None,
+    provider_name: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> int:
+    """Execute a command with secrets injected as environment variables.
+
+    Secrets are loaded from the configured provider and set in the
+    subprocess environment. They never appear in CLI arguments, logs,
+    or the parent process environment.
+
+    Args:
+        command: Command and arguments to execute.
+        project_id: Override auto-detected project ID.
+        provider_name: Force a specific provider ("aws", "dotenv").
+        extra_env: Additional environment variables to set.
+
+    Returns:
+        The subprocess exit code.
+    """
+    if not command:
+        raise ValueError("command must not be empty")
+
+    if project_id is None:
+        project_id = get_project_id()
+
+    provider = _get_bundle_provider(provider_name)
+    bundle = provider.get_bundle(project_id)
+
+    if not bundle.secrets:
+        logger.info(f"No secrets found for project '{project_id}', "
+                     "running command without injection")
+
+    # Build subprocess environment
+    env = os.environ.copy()
+    env.update(bundle.secrets)
+    if extra_env:
+        env.update(extra_env)
+
+    # Log the action (never the values)
+    log_action(
+        action="run",
+        project_id=project_id,
+        details=f"command={shlex.join(command)}, "
+                f"secrets_injected={len(bundle.secrets)}, "
+                f"provider={provider.name}",
+    )
+
+    logger.info(
+        f"Running with {len(bundle.secrets)} secrets from {provider.name}: "
+        f"{shlex.join(command)}"
+    )
+
+    try:
+        result = subprocess.run(command, env=env)
+        return result.returncode
+    except FileNotFoundError:
+        print(f"Error: command not found: {command[0]}", file=sys.stderr)
+        return 127
+    except KeyboardInterrupt:
+        return 130

--- a/lib/creds/ui/__init__.py
+++ b/lib/creds/ui/__init__.py
@@ -1,0 +1,15 @@
+"""FastAPI web UI for secrets management.
+
+Local-only server with bearer token auth for CRUD operations
+on project secrets.
+
+Usage:
+    from lib.creds.ui import create_app, run_server
+
+    app = create_app("my-project")
+    run_server(app, port=8090)
+"""
+
+from .app import create_app, run_server
+
+__all__ = ["create_app", "run_server"]

--- a/lib/creds/ui/app.py
+++ b/lib/creds/ui/app.py
@@ -1,0 +1,456 @@
+"""FastAPI application for secrets management UI.
+
+Provides a local-only web interface for managing project secrets
+with bearer token authentication.
+
+Security:
+- Binds to 127.0.0.1 only (no network exposure)
+- Random bearer token generated on startup, printed to terminal
+- Values hidden by default (explicit reveal action)
+- CSRF protection via token-based auth
+- Content-Security-Policy headers
+"""
+
+from __future__ import annotations
+
+import secrets
+import sys
+from typing import Optional
+
+from ..audit import log_action
+from ..base import BundleProvider, SecretBundle, SecretNotFoundError
+from ..config import SecretsConfig
+from ..project import get_project_id
+
+# Lazy imports for optional dependencies
+_fastapi = None
+_uvicorn = None
+
+
+def _import_deps():
+    """Import FastAPI and uvicorn (optional dependencies)."""
+    global _fastapi, _uvicorn
+    try:
+        import fastapi
+        import uvicorn
+        _fastapi = fastapi
+        _uvicorn = uvicorn
+    except ImportError:
+        print(
+            "Error: FastAPI and uvicorn are required for the secrets UI.\n"
+            "Install with: uv pip install 'creds[ui]'\n"
+            "  or: pip install fastapi uvicorn",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _get_provider(
+    config: SecretsConfig,
+) -> BundleProvider:
+    """Get the configured bundle provider."""
+    from ..providers.dotenv import DotEnvSecretsProvider
+    from ..providers.aws import AWSSecretsProvider
+
+    if config.default_provider == "aws":
+        return AWSSecretsProvider(
+            region=config.aws_region,
+            role_arn=config.aws_role_arn or None,
+        )
+    elif config.default_provider == "dotenv":
+        return DotEnvSecretsProvider()
+    else:
+        # Auto-detect
+        aws = AWSSecretsProvider(region=config.aws_region)
+        if aws.is_available():
+            return aws
+        return DotEnvSecretsProvider()
+
+
+def create_app(
+    project_id: str | None = None,
+    config: SecretsConfig | None = None,
+    auth_token: str | None = None,
+) -> tuple:
+    """Create the FastAPI application.
+
+    Args:
+        project_id: Override auto-detected project ID.
+        config: Override auto-loaded config.
+        auth_token: Override generated auth token.
+
+    Returns:
+        Tuple of (FastAPI app, auth_token string).
+    """
+    _import_deps()
+
+    from fastapi import FastAPI, HTTPException, Depends, Request
+    from fastapi.responses import HTMLResponse, JSONResponse
+    from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+    if project_id is None:
+        project_id = get_project_id()
+    if config is None:
+        config = SecretsConfig.load()
+    if auth_token is None:
+        auth_token = secrets.token_urlsafe(32)
+
+    provider = _get_provider(config)
+
+    app = FastAPI(
+        title="Claude Power Pack — Secrets",
+        description="Local secrets management UI",
+        docs_url=None,
+        redoc_url=None,
+    )
+
+    security = HTTPBearer()
+
+    # --- Middleware ---
+
+    @app.middleware("http")
+    async def security_headers(request: Request, call_next):
+        response = await call_next(request)
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "script-src 'self' 'unsafe-inline'; "
+            "form-action 'self'"
+        )
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Cache-Control"] = "no-store"
+        return response
+
+    # --- Auth ---
+
+    async def verify_token(
+        credentials: HTTPAuthorizationCredentials = Depends(security),
+    ):
+        if not secrets.compare_digest(credentials.credentials, auth_token):
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+    # --- API Routes ---
+
+    @app.get("/api/secrets", dependencies=[Depends(verify_token)])
+    async def list_secrets():
+        """List all secret keys (values hidden)."""
+        bundle = provider.get_bundle(project_id)
+        return {
+            "project_id": project_id,
+            "provider": provider.name,
+            "count": len(bundle.secrets),
+            "keys": [
+                {"key": k, "length": len(v)}
+                for k, v in sorted(bundle.secrets.items())
+            ],
+        }
+
+    @app.get("/api/secrets/{key}", dependencies=[Depends(verify_token)])
+    async def get_secret(key: str, reveal: bool = False):
+        """Get a single secret (masked unless reveal=true)."""
+        bundle = provider.get_bundle(project_id)
+        value = bundle.get(key)
+        if value is None:
+            raise HTTPException(status_code=404, detail=f"Key '{key}' not found")
+
+        log_action("ui_get", project_id, f"key={key}, revealed={reveal}")
+
+        if reveal:
+            return {"key": key, "value": value, "masked": False}
+        else:
+            masked = value[:2] + "*" * max(0, len(value) - 4) + value[-2:] if len(value) > 4 else "****"
+            return {"key": key, "value": masked, "masked": True}
+
+    @app.put("/api/secrets/{key}", dependencies=[Depends(verify_token)])
+    async def set_secret(key: str, request: Request):
+        """Set or update a secret value."""
+        body = await request.json()
+        value = body.get("value", "")
+        if not value:
+            raise HTTPException(status_code=400, detail="value is required")
+
+        bundle = SecretBundle(
+            project_id=project_id,
+            secrets={key: value},
+        )
+        provider.put_bundle(bundle, mode="merge")
+
+        log_action("ui_set", project_id, f"key={key}")
+
+        return {"status": "ok", "key": key}
+
+    @app.delete("/api/secrets/{key}", dependencies=[Depends(verify_token)])
+    async def delete_secret(key: str):
+        """Delete a secret key."""
+        try:
+            provider.delete_key(project_id, key)
+        except SecretNotFoundError:
+            raise HTTPException(status_code=404, detail=f"Key '{key}' not found")
+
+        log_action("ui_delete", project_id, f"key={key}")
+
+        return {"status": "ok", "key": key, "deleted": True}
+
+    @app.post("/api/promote", dependencies=[Depends(verify_token)])
+    async def promote_to_aws(request: Request):
+        """Promote local secrets to AWS Secrets Manager."""
+        from ..providers.aws import AWSSecretsProvider
+        from ..providers.dotenv import DotEnvSecretsProvider
+
+        local = DotEnvSecretsProvider()
+        local_bundle = local.get_bundle(project_id)
+
+        if not local_bundle.secrets:
+            raise HTTPException(
+                status_code=400,
+                detail="No local secrets to promote",
+            )
+
+        aws = AWSSecretsProvider(region=config.aws_region)
+        if not aws.is_available():
+            raise HTTPException(
+                status_code=503,
+                detail="AWS Secrets Manager not available",
+            )
+
+        aws.put_bundle(local_bundle, mode="merge")
+
+        log_action(
+            "ui_promote",
+            project_id,
+            f"keys={','.join(local_bundle.keys)}, provider=aws",
+        )
+
+        return {
+            "status": "ok",
+            "promoted": len(local_bundle.secrets),
+            "keys": local_bundle.keys,
+        }
+
+    @app.get("/api/info", dependencies=[Depends(verify_token)])
+    async def info():
+        """Get provider and project info."""
+        caps = provider.caps()
+        return {
+            "project_id": project_id,
+            "provider": provider.name,
+            "capabilities": {
+                "read": caps.can_read,
+                "write": caps.can_write,
+                "delete": caps.can_delete,
+                "list": caps.can_list,
+                "rotate": caps.can_rotate,
+                "versions": caps.supports_versions,
+            },
+        }
+
+    # --- HTML UI ---
+
+    @app.get("/", response_class=HTMLResponse)
+    async def home():
+        """Serve the main UI page."""
+        return _render_html(project_id, auth_token)
+
+    return app, auth_token
+
+
+def _render_html(project_id: str, token: str) -> str:
+    """Render the single-page HTML UI."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Secrets — {project_id}</title>
+<style>
+  * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+         background: #1a1a2e; color: #e0e0e0; padding: 2rem; max-width: 800px; margin: 0 auto; }}
+  h1 {{ color: #7c8cf8; margin-bottom: 0.5rem; }}
+  .subtitle {{ color: #888; margin-bottom: 2rem; }}
+  .card {{ background: #16213e; border-radius: 8px; padding: 1.5rem; margin-bottom: 1rem; }}
+  .key-row {{ display: flex; align-items: center; justify-content: space-between;
+              padding: 0.75rem 0; border-bottom: 1px solid #1a1a2e; }}
+  .key-row:last-child {{ border-bottom: none; }}
+  .key-name {{ font-family: monospace; font-size: 0.95rem; color: #7c8cf8; }}
+  .key-value {{ font-family: monospace; color: #888; }}
+  .actions {{ display: flex; gap: 0.5rem; }}
+  button {{ background: #7c8cf8; color: #fff; border: none; padding: 0.4rem 0.8rem;
+            border-radius: 4px; cursor: pointer; font-size: 0.85rem; }}
+  button:hover {{ background: #6b7de8; }}
+  button.danger {{ background: #e74c3c; }}
+  button.danger:hover {{ background: #c0392b; }}
+  button.secondary {{ background: #333; }}
+  button.secondary:hover {{ background: #444; }}
+  input {{ background: #0f3460; border: 1px solid #333; color: #e0e0e0; padding: 0.4rem 0.8rem;
+           border-radius: 4px; font-family: monospace; width: 100%; }}
+  input[type="password"] {{ letter-spacing: 0.2em; }}
+  .add-form {{ display: flex; gap: 0.5rem; margin-top: 1rem; }}
+  .add-form input {{ flex: 1; }}
+  .info {{ color: #888; font-size: 0.85rem; margin-top: 1rem; }}
+  .status {{ padding: 0.5rem 1rem; border-radius: 4px; margin-bottom: 1rem; }}
+  .status.ok {{ background: #1e4620; color: #4caf50; }}
+  .status.error {{ background: #4a1515; color: #e74c3c; }}
+  .hidden {{ display: none; }}
+  #promote-btn {{ margin-top: 1rem; }}
+  .autocomplete-off input {{ autocomplete: off; }}
+</style>
+</head>
+<body>
+<h1>Secrets Manager</h1>
+<p class="subtitle">Project: <strong>{project_id}</strong></p>
+
+<div id="status" class="status hidden"></div>
+
+<div class="card">
+  <div id="secrets-list">Loading...</div>
+  <form class="add-form autocomplete-off" onsubmit="addSecret(event)">
+    <input type="text" id="new-key" placeholder="KEY_NAME" autocomplete="off">
+    <input type="password" id="new-value" placeholder="secret value" autocomplete="off">
+    <button type="submit">Add</button>
+  </form>
+</div>
+
+<button id="promote-btn" class="secondary" onclick="promote()">
+  Promote to AWS
+</button>
+
+<p class="info" id="provider-info">Loading provider info...</p>
+
+<script>
+const TOKEN = "{token}";
+const H = {{"Authorization": "Bearer " + TOKEN, "Content-Type": "application/json"}};
+
+async function api(method, path, body) {{
+  const opts = {{method, headers: H}};
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch("/api" + path, opts);
+  if (!res.ok) {{
+    const err = await res.json().catch(() => ({{detail: res.statusText}}));
+    throw new Error(err.detail || res.statusText);
+  }}
+  return res.json();
+}}
+
+function showStatus(msg, ok) {{
+  const el = document.getElementById("status");
+  el.textContent = msg;
+  el.className = "status " + (ok ? "ok" : "error");
+  el.classList.remove("hidden");
+  setTimeout(() => el.classList.add("hidden"), 3000);
+}}
+
+async function loadSecrets() {{
+  try {{
+    const data = await api("GET", "/secrets");
+    const list = document.getElementById("secrets-list");
+    if (data.keys.length === 0) {{
+      list.innerHTML = '<p style="color:#888">No secrets yet. Add one below.</p>';
+      return;
+    }}
+    list.innerHTML = data.keys.map(k => `
+      <div class="key-row" id="row-${{k.key}}">
+        <span class="key-name">${{k.key}}</span>
+        <span class="key-value" id="val-${{k.key}}">**** (${{k.length}} chars)</span>
+        <div class="actions">
+          <button class="secondary" onclick="reveal('${{k.key}}')">Reveal</button>
+          <button class="danger" onclick="del('${{k.key}}')">Delete</button>
+        </div>
+      </div>
+    `).join("");
+  }} catch (e) {{
+    showStatus("Error loading secrets: " + e.message, false);
+  }}
+}}
+
+async function reveal(key) {{
+  try {{
+    const data = await api("GET", "/secrets/" + key + "?reveal=true");
+    document.getElementById("val-" + key).textContent = data.value;
+    setTimeout(() => loadSecrets(), 5000);
+  }} catch (e) {{ showStatus(e.message, false); }}
+}}
+
+async function del(key) {{
+  if (!confirm("Delete " + key + "?")) return;
+  try {{
+    await api("DELETE", "/secrets/" + key);
+    showStatus("Deleted " + key, true);
+    loadSecrets();
+  }} catch (e) {{ showStatus(e.message, false); }}
+}}
+
+async function addSecret(e) {{
+  e.preventDefault();
+  const key = document.getElementById("new-key").value.trim();
+  const value = document.getElementById("new-value").value;
+  if (!key || !value) return;
+  try {{
+    await api("PUT", "/secrets/" + key, {{value}});
+    showStatus("Added " + key, true);
+    document.getElementById("new-key").value = "";
+    document.getElementById("new-value").value = "";
+    loadSecrets();
+  }} catch (e) {{ showStatus(e.message, false); }}
+}}
+
+async function promote() {{
+  if (!confirm("Promote all local secrets to AWS Secrets Manager?")) return;
+  try {{
+    const data = await api("POST", "/promote");
+    showStatus("Promoted " + data.promoted + " secrets to AWS", true);
+  }} catch (e) {{ showStatus(e.message, false); }}
+}}
+
+async function loadInfo() {{
+  try {{
+    const data = await api("GET", "/info");
+    document.getElementById("provider-info").textContent =
+      "Provider: " + data.provider + " | " +
+      "Capabilities: " + Object.entries(data.capabilities)
+        .filter(([k,v]) => v).map(([k]) => k).join(", ");
+  }} catch (e) {{}}
+}}
+
+loadSecrets();
+loadInfo();
+</script>
+</body>
+</html>"""
+
+
+def run_server(
+    project_id: str | None = None,
+    config: SecretsConfig | None = None,
+    host: str | None = None,
+    port: int | None = None,
+) -> None:
+    """Start the secrets management UI server.
+
+    Args:
+        project_id: Override auto-detected project ID.
+        config: Override auto-loaded config.
+        host: Override bind host (default: 127.0.0.1).
+        port: Override bind port (default: 8090).
+    """
+    _import_deps()
+    import uvicorn
+
+    if config is None:
+        config = SecretsConfig.load()
+
+    host = host or config.ui_host
+    port = port or config.ui_port
+
+    app, token = create_app(project_id, config)
+
+    print(f"\nSecrets Manager UI starting...")
+    print(f"  URL:   http://{host}:{port}/")
+    print(f"  Token: {token}")
+    print(f"  (Copy the token — it's required for API access)")
+    print()
+
+    log_action("ui_start", project_id or "", f"host={host}, port={port}")
+
+    uvicorn.run(app, host=host, port=port, log_level="warning")


### PR DESCRIPTION
## Summary

- Add tiered secrets management: `.env` global config (Tier 0), legacy env vars (Tier 1), AWS Secrets Manager with IAM role assumption (Tier 2)
- Add project identity system (`project.py`) deriving stable IDs from git repo root, shared across worktrees
- Add `SecretBundle` and `BundleProvider` protocol for full CRUD operations on project secrets
- Add `DotEnvSecretsProvider` storing secrets at `~/.config/claude-power-pack/secrets/{project_id}/.env` (outside repo)
- Expand `AWSSecretsProvider` with bundle operations, IAM role assumption, and IAM bootstrap helper
- Add `run.py` for secret injection via subprocess (`creds run -- make deploy`)
- Add `audit.py` for action logging (who/when/what, never values) at `~/.config/claude-power-pack/audit.log`
- Add `config.py` for `.claude/secrets.yml` project-level configuration
- Add FastAPI web UI (`ui/`) with bearer token auth, masked display, CRUD, and AWS promotion
- Expand CLI with `set`, `list`, `run`, `ui`, `rotate` commands alongside existing `get`/`validate`
- Add 6 new skill commands: `/secrets:set`, `/secrets:list`, `/secrets:run`, `/secrets:ui`, `/secrets:rotate`, `/secrets:help`
- Update CLAUDE.md with new architecture docs and repository structure
- Bump version to 0.2.0 with new optional deps (fastapi, uvicorn, cryptography, pyyaml)

## Test plan

- [x] Verified all imports load correctly (`from lib.creds import ...`)
- [x] Tested project identity detection (`get_project_id()` returns correct value)
- [x] Tested `SecretBundle` repr/str masking
- [x] End-to-end test of DotEnvSecretsProvider: put, get, list, delete
- [x] Tested audit log writes with correct format
- [x] Tested config loading with defaults
- [x] Verified CLI help shows all 7 subcommands
- [x] Tested `creds set` / `creds list` / `creds run -- env | grep` workflow
- [x] Tested `creds validate --dotenv` output
- [ ] Manual: Test `creds ui` launches FastAPI server (requires fastapi/uvicorn)
- [ ] Manual: Test AWS provider with real credentials
- [ ] Manual: Test IAM bootstrap policy generation

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)