### PR TITLE
feat(spec): Add Wave 6 spec and simplify command permissions

### DIFF
--- a/.claude/commands/project-lite.md
+++ b/.claude/commands/project-lite.md
@@ -1,6 +1,6 @@
 ---
 description: Quick project reference with minimal context usage (context-efficient alternative to /project-next)
-allowed-tools: Bash(gh repo view:*), Bash(git worktree list:*), Bash(cat:*), Bash(head:*), Read
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(~/.claude/:*), Read, Glob
 ---
 
 # Project Lite - Quick Reference

--- a/.claude/commands/project-next.md
+++ b/.claude/commands/project-next.md
@@ -1,6 +1,6 @@
 ---
 description: Scan GitHub issues and worktree to recommend prioritized next steps (generic)
-allowed-tools: Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh repo view:*), Bash(git worktree:*), Bash(git worktree list:*), Bash(git status:*), Bash(git branch:*), Bash(git log:*), Bash(tree:*), Bash(ls:*), Bash(printf:*), Bash(grep:*), Bash(tmux rename-window:*), Bash(*session-register.sh:*), Bash(*claim-issue.sh:*)
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(PYTHONPATH=:*), Bash(for :*), Bash(~/.claude/:*), Bash(sort:*), Bash(printf:*), Read, Glob, Grep
 ---
 
 # Project Next Steps Recommendation

--- a/.specify/specs/wave-6-polish-quality-dx/plan.md
+++ b/.specify/specs/wave-6-polish-quality-dx/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Wave 6 — Polish, Quality & DX
+
+> **Spec:** [spec.md](./spec.md)
+> **Created:** 2026-02-16
+> **Status:** Approved
+
+---
+
+## Summary
+
+Wave 6 cleans up technical debt from v4.0, adds test infrastructure, generalizes the QA framework, improves developer experience with health checks and templates, and adds missing capabilities (`/secrets:delete`, `/flow:check`). The wave culminates in a version bump to 5.0.0.
+
+---
+
+## Technical Context
+
+| Aspect | Choice | Rationale |
+|--------|--------|-----------|
+| Language | Python 3.11+ | Existing project standard |
+| Package Manager | uv | Existing project standard |
+| Testing | pytest | Standard Python testing; new to this project |
+| Config Format | YAML | Consistent with existing `.claude/security.yml`, `.claude/secrets.yml` |
+
+---
+
+## Architecture
+
+### Key Design Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| QA config format | JSON, YAML, TOML | YAML | Consistent with security.yml and secrets.yml |
+| Test framework | pytest, unittest | pytest | Industry standard, better DX |
+| Health check approach | Dedicated command, integrate into existing | Integrate into /flow:doctor + /cpp:status | No new commands needed, leverages existing tools |
+| /flow:check scope | Lint only, lint+test, lint+security | Lint + security quick | Fast feedback without slow test suites |
+
+---
+
+## Dependencies
+
+### External Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| pytest | >=7.0 | Test runner (new dev dependency) |
+| pyyaml | >=6.0 | QA config parsing (already in spec_bridge) |
+
+### Internal Dependencies
+
+| Module | Purpose |
+|--------|---------|
+| `lib/creds/` | Add delete operation to providers |
+| `lib/security/` | Used by /flow:check for quick scan |
+| `lib/spec_bridge/` | Test target |
+
+---
+
+## File Structure
+
+### New Files
+
+```
+tests/
+├── conftest.py                          # Shared fixtures
+├── test_spec_bridge/
+│   ├── test_parser.py
+│   └── test_status.py
+├── test_security/
+│   ├── test_models.py
+│   ├── test_orchestrator.py
+│   └── test_native_scanners.py
+└── test_creds/
+    ├── test_base.py
+    ├── test_config.py
+    ├── test_masking.py
+    └── test_project.py
+
+templates/
+├── Makefile.example                     # Existing
+├── Makefile.python                      # New: uv + pytest + ruff
+├── Makefile.node                        # New: npm + jest + eslint
+└── Makefile.django                      # New: uv + manage.py + deploy
+
+.claude/commands/
+├── flow/check.md                        # New: lightweight validation
+├── secrets/delete.md                    # New: secret deletion
+└── qa/test.md                           # Modified: project-agnostic
+```
+
+### Modified Files
+
+```
+.claude/commands/flow/doctor.md          # Add MCP health checks
+.claude/commands/flow/help.md            # Document security gates, /flow:check
+.claude/commands/cpp/status.md           # Add MCP status section
+.claude/commands/qa/test.md              # Generalize for any project
+.claude/commands/qa/help.md              # Update for new config
+lib/creds/cli.py                         # Add delete subcommand
+lib/creds/providers/dotenv.py            # Add delete method
+lib/creds/providers/aws.py               # Add delete method
+CHANGELOG.md                             # v5.0.0 entries
+README.md                                # Version bump, new features
+CLAUDE.md                                # Structure update, new commands
+```
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| spec:sync creates duplicate issues | Low | Medium | Check existing labels before creating |
+| Tests too coupled to implementation | Medium | Low | Test public APIs only, use fixtures |
+| QA config breaks existing chess-agent usage | Low | Medium | Keep backward compat, graceful fallback |
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License)*

--- a/.specify/specs/wave-6-polish-quality-dx/spec.md
+++ b/.specify/specs/wave-6-polish-quality-dx/spec.md
@@ -1,0 +1,131 @@
+# Feature Specification: Wave 6 — Polish, Quality & DX
+
+> **Created:** 2026-02-16
+> **Status:** Approved
+
+---
+
+## Overview
+
+Wave 5 shipped 15 issues overhauling the `/flow` workflow, secrets management, and security scanning. It left behind orphaned files, no test coverage, a chess-hardcoded QA skill, and DX gaps. Wave 6 addresses the highest-impact items across cleanup, quality, and new capabilities to bring CPP to production-grade 5.0.0.
+
+---
+
+## User Stories
+
+### US1: Codebase Hygiene [P1]
+
+**As a** CPP maintainer,
+**I want** orphaned files and stale commands removed,
+**So that** the project structure matches the documented v4.0 architecture.
+
+**Acceptance Criteria:**
+- [ ] Root `mcp-coordination/` directory deleted (moved to `extras/` in v4.0)
+- [ ] `.claude/commands/coordination/` deleted (replaced by `/flow:finish`, `/flow:merge`)
+- [ ] No dangling references to removed paths in CLAUDE.md or README
+- [ ] File permissions normalized (`.claude/skills/project-deploy.md` → 644)
+
+---
+
+### US2: Project-Agnostic QA [P1]
+
+**As a** developer using CPP on any project,
+**I want** `/qa:test` to work with configurable test areas,
+**So that** I can run browser-based QA without chess-specific hardcoding.
+
+**Acceptance Criteria:**
+- [ ] `/qa:test` reads test configuration from `.claude/qa.yml`
+- [ ] Config supports: project URL, test areas (name + path + description), shortcuts
+- [ ] Falls back to sensible defaults when no config exists
+- [ ] Chess-agent config moved to chess-agent project's `.claude/qa.yml`
+
+---
+
+### US3: Test Coverage [P1]
+
+**As a** CPP contributor,
+**I want** unit tests for the Python libraries,
+**So that** regressions are caught before merge.
+
+**Acceptance Criteria:**
+- [ ] `tests/` directory with pytest configuration
+- [ ] Tests for `lib/spec_bridge/` (parser, status)
+- [ ] Tests for `lib/security/` (models, orchestrator, native scanners)
+- [ ] Tests for `lib/creds/` (base, config, masking, project identity)
+- [ ] CPP Makefile with `test` and `lint` targets
+
+---
+
+### US4: Developer Experience [P2]
+
+**As a** developer setting up a new project with CPP,
+**I want** health checks, templates, and docs,
+**So that** I can get started quickly and troubleshoot issues.
+
+**Acceptance Criteria:**
+- [ ] `/flow:doctor` reports MCP server connectivity status
+- [ ] `/cpp:status` shows which MCP servers are reachable
+- [ ] Stack-specific Makefile templates available (Python, Node.js, Django)
+- [ ] Security gate behavior documented in `/flow:help`
+
+---
+
+### US5: Secret Lifecycle [P2]
+
+**As a** developer managing secrets,
+**I want** a `/secrets:delete` command,
+**So that** I can remove compromised or unused secrets.
+
+**Acceptance Criteria:**
+- [ ] Delete operation supported in dotenv and AWS providers
+- [ ] CLI: `python -m lib.creds delete KEY`
+- [ ] `/secrets:delete KEY` skill command
+- [ ] Audit log records delete operations
+
+---
+
+### US6: Pre-Commit Validation [P2]
+
+**As a** developer iterating on code,
+**I want** a lightweight check command,
+**So that** I can validate lint + security before running the full finish flow.
+
+**Acceptance Criteria:**
+- [ ] `/flow:check` runs lint (via Makefile) and security quick scan
+- [ ] Does NOT commit, push, or create PR
+- [ ] Reports pass/fail per check with clear output
+- [ ] Exit code reflects overall pass/fail
+
+---
+
+## Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| No `.claude/qa.yml` exists | QA skill prompts user to create one or uses interactive mode |
+| MCP server not configured | Health check reports "not configured" (not error) |
+| Delete non-existent secret | Clear error message, no crash |
+| No Makefile for /flow:check | Skip lint, run security only, warn about missing Makefile |
+
+---
+
+## Out of Scope
+
+- Redis coordination removal (already in `extras/`, keep as-is)
+- New MCP server development
+- CI/CD pipeline setup
+- Cross-platform (Windows) testing
+
+---
+
+## Success Criteria
+
+- [ ] All acceptance criteria met
+- [ ] All new tests passing
+- [ ] CHANGELOG updated for 5.0.0
+- [ ] README and CLAUDE.md reflect current state
+- [ ] No regressions in existing functionality
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License)*

--- a/.specify/specs/wave-6-polish-quality-dx/tasks.md
+++ b/.specify/specs/wave-6-polish-quality-dx/tasks.md
@@ -1,0 +1,152 @@
+# Tasks: Wave 6 — Polish, Quality & DX
+
+> **Plan:** [plan.md](./plan.md)
+> **Created:** 2026-02-16
+> **Status:** Ready
+
+---
+
+## Wave 1: Remove orphaned files and stale commands
+
+- [ ] **T001** [US1] Delete root `mcp-coordination/` directory (moved to extras/ in v4.0)
+- [ ] **T002** [US1] Delete `.claude/commands/coordination/` directory (pr-create.md, merge-main.md)
+- [ ] **T003** [US1] Remove stale references to coordination/ and env/ from CLAUDE.md
+- [ ] **T004** [US1] Fix `.claude/skills/project-deploy.md` permissions (600 → 644)
+
+**Checkpoint:** `git status` shows only deletions and permission fixes; no broken references in docs
+
+---
+
+## Wave 2: Generalize QA skill for any project
+
+- [ ] **T005** [US2] Define `.claude/qa.yml` config schema (project URL, test areas, shortcuts)
+- [ ] **T006** [US2] Refactor `/qa:test` command to read from `.claude/qa.yml` `qa/test.md`
+- [ ] **T007** [US2] Add fallback behavior when no qa.yml exists (interactive prompt)
+- [ ] **T008** [US2] Update `/qa:help` with new config documentation `qa/help.md`
+
+**Checkpoint:** `/qa:test` works with a sample `.claude/qa.yml` on a non-chess project
+
+---
+
+## Wave 3: Add unit tests for Python libraries
+
+- [ ] **T009** [US3] Create `tests/` directory with `conftest.py` and pytest config in `pyproject.toml`
+- [ ] **T010** [P] [US3] Add tests for `lib/spec_bridge/parser.py` (parse_tasks, parse_spec)
+- [ ] **T011** [P] [US3] Add tests for `lib/spec_bridge/status.py` (get_all_status)
+- [ ] **T012** [P] [US3] Add tests for `lib/security/models.py` and `lib/security/orchestrator.py`
+- [ ] **T013** [P] [US3] Add tests for native scanners (gitignore, permissions, secrets, debug_flags)
+- [ ] **T014** [P] [US3] Add tests for `lib/creds/base.py`, `lib/creds/config.py`, `lib/creds/masking.py`
+- [ ] **T015** [US3] Create CPP `Makefile` with `test` and `lint` targets (depends on T009)
+
+**Checkpoint:** `make test` passes with all new tests; `make lint` passes
+
+---
+
+## Wave 4: Consolidate MCP health checks
+
+- [ ] **T016** [US4] Add MCP server connectivity check to `/flow:doctor` `flow/doctor.md`
+- [ ] **T017** [US4] Add MCP status section to `/cpp:status` `cpp/status.md`
+- [ ] **T018** [US4] Check ports 8080 (second-opinion), 8081 (playwright), 8082 (coordination)
+
+**Checkpoint:** `/flow:doctor` and `/cpp:status` report MCP server status correctly
+
+---
+
+## Wave 5: Add /secrets:delete command
+
+- [ ] **T019** [US5] Add `delete_secret()` to dotenv provider `lib/creds/providers/dotenv.py`
+- [ ] **T020** [US5] Add `delete_secret()` to AWS provider `lib/creds/providers/aws.py`
+- [ ] **T021** [US5] Add `delete` subcommand to CLI `lib/creds/cli.py`
+- [ ] **T022** [US5] Create `/secrets:delete` command file `.claude/commands/secrets/delete.md`
+- [ ] **T023** [US5] Add audit logging for delete operations `lib/creds/audit.py`
+
+**Checkpoint:** `python -m lib.creds delete TEST_KEY` removes secret; audit log records action
+
+---
+
+## Wave 6: Stack-specific Makefile templates
+
+- [ ] **T024** [P] [US4] Create `templates/Makefile.python` (uv + pytest + ruff)
+- [ ] **T025** [P] [US4] Create `templates/Makefile.node` (npm + jest + eslint)
+- [ ] **T026** [P] [US4] Create `templates/Makefile.django` (uv + pytest + ruff + manage.py + deploy)
+- [ ] **T027** [US4] Update `/flow:doctor` to suggest relevant template when no Makefile found
+
+**Checkpoint:** Each template has working `test`, `lint`, and `deploy` targets
+
+---
+
+## Wave 7: Document security gate behavior
+
+- [ ] **T028** [US4] Expand `/flow:help` with security gate integration section `flow/help.md`
+- [ ] **T029** [US4] Add annotated `.claude/security.yml` example to docs `docs/security-gates.md`
+- [ ] **T030** [US4] Document CRITICAL/HIGH gate effects on `/flow:finish` and `/flow:deploy`
+
+**Checkpoint:** `/flow:help` output includes security gate documentation
+
+---
+
+## Wave 8: Update CHANGELOG and version to 5.0.0
+
+- [ ] **T031** [US1] Add CHANGELOG entries for all Wave 5 features (15 issues)
+- [ ] **T032** [US1] Add CHANGELOG entries for Wave 6 features
+- [ ] **T033** [US1] Bump version to 5.0.0 in README.md and CLAUDE.md
+
+**Checkpoint:** CHANGELOG.md is current; version references updated
+
+---
+
+## Wave 9: Add /flow:check command
+
+- [ ] **T034** [US6] Create `/flow:check` command file `.claude/commands/flow/check.md`
+- [ ] **T035** [US6] Implement lint check via Makefile target detection
+- [ ] **T036** [US6] Implement security quick scan integration
+- [ ] **T037** [US6] Report pass/fail per check with clear output
+
+**Checkpoint:** `/flow:check` runs lint + security and reports results without committing
+
+---
+
+## Wave 10: Integration and documentation update
+
+- [ ] **T038** [US1,US4] Update README.md with Wave 6 features (QA, /flow:check, /secrets:delete)
+- [ ] **T039** [US1,US4] Update CLAUDE.md repository structure section
+- [ ] **T040** [US1,US4] Verify all `/help` commands reference new additions
+- [ ] **T041** [US1,US4] Final QA pass — all commands documented, no broken references
+
+**Checkpoint:** All documentation reflects current state; no stale references
+
+---
+
+## Issue Sync
+
+| Wave | Tasks | Issue | Status |
+|------|-------|-------|--------|
+| 1 | T001-T004 | - | pending |
+| 2 | T005-T008 | - | pending |
+| 3 | T009-T015 | - | pending |
+| 4 | T016-T018 | - | pending |
+| 5 | T019-T023 | - | pending |
+| 6 | T024-T027 | - | pending |
+| 7 | T028-T030 | - | pending |
+| 8 | T031-T033 | - | pending |
+| 9 | T034-T037 | - | pending |
+| 10 | T038-T041 | - | pending |
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License)*
+
+## Issue Sync
+
+| Wave | Tasks | Issue | Status |
+|------|-------|-------|--------|
+| 1 | T001, T002, T003, T004 | #117 | synced |
+| 2 | T005, T006, T007, T008 | #118 | synced |
+| 3 | T009, T010, T011, T012, T013, T014, T015 | #119 | synced |
+| 4 | T016, T017, T018 | #120 | synced |
+| 5 | T019, T020, T021, T022, T023 | #121 | synced |
+| 6 | T024, T025, T026, T027 | #122 | synced |
+| 7 | T028, T029, T030 | #123 | synced |
+| 8 | T031, T032, T033 | #124 | synced |
+| 9 | T034, T035, T036, T037 | #125 | synced |
+| 10 | T038, T039, T040, T041 | #126 | synced |


### PR DESCRIPTION
## Summary
- Create Wave 6 (Polish, Quality & DX) spec in `.specify/specs/wave-6-polish-quality-dx/` with spec.md, plan.md, and tasks.md
- 10 child issues (#117-#126) synced to GitHub from tasks.md via `/spec:sync`, linked to epic #116
- Simplify `allowed-tools` in `/project-next` and `/project-lite` to use broad patterns (`Bash(gh:*)`, `Bash(git:*)`) instead of overly-specific ones, reducing permission prompts

## Test plan
- [x] Spec files created with correct structure
- [x] `/spec:sync` created 10 issues with correct labels and traceability
- [x] tasks.md updated with issue numbers
- [x] Epic #116 links to all child issues via `wave-6` label
- [ ] `/project-next` runs without extra permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)