### PR TITLE
feat(qa): Generalize QA skill for any project (Closes #118)

### DIFF
--- a/.claude/commands/qa/help.md
+++ b/.claude/commands/qa/help.md
@@ -7,50 +7,91 @@ Automated QA testing commands for web applications.
 | Command | Description |
 |---------|-------------|
 | `/qa:test <target> [area]` | Run QA tests, log bugs as GitHub issues |
+| `/qa:help` | This help page |
 
 ## Usage Examples
 
 ```bash
-# Test entire site
-/qa:test https://agentic-chess.ca
+# Test a URL directly
+/qa:test https://myapp.example.com
 
-# Test specific area
-/qa:test chess play
+# Test using a shortcut from qa.yml
+/qa:test myapp dashboard
 
 # Find multiple bugs before stopping
-/qa:test chess dashboard --find 5
+/qa:test myapp login --find 5
 
-# Test external URL
-/qa:test https://myapp.com/login
+# Test any external URL (no config needed)
+/qa:test https://other-site.com/page
 ```
 
-## Project Shortcuts
+## Configuration: `.claude/qa.yml`
 
-Currently configured shortcuts:
+Place a `qa.yml` file in your project's `.claude/` directory to configure shortcuts, test areas, and project metadata.
 
-| Shortcut | URL | Repository |
-|----------|-----|------------|
-| `chess` | https://agentic-chess.ca | cooneycw/chess-agent |
+**Setup:**
+```bash
+# Copy the template
+cp ~/Projects/claude-power-pack/templates/qa.yml.example .claude/qa.yml
 
-## Test Areas (for chess)
+# Edit for your project
+```
 
-| Area | Path | Tests |
-|------|------|-------|
-| `dashboard` | `/` | Stats, actions, health |
-| `play` | `/game/` | Board, moves, AI |
-| `training` | `/training/` | Controls, progress |
-| `analysis` | `/analysis/` | FEN input, MCTS |
-| `viewer` | `/viewer/` | Game list, replay |
-| `explainer` | `/explainer/` | Content, examples |
+**If no `.claude/qa.yml` exists**, `/qa:test` runs in interactive mode — it prompts for a URL and uses generic testing (clicking elements, checking forms, scanning console errors).
+
+### Config Schema
+
+```yaml
+# Project information
+project:
+  url: https://myapp.example.com        # Default URL
+  repository: owner/repo-name           # GitHub repo for bug issues
+
+# Shortcuts — short names that resolve to URLs
+shortcuts:
+  myapp: https://myapp.example.com
+  staging: https://staging.myapp.example.com
+
+# Test areas — named sections with paths and test checklists
+test_areas:
+  home:
+    path: /                              # URL path appended to project URL
+    description: "Homepage and landing"  # Shown in test reports
+    tests:                               # Checklist of things to verify
+      - "Page loads without errors"
+      - "Navigation links work"
+      - "Key content visible"
+
+  login:
+    path: /login
+    description: "Authentication flow"
+    tests:
+      - "Login form renders"
+      - "Form validation works"
+      - "Successful login redirects"
+```
+
+### Config Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `project.url` | Yes | Default base URL for the application |
+| `project.repository` | No | GitHub `owner/repo` for issue creation (auto-detected if omitted) |
+| `shortcuts` | No | Map of short names to URLs |
+| `test_areas` | No | Named test areas with paths and test checklists |
+| `test_areas.<name>.path` | Yes | URL path relative to project URL |
+| `test_areas.<name>.description` | No | Human-readable area description |
+| `test_areas.<name>.tests` | No | List of specific checks to perform |
 
 ## How It Works
 
-1. Creates headless Playwright browser session
-2. Navigates to target URL
-3. Tests interactive elements (clicks, forms, navigation)
-4. Checks console for errors
-5. Logs bugs as GitHub issues
-6. Reports summary
+1. Loads `.claude/qa.yml` config (or prompts interactively)
+2. Creates headless Playwright browser session
+3. Navigates to target URL (resolving shortcuts and area paths)
+4. Runs test checklist from config (or generic element testing)
+5. Checks console for errors
+6. Logs bugs as GitHub issues
+7. Reports summary with test coverage
 
 ## Requirements
 

--- a/.claude/commands/qa/test.md
+++ b/.claude/commands/qa/test.md
@@ -3,32 +3,69 @@
 Perform automated QA testing on a web application using Playwright MCP.
 
 **Arguments:** `$ARGUMENTS`
-- Format: `<url-or-project> [area] [--find N]`
+- Format: `<url-or-shortcut> [area] [--find N]`
 - Examples:
   - `/qa:test https://example.com` - Test full site
-  - `/qa:test chess dashboard` - Test chess-agent dashboard
-  - `/qa:test chess play --find 3` - Find up to 3 bugs in play area
-
-## Project Shortcuts
-
-| Shortcut | URL | Repository |
-|----------|-----|------------|
-| `chess` | https://agentic-chess.ca | cooneycw/chess-agent |
+  - `/qa:test myapp dashboard` - Test named area via shortcut
+  - `/qa:test myapp login --find 3` - Find up to 3 bugs in login area
 
 ---
 
-## Step 1: Parse Arguments
+## Step 1: Load Configuration
+
+Check for `.claude/qa.yml` in the project root:
+
+```bash
+# Look for config file
+cat .claude/qa.yml 2>/dev/null
+```
+
+**If `.claude/qa.yml` exists**, parse it to extract:
+- `project.url` — default project URL
+- `project.repository` — GitHub repo for issue creation
+- `shortcuts` — map of shortcut names to URLs
+- `test_areas` — named areas with paths, descriptions, and test checks
+
+**If `.claude/qa.yml` does NOT exist**, use interactive fallback (see Step 1b).
+
+---
+
+## Step 1b: Interactive Fallback (no config)
+
+If no `.claude/qa.yml` is found and no URL was provided in arguments:
+
+1. **Inform the user:**
+   ```
+   No .claude/qa.yml found. Running in interactive mode.
+   Tip: Copy templates/qa.yml.example to .claude/qa.yml for persistent config.
+   ```
+
+2. **Ask for the target URL** using AskUserQuestion.
+
+3. **Ask for the repository** (for GitHub issue creation) or detect from `gh repo view`.
+
+4. **Proceed with generic test areas** — test the entire page without area-specific plans:
+   - Click all interactive elements
+   - Fill and submit forms
+   - Check console for errors
+   - Test navigation links
+
+---
+
+## Step 2: Parse Arguments
 
 Extract from `$ARGUMENTS`:
-1. **Target**: URL or project shortcut
-2. **Area** (optional): dashboard, play, training, analysis, viewer, explainer
+1. **Target**: URL or shortcut name (resolve via `shortcuts` from config)
+2. **Area** (optional): Must match a key in `test_areas` from config
 3. **Find count** (optional): `--find N` to stop after N bugs (default: 1)
 
-If no arguments, prompt user for target.
+If a shortcut is used but not found in config, report the error and list available shortcuts.
+
+If an area is specified but not found in config, report available areas.
 
 ---
 
-## Step 2: Create Browser Session
+## Step 3: Create Browser Session
 
 Use Playwright MCP to create a headless browser session:
 
@@ -40,11 +77,11 @@ Store the `session_id` for subsequent operations.
 
 ---
 
-## Step 3: Navigate to Target
+## Step 4: Navigate to Target
 
 Navigate to the target URL:
-- If shortcut used, resolve to full URL
-- If area specified, append appropriate path (e.g., `/game/` for play)
+- If shortcut used, resolve to full URL from config
+- If area specified, append the area's `path` from config
 
 ```
 browser_navigate(session_id, url, wait_until="networkidle")
@@ -52,37 +89,49 @@ browser_navigate(session_id, url, wait_until="networkidle")
 
 ---
 
-## Step 4: Test Methodology
+## Step 5: Test Methodology
 
-For each area, perform these tests:
+### If area is specified and config has test plans:
 
-### Click Response Testing
+Use the `tests` list from the area's config as the test checklist. For each test item:
+1. Identify the relevant elements on the page
+2. Perform the interaction (click, fill, navigate)
+3. Verify the expected behavior
+4. Check console for errors: `browser_console_messages(session_id)`
+5. Note any failures
 
+### If no area specified (full site test):
+
+Test all areas defined in config sequentially:
+1. For each area in `test_areas`, navigate to its `path`
+2. Run through its `tests` checklist
+3. Move to the next area
+
+### Generic testing (no config or no test plans):
+
+#### Click Response Testing
 1. **Identify interactive elements**:
    ```
-   browser_query_selector_all(session_id, "[hx-post], [hx-get], button, [onclick], a[href]")
+   browser_query_selector_all(session_id, "button, [onclick], a[href], input[type=submit], [role=button]")
    ```
-
 2. **Click and verify** each element:
-   - Check console for errors: `browser_console_messages(session_id)`
+   - Check console for errors
    - Verify expected state change occurred
    - Note any 4xx/5xx errors, JS exceptions
 
-### Form Testing
-
+#### Form Testing
 1. Find form inputs
 2. Fill with test data
 3. Submit and verify response
 
-### Navigation Testing
-
+#### Navigation Testing
 1. Click navigation links
 2. Verify correct page loads
 3. Check for broken links
 
 ---
 
-## Step 5: Bug Classification
+## Step 6: Bug Classification
 
 Classify issues by severity:
 
@@ -95,19 +144,19 @@ Classify issues by severity:
 
 ---
 
-## Step 6: Log Bugs as GitHub Issues
+## Step 7: Log Bugs as GitHub Issues
 
-For each bug found:
+For each bug found, create a GitHub issue:
 
-1. **Title format**: `[Bug] <Area>: <Brief description>`
-2. **Body includes**:
+1. **Determine repository**: Use `project.repository` from config, or detect via `gh repo view`
+2. **Title format**: `[Bug] <Area>: <Brief description>`
+3. **Body includes**:
    - Steps to reproduce
    - Expected vs actual behavior
    - Console errors (verbatim)
    - Technical analysis
    - Environment details
-
-3. **Labels**: `bug`, optional severity label
+4. **Labels**: `bug`, optional severity label
 
 ```bash
 gh issue create --repo <repo> --title "<title>" --body "<body>" --label "bug"
@@ -115,7 +164,7 @@ gh issue create --repo <repo> --title "<title>" --body "<body>" --label "bug"
 
 ---
 
-## Step 7: Report Summary
+## Step 8: Report Summary
 
 After testing (or reaching `--find N` limit), output:
 
@@ -123,72 +172,27 @@ After testing (or reaching `--find N` limit), output:
 ## QA Test Results
 
 **Target:** <URL>
+**Config:** .claude/qa.yml | interactive mode
 **Areas Tested:** <list>
 **Bugs Found:** N
 
 ### Issues Created
 | # | Severity | Area | Description |
 |---|----------|------|-------------|
-| 1 | Critical | Play | CSRF 403 on square click |
+| 1 | Critical | login | Form 500 on submit |
 
 ### Test Coverage
-- [ ] Dashboard widgets
-- [x] Play - board interaction
-- [ ] Training controls
-- [ ] Analysis tools
-- [ ] Viewer functionality
-- [ ] Explainer content
+(Dynamic checklist from config test_areas, or generic areas tested)
 
 ---
-Run `/qa:test <project> <area>` to continue testing.
+Run `/qa:test <shortcut> <area>` to continue testing.
 ```
 
 ---
 
-## Step 8: Cleanup
+## Step 9: Cleanup
 
 Close the browser session:
 ```
 close_session(session_id)
 ```
-
----
-
-## Area-Specific Test Plans
-
-### Dashboard
-- Stat card data loads
-- Quick action buttons work
-- Recent games list populates
-- System health indicators accurate
-
-### Play
-- Board renders correctly
-- Square clicks register
-- Moves execute
-- AI responds
-- Game state updates
-- Resign/Reset work
-
-### Training
-- Status indicators work
-- Start/Stop controls function
-- Progress updates live
-- Loss charts render
-
-### Analysis
-- FEN input works
-- Position loads
-- MCTS visualization renders
-- Move suggestions appear
-
-### Viewer
-- Game list loads
-- Game selection works
-- Move navigation functions
-- Board syncs with moves
-
-### Explainer
-- Content loads
-- Interactive elements work
-- Examples render

--- a/templates/qa.yml.example
+++ b/templates/qa.yml.example
@@ -1,0 +1,102 @@
+# .claude/qa.yml — QA Test Configuration
+#
+# Place this file in your project's .claude/ directory to configure /qa:test.
+# Copy from: ~/Projects/claude-power-pack/templates/qa.yml.example
+#
+# If this file doesn't exist, /qa:test will prompt you interactively.
+
+# Project information
+project:
+  url: https://myapp.example.com
+  repository: owner/repo-name    # GitHub repo for issue creation
+
+# Shortcuts map short names to URLs (used as: /qa:test myapp dashboard)
+shortcuts:
+  myapp: https://myapp.example.com
+
+# Test areas define named sections of your application
+# Each area has a path, description, and specific test checks
+test_areas:
+  home:
+    path: /
+    description: "Homepage and landing"
+    tests:
+      - "Page loads without errors"
+      - "Navigation links work"
+      - "Key content visible"
+
+  login:
+    path: /login
+    description: "Authentication flow"
+    tests:
+      - "Login form renders"
+      - "Form validation works"
+      - "Successful login redirects"
+      - "Invalid credentials show error"
+
+  dashboard:
+    path: /dashboard
+    description: "Main dashboard"
+    tests:
+      - "Data loads correctly"
+      - "Interactive elements respond"
+      - "Navigation within dashboard works"
+
+# --- Example: chess-agent project ---
+# project:
+#   url: https://agentic-chess.ca
+#   repository: cooneycw/chess-agent
+#
+# shortcuts:
+#   chess: https://agentic-chess.ca
+#
+# test_areas:
+#   dashboard:
+#     path: /
+#     description: "Dashboard and stats"
+#     tests:
+#       - "Stat card data loads"
+#       - "Quick action buttons work"
+#       - "Recent games list populates"
+#       - "System health indicators accurate"
+#   play:
+#     path: /game/
+#     description: "Game play functionality"
+#     tests:
+#       - "Board renders correctly"
+#       - "Square clicks register"
+#       - "Moves execute"
+#       - "AI responds"
+#       - "Game state updates"
+#       - "Resign/Reset work"
+#   training:
+#     path: /training/
+#     description: "Training controls"
+#     tests:
+#       - "Status indicators work"
+#       - "Start/Stop controls function"
+#       - "Progress updates live"
+#       - "Loss charts render"
+#   analysis:
+#     path: /analysis/
+#     description: "Position analysis"
+#     tests:
+#       - "FEN input works"
+#       - "Position loads"
+#       - "MCTS visualization renders"
+#       - "Move suggestions appear"
+#   viewer:
+#     path: /viewer/
+#     description: "Game replay viewer"
+#     tests:
+#       - "Game list loads"
+#       - "Game selection works"
+#       - "Move navigation functions"
+#       - "Board syncs with moves"
+#   explainer:
+#     path: /explainer/
+#     description: "Educational content"
+#     tests:
+#       - "Content loads"
+#       - "Interactive elements work"
+#       - "Examples render"


### PR DESCRIPTION
## Summary
- Replace hardcoded chess-agent shortcuts and test areas in `/qa:test` and `/qa:help` with config-driven `.claude/qa.yml` support
- Add interactive fallback mode when no config file exists (prompts for URL, uses generic testing)
- Create `templates/qa.yml.example` with documented schema and chess-agent example config

## Changes
| File | Change |
|------|--------|
| `.claude/commands/qa/test.md` | Rewritten: config loading → arg parsing → config-driven test methodology with generic fallback |
| `.claude/commands/qa/help.md` | Rewritten: full qa.yml schema documentation, setup instructions, field reference |
| `templates/qa.yml.example` | New: annotated template with generic + chess-agent example |

## Test plan
- [ ] Verify `/qa:test https://example.com` works without qa.yml (interactive fallback)
- [ ] Verify `/qa:test` with a `.claude/qa.yml` resolves shortcuts and test areas
- [ ] Verify `/qa:help` displays config schema documentation
- [ ] Verify `templates/qa.yml.example` is valid YAML

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)