### PR TITLE
feat(self-improvement): Add deployment retrospective command and Makefile best practices

### DIFF
--- a/.claude/commands/load-best-practices.md
+++ b/.claude/commands/load-best-practices.md
@@ -15,6 +15,7 @@ Read and summarize the key points from:
 - `idd-workflow` - Issue-driven dev
 - `claude-md-config` - CLAUDE.md tips
 - `code-quality` - Quality patterns
+- `build-deploy` - Makefile, uv, and deployment patterns
 
 Focus on:
 1. **Top Tips from Power Users** - Most impactful practices from experienced users
@@ -23,6 +24,7 @@ Focus on:
 4. **MCP Best Practices** - Token efficiency and selection
 5. **Context-Efficient Architecture** - Progressive disclosure principles
 6. **Hooks & Automation** - Hook system and advanced usage
+7. **Build, Test & Deploy Patterns** - Makefile integration, uv, and retrospective improvement
 
 Provide a concise overview highlighting the most actionable insights from the community.
 

--- a/.claude/commands/self-improvement/deployment.md
+++ b/.claude/commands/self-improvement/deployment.md
@@ -1,0 +1,197 @@
+# Self-Improvement: Deployment — Retrospective Makefile Analysis
+
+Examine recent errors from the current session and deploy history, then propose concrete Makefile improvements to prevent recurrence.
+
+## Arguments
+
+None. This command operates on conversation context and project state.
+
+## Instructions
+
+When the user invokes `/self-improvement:deployment`, perform these steps:
+
+### Step 1: Gather Context — Recent Errors
+
+Review the current conversation for:
+- Failed `make` commands (any target) and their stderr output
+- Failed deployment attempts (`make deploy`, `make deploy-staging`, etc.)
+- Build/test failures (`make test`, `make lint`)
+- Missing target errors ("No rule to make target...")
+- Dependency failures (target prerequisites failing)
+- Any other build or deployment errors
+
+Summarize what went wrong, including:
+- Which Makefile targets were involved
+- The exact error messages
+- How many times the same error pattern occurred
+
+If no errors are visible in the conversation, inform the user:
+
+```
+No recent errors found in this session.
+
+To use this command effectively:
+  1. Run it after a failed deployment or build
+  2. Or describe what went wrong: "The deploy failed because..."
+```
+
+### Step 2: Gather Context — Deploy History
+
+```bash
+if [ -f ".claude/deploy.log" ]; then
+    echo "=== Recent Deploy History ==="
+    tail -20 .claude/deploy.log
+else
+    echo "No deploy.log found"
+fi
+```
+
+Analyze the deploy log for:
+- Repeated failures (exit_code != 0)
+- Patterns in which targets fail
+- Time gaps suggesting abandoned deploy attempts
+- Whether failures cluster on certain branches
+
+### Step 3: Gather Context — Current Makefile
+
+```bash
+if [ -f "Makefile" ]; then
+    cat Makefile
+else
+    echo "NO_MAKEFILE"
+fi
+```
+
+If no Makefile exists, recommend creating one from the template:
+
+```
+No Makefile found. Create one from the CPP template:
+
+  cp ~/Projects/claude-power-pack/templates/Makefile.example Makefile
+
+Then customize targets for your project.
+```
+
+Stop here — no further analysis is possible without a Makefile.
+
+### Step 4: Analyze — Pattern Detection
+
+Cross-reference the errors (Step 1) with the Makefile contents (Step 3) to identify:
+
+**Missing targets:**
+- Errors referencing targets that do not exist
+- Targets called by `/flow` commands but not defined (e.g., `/flow:finish` expects `lint` and `test`)
+
+**Dependency gaps:**
+- Targets that should depend on others but run independently
+- Example: `deploy` should depend on `test` and `lint` but does not
+
+**Error handling gaps:**
+- Targets that fail silently (no error checking)
+- Missing `.PHONY` declarations causing stale file conflicts
+- Missing `@` prefix on informational echo commands (noise vs. signal)
+
+**Missing standard targets:**
+Compare against the CPP standard set and report which are absent:
+
+| Target | Used By | Purpose |
+|--------|---------|---------|
+| `lint` | `/flow:finish` | Code linting (auto-discovered) |
+| `test` | `/flow:finish` | Test suite (auto-discovered) |
+| `format` | Manual | Code formatting |
+| `deploy` | `/flow:deploy` | Production deployment |
+| `deploy-staging` | `/flow:deploy staging` | Staging deployment |
+| `clean` | Manual | Remove build artifacts |
+
+**uv integration issues:**
+- Commands using bare `python`/`pytest`/`ruff` instead of `uv run` (causes environment isolation failures)
+- Missing virtual environment setup
+
+### Step 5: Propose Improvements
+
+Present findings in this format:
+
+```
+## Deployment Retrospective
+
+### What Went Wrong
+
+1. **[Error category]**: [description]
+   - Observed: [what happened]
+   - Root cause: [why it happened]
+
+### Makefile Improvements
+
+#### Fix 1: [Short title]
+
+**Problem:** [what's wrong]
+**Solution:** [what to change]
+
+Before:
+  deploy:
+      rsync -avz . server:/app
+
+After:
+  deploy: test lint
+      rsync -avz . server:/app
+
+#### Fix 2: [Short title]
+...
+
+### Missing Standard Targets
+
+| Target | Status | Recommendation |
+|--------|--------|---------------|
+| lint | Missing | Add: `uv run ruff check .` |
+| test | Present | OK |
+| ...  | ...     | ... |
+
+### .PHONY Declarations
+
+  .PHONY: test lint format deploy deploy-staging clean
+```
+
+### Step 6: Offer to Apply
+
+Ask the user:
+
+```
+Would you like me to apply these Makefile improvements?
+
+Changes:
+  - [list of specific changes]
+```
+
+If the user approves, edit the Makefile using the Edit tool. If not, the analysis stands as documentation.
+
+## Output Format
+
+```
+Self-Improvement: Deployment Retrospective
+==========================================
+
+Session Errors Analyzed: N
+Deploy Log Entries:      N (M failures)
+Makefile Targets:        N defined
+
+[Analysis sections from Step 5]
+
+Proposed Changes: N improvements
+Apply changes? [y/N]
+```
+
+## Error Handling
+
+- **No errors in session:** Report that no errors were found; suggest running after a failure or describing the issue
+- **No Makefile:** Recommend creating one from the CPP template and stop
+- **No deploy.log:** Note absence, proceed with session-only analysis
+- **Makefile is read-only:** Report the issue and output the proposed changes as a diff
+
+## Notes
+
+- This is a **retrospective** command — it looks backward at what happened, not forward
+- It never modifies the Makefile without explicit user approval
+- The deploy.log at `.claude/deploy.log` provides historical context beyond the current session
+- Pair with `/flow:doctor` for a forward-looking health check of your workflow environment
+- Reference template: `~/Projects/claude-power-pack/templates/Makefile.example`
+- All Makefile targets should use `uv run` for Python commands to ensure environment isolation

--- a/.claude/commands/self-improvement/help.md
+++ b/.claude/commands/self-improvement/help.md
@@ -1,0 +1,54 @@
+---
+description: Overview of self-improvement commands
+---
+
+# Self-Improvement Commands
+
+Retrospective analysis commands that examine recent failures and suggest improvements to project tooling.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/self-improvement:deployment` | Analyze deployment errors and propose Makefile improvements |
+| `/self-improvement:help` | This help page |
+
+## Philosophy
+
+The `/flow` workflow is forward-focused: start, implement, finish, merge, deploy. But when things go wrong, there is value in looking backward to improve the tooling itself.
+
+Self-improvement commands:
+- Examine errors from the current session and project history
+- Identify patterns of recurring failure
+- Propose concrete changes to build/deploy infrastructure
+- Optionally apply approved changes
+
+## When to Use
+
+Run `/self-improvement:deployment` after:
+- A failed `make deploy` or `make test`
+- Repeated build failures in a session
+- Setting up a new project's Makefile
+- Periodically to audit Makefile quality against CPP standards
+
+## Feedback Loop
+
+```
+/flow:deploy -> fails -> /self-improvement:deployment -> fix Makefile -> /flow:deploy -> succeeds
+```
+
+## Future Commands
+
+The self-improvement category may grow to include:
+- **test** — Analyze test failure patterns, suggest test infrastructure improvements
+- **review** — Analyze PR review feedback patterns, suggest code quality improvements
+- **session** — Analyze session patterns, suggest CLAUDE.md improvements
+
+## Related Commands
+
+| Command | Relationship |
+|---------|-------------|
+| `/flow:doctor` | Forward-looking health check (complements retrospective) |
+| `/flow:deploy` | The deploy command whose failures this analyzes |
+| `/flow:finish` | Quality gates that depend on Makefile targets |
+| `/security:scan` | Security-focused analysis (complementary) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ This repository contains four core components and optional extras:
 2. **Spec-Driven Development** - GitHub Spec Kit integration for structured workflows
 3. **MCP Second Opinion Server** - Gemini-powered code review
 4. **MCP Playwright Server** - Browser automation for testing
-5. **Redis Coordination** (optional, in `extras/`) - Distributed locking for teams
+5. **Sequential Thinking** (optional, in `extras/`) - Structured step-by-step reasoning
+6. **Redis Coordination** (optional, in `extras/`) - Distributed locking for teams
 
 ## Quick References
 
@@ -18,6 +19,7 @@ This repository contains four core components and optional extras:
 - **MCP Token Audit:** `MCP_TOKEN_AUDIT_CHECKLIST.md`
 - **MCP Second Opinion:** `mcp-second-opinion/`
 - **MCP Playwright:** `mcp-playwright-persistent/`
+- **Sequential Thinking (optional):** `extras/sequential-thinking/`
 - **MCP Coordination (optional):** `extras/redis-coordination/`
 
 ## Key Conventions
@@ -74,6 +76,8 @@ claude-power-pack/
 │   ├── deploy/                                 # systemd, docker configs
 │   └── README.md                               # Full documentation
 ├── extras/                                      # Optional components
+│   ├── sequential-thinking/                    # Structured reasoning (stdio, npm)
+│   │   └── README.md                           # Setup & usage guide
 │   └── redis-coordination/                     # Distributed locking (teams only)
 │       ├── mcp-server/                         # MCP Coordination server (8 tools)
 │       └── scripts/                            # Session coordination scripts
@@ -168,6 +172,9 @@ claude-power-pack/
 │   │   │   ├── ui.md                           # Launch web UI
 │   │   │   ├── rotate.md                       # Rotate a secret
 │   │   │   └── help.md                         # Secrets command overview
+│   │   ├── self-improvement/                   # Retrospective analysis
+│   │   │   ├── deployment.md                   # Analyze errors, improve Makefile
+│   │   │   └── help.md                         # Self-improvement command overview
 │   │   ├── project-next.md                     # Next steps orchestrator
 │   │   ├── project-lite.md                     # Quick reference
 │   │   └── happy-check.md                      # Happy CLI version check (optional)
@@ -205,6 +212,7 @@ To preserve context, documentation is NOT auto-loaded. Use topic-specific skills
 | Issue-Driven Dev | "worktree", "IDD" |
 | CLAUDE.md Config | "CLAUDE.md", "configuration" |
 | Code Quality | "code review", "quality" |
+| Build & Deploy | "Makefile", "uv", "deploy patterns" |
 
 **Commands:**
 - `/load-best-practices` - Load full guide (25K tokens)
@@ -624,6 +632,27 @@ suppressions:
     path: tests/fixtures/.*
     reason: "Test fixtures with fake credentials"
 ```
+
+## Self-Improvement Commands
+
+Retrospective analysis commands that examine recent failures and suggest tooling improvements.
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/self-improvement:deployment` | Analyze recent errors and propose Makefile improvements |
+| `/self-improvement:help` | Overview of self-improvement commands |
+
+### When to Use
+
+Run after failed deployments or builds to close the feedback loop:
+
+```
+/flow:deploy -> fails -> /self-improvement:deployment -> fix Makefile -> /flow:deploy
+```
+
+Pair with `/flow:doctor` for forward-looking health checks.
 
 ## Makefile Integration
 


### PR DESCRIPTION
## Summary
- Adds new `/self-improvement:deployment` command that analyzes recent session errors, deploy history, and current Makefile to propose concrete improvements (missing targets, dependency chains, uv integration, .PHONY gaps)
- Adds new `/self-improvement:help` category help page
- Adds "Build, Test & Deploy Patterns" section to best practices reference doc, covering Makefile as canonical interface and uv as recommended Python environment manager
- Registers new command category in CLAUDE.md (repo tree, topic table, commands section)

## Test plan
- [x] New commands appear in skill list (`self-improvement:deployment`, `self-improvement:help`)
- [x] `ls .claude/commands/self-improvement/` shows both files
- [x] `grep "self-improvement" CLAUDE.md` returns 4 references
- [x] `grep "Build, Test" docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md` shows new section + TOC entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)