### PR TITLE
fix(flow): Add hard gates for worktree entry and exit

### DIFF
--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -65,21 +65,33 @@ git -C "$MAIN_REPO" pull origin main
 
 ### Step 5: Clean Up Worktree
 
-If we're in a worktree:
+**CRITICAL: You MUST `cd` to the main repo BEFORE removing the worktree. NEVER remove a worktree while your working directory is inside it — this destroys your CWD and kills all subsequent bash commands. Execute these as SEPARATE Bash calls.**
 
+If we're in a worktree (`IS_WORKTREE=true`):
+
+**Step 5a — Exit the worktree (separate Bash call):**
 ```bash
-# Use the safe worktree removal script
-if command -v worktree-remove.sh &>/dev/null || [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
+cd "$MAIN_REPO"
+pwd  # Verify you are in the main repo, NOT the worktree
+```
+
+**Step 5b — Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
+```bash
+if [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
     ~/.claude/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
 else
-    # Manual cleanup (less safe but functional)
-    cd "$MAIN_REPO"
     git worktree remove "$WORKTREE_PATH" --force
     git branch -D "$BRANCH" 2>/dev/null || true
 fi
 ```
 
-If we're in the main repo:
+**Step 5c — Verify working directory is valid:**
+```bash
+pwd  # MUST show main repo path, NOT the deleted worktree
+git status  # MUST succeed — if this fails, your CWD was deleted
+```
+
+If we're in the main repo (not a worktree):
 ```bash
 # Just delete the local branch
 git branch -D "$BRANCH" 2>/dev/null || true

--- a/.claude/commands/flow/start.md
+++ b/.claude/commands/flow/start.md
@@ -53,20 +53,33 @@ git fetch origin
 git branch -r | grep "issue-${ISSUE_NUM}-"
 ```
 
-- **If worktree exists:** Inform user of the path. Do not recreate.
-- **If remote branch exists (no local worktree):** Create worktree tracking the remote branch:
+- **If worktree exists:** Inform user of the path. Do not recreate. `cd` into the existing worktree.
+- **If remote branch exists (no local worktree):** Create worktree tracking the remote branch, then `cd` into it:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
   git worktree add -b "$LOCAL_BRANCH" "$WORKTREE_DIR" "$REMOTE_BRANCH"
+  cd "$WORKTREE_DIR"
   ```
-- **If neither exists:** Create fresh:
+- **If neither exists:** Create fresh, then `cd` into it:
   ```bash
   git fetch origin main
   git worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main
+  cd "$WORKTREE_DIR"
   ```
 
-### Step 5: Output
+### Step 5: Verify and Output
+
+**CRITICAL: Verify you are in the worktree, not on main/master.**
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "ERROR: Still on main/master. Worktree creation or cd failed."
+    exit 1
+fi
+echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
+```
 
 Report to the user:
 
@@ -75,8 +88,7 @@ Created worktree for issue #42: "Fix login bug"
 
   Directory: ../my-project-issue-42
   Branch:    issue-42-fix-login-bug
-
-  To start working:  cd ../my-project-issue-42
+  Verified:  Working directory is now the worktree (not main)
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- Adds CRITICAL entry gates to `auto.md` and `start.md` — worktree creation is now mandatory with verification before proceeding
- Adds CRITICAL exit gates to `auto.md` and `merge.md` — cd out of worktree before removal, split into separate Bash calls
- Fixes the root cause of two bugs: Claude skipping worktree creation (editing main directly) and Claude deleting its own CWD (killing bash)

## Test plan
- [ ] Run `/flow:start <issue>` and verify worktree is created + cd'd into
- [ ] Run `/flow:auto <issue>` and verify worktree entry gate fires
- [ ] Run `/flow:merge` from a worktree and verify cd-out-first pattern works
- [ ] Verify verification gate catches main branch and STOPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)