### PR TITLE
fix(deploy): Make systemd service files generic for any user

### DIFF
--- a/extras/redis-coordination/mcp-server/deploy/mcp-coordination.service
+++ b/extras/redis-coordination/mcp-server/deploy/mcp-coordination.service
@@ -1,10 +1,15 @@
+# Install as a user service: systemctl --user enable mcp-coordination
+# Copy to: ~/.config/systemd/user/mcp-coordination.service
+# %h expands to the user's home directory in user services.
+
 [Unit]
 Description=MCP Coordination Server (Redis-backed distributed locking)
-After=network.target
+After=network.target redis-server.service
 
 [Service]
 Type=simple
-WorkingDirectory=%h/Projects/claude-power-pack/mcp-coordination
+WorkingDirectory=%h/Projects/claude-power-pack/extras/redis-coordination/mcp-server
+EnvironmentFile=%h/Projects/claude-power-pack/extras/redis-coordination/mcp-server/.env
 ExecStart=%h/.local/bin/uv run python src/server.py
 Restart=on-failure
 RestartSec=5
@@ -16,6 +21,9 @@ Environment="PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=mcp-coordination
+
+# Security hardening
+NoNewPrivileges=true
 
 [Install]
 WantedBy=default.target

--- a/mcp-playwright-persistent/deploy/mcp-playwright.service
+++ b/mcp-playwright-persistent/deploy/mcp-playwright.service
@@ -1,0 +1,39 @@
+# Install as a user service: systemctl --user enable mcp-playwright
+# Copy to: ~/.config/systemd/user/mcp-playwright.service
+# %h expands to the user's home directory in user services.
+
+[Unit]
+Description=MCP Playwright Persistent Server (SSE Transport)
+After=network.target
+Documentation=https://github.com/cooneycw/claude-power-pack
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Projects/claude-power-pack/mcp-playwright-persistent
+
+# Load environment variables from .env file (if exists)
+EnvironmentFile=-%h/Projects/claude-power-pack/mcp-playwright-persistent/.env
+
+# Explicit port configuration
+Environment="SERVER_PORT=8081"
+Environment="SERVER_HOST=127.0.0.1"
+
+# Use uv to run in the project environment
+ExecStart=%h/.local/bin/uv run --project %h/Projects/claude-power-pack/mcp-playwright-persistent python src/server.py
+
+# Restart policy
+Restart=on-failure
+RestartSec=10s
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=mcp-playwright
+
+# Security hardening
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target

--- a/mcp-second-opinion/deploy/mcp-second-opinion.service
+++ b/mcp-second-opinion/deploy/mcp-second-opinion.service
@@ -1,3 +1,7 @@
+# Install as a user service: systemctl --user enable mcp-second-opinion
+# Copy to: ~/.config/systemd/user/mcp-second-opinion.service
+# %h expands to the user's home directory in user services.
+
 [Unit]
 Description=MCP Second Opinion Server (SSE Transport)
 After=network.target
@@ -5,19 +9,17 @@ Documentation=https://github.com/cooneycw/claude-power-pack
 
 [Service]
 Type=simple
-User=cooneycw
-Group=cooneycw
-WorkingDirectory=/home/cooneycw/Projects/claude-power-pack/mcp-second-opinion
+WorkingDirectory=%h/Projects/claude-power-pack/mcp-second-opinion
 
 # Load environment variables from .env file
-EnvironmentFile=/home/cooneycw/Projects/claude-power-pack/mcp-second-opinion/.env
+EnvironmentFile=%h/Projects/claude-power-pack/mcp-second-opinion/.env
 
 # Explicit port configuration (won't conflict with web servers on 80/443)
 Environment="MCP_SERVER_PORT=8080"
 Environment="MCP_SERVER_HOST=127.0.0.1"
 
 # Use uv to run in the project environment
-ExecStart=/home/cooneycw/.local/bin/uv run --project /home/cooneycw/Projects/claude-power-pack/mcp-second-opinion python src/server.py
+ExecStart=%h/.local/bin/uv run --project %h/Projects/claude-power-pack/mcp-second-opinion python src/server.py
 
 # Restart policy
 Restart=on-failure
@@ -32,10 +34,6 @@ SyslogIdentifier=mcp-second-opinion
 
 # Security hardening
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=/home/cooneycw/Projects/claude-power-pack/mcp-second-opinion
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary
- Replace hardcoded `/home/cooneycw` paths with `%h` in all three MCP service files
- Remove `User=/Group=` and system-only directives (`ProtectSystem`, `ProtectHome`, `ReadWritePaths`) that don't work with `systemctl --user`
- Fix coordination service stale `WorkingDirectory` path, add `redis-server.service` dependency
- Add new `mcp-playwright.service` file
- Add install instructions as comments at top of each file

## Test plan
- [ ] Verify `%h` expands correctly with `systemctl --user start mcp-second-opinion`
- [ ] Confirm no hardcoded usernames remain in service files

🤖 Generated with [Claude Code](https://claude.com/claude-code)