### PR TITLE
feat(cicd): Add lib/cicd package foundation for Tier 4 (Closes #142)

### DIFF
--- a/lib/cicd/__init__.py
+++ b/lib/cicd/__init__.py
@@ -1,0 +1,47 @@
+"""CI/CD & Verification for Claude Code projects.
+
+Provides:
+- Framework detection (Python/Node/Go/Rust/multi)
+- Makefile validation and generation
+- Configuration from .claude/cicd.yml
+
+Quick Start:
+    from lib.cicd import detect_framework, check_makefile
+
+    # Detect project framework
+    info = detect_framework("/path/to/project")
+    print(info.framework, info.package_manager)
+
+    # Check Makefile completeness
+    result = check_makefile("/path/to/project")
+    for gap in result.missing_required:
+        print(f"Missing: {gap}")
+"""
+
+from .config import CICDConfig
+from .detector import detect_framework
+from .makefile import check_makefile, generate_makefile, parse_makefile
+from .models import (
+    Framework,
+    FrameworkInfo,
+    MakefileCheckResult,
+    MakefileTarget,
+    PackageManager,
+)
+
+__all__ = [
+    # Config
+    "CICDConfig",
+    # Detector
+    "detect_framework",
+    # Makefile
+    "check_makefile",
+    "generate_makefile",
+    "parse_makefile",
+    # Models
+    "Framework",
+    "FrameworkInfo",
+    "MakefileCheckResult",
+    "MakefileTarget",
+    "PackageManager",
+]

--- a/lib/cicd/__main__.py
+++ b/lib/cicd/__main__.py
@@ -1,0 +1,17 @@
+"""Enable python -m lib.cicd invocation.
+
+Usage:
+    python -m lib.cicd detect [OPTIONS]
+    python -m lib.cicd check [OPTIONS]
+
+Examples:
+    python -m lib.cicd detect
+    python -m lib.cicd detect --json
+    python -m lib.cicd check
+    python -m lib.cicd check --summary
+"""
+
+from .cli import run
+
+if __name__ == "__main__":
+    run()

--- a/lib/cicd/cli.py
+++ b/lib/cicd/cli.py
@@ -1,0 +1,213 @@
+"""Command-line interface for CI/CD & Verification.
+
+Usage:
+    python -m lib.cicd detect [OPTIONS]
+    python -m lib.cicd check [OPTIONS]
+
+Examples:
+    python -m lib.cicd detect
+    python -m lib.cicd detect --json
+    python -m lib.cicd check
+    python -m lib.cicd check --summary
+    python -m lib.cicd check --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import NoReturn
+
+from .config import CICDConfig
+from .detector import detect_framework
+from .makefile import check_makefile
+
+
+def cmd_detect(args: argparse.Namespace) -> int:
+    """Detect project framework and package manager."""
+    info = detect_framework(args.path)
+
+    if args.json:
+        print(json.dumps(info.to_dict(), indent=2))
+    elif args.quiet:
+        print(f"{info.framework.value}:{info.package_manager.value}")
+    else:
+        print(f"Framework:       {info.framework.label}")
+        print(f"Package Manager: {info.package_manager.label}")
+        if info.detected_files:
+            print(f"Detected Files:  {', '.join(info.detected_files)}")
+        if info.secondary_frameworks:
+            secondary = ", ".join(f.label for f in info.secondary_frameworks)
+            print(f"Also Found:      {secondary}")
+        if info.recommended_targets:
+            print(f"Recommended Targets: {', '.join(info.recommended_targets)}")
+        if info.runner_commands:
+            print("\nRunner Commands:")
+            for target, cmd in info.runner_commands.items():
+                print(f"  {target}: {cmd}")
+
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    """Validate Makefile completeness."""
+    config = CICDConfig.load(args.path)
+    result = check_makefile(args.path, config)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+        return 0 if result.is_healthy else 1
+
+    if args.summary:
+        print(result.summary_line())
+        return 0 if result.is_healthy else 1
+
+    # No Makefile — early exit
+    if not result.targets_found and "No Makefile found" in result.issues:
+        print("Makefile Check: No Makefile found")
+        print()
+        print("  Create one with /cicd:init or copy a template:")
+        print("    cp ~/Projects/claude-power-pack/templates/Makefile.example Makefile")
+        return 1
+
+    print("## Makefile Health Check")
+    print()
+
+    # Targets table
+    print("| Target | Status | Notes |")
+    print("|--------|--------|-------|")
+
+    all_targets = set(result.targets_found) | set(result.missing_required) | set(result.missing_recommended)
+    for target in sorted(all_targets):
+        if target in result.targets_found:
+            status = "present"
+            notes = ""
+        elif target in result.missing_required:
+            status = "MISSING"
+            notes = "Required by /flow"
+        else:
+            status = "missing"
+            notes = "Recommended"
+        print(f"| {target} | {status} | {notes} |")
+
+    print()
+
+    # .PHONY status
+    if result.phony_declared:
+        declared = len(result.phony_declared)
+        total = len(result.targets_found)
+        print(f".PHONY: declared for {declared}/{total} targets")
+    elif result.targets_found:
+        print(".PHONY: not declared (add to prevent stale file conflicts)")
+
+    if result.phony_missing:
+        print(f"  Missing .PHONY for: {', '.join(result.phony_missing)}")
+
+    print()
+
+    # Issues
+    if result.issues:
+        print("Issues:")
+        for issue in result.issues:
+            print(f"  - {issue}")
+        print()
+
+    # Summary
+    if result.is_healthy:
+        print(f"Result: Makefile OK ({result.target_coverage})")
+    else:
+        parts = []
+        if result.missing_required:
+            parts.append(f"{len(result.missing_required)} required targets missing")
+        if result.issues:
+            parts.append(f"{len(result.issues)} issues found")
+        print(f"Result: {', '.join(parts)}")
+
+    return 0 if result.is_healthy else 1
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments to a parser."""
+    parser.add_argument(
+        "--path",
+        "-p",
+        default=os.getcwd(),
+        help="Project root directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--json",
+        "-j",
+        action="store_true",
+        help="Output as JSON",
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="python -m lib.cicd",
+        description="CI/CD & Verification for Claude Code projects",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # 'detect' subcommand
+    detect_parser = subparsers.add_parser(
+        "detect",
+        help="Detect project framework and package manager",
+    )
+    _add_common_args(detect_parser)
+    detect_parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Minimal output: framework:package_manager",
+    )
+
+    # 'check' subcommand
+    check_parser = subparsers.add_parser(
+        "check",
+        help="Validate Makefile completeness against standards",
+    )
+    _add_common_args(check_parser)
+    check_parser.add_argument(
+        "--summary",
+        "-s",
+        action="store_true",
+        help="One-line summary for flow integration",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for the CLI."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    commands = {
+        "detect": cmd_detect,
+        "check": cmd_check,
+    }
+
+    handler = commands.get(args.command)
+    if handler:
+        return handler(args)
+
+    parser.print_help()
+    return 1
+
+
+def run() -> NoReturn:
+    """Entry point that exits with the return code."""
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/lib/cicd/config.py
+++ b/lib/cicd/config.py
@@ -1,0 +1,204 @@
+"""CI/CD configuration.
+
+Loads configuration from .claude/cicd.yml if present,
+otherwise uses sensible defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass
+class BuildConfig:
+    """Build system configuration."""
+
+    framework: str = "auto"
+    package_manager: str = "auto"
+    required_targets: list[str] = field(default_factory=lambda: ["lint", "test"])
+    recommended_targets: list[str] = field(
+        default_factory=lambda: ["format", "typecheck", "build", "deploy", "clean", "verify"]
+    )
+
+
+@dataclass
+class HealthEndpoint:
+    """A single health check endpoint."""
+
+    url: str
+    name: str = ""
+    expected_status: int = 200
+    expected_body: str = ""
+    timeout: int = 5
+
+
+@dataclass
+class ProcessCheck:
+    """A process health check."""
+
+    name: str
+    port: int
+
+
+@dataclass
+class SmokeTest:
+    """A smoke test definition."""
+
+    name: str
+    command: str
+    expected_exit: int = 0
+    expected_output: str = ""
+    timeout: int = 10
+
+
+@dataclass
+class HealthConfig:
+    """Health check and smoke test configuration."""
+
+    endpoints: list[HealthEndpoint] = field(default_factory=list)
+    processes: list[ProcessCheck] = field(default_factory=list)
+    smoke_tests: list[SmokeTest] = field(default_factory=list)
+    post_deploy: bool = False
+    startup_delay: int = 0
+
+
+@dataclass
+class PipelineConfig:
+    """CI/CD pipeline configuration."""
+
+    provider: str = "github-actions"
+    branches: dict[str, list[str]] = field(
+        default_factory=lambda: {
+            "main": ["lint", "test", "typecheck", "build"],
+            "pr": ["lint", "test", "typecheck"],
+        }
+    )
+    matrix: dict[str, list[str]] = field(default_factory=dict)
+    secrets_needed: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BranchProtection:
+    """Branch protection rule suggestions."""
+
+    require_pr_review: bool = True
+    require_status_checks: list[str] = field(default_factory=lambda: ["lint", "test"])
+    require_up_to_date: bool = True
+
+
+@dataclass
+class ContainerConfig:
+    """Container configuration."""
+
+    enabled: bool = False
+    base_image: str = "auto"
+    expose_ports: list[int] = field(default_factory=list)
+    compose_services: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class CICDConfig:
+    """Full CI/CD configuration."""
+
+    build: BuildConfig = field(default_factory=BuildConfig)
+    health: HealthConfig = field(default_factory=HealthConfig)
+    pipeline: PipelineConfig = field(default_factory=PipelineConfig)
+    container: ContainerConfig = field(default_factory=ContainerConfig)
+
+    @classmethod
+    def load(cls, project_root: Optional[str] = None) -> CICDConfig:
+        """Load config from .claude/cicd.yml or use defaults."""
+        if project_root is None:
+            project_root = os.getcwd()
+
+        config_path = Path(project_root) / ".claude" / "cicd.yml"
+        if config_path.exists():
+            return cls._from_yaml(config_path)
+
+        return cls._defaults()
+
+    @classmethod
+    def _defaults(cls) -> CICDConfig:
+        return cls()
+
+    @classmethod
+    def _from_yaml(cls, path: Path) -> CICDConfig:
+        """Parse YAML config file."""
+        try:
+            import yaml
+        except ImportError:
+            return cls._defaults()
+
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+        config = cls._defaults()
+
+        # Parse build section
+        build_data = data.get("build", {})
+        if build_data:
+            config.build.framework = build_data.get("framework", "auto")
+            config.build.package_manager = build_data.get("package_manager", "auto")
+            if "required_targets" in build_data:
+                config.build.required_targets = build_data["required_targets"]
+            if "recommended_targets" in build_data:
+                config.build.recommended_targets = build_data["recommended_targets"]
+
+        # Parse health section
+        health_data = data.get("health", {})
+        if health_data:
+            config.health.post_deploy = health_data.get("post_deploy", False)
+            config.health.startup_delay = health_data.get("startup_delay", 0)
+
+            for ep in health_data.get("endpoints", []):
+                config.health.endpoints.append(
+                    HealthEndpoint(
+                        url=ep["url"],
+                        name=ep.get("name", ""),
+                        expected_status=ep.get("expected_status", 200),
+                        expected_body=ep.get("expected_body", ""),
+                        timeout=ep.get("timeout", 5),
+                    )
+                )
+
+            for proc in health_data.get("processes", []):
+                config.health.processes.append(
+                    ProcessCheck(name=proc["name"], port=proc["port"])
+                )
+
+            for st in health_data.get("smoke_tests", []):
+                config.health.smoke_tests.append(
+                    SmokeTest(
+                        name=st["name"],
+                        command=st["command"],
+                        expected_exit=st.get("expected_exit", 0),
+                        expected_output=st.get("expected_output", ""),
+                        timeout=st.get("timeout", 10),
+                    )
+                )
+
+        # Parse pipeline section
+        pipeline_data = data.get("pipeline", {})
+        if pipeline_data:
+            config.pipeline.provider = pipeline_data.get("provider", "github-actions")
+            if "branches" in pipeline_data:
+                config.pipeline.branches = pipeline_data["branches"]
+            if "matrix" in pipeline_data:
+                config.pipeline.matrix = pipeline_data["matrix"]
+            if "secrets_needed" in pipeline_data:
+                config.pipeline.secrets_needed = pipeline_data["secrets_needed"]
+
+        # Parse container section
+        container_data = data.get("container", {})
+        if container_data:
+            config.container.enabled = container_data.get("enabled", False)
+            config.container.base_image = container_data.get("base_image", "auto")
+            if "expose_ports" in container_data:
+                config.container.expose_ports = container_data["expose_ports"]
+            if "compose_services" in container_data:
+                config.container.compose_services = container_data["compose_services"]
+
+        return config

--- a/lib/cicd/detector.py
+++ b/lib/cicd/detector.py
@@ -1,0 +1,151 @@
+"""Framework detection from project files.
+
+Detects the primary framework and package manager by examining
+marker files in the project root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .models import (
+    FRAMEWORK_RUNNERS,
+    FRAMEWORK_TARGETS,
+    Framework,
+    FrameworkInfo,
+    PackageManager,
+)
+
+
+# Marker files → (Framework, PackageManager or None)
+# Order matters: more specific markers first
+_FRAMEWORK_MARKERS: list[tuple[str, Framework, Optional[PackageManager]]] = [
+    # Python markers
+    ("pyproject.toml", Framework.PYTHON, None),
+    ("setup.py", Framework.PYTHON, None),
+    ("setup.cfg", Framework.PYTHON, None),
+    ("requirements.txt", Framework.PYTHON, None),
+    # Node markers
+    ("package.json", Framework.NODE, None),
+    # Go markers
+    ("go.mod", Framework.GO, PackageManager.GO),
+    # Rust markers
+    ("Cargo.toml", Framework.RUST, PackageManager.CARGO),
+]
+
+# Lock files → PackageManager
+_LOCK_FILES: list[tuple[str, PackageManager]] = [
+    ("uv.lock", PackageManager.UV),
+    ("poetry.lock", PackageManager.POETRY),
+    ("Pipfile.lock", PackageManager.PIP),
+    ("package-lock.json", PackageManager.NPM),
+    ("yarn.lock", PackageManager.YARN),
+    ("pnpm-lock.yaml", PackageManager.PNPM),
+    ("Cargo.lock", PackageManager.CARGO),
+    ("go.sum", PackageManager.GO),
+]
+
+
+def detect_framework(project_root: str | Path) -> FrameworkInfo:
+    """Detect project framework and package manager from files present.
+
+    Args:
+        project_root: Path to project root directory.
+
+    Returns:
+        FrameworkInfo with detection results and recommendations.
+    """
+    root = Path(project_root)
+    detected_files: list[str] = []
+    frameworks_found: list[tuple[Framework, Optional[PackageManager]]] = []
+
+    # Check marker files at root
+    for filename, framework, pm in _FRAMEWORK_MARKERS:
+        if (root / filename).exists():
+            detected_files.append(filename)
+            frameworks_found.append((framework, pm))
+
+    # Check lock files for package manager detection
+    detected_pm: Optional[PackageManager] = None
+    for filename, pm in _LOCK_FILES:
+        if (root / filename).exists():
+            detected_files.append(filename)
+            if detected_pm is None:
+                detected_pm = pm
+
+    # If no root-level markers, check immediate subdirectories (monorepo/workspace)
+    if not frameworks_found:
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            for filename, framework, pm in _FRAMEWORK_MARKERS:
+                if (child / filename).exists():
+                    detected_files.append(f"{child.name}/{filename}")
+                    frameworks_found.append((framework, pm))
+                    break  # One marker per subdir is enough
+
+        # Also check subdirectory lock files
+        if detected_pm is None:
+            for child in sorted(root.iterdir()):
+                if not child.is_dir() or child.name.startswith("."):
+                    continue
+                for filename, pm in _LOCK_FILES:
+                    if (child / filename).exists():
+                        detected_files.append(f"{child.name}/{filename}")
+                        if detected_pm is None:
+                            detected_pm = pm
+                        break
+
+    if not frameworks_found:
+        return FrameworkInfo(
+            framework=Framework.UNKNOWN,
+            package_manager=PackageManager.UNKNOWN,
+            detected_files=detected_files,
+            recommended_targets=FRAMEWORK_TARGETS[Framework.UNKNOWN],
+        )
+
+    # Deduplicate frameworks
+    unique_frameworks = list(dict.fromkeys(fw for fw, _ in frameworks_found))
+
+    if len(unique_frameworks) > 1:
+        # Multi-language project
+        primary = Framework.MULTI
+        secondary = unique_frameworks
+    else:
+        primary = unique_frameworks[0]
+        secondary = []
+
+    # Determine package manager
+    if detected_pm is None:
+        # Use the PM from framework markers if available
+        for fw, pm in frameworks_found:
+            if pm is not None:
+                detected_pm = pm
+                break
+
+    # Fall back to defaults
+    if detected_pm is None:
+        if primary == Framework.PYTHON:
+            # Check for pyproject.toml with uv-compatible content
+            if (root / "uv.lock").exists():
+                detected_pm = PackageManager.UV
+            else:
+                detected_pm = PackageManager.PIP
+        elif primary == Framework.NODE:
+            detected_pm = PackageManager.NPM
+        else:
+            detected_pm = PackageManager.UNKNOWN
+
+    # Get recommended targets and runner commands
+    recommended = FRAMEWORK_TARGETS.get(primary, FRAMEWORK_TARGETS[Framework.UNKNOWN])
+    runners = FRAMEWORK_RUNNERS.get((primary, detected_pm), {})
+
+    return FrameworkInfo(
+        framework=primary,
+        package_manager=detected_pm,
+        detected_files=detected_files,
+        recommended_targets=recommended,
+        runner_commands=runners,
+        secondary_frameworks=secondary,
+    )

--- a/lib/cicd/makefile.py
+++ b/lib/cicd/makefile.py
@@ -1,0 +1,344 @@
+"""Makefile parsing, validation, and generation.
+
+Provides:
+- parse_makefile: Extract targets, dependencies, and commands
+- check_makefile: Validate against framework standards
+- generate_makefile: Create from template based on detected framework
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from .config import CICDConfig
+from .detector import detect_framework
+from .models import (
+    FRAMEWORK_TARGETS,
+    Framework,
+    MakefileCheckResult,
+    MakefileTarget,
+    PackageManager,
+)
+
+
+def parse_makefile(project_root: str | Path) -> list[MakefileTarget]:
+    """Parse a Makefile and extract targets with dependencies and commands.
+
+    Args:
+        project_root: Path to directory containing Makefile.
+
+    Returns:
+        List of MakefileTarget objects.
+    """
+    makefile_path = Path(project_root) / "Makefile"
+    if not makefile_path.exists():
+        return []
+
+    content = makefile_path.read_text()
+    targets: list[MakefileTarget] = []
+
+    # Extract .PHONY declarations
+    phony_targets: set[str] = set()
+    for match in re.finditer(r"^\.PHONY:\s*(.+)$", content, re.MULTILINE):
+        phony_targets.update(match.group(1).split())
+
+    # Parse targets: lines matching "name: [deps]"
+    # Followed by tab-indented command lines
+    lines = content.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # Match target definition (not .PHONY, not comments, not variable assignments)
+        target_match = re.match(r"^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*?)$", line)
+        if target_match and not line.startswith("#") and "=" not in line.split(":")[0]:
+            name = target_match.group(1)
+            deps_str = target_match.group(2).strip()
+            deps = deps_str.split() if deps_str else []
+
+            # Collect command lines (tab-indented)
+            commands: list[str] = []
+            j = i + 1
+            while j < len(lines) and lines[j].startswith("\t"):
+                cmd = lines[j].lstrip("\t")
+                commands.append(cmd)
+                j += 1
+
+            targets.append(
+                MakefileTarget(
+                    name=name,
+                    dependencies=deps,
+                    commands=commands,
+                    is_phony=name in phony_targets,
+                )
+            )
+            i = j
+        else:
+            i += 1
+
+    return targets
+
+
+def check_makefile(
+    project_root: str | Path,
+    config: Optional[CICDConfig] = None,
+) -> MakefileCheckResult:
+    """Validate Makefile completeness against framework standards.
+
+    Args:
+        project_root: Path to project root.
+        config: Optional CICDConfig. Auto-loads if not provided.
+
+    Returns:
+        MakefileCheckResult with validation details.
+    """
+    root = Path(project_root)
+    if config is None:
+        config = CICDConfig.load(str(root))
+
+    # Detect framework
+    info = detect_framework(root)
+    result = MakefileCheckResult(
+        framework=info.framework,
+        package_manager=info.package_manager,
+    )
+
+    makefile_path = root / "Makefile"
+    if not makefile_path.exists():
+        result.issues.append("No Makefile found")
+        result.missing_required = list(config.build.required_targets)
+        result.missing_recommended = list(config.build.recommended_targets)
+        return result
+
+    # Parse targets
+    targets = parse_makefile(root)
+    target_names = {t.name for t in targets}
+    result.targets_found = sorted(target_names)
+
+    # Check required targets
+    for target in config.build.required_targets:
+        if target not in target_names:
+            result.missing_required.append(target)
+
+    # Check recommended targets (framework-specific)
+    framework_recommended = FRAMEWORK_TARGETS.get(
+        info.framework, config.build.recommended_targets
+    )
+    for target in framework_recommended:
+        if target not in target_names and target not in config.build.required_targets:
+            result.missing_recommended.append(target)
+    # Deduplicate: remove from recommended if already in required missing
+    result.missing_recommended = [
+        t for t in result.missing_recommended if t not in result.missing_required
+    ]
+
+    # Check .PHONY declarations
+    phony_set = set()
+    content = makefile_path.read_text()
+    for match in re.finditer(r"^\.PHONY:\s*(.+)$", content, re.MULTILINE):
+        phony_set.update(match.group(1).split())
+    result.phony_declared = sorted(phony_set)
+
+    for target in targets:
+        if target.name not in phony_set and not _target_produces_file(target):
+            result.phony_missing.append(target.name)
+
+    # Check for common anti-patterns
+    _check_antipatterns(targets, info, result, content)
+
+    return result
+
+
+def _target_produces_file(target: MakefileTarget) -> bool:
+    """Heuristic: does this target produce a file with the same name?
+
+    Most CI/CD targets (lint, test, deploy) do NOT produce files,
+    so they should be .PHONY. Only build targets that create
+    artifacts (like 'dist/' or a binary) are non-phony.
+    """
+    # If it has commands that create files/dirs matching the target name, it's file-based
+    # For simplicity, assume targets without file-creating patterns are phony
+    return False
+
+
+def _check_antipatterns(
+    targets: list[MakefileTarget],
+    info: FrameworkInfo,
+    result: MakefileCheckResult,
+    content: str,
+) -> None:
+    """Check for common Makefile anti-patterns."""
+    # Python: bare python/pytest instead of uv run
+    if info.framework == Framework.PYTHON and info.package_manager == PackageManager.UV:
+        for target in targets:
+            for cmd in target.commands:
+                clean_cmd = cmd.lstrip("@-")
+                if re.match(r"^(python|python3|pytest|ruff|mypy)\s", clean_cmd):
+                    result.issues.append(
+                        f"Target '{target.name}': uses bare '{clean_cmd.split()[0]}' "
+                        f"instead of 'uv run {clean_cmd.split()[0]}' — "
+                        f"may fail outside the virtual environment"
+                    )
+
+    # Deploy without test/lint dependencies
+    deploy_targets = [t for t in targets if t.name.startswith("deploy")]
+    for dt in deploy_targets:
+        has_quality_deps = any(d in ("test", "lint", "verify") for d in dt.dependencies)
+        if not has_quality_deps and dt.commands:
+            result.issues.append(
+                f"Target '{dt.name}': runs without test/lint dependencies — "
+                f"consider adding 'test lint' as prerequisites"
+            )
+
+
+def generate_makefile(
+    project_root: str | Path,
+    template_dir: Optional[str | Path] = None,
+) -> str:
+    """Generate Makefile content based on detected framework.
+
+    Args:
+        project_root: Path to project root.
+        template_dir: Directory containing .mk templates. If None, generates inline.
+
+    Returns:
+        Makefile content as string.
+    """
+    info = detect_framework(project_root)
+
+    # Try to load from template file
+    if template_dir is not None:
+        template_path = _get_template_path(info, Path(template_dir))
+        if template_path and template_path.exists():
+            return template_path.read_text()
+
+    # Generate inline
+    return _generate_inline(info)
+
+
+def _get_template_path(info: FrameworkInfo, template_dir: Path) -> Optional[Path]:
+    """Determine which template file to use."""
+    mapping = {
+        (Framework.PYTHON, PackageManager.UV): "python-uv.mk",
+        (Framework.PYTHON, PackageManager.PIP): "python-pip.mk",
+        (Framework.PYTHON, PackageManager.POETRY): "python-pip.mk",
+        (Framework.NODE, PackageManager.NPM): "node-npm.mk",
+        (Framework.NODE, PackageManager.YARN): "node-yarn.mk",
+        (Framework.NODE, PackageManager.PNPM): "node-npm.mk",
+        (Framework.GO, PackageManager.GO): "go.mk",
+        (Framework.RUST, PackageManager.CARGO): "rust.mk",
+        (Framework.MULTI, PackageManager.UNKNOWN): "multi.mk",
+    }
+
+    filename = mapping.get((info.framework, info.package_manager))
+    if filename:
+        return template_dir / filename
+
+    # Fallback: try just the framework
+    fw_mapping = {
+        Framework.PYTHON: "python-uv.mk",
+        Framework.NODE: "node-npm.mk",
+        Framework.GO: "go.mk",
+        Framework.RUST: "rust.mk",
+    }
+    filename = fw_mapping.get(info.framework)
+    if filename:
+        return template_dir / filename
+
+    return None
+
+
+def _generate_inline(info: FrameworkInfo) -> str:
+    """Generate a Makefile inline without templates."""
+    runners = info.runner_commands
+    targets = info.recommended_targets
+
+    lines = [
+        "# Project Makefile — Claude Power Pack Integration",
+        "#",
+        "# The /flow commands auto-discover these targets:",
+        "#   /flow:finish  → runs `make lint` and `make test` (if targets exist)",
+        "#   /flow:deploy  → runs `make deploy` (or any target you specify)",
+        "#   /flow:doctor  → reports which targets are available",
+        "#",
+        f"# Detected: {info.framework.label} ({info.package_manager.label})",
+        "",
+        f".PHONY: {' '.join(targets)}",
+        "",
+        "## Quality gates (used by /flow:finish)",
+        "",
+    ]
+
+    # Quality gate targets
+    for target in ["lint", "test", "typecheck", "format"]:
+        if target in targets:
+            cmd = runners.get(target, f'@echo "TODO: implement {target}"')
+            lines.append(f"{target}:")
+            lines.append(f"\t{cmd}")
+            lines.append("")
+
+    # Build target
+    if "build" in targets:
+        cmd = runners.get("build", '@echo "TODO: implement build"')
+        lines.append("## Build")
+        lines.append("")
+        lines.append("build:")
+        lines.append(f"\t{cmd}")
+        lines.append("")
+
+    # Verify target (pre-deploy gate)
+    verify_deps = [t for t in ["lint", "test", "typecheck"] if t in targets]
+    if verify_deps:
+        lines.append(f"verify: {' '.join(verify_deps)}")
+        lines.append('\t@echo "All quality gates passed"')
+        lines.append("")
+
+    # Deploy targets
+    lines.append("## Deployment (used by /flow:deploy)")
+    lines.append("")
+    lines.append("deploy:")
+    lines.append('\t@echo "Define your deploy steps here"')
+    lines.append("")
+
+    # Framework-specific extra targets
+    if "vet" in targets:
+        cmd = runners.get("vet", "go vet ./...")
+        lines.append("vet:")
+        lines.append(f"\t{cmd}")
+        lines.append("")
+
+    if "build-release" in targets:
+        cmd = runners.get("build-release", "cargo build --release")
+        lines.append("build-release:")
+        lines.append(f"\t{cmd}")
+        lines.append("")
+
+    if "dev" in targets:
+        cmd = runners.get("dev", '@echo "TODO: implement dev server"')
+        lines.append("dev:")
+        lines.append(f"\t{cmd}")
+        lines.append("")
+
+    # Clean target
+    if "clean" in targets:
+        lines.append("## Utilities")
+        lines.append("")
+        lines.append("clean:")
+        clean_cmd = _get_clean_command(info.framework)
+        lines.append(f"\t{clean_cmd}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _get_clean_command(framework: Framework) -> str:
+    """Get the clean command for a framework."""
+    commands = {
+        Framework.PYTHON: "rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache dist build *.egg-info .coverage htmlcov",
+        Framework.NODE: "rm -rf node_modules dist build .next .nuxt coverage",
+        Framework.GO: "rm -rf bin/ coverage.out",
+        Framework.RUST: "cargo clean",
+        Framework.MULTI: "rm -rf dist build coverage",
+    }
+    return commands.get(framework, "rm -rf dist build")

--- a/lib/cicd/models.py
+++ b/lib/cicd/models.py
@@ -1,0 +1,197 @@
+"""Data models for CI/CD & Verification.
+
+Provides:
+- Framework: Enum for detected project frameworks
+- PackageManager: Enum for detected package managers
+- FrameworkInfo: Detection results with recommendations
+- MakefileTarget: A parsed Makefile target
+- MakefileCheckResult: Validation results for a Makefile
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class Framework(Enum):
+    """Detected project framework."""
+
+    PYTHON = "python"
+    NODE = "node"
+    GO = "go"
+    RUST = "rust"
+    MULTI = "multi"
+    UNKNOWN = "unknown"
+
+    @property
+    def label(self) -> str:
+        labels = {
+            Framework.PYTHON: "Python",
+            Framework.NODE: "Node.js",
+            Framework.GO: "Go",
+            Framework.RUST: "Rust",
+            Framework.MULTI: "Multi-language",
+            Framework.UNKNOWN: "Unknown",
+        }
+        return labels[self]
+
+
+class PackageManager(Enum):
+    """Detected package manager."""
+
+    UV = "uv"
+    PIP = "pip"
+    POETRY = "poetry"
+    NPM = "npm"
+    YARN = "yarn"
+    PNPM = "pnpm"
+    CARGO = "cargo"
+    GO = "go"
+    UNKNOWN = "unknown"
+
+    @property
+    def label(self) -> str:
+        return self.value
+
+
+# Standard Makefile targets that /flow commands expect
+REQUIRED_TARGETS = ["lint", "test"]
+RECOMMENDED_TARGETS = ["format", "typecheck", "build", "deploy", "clean", "verify"]
+
+
+# Framework-specific recommended targets
+FRAMEWORK_TARGETS: dict[Framework, list[str]] = {
+    Framework.PYTHON: ["lint", "test", "typecheck", "format", "build", "deploy", "clean", "verify"],
+    Framework.NODE: ["lint", "test", "typecheck", "build", "deploy", "clean", "dev", "verify"],
+    Framework.GO: ["lint", "test", "vet", "build", "deploy", "clean", "verify"],
+    Framework.RUST: ["lint", "test", "build", "build-release", "deploy", "clean", "verify"],
+    Framework.MULTI: ["lint", "test", "build", "deploy", "clean", "verify"],
+    Framework.UNKNOWN: ["lint", "test", "build", "deploy", "clean"],
+}
+
+# Framework-specific runner commands
+FRAMEWORK_RUNNERS: dict[tuple[Framework, PackageManager], dict[str, str]] = {
+    (Framework.PYTHON, PackageManager.UV): {
+        "lint": "uv run ruff check .",
+        "test": "uv run pytest",
+        "typecheck": "uv run mypy .",
+        "format": "uv run ruff format .",
+        "build": "uv build",
+    },
+    (Framework.PYTHON, PackageManager.PIP): {
+        "lint": "python -m ruff check .",
+        "test": "python -m pytest",
+        "typecheck": "python -m mypy .",
+        "format": "python -m ruff format .",
+        "build": "python -m build",
+    },
+    (Framework.NODE, PackageManager.NPM): {
+        "lint": "npm run lint",
+        "test": "npm test",
+        "typecheck": "npx tsc --noEmit",
+        "build": "npm run build",
+        "dev": "npm run dev",
+    },
+    (Framework.NODE, PackageManager.YARN): {
+        "lint": "yarn lint",
+        "test": "yarn test",
+        "typecheck": "yarn tsc --noEmit",
+        "build": "yarn build",
+        "dev": "yarn dev",
+    },
+    (Framework.GO, PackageManager.GO): {
+        "lint": "golangci-lint run",
+        "test": "go test ./...",
+        "vet": "go vet ./...",
+        "build": "go build -o bin/ ./...",
+    },
+    (Framework.RUST, PackageManager.CARGO): {
+        "lint": "cargo clippy -- -D warnings",
+        "test": "cargo test",
+        "build": "cargo build",
+        "build-release": "cargo build --release",
+    },
+}
+
+
+@dataclass
+class FrameworkInfo:
+    """Results from framework detection."""
+
+    framework: Framework
+    package_manager: PackageManager
+    detected_files: list[str] = field(default_factory=list)
+    recommended_targets: list[str] = field(default_factory=list)
+    runner_commands: dict[str, str] = field(default_factory=dict)
+    secondary_frameworks: list[Framework] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dict."""
+        return {
+            "framework": self.framework.value,
+            "package_manager": self.package_manager.value,
+            "detected_files": self.detected_files,
+            "recommended_targets": self.recommended_targets,
+            "runner_commands": self.runner_commands,
+            "secondary_frameworks": [f.value for f in self.secondary_frameworks],
+        }
+
+
+@dataclass
+class MakefileTarget:
+    """A parsed target from a Makefile."""
+
+    name: str
+    dependencies: list[str] = field(default_factory=list)
+    commands: list[str] = field(default_factory=list)
+    is_phony: bool = False
+
+
+@dataclass
+class MakefileCheckResult:
+    """Validation results for a Makefile."""
+
+    targets_found: list[str] = field(default_factory=list)
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+    phony_declared: list[str] = field(default_factory=list)
+    phony_missing: list[str] = field(default_factory=list)
+    issues: list[str] = field(default_factory=list)
+    framework: Optional[Framework] = None
+    package_manager: Optional[PackageManager] = None
+
+    @property
+    def is_healthy(self) -> bool:
+        return len(self.missing_required) == 0 and len(self.issues) == 0
+
+    @property
+    def target_coverage(self) -> str:
+        """e.g. '5/7 targets'"""
+        total = len(self.targets_found) + len(self.missing_required) + len(self.missing_recommended)
+        return f"{len(self.targets_found)}/{total} targets"
+
+    def summary_line(self) -> str:
+        """One-line summary for flow integration."""
+        if self.is_healthy:
+            return f"Makefile OK: {self.target_coverage}"
+        parts = []
+        if self.missing_required:
+            parts.append(f"{len(self.missing_required)} required missing")
+        if self.issues:
+            parts.append(f"{len(self.issues)} issues")
+        return f"Makefile: {', '.join(parts)}"
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dict."""
+        return {
+            "targets_found": self.targets_found,
+            "missing_required": self.missing_required,
+            "missing_recommended": self.missing_recommended,
+            "phony_declared": self.phony_declared,
+            "phony_missing": self.phony_missing,
+            "issues": self.issues,
+            "is_healthy": self.is_healthy,
+            "target_coverage": self.target_coverage,
+        }

--- a/lib/cicd/pyproject.toml
+++ b/lib/cicd/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "cicd"
+version = "0.1.0"
+description = "CI/CD & Verification for Claude Power Pack"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "cooneycw"}
+]
+dependencies = []
+
+[project.optional-dependencies]
+yaml = ["pyyaml>=6.0"]
+all = ["pyyaml>=6.0"]
+
+[project.scripts]
+cicd = "cicd.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv]
+dev-dependencies = []


### PR DESCRIPTION
## Summary
- Create `lib/cicd/` Python package with framework detection (Python/Node/Go/Rust/Multi), Makefile validation/generation, and YAML config support
- CLI with `detect` and `check` subcommands (`python -m lib.cicd detect`, `python -m lib.cicd check`)
- Follows `lib/security/` patterns: models.py, config.py, cli.py, __main__.py, pyproject.toml
- Monorepo-aware detection scans subdirectories when no root-level markers found

## Test plan
- [x] `detect` correctly identifies Python+uv on CPP repo
- [x] `detect --json` and `detect --quiet` output modes work
- [x] `check` reports missing Makefile when none exists
- [x] `check` validates template Makefile (finds antipatterns)
- [x] `check --json` and `check --summary` output modes work
- [x] Node+yarn, Go, Rust, and multi-language projects detected correctly
- [x] Config loads defaults when `.claude/cicd.yml` missing
- [x] All public imports work (`from lib.cicd import ...`)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)