### PR TITLE
feat(cicd): Add Makefile templates for all frameworks (Closes #143)

### DIFF
--- a/templates/cicd.yml.example
+++ b/templates/cicd.yml.example
@@ -1,0 +1,94 @@
+# .claude/cicd.yml — CI/CD configuration for Claude Power Pack
+#
+# This file configures the /cicd commands and Makefile generation.
+# Place in your project's .claude/ directory.
+#
+# Detection is automatic — this file is optional and only needed
+# to override defaults or add custom configuration.
+
+# -------------------------------------------------------------------
+# Framework & Package Manager
+# -------------------------------------------------------------------
+# Auto-detected from project files (pyproject.toml, package.json, etc.)
+# Override here if detection is wrong.
+
+# framework: python          # python | node | go | rust | multi
+# package_manager: uv        # uv | pip | poetry | npm | yarn | pnpm | cargo | go
+
+# -------------------------------------------------------------------
+# Build Configuration
+# -------------------------------------------------------------------
+build:
+  # Targets that /flow:finish requires (fail the gate if missing)
+  required_targets:
+    - lint
+    - test
+
+  # Targets that /flow:doctor recommends (warn if missing)
+  recommended_targets:
+    - format
+    - typecheck
+    - build
+    - deploy
+    - clean
+    - verify
+
+# -------------------------------------------------------------------
+# Deployment
+# -------------------------------------------------------------------
+deploy:
+  # Default target for /flow:deploy (if not specified on CLI)
+  default_target: deploy
+
+  # Per-target metadata
+  targets:
+    deploy:
+      description: "Deploy to production"
+      requires_confirmation: true
+    deploy-staging:
+      description: "Deploy to staging"
+      requires_confirmation: false
+
+# -------------------------------------------------------------------
+# Health Checks (used by /cicd:health)
+# -------------------------------------------------------------------
+# health:
+#   url: https://your-app.com/health
+#   timeout: 30
+#   expected_status: 200
+#   expected_body: '"status":"ok"'
+
+# -------------------------------------------------------------------
+# Smoke Tests (used by /cicd:smoke)
+# -------------------------------------------------------------------
+# smoke:
+#   tests:
+#     - name: "Homepage loads"
+#       url: https://your-app.com/
+#       expected_status: 200
+#     - name: "API responds"
+#       url: https://your-app.com/api/health
+#       expected_status: 200
+#       expected_body: '"ok"'
+
+# -------------------------------------------------------------------
+# Pipeline Configuration (used by /cicd:pipeline)
+# -------------------------------------------------------------------
+# pipeline:
+#   provider: github-actions   # github-actions | woodpecker
+#   triggers:
+#     - push: [main]
+#     - pull_request: [main]
+#   steps:
+#     - lint
+#     - test
+#     - build
+#     - deploy
+
+# -------------------------------------------------------------------
+# Container Configuration (used by /cicd:container)
+# -------------------------------------------------------------------
+# container:
+#   base_image: python:3.12-slim
+#   port: 8000
+#   entrypoint: "uvicorn app:app --host 0.0.0.0 --port 8000"

--- a/templates/makefiles/go.mk
+++ b/templates/makefiles/go.mk
@@ -1,0 +1,51 @@
+# Makefile — Go (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# Requires: go, golangci-lint (https://golangci-lint.run/)
+# Copy to your project root as "Makefile" and customize.
+
+BINARY_NAME ?= $(shell basename $(CURDIR))
+BUILD_DIR   ?= bin
+
+.PHONY: lint test vet build deploy clean verify tidy
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	golangci-lint run
+
+test:
+	go test ./...
+
+## Recommended targets
+
+vet:
+	go vet ./...
+
+build:
+	go build -o $(BUILD_DIR)/$(BINARY_NAME) ./...
+
+tidy:
+	go mod tidy
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test vet
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify build
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  scp $(BUILD_DIR)/$(BINARY_NAME) prod:/usr/local/bin/"
+	@echo "  docker build -t $(BINARY_NAME) . && docker push $(BINARY_NAME)"
+
+## Utilities
+
+clean:
+	rm -rf $(BUILD_DIR) coverage.out
+	go clean -testcache

--- a/templates/makefiles/multi.mk
+++ b/templates/makefiles/multi.mk
@@ -1,0 +1,65 @@
+# Makefile — Multi-language / Polyglot (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# Delegates to sub-project Makefiles. Adjust PROJECTS list and paths
+# to match your monorepo structure.
+# Copy to your project root as "Makefile" and customize.
+
+# List sub-projects (directories containing their own Makefile)
+PROJECTS := backend frontend
+
+.PHONY: lint test build deploy clean verify $(PROJECTS)
+
+## Quality gates (used by /flow:finish)
+## Runs target in each sub-project that defines it
+
+lint:
+	@for proj in $(PROJECTS); do \
+		if [ -f "$$proj/Makefile" ] && grep -q '^lint:' "$$proj/Makefile"; then \
+			echo "=== lint: $$proj ==="; \
+			$(MAKE) -C "$$proj" lint || exit 1; \
+		fi; \
+	done
+
+test:
+	@for proj in $(PROJECTS); do \
+		if [ -f "$$proj/Makefile" ] && grep -q '^test:' "$$proj/Makefile"; then \
+			echo "=== test: $$proj ==="; \
+			$(MAKE) -C "$$proj" test || exit 1; \
+		fi; \
+	done
+
+## Recommended targets
+
+build:
+	@for proj in $(PROJECTS); do \
+		if [ -f "$$proj/Makefile" ] && grep -q '^build:' "$$proj/Makefile"; then \
+			echo "=== build: $$proj ==="; \
+			$(MAKE) -C "$$proj" build || exit 1; \
+		fi; \
+	done
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify build
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  docker compose up -d --build"
+	@echo "  $(MAKE) -C backend deploy && $(MAKE) -C frontend deploy"
+
+## Utilities
+
+clean:
+	@for proj in $(PROJECTS); do \
+		if [ -f "$$proj/Makefile" ] && grep -q '^clean:' "$$proj/Makefile"; then \
+			$(MAKE) -C "$$proj" clean; \
+		fi; \
+	done

--- a/templates/makefiles/node-npm.mk
+++ b/templates/makefiles/node-npm.mk
@@ -1,0 +1,53 @@
+# Makefile — Node.js + npm (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# Assumes package.json scripts: "lint", "test", "build", "dev".
+# Copy to your project root as "Makefile" and customize.
+
+.PHONY: lint test typecheck build deploy clean verify dev install
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	npm run lint
+
+test:
+	npm test
+
+## Recommended targets
+
+typecheck:
+	npx tsc --noEmit
+
+build:
+	npm run build
+
+dev:
+	npm run dev
+
+## Dependencies
+
+install:
+	npm ci
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test typecheck
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify build
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  npx wrangler deploy          # Cloudflare"
+	@echo "  npx vercel --prod            # Vercel"
+	@echo "  aws s3 sync dist/ s3://bucket # S3 static"
+
+## Utilities
+
+clean:
+	rm -rf node_modules dist .next .nuxt .cache coverage

--- a/templates/makefiles/node-yarn.mk
+++ b/templates/makefiles/node-yarn.mk
@@ -1,0 +1,53 @@
+# Makefile — Node.js + yarn (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# Assumes package.json scripts: "lint", "test", "build", "dev".
+# Copy to your project root as "Makefile" and customize.
+
+.PHONY: lint test typecheck build deploy clean verify dev install
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	yarn lint
+
+test:
+	yarn test
+
+## Recommended targets
+
+typecheck:
+	yarn tsc --noEmit
+
+build:
+	yarn build
+
+dev:
+	yarn dev
+
+## Dependencies
+
+install:
+	yarn install --frozen-lockfile
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test typecheck
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify build
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  npx wrangler deploy          # Cloudflare"
+	@echo "  npx vercel --prod            # Vercel"
+	@echo "  aws s3 sync dist/ s3://bucket # S3 static"
+
+## Utilities
+
+clean:
+	rm -rf node_modules dist .next .nuxt .cache coverage

--- a/templates/makefiles/python-pip.mk
+++ b/templates/makefiles/python-pip.mk
@@ -1,0 +1,54 @@
+# Makefile — Python + pip (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# Uses pip with a virtual environment. Activate your venv first,
+# or adjust commands to use `python -m` prefix.
+# Copy to your project root as "Makefile" and customize.
+
+.PHONY: lint test typecheck format build deploy clean verify venv
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	python -m ruff check .
+
+test:
+	python -m pytest
+
+## Recommended targets
+
+typecheck:
+	python -m mypy .
+
+format:
+	python -m ruff format .
+
+build:
+	python -m build
+
+## Virtual environment setup
+
+venv:
+	python -m venv .venv
+	.venv/bin/pip install -r requirements.txt
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test typecheck
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  ssh prod 'cd /app && git pull && systemctl restart app'"
+	@echo "  docker compose up -d --build"
+
+## Utilities
+
+clean:
+	rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache dist build *.egg-info

--- a/templates/makefiles/python-uv.mk
+++ b/templates/makefiles/python-uv.mk
@@ -1,0 +1,47 @@
+# Makefile — Python + uv (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# All commands use `uv run` for dependency isolation.
+# Copy to your project root as "Makefile" and customize.
+
+.PHONY: lint test typecheck format build deploy clean verify
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	uv run ruff check .
+
+test:
+	uv run pytest
+
+## Recommended targets
+
+typecheck:
+	uv run mypy .
+
+format:
+	uv run ruff format .
+
+build:
+	uv build
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test typecheck
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  ssh prod 'cd /app && git pull && systemctl restart app'"
+	@echo "  docker compose up -d --build"
+
+## Utilities
+
+clean:
+	rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache dist build *.egg-info .venv

--- a/templates/makefiles/rust.mk
+++ b/templates/makefiles/rust.mk
@@ -1,0 +1,47 @@
+# Makefile — Rust (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# Requires: cargo, clippy, rustfmt
+# Copy to your project root as "Makefile" and customize.
+
+.PHONY: lint test format build build-release deploy clean verify
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	cargo clippy -- -D warnings
+
+test:
+	cargo test
+
+## Recommended targets
+
+format:
+	cargo fmt
+
+build:
+	cargo build
+
+build-release:
+	cargo build --release
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify build-release
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  scp target/release/$(shell basename $(CURDIR)) prod:/usr/local/bin/"
+	@echo "  docker build -t $(shell basename $(CURDIR)) ."
+
+## Utilities
+
+clean:
+	cargo clean


### PR DESCRIPTION
## Summary

- Create 7 framework-specific Makefile templates in `templates/makefiles/`
- Create `templates/cicd.yml.example` — documented config for `.claude/cicd.yml`
- Each template includes standard targets: lint, test, build, deploy, clean, verify
- Commands match `FRAMEWORK_RUNNERS` from `lib/cicd/models.py`

## Templates

| Template | Framework | Key Commands |
|----------|-----------|-------------|
| `python-uv.mk` | Python + uv | `uv run ruff`, `uv run pytest`, `uv run mypy` |
| `python-pip.mk` | Python + pip | `python -m ruff`, `python -m pytest`, `python -m mypy` |
| `node-npm.mk` | Node + npm | `npm run lint`, `npm test`, `npx tsc` |
| `node-yarn.mk` | Node + yarn | `yarn lint`, `yarn test`, `yarn tsc` |
| `go.mk` | Go | `golangci-lint run`, `go test`, `go build` |
| `rust.mk` | Rust | `cargo clippy`, `cargo test`, `cargo build` |
| `multi.mk` | Polyglot | Delegates to sub-project Makefiles |

## Test plan

- [x] All 7 templates parse without syntax errors (`make -n`)
- [x] Each template has lint, test, build, deploy, clean, verify targets
- [x] `cicd.yml.example` documents all config sections
- [x] Commands match `lib/cicd/models.py` FRAMEWORK_RUNNERS

Closes #143
Part of #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)