### PR TITLE
feat(cicd): Add health check and smoke test modules (Closes #145)

### DIFF
--- a/lib/cicd/__init__.py
+++ b/lib/cicd/__init__.py
@@ -3,6 +3,8 @@
 Provides:
 - Framework detection (Python/Node/Go/Rust/multi)
 - Makefile validation and generation
+- Health checks (HTTP endpoints, process ports)
+- Smoke tests (command execution with assertions)
 - Configuration from .claude/cicd.yml
 
 Quick Start:
@@ -16,25 +18,47 @@ Quick Start:
     result = check_makefile("/path/to/project")
     for gap in result.missing_required:
         print(f"Missing: {gap}")
+
+    # Run health checks
+    from lib.cicd import run_health_checks
+    result = run_health_checks(project_root="/path/to/project")
+    print(result.summary_line())
+
+    # Run smoke tests
+    from lib.cicd import run_smoke_tests
+    result = run_smoke_tests(project_root="/path/to/project")
+    print(result.summary_line())
 """
 
 from .config import CICDConfig
 from .detector import detect_framework
+from .health import check_endpoint, check_process, run_health_checks
 from .makefile import check_makefile, generate_makefile, parse_makefile
-from .pipeline import generate_github_actions, generate_pipeline, generate_woodpecker
 from .models import (
     Framework,
     FrameworkInfo,
+    HealthCheckEntry,
+    HealthCheckResult,
     MakefileCheckResult,
     MakefileTarget,
     PackageManager,
+    SmokeTestEntry,
+    SmokeTestResult,
 )
+from .pipeline import generate_github_actions, generate_pipeline, generate_woodpecker
+from .smoke import run_smoke_tests
 
 __all__ = [
     # Config
     "CICDConfig",
     # Detector
     "detect_framework",
+    # Health
+    "run_health_checks",
+    "check_endpoint",
+    "check_process",
+    # Smoke
+    "run_smoke_tests",
     # Makefile
     "check_makefile",
     "generate_makefile",
@@ -46,7 +70,11 @@ __all__ = [
     # Models
     "Framework",
     "FrameworkInfo",
+    "HealthCheckEntry",
+    "HealthCheckResult",
     "MakefileCheckResult",
     "MakefileTarget",
     "PackageManager",
+    "SmokeTestEntry",
+    "SmokeTestResult",
 ]

--- a/lib/cicd/cli.py
+++ b/lib/cicd/cli.py
@@ -3,6 +3,8 @@
 Usage:
     python -m lib.cicd detect [OPTIONS]
     python -m lib.cicd check [OPTIONS]
+    python -m lib.cicd health [OPTIONS]
+    python -m lib.cicd smoke [OPTIONS]
 
 Examples:
     python -m lib.cicd detect
@@ -10,6 +12,10 @@ Examples:
     python -m lib.cicd check
     python -m lib.cicd check --summary
     python -m lib.cicd check --json
+    python -m lib.cicd health
+    python -m lib.cicd health --json
+    python -m lib.cicd smoke
+    python -m lib.cicd smoke --json
 """
 
 from __future__ import annotations
@@ -22,8 +28,10 @@ from typing import NoReturn
 
 from .config import CICDConfig
 from .detector import detect_framework
+from .health import run_health_checks
 from .makefile import check_makefile
 from .pipeline import generate_pipeline
+from .smoke import run_smoke_tests
 
 
 def cmd_detect(args: argparse.Namespace) -> int:
@@ -167,6 +175,88 @@ def cmd_pipeline(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_health(args: argparse.Namespace) -> int:
+    """Run health checks against configured endpoints and processes."""
+    config = CICDConfig.load(args.path)
+    result = run_health_checks(config=config, project_root=args.path)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+        return 0 if result.all_passed else 1
+
+    if args.summary:
+        print(result.summary_line())
+        return 0 if result.all_passed else 1
+
+    if not result.checks:
+        print("Health Check: no checks configured")
+        print()
+        print("  Configure endpoints and processes in .claude/cicd.yml:")
+        print("    health:")
+        print("      endpoints:")
+        print("        - url: http://localhost:8000/health")
+        print("          name: API Server")
+        print("      processes:")
+        print("        - name: uvicorn")
+        print("          port: 8000")
+        return 0
+
+    print("## Health Checks")
+    print()
+    print("| Check | Type | Status | Detail | Time |")
+    print("|-------|------|--------|--------|------|")
+
+    for check in result.checks:
+        status = "PASS" if check.passed else "FAIL"
+        elapsed = f"{check.elapsed_ms:.0f}ms"
+        print(f"| {check.name} | {check.kind} | {status} | {check.detail} | {elapsed} |")
+
+    print()
+    print(f"Result: {result.summary_line()}")
+
+    return 0 if result.all_passed else 1
+
+
+def cmd_smoke(args: argparse.Namespace) -> int:
+    """Run smoke tests from cicd.yml configuration."""
+    config = CICDConfig.load(args.path)
+    result = run_smoke_tests(config=config, project_root=args.path)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+        return 0 if result.all_passed else 1
+
+    if args.summary:
+        print(result.summary_line())
+        return 0 if result.all_passed else 1
+
+    if not result.tests:
+        print("Smoke Tests: no tests configured")
+        print()
+        print("  Configure smoke tests in .claude/cicd.yml:")
+        print("    health:")
+        print("      smoke_tests:")
+        print("        - name: API responds")
+        print('          command: "curl -sf http://localhost:8000/health"')
+        print("          expected_exit: 0")
+        return 0
+
+    print("## Smoke Tests")
+    print()
+    print("| Test | Status | Detail | Time |")
+    print("|------|--------|--------|------|")
+
+    for test in result.tests:
+        status = "PASS" if test.passed else "FAIL"
+        elapsed = f"{test.elapsed_ms:.0f}ms"
+        print(f"| {test.name} | {status} | {test.detail} | {elapsed} |")
+
+    print()
+    print(f"Result: {result.summary_line()}")
+
+    return 0 if result.all_passed else 1
+
+
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add common arguments to a parser."""
     parser.add_argument(
@@ -218,6 +308,32 @@ def create_parser() -> argparse.ArgumentParser:
         help="One-line summary for flow integration",
     )
 
+    # 'health' subcommand
+    health_parser = subparsers.add_parser(
+        "health",
+        help="Run health checks against configured endpoints and processes",
+    )
+    _add_common_args(health_parser)
+    health_parser.add_argument(
+        "--summary",
+        "-s",
+        action="store_true",
+        help="One-line summary for flow integration",
+    )
+
+    # 'smoke' subcommand
+    smoke_parser = subparsers.add_parser(
+        "smoke",
+        help="Run smoke tests from cicd.yml configuration",
+    )
+    _add_common_args(smoke_parser)
+    smoke_parser.add_argument(
+        "--summary",
+        "-s",
+        action="store_true",
+        help="One-line summary for flow integration",
+    )
+
     # 'pipeline' subcommand
     pipeline_parser = subparsers.add_parser(
         "pipeline",
@@ -252,6 +368,8 @@ def main(argv: list[str] | None = None) -> int:
     commands = {
         "detect": cmd_detect,
         "check": cmd_check,
+        "health": cmd_health,
+        "smoke": cmd_smoke,
         "pipeline": cmd_pipeline,
     }
 

--- a/lib/cicd/health.py
+++ b/lib/cicd/health.py
@@ -1,0 +1,261 @@
+"""Health check runner for CI/CD & Verification.
+
+Checks HTTP endpoints and running processes to verify deployment health.
+Uses curl for HTTP checks and ss/lsof for process checks — no Python deps.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from .config import CICDConfig, HealthEndpoint, ProcessCheck
+from .models import HealthCheckEntry, HealthCheckResult
+
+
+def run_health_checks(
+    config: Optional[CICDConfig] = None,
+    project_root: Optional[str] = None,
+) -> HealthCheckResult:
+    """Run all configured health checks.
+
+    Args:
+        config: CI/CD config (loaded from project_root if None).
+        project_root: Project root for config loading.
+
+    Returns:
+        HealthCheckResult with all check entries.
+    """
+    if config is None:
+        config = CICDConfig.load(project_root)
+
+    result = HealthCheckResult()
+
+    # Wait for startup if configured
+    if config.health.startup_delay > 0:
+        time.sleep(config.health.startup_delay)
+
+    # Run endpoint checks
+    for endpoint in config.health.endpoints:
+        entry = check_endpoint(endpoint)
+        result.checks.append(entry)
+
+    # Run process checks
+    for process in config.health.processes:
+        entry = check_process(process)
+        result.checks.append(entry)
+
+    return result
+
+
+def check_endpoint(endpoint: HealthEndpoint) -> HealthCheckEntry:
+    """Check a single HTTP endpoint using curl.
+
+    Args:
+        endpoint: Endpoint configuration.
+
+    Returns:
+        HealthCheckEntry with pass/fail and details.
+    """
+    name = endpoint.name or endpoint.url
+    start = time.monotonic()
+
+    curl_path = shutil.which("curl")
+    if not curl_path:
+        return HealthCheckEntry(
+            name=name,
+            kind="endpoint",
+            passed=False,
+            detail="curl not found in PATH",
+        )
+
+    try:
+        # Use curl to get status code and body
+        proc = subprocess.run(
+            [
+                curl_path,
+                "-sf",
+                "-o", "/dev/stdout",
+                "-w", "\n%{http_code}",
+                "--max-time", str(endpoint.timeout),
+                endpoint.url,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=endpoint.timeout + 2,
+        )
+        elapsed = (time.monotonic() - start) * 1000
+
+        # Parse output: body lines + last line is status code
+        output_lines = proc.stdout.rstrip("\n").rsplit("\n", 1)
+        if len(output_lines) == 2:
+            body, status_str = output_lines
+        elif len(output_lines) == 1:
+            # Could be just status code (empty body) or just body (no code)
+            try:
+                int(output_lines[0])
+                body, status_str = "", output_lines[0]
+            except ValueError:
+                body, status_str = output_lines[0], ""
+        else:
+            body, status_str = "", ""
+
+        # If curl failed entirely (connection refused, etc.)
+        if proc.returncode != 0 and not status_str:
+            stderr = proc.stderr.strip()
+            detail = stderr if stderr else f"curl exit code {proc.returncode}"
+            return HealthCheckEntry(
+                name=name,
+                kind="endpoint",
+                passed=False,
+                detail=detail,
+                elapsed_ms=elapsed,
+            )
+
+        try:
+            status_code = int(status_str)
+        except (ValueError, TypeError):
+            return HealthCheckEntry(
+                name=name,
+                kind="endpoint",
+                passed=False,
+                detail="Could not parse HTTP status from curl output",
+                elapsed_ms=elapsed,
+            )
+
+        # Check status code
+        if status_code != endpoint.expected_status:
+            return HealthCheckEntry(
+                name=name,
+                kind="endpoint",
+                passed=False,
+                detail=f"HTTP {status_code} (expected {endpoint.expected_status})",
+                elapsed_ms=elapsed,
+            )
+
+        # Check body content if specified
+        if endpoint.expected_body and endpoint.expected_body not in body:
+            return HealthCheckEntry(
+                name=name,
+                kind="endpoint",
+                passed=False,
+                detail=f"Response body missing expected content: {endpoint.expected_body!r}",
+                elapsed_ms=elapsed,
+            )
+
+        return HealthCheckEntry(
+            name=name,
+            kind="endpoint",
+            passed=True,
+            detail=f"HTTP {status_code}",
+            elapsed_ms=elapsed,
+        )
+
+    except subprocess.TimeoutExpired:
+        elapsed = (time.monotonic() - start) * 1000
+        return HealthCheckEntry(
+            name=name,
+            kind="endpoint",
+            passed=False,
+            detail=f"Timeout after {endpoint.timeout}s",
+            elapsed_ms=elapsed,
+        )
+    except OSError as e:
+        elapsed = (time.monotonic() - start) * 1000
+        return HealthCheckEntry(
+            name=name,
+            kind="endpoint",
+            passed=False,
+            detail=str(e),
+            elapsed_ms=elapsed,
+        )
+
+
+def check_process(process: ProcessCheck) -> HealthCheckEntry:
+    """Check if a process is listening on the expected port.
+
+    Uses ss (preferred) or lsof as fallback.
+
+    Args:
+        process: Process check configuration.
+
+    Returns:
+        HealthCheckEntry with pass/fail and details.
+    """
+    name = f"{process.name} (port {process.port})"
+    start = time.monotonic()
+
+    # Try ss first (Linux standard)
+    ss_path = shutil.which("ss")
+    if ss_path:
+        try:
+            proc = subprocess.run(
+                [ss_path, "-tlnp"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            elapsed = (time.monotonic() - start) * 1000
+
+            port_str = f":{process.port}"
+            for line in proc.stdout.splitlines():
+                if port_str in line:
+                    return HealthCheckEntry(
+                        name=name,
+                        kind="process",
+                        passed=True,
+                        detail=f"Listening on port {process.port}",
+                        elapsed_ms=elapsed,
+                    )
+
+            return HealthCheckEntry(
+                name=name,
+                kind="process",
+                passed=False,
+                detail=f"Nothing listening on port {process.port}",
+                elapsed_ms=elapsed,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            pass  # Fall through to lsof
+
+    # Try lsof fallback (macOS, some Linux)
+    lsof_path = shutil.which("lsof")
+    if lsof_path:
+        try:
+            proc = subprocess.run(
+                [lsof_path, "-i", f":{process.port}", "-sTCP:LISTEN", "-P", "-n"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            elapsed = (time.monotonic() - start) * 1000
+
+            if proc.returncode == 0 and proc.stdout.strip():
+                return HealthCheckEntry(
+                    name=name,
+                    kind="process",
+                    passed=True,
+                    detail=f"Listening on port {process.port}",
+                    elapsed_ms=elapsed,
+                )
+
+            return HealthCheckEntry(
+                name=name,
+                kind="process",
+                passed=False,
+                detail=f"Nothing listening on port {process.port}",
+                elapsed_ms=elapsed,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    elapsed = (time.monotonic() - start) * 1000
+    return HealthCheckEntry(
+        name=name,
+        kind="process",
+        passed=False,
+        detail="Neither ss nor lsof found in PATH",
+        elapsed_ms=elapsed,
+    )

--- a/lib/cicd/models.py
+++ b/lib/cicd/models.py
@@ -6,6 +6,8 @@ Provides:
 - FrameworkInfo: Detection results with recommendations
 - MakefileTarget: A parsed Makefile target
 - MakefileCheckResult: Validation results for a Makefile
+- HealthCheckResult: Results from health endpoint/process checks
+- SmokeTestResult: Results from smoke test execution
 """
 
 from __future__ import annotations
@@ -194,4 +196,126 @@ class MakefileCheckResult:
             "issues": self.issues,
             "is_healthy": self.is_healthy,
             "target_coverage": self.target_coverage,
+        }
+
+
+@dataclass
+class HealthCheckEntry:
+    """Result of a single health check (endpoint or process)."""
+
+    name: str
+    kind: str  # "endpoint" or "process"
+    passed: bool
+    detail: str = ""
+    elapsed_ms: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "passed": self.passed,
+            "detail": self.detail,
+            "elapsed_ms": round(self.elapsed_ms, 1),
+        }
+
+
+@dataclass
+class HealthCheckResult:
+    """Aggregated results from all health checks."""
+
+    checks: list[HealthCheckEntry] = field(default_factory=list)
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for c in self.checks if c.passed)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for c in self.checks if not c.passed)
+
+    @property
+    def total(self) -> int:
+        return len(self.checks)
+
+    @property
+    def all_passed(self) -> bool:
+        return self.total > 0 and self.failed == 0
+
+    def summary_line(self) -> str:
+        if not self.checks:
+            return "Health: no checks configured"
+        if self.all_passed:
+            return f"Health: {self.passed}/{self.total} checks passed"
+        return f"Health: {self.failed}/{self.total} checks FAILED"
+
+    def to_dict(self) -> dict:
+        return {
+            "checks": [c.to_dict() for c in self.checks],
+            "passed": self.passed,
+            "failed": self.failed,
+            "total": self.total,
+            "all_passed": self.all_passed,
+        }
+
+
+@dataclass
+class SmokeTestEntry:
+    """Result of a single smoke test."""
+
+    name: str
+    command: str
+    passed: bool
+    exit_code: int = 0
+    output: str = ""
+    detail: str = ""
+    elapsed_ms: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "command": self.command,
+            "passed": self.passed,
+            "exit_code": self.exit_code,
+            "output": self.output,
+            "detail": self.detail,
+            "elapsed_ms": round(self.elapsed_ms, 1),
+        }
+
+
+@dataclass
+class SmokeTestResult:
+    """Aggregated results from all smoke tests."""
+
+    tests: list[SmokeTestEntry] = field(default_factory=list)
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for t in self.tests if t.passed)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for t in self.tests if not t.passed)
+
+    @property
+    def total(self) -> int:
+        return len(self.tests)
+
+    @property
+    def all_passed(self) -> bool:
+        return self.total > 0 and self.failed == 0
+
+    def summary_line(self) -> str:
+        if not self.tests:
+            return "Smoke: no tests configured"
+        if self.all_passed:
+            return f"Smoke: {self.passed}/{self.total} tests passed"
+        return f"Smoke: {self.failed}/{self.total} tests FAILED"
+
+    def to_dict(self) -> dict:
+        return {
+            "tests": [t.to_dict() for t in self.tests],
+            "passed": self.passed,
+            "failed": self.failed,
+            "total": self.total,
+            "all_passed": self.all_passed,
         }

--- a/lib/cicd/smoke.py
+++ b/lib/cicd/smoke.py
@@ -1,0 +1,123 @@
+"""Smoke test runner for CI/CD & Verification.
+
+Executes lightweight smoke tests defined in .claude/cicd.yml.
+Each test runs a shell command and checks exit code and optional output patterns.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from typing import Optional
+
+from .config import CICDConfig, SmokeTest
+from .models import SmokeTestEntry, SmokeTestResult
+
+
+def run_smoke_tests(
+    config: Optional[CICDConfig] = None,
+    project_root: Optional[str] = None,
+) -> SmokeTestResult:
+    """Run all configured smoke tests.
+
+    Args:
+        config: CI/CD config (loaded from project_root if None).
+        project_root: Project root for config loading.
+
+    Returns:
+        SmokeTestResult with all test entries.
+    """
+    if config is None:
+        config = CICDConfig.load(project_root)
+
+    result = SmokeTestResult()
+
+    for test in config.health.smoke_tests:
+        entry = run_single_test(test)
+        result.tests.append(entry)
+
+    return result
+
+
+def run_single_test(test: SmokeTest) -> SmokeTestEntry:
+    """Run a single smoke test.
+
+    Args:
+        test: Smoke test configuration.
+
+    Returns:
+        SmokeTestEntry with pass/fail and details.
+    """
+    start = time.monotonic()
+
+    try:
+        proc = subprocess.run(
+            test.command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=test.timeout,
+        )
+        elapsed = (time.monotonic() - start) * 1000
+
+        output = proc.stdout.strip()
+        stderr = proc.stderr.strip()
+        passed = True
+        detail_parts = []
+
+        # Check exit code
+        if proc.returncode != test.expected_exit:
+            passed = False
+            detail_parts.append(
+                f"exit {proc.returncode} (expected {test.expected_exit})"
+            )
+
+        # Check expected output if specified
+        if test.expected_output:
+            if test.expected_output not in output:
+                passed = False
+                detail_parts.append(
+                    f"output missing: {test.expected_output!r}"
+                )
+
+        if passed:
+            detail = f"exit {proc.returncode}"
+        else:
+            detail = "; ".join(detail_parts)
+            # Append stderr for debugging if available
+            if stderr and not passed:
+                # Truncate long stderr
+                if len(stderr) > 200:
+                    stderr = stderr[:200] + "..."
+                detail += f" | stderr: {stderr}"
+
+        return SmokeTestEntry(
+            name=test.name,
+            command=test.command,
+            passed=passed,
+            exit_code=proc.returncode,
+            output=output[:500] if output else "",
+            detail=detail,
+            elapsed_ms=elapsed,
+        )
+
+    except subprocess.TimeoutExpired:
+        elapsed = (time.monotonic() - start) * 1000
+        return SmokeTestEntry(
+            name=test.name,
+            command=test.command,
+            passed=False,
+            exit_code=-1,
+            detail=f"Timeout after {test.timeout}s",
+            elapsed_ms=elapsed,
+        )
+    except OSError as e:
+        elapsed = (time.monotonic() - start) * 1000
+        return SmokeTestEntry(
+            name=test.name,
+            command=test.command,
+            passed=False,
+            exit_code=-1,
+            detail=str(e),
+            elapsed_ms=elapsed,
+        )

--- a/tests/test_cicd_health.py
+++ b/tests/test_cicd_health.py
@@ -1,0 +1,301 @@
+"""Tests for lib/cicd/health.py and lib/cicd/smoke.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from lib.cicd.config import CICDConfig, HealthEndpoint, ProcessCheck, SmokeTest
+from lib.cicd.health import check_endpoint, check_process, run_health_checks
+from lib.cicd.models import HealthCheckEntry, HealthCheckResult
+from lib.cicd.smoke import run_single_test, run_smoke_tests
+from lib.cicd.models import SmokeTestEntry, SmokeTestResult
+
+
+class TestHealthCheckModels:
+    """Test HealthCheckResult and HealthCheckEntry."""
+
+    def test_empty_result(self) -> None:
+        result = HealthCheckResult()
+        assert result.total == 0
+        assert result.passed == 0
+        assert result.failed == 0
+        assert not result.all_passed
+        assert "no checks configured" in result.summary_line()
+
+    def test_all_passed(self) -> None:
+        result = HealthCheckResult(
+            checks=[
+                HealthCheckEntry(name="api", kind="endpoint", passed=True),
+                HealthCheckEntry(name="db", kind="process", passed=True),
+            ]
+        )
+        assert result.total == 2
+        assert result.passed == 2
+        assert result.failed == 0
+        assert result.all_passed
+        assert "2/2" in result.summary_line()
+
+    def test_some_failed(self) -> None:
+        result = HealthCheckResult(
+            checks=[
+                HealthCheckEntry(name="api", kind="endpoint", passed=True),
+                HealthCheckEntry(name="db", kind="process", passed=False),
+            ]
+        )
+        assert result.total == 2
+        assert result.passed == 1
+        assert result.failed == 1
+        assert not result.all_passed
+        assert "FAILED" in result.summary_line()
+
+    def test_to_dict(self) -> None:
+        entry = HealthCheckEntry(
+            name="api", kind="endpoint", passed=True, detail="HTTP 200", elapsed_ms=42.5
+        )
+        d = entry.to_dict()
+        assert d["name"] == "api"
+        assert d["kind"] == "endpoint"
+        assert d["passed"] is True
+        assert d["elapsed_ms"] == 42.5
+
+
+class TestCheckEndpoint:
+    """Test check_endpoint function."""
+
+    @patch("lib.cicd.health.shutil.which")
+    def test_curl_not_found(self, mock_which: MagicMock) -> None:
+        mock_which.return_value = None
+        endpoint = HealthEndpoint(url="http://localhost:8080/health")
+        result = check_endpoint(endpoint)
+        assert not result.passed
+        assert "curl not found" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_successful_check(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/curl"
+        mock_run.return_value = MagicMock(
+            stdout='{"status":"ok"}\n200',
+            stderr="",
+            returncode=0,
+        )
+        endpoint = HealthEndpoint(url="http://localhost:8080/health")
+        result = check_endpoint(endpoint)
+        assert result.passed
+        assert "200" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_wrong_status_code(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/curl"
+        mock_run.return_value = MagicMock(
+            stdout="\n500",
+            stderr="",
+            returncode=0,
+        )
+        endpoint = HealthEndpoint(url="http://localhost:8080/health", expected_status=200)
+        result = check_endpoint(endpoint)
+        assert not result.passed
+        assert "500" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_expected_body_missing(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/curl"
+        mock_run.return_value = MagicMock(
+            stdout='{"status":"error"}\n200',
+            stderr="",
+            returncode=0,
+        )
+        endpoint = HealthEndpoint(
+            url="http://localhost:8080/health",
+            expected_body="ok",
+        )
+        result = check_endpoint(endpoint)
+        assert not result.passed
+        assert "missing expected content" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_connection_refused(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/curl"
+        mock_run.return_value = MagicMock(
+            stdout="",
+            stderr="curl: (7) Failed to connect",
+            returncode=7,
+        )
+        endpoint = HealthEndpoint(url="http://localhost:9999/health")
+        result = check_endpoint(endpoint)
+        assert not result.passed
+        assert "Failed to connect" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_timeout(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        import subprocess
+
+        mock_which.return_value = "/usr/bin/curl"
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="curl", timeout=5)
+        endpoint = HealthEndpoint(url="http://localhost:8080/health", timeout=5)
+        result = check_endpoint(endpoint)
+        assert not result.passed
+        assert "Timeout" in result.detail
+
+
+class TestCheckProcess:
+    """Test check_process function."""
+
+    @patch("lib.cicd.health.shutil.which")
+    def test_no_tools_available(self, mock_which: MagicMock) -> None:
+        mock_which.return_value = None
+        process = ProcessCheck(name="uvicorn", port=8000)
+        result = check_process(process)
+        assert not result.passed
+        assert "Neither ss nor lsof" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_process_found_via_ss(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/ss"
+        mock_run.return_value = MagicMock(
+            stdout="LISTEN  0  128  *:8000  *:*  users:((\"uvicorn\",pid=1234))\n",
+            returncode=0,
+        )
+        process = ProcessCheck(name="uvicorn", port=8000)
+        result = check_process(process)
+        assert result.passed
+        assert "Listening" in result.detail
+
+    @patch("lib.cicd.health.subprocess.run")
+    @patch("lib.cicd.health.shutil.which")
+    def test_process_not_found(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/ss"
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        process = ProcessCheck(name="uvicorn", port=8000)
+        result = check_process(process)
+        assert not result.passed
+        assert "Nothing listening" in result.detail
+
+
+class TestRunHealthChecks:
+    """Test run_health_checks orchestrator."""
+
+    def test_no_config(self) -> None:
+        config = CICDConfig()
+        result = run_health_checks(config=config)
+        assert result.total == 0
+        assert "no checks configured" in result.summary_line()
+
+    @patch("lib.cicd.health.check_endpoint")
+    @patch("lib.cicd.health.check_process")
+    def test_with_endpoints_and_processes(
+        self, mock_proc: MagicMock, mock_ep: MagicMock
+    ) -> None:
+        mock_ep.return_value = HealthCheckEntry(
+            name="api", kind="endpoint", passed=True
+        )
+        mock_proc.return_value = HealthCheckEntry(
+            name="db", kind="process", passed=True
+        )
+        config = CICDConfig()
+        config.health.endpoints = [
+            HealthEndpoint(url="http://localhost:8000/health")
+        ]
+        config.health.processes = [ProcessCheck(name="postgres", port=5432)]
+        result = run_health_checks(config=config)
+        assert result.total == 2
+        assert result.all_passed
+
+
+class TestSmokeTestModels:
+    """Test SmokeTestResult and SmokeTestEntry."""
+
+    def test_empty_result(self) -> None:
+        result = SmokeTestResult()
+        assert result.total == 0
+        assert "no tests configured" in result.summary_line()
+
+    def test_all_passed(self) -> None:
+        result = SmokeTestResult(
+            tests=[
+                SmokeTestEntry(name="curl test", command="curl -sf ...", passed=True),
+            ]
+        )
+        assert result.all_passed
+        assert "1/1" in result.summary_line()
+
+    def test_to_dict(self) -> None:
+        entry = SmokeTestEntry(
+            name="test", command="echo ok", passed=True, exit_code=0,
+            output="ok", detail="exit 0", elapsed_ms=10.2,
+        )
+        d = entry.to_dict()
+        assert d["name"] == "test"
+        assert d["passed"] is True
+        assert d["exit_code"] == 0
+
+
+class TestRunSingleTest:
+    """Test run_single_test function."""
+
+    @patch("lib.cicd.smoke.subprocess.run")
+    def test_successful_test(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            stdout="ok\n", stderr="", returncode=0,
+        )
+        test = SmokeTest(name="echo test", command="echo ok")
+        result = run_single_test(test)
+        assert result.passed
+        assert result.exit_code == 0
+
+    @patch("lib.cicd.smoke.subprocess.run")
+    def test_failed_exit_code(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            stdout="", stderr="error", returncode=1,
+        )
+        test = SmokeTest(name="fail test", command="false")
+        result = run_single_test(test)
+        assert not result.passed
+        assert "exit 1" in result.detail
+
+    @patch("lib.cicd.smoke.subprocess.run")
+    def test_expected_output_missing(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            stdout="wrong output\n", stderr="", returncode=0,
+        )
+        test = SmokeTest(name="output test", command="echo wrong", expected_output="expected")
+        result = run_single_test(test)
+        assert not result.passed
+        assert "output missing" in result.detail
+
+    @patch("lib.cicd.smoke.subprocess.run")
+    def test_timeout(self, mock_run: MagicMock) -> None:
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sleep", timeout=10)
+        test = SmokeTest(name="timeout test", command="sleep 100", timeout=10)
+        result = run_single_test(test)
+        assert not result.passed
+        assert "Timeout" in result.detail
+
+
+class TestRunSmokeTests:
+    """Test run_smoke_tests orchestrator."""
+
+    def test_no_config(self) -> None:
+        config = CICDConfig()
+        result = run_smoke_tests(config=config)
+        assert result.total == 0
+
+    @patch("lib.cicd.smoke.run_single_test")
+    def test_with_tests(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = SmokeTestEntry(
+            name="test", command="echo ok", passed=True,
+        )
+        config = CICDConfig()
+        config.health.smoke_tests = [
+            SmokeTest(name="test", command="echo ok"),
+        ]
+        result = run_smoke_tests(config=config)
+        assert result.total == 1
+        assert result.all_passed


### PR DESCRIPTION
## Summary
- Add `lib/cicd/health.py` — HTTP endpoint checks (via curl) and process port checks (via ss/lsof) with configurable status codes, response body matching, and timeouts
- Add `lib/cicd/smoke.py` — command-based smoke test runner with exit code and output pattern verification
- Add `HealthCheckResult`, `HealthCheckEntry`, `SmokeTestResult`, `SmokeTestEntry` dataclasses to `models.py`
- Add `health` and `smoke` CLI subcommands with table, JSON, and summary output modes
- 24 unit tests covering all functions, error paths, and edge cases

## Test plan
- [x] `python3 -m lib.cicd health` with no config shows guidance message
- [x] `python3 -m lib.cicd smoke` with no config shows guidance message
- [x] Health checks detect running processes and failed endpoints
- [x] Smoke tests verify exit codes and output patterns
- [x] JSON output mode works for both commands
- [x] Summary mode works for both commands
- [x] Connection refused, timeout, and unexpected status handled gracefully
- [x] 24/24 unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)