### PR TITLE
feat(mcp): Add --stdio transport to all MCP servers (Closes #138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,10 @@ This repository contains four core components and optional extras:
 
 - Python 3.11+
 - Use uv for dependency management (pyproject.toml)
-- MCP Second Opinion: port 8080
-- MCP Playwright: port 8081
-- MCP Coordination: port 8082
+- MCP servers support both stdio (recommended) and SSE transport
+- MCP Second Opinion: port 8080 (SSE) or `--stdio`
+- MCP Playwright: port 8081 (SSE) or `--stdio`
+- MCP Coordination: port 8082 (SSE) or `--stdio`
 - All documentation uses progressive disclosure principles
 
 ## Environment Variables
@@ -781,6 +782,12 @@ uv run playwright install chromium
 
 ### Add to Claude Code
 
+**stdio (recommended — auto-start, no manual server management):**
+```bash
+claude mcp add playwright-persistent --transport stdio -- uv run --directory /path/to/claude-power-pack/mcp-playwright-persistent python src/server.py --stdio
+```
+
+**SSE (for systemd/docker deployments):**
 ```bash
 claude mcp add playwright-persistent --transport sse --url http://127.0.0.1:8081/sse
 ```
@@ -937,12 +944,12 @@ This project uses [uv](https://docs.astral.sh/uv/) for Python dependency managem
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Run any MCP server (dependencies installed automatically)
+# stdio mode (recommended — Claude Code auto-manages the server)
+claude mcp add second-opinion --transport stdio -- uv run --directory /path/to/mcp-second-opinion python src/server.py --stdio
+
+# Or SSE mode (manual start, for systemd/docker)
 cd mcp-second-opinion
 ./start-server.sh
-
-# Or run directly with uv
-uv run python src/server.py
 ```
 
 ### Project Structure

--- a/extras/redis-coordination/mcp-server/src/server.py
+++ b/extras/redis-coordination/mcp-server/src/server.py
@@ -13,6 +13,8 @@ Lock naming follows wave/issue pattern:
 - "wave:5c.1" - Lock for wave 5c issue 1
 - "pytest", "pr-create" - Resource locks
 """
+import argparse
+
 from fastmcp import FastMCP
 
 from config import config
@@ -257,15 +259,25 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Main entry point for the MCP server."""
-    logger.info(f"Starting {config.SERVER_NAME}")
-    logger.info(f"Transport: SSE on 127.0.0.1:{config.SERVER_PORT}")
-
-    # Run the MCP server with SSE transport
-    mcp.run(
-        transport="sse",
-        host="127.0.0.1",
-        port=config.SERVER_PORT,
+    parser = argparse.ArgumentParser(description=config.SERVER_NAME)
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Run with stdio transport (for Claude Code auto-start)",
     )
+    args = parser.parse_args()
+
+    if args.stdio:
+        logger.info(f"Starting {config.SERVER_NAME} via stdio transport")
+        mcp.run(transport="stdio")
+    else:
+        logger.info(f"Starting {config.SERVER_NAME}")
+        logger.info(f"Transport: SSE on 127.0.0.1:{config.SERVER_PORT}")
+        mcp.run(
+            transport="sse",
+            host="127.0.0.1",
+            port=config.SERVER_PORT,
+        )
 
 
 if __name__ == "__main__":

--- a/mcp-playwright-persistent/README.md
+++ b/mcp-playwright-persistent/README.md
@@ -26,8 +26,11 @@ uv run playwright install chromium
 # 3. Start server (uv handles dependencies automatically)
 ./start-server.sh
 
-# 4. Add to Claude Code
-claude mcp add playwright-persistent --transport sse --url http://127.0.0.1:8081/sse
+# 4. Add to Claude Code (stdio — recommended, auto-start)
+claude mcp add playwright-persistent --transport stdio -- uv run --directory /path/to/claude-power-pack/mcp-playwright-persistent python src/server.py --stdio
+
+# Or add via SSE (for systemd/docker deployments — requires manual start)
+# claude mcp add playwright-persistent --transport sse --url http://127.0.0.1:8081/sse
 ```
 
 ## Configuration

--- a/mcp-playwright-persistent/src/server.py
+++ b/mcp-playwright-persistent/src/server.py
@@ -13,6 +13,7 @@ Features:
 - Screenshot and PDF generation
 """
 
+import argparse
 import asyncio
 import base64
 import logging
@@ -999,14 +1000,24 @@ async def health_check() -> dict:
 
 def main():
     """Main entry point for the MCP server."""
-    logger.info(f"Starting MCP Playwright Persistent on {SERVER_HOST}:{SERVER_PORT}")
-
-    # Run the MCP server with SSE transport
-    mcp.run(
-        transport="sse",
-        host=SERVER_HOST,
-        port=SERVER_PORT,
+    parser = argparse.ArgumentParser(description="MCP Playwright Persistent")
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Run with stdio transport (for Claude Code auto-start)",
     )
+    args = parser.parse_args()
+
+    if args.stdio:
+        logger.info("Starting MCP Playwright Persistent via stdio transport")
+        mcp.run(transport="stdio")
+    else:
+        logger.info(f"Starting MCP Playwright Persistent on {SERVER_HOST}:{SERVER_PORT}")
+        mcp.run(
+            transport="sse",
+            host=SERVER_HOST,
+            port=SERVER_PORT,
+        )
 
 
 if __name__ == "__main__":

--- a/mcp-second-opinion/README.md
+++ b/mcp-second-opinion/README.md
@@ -21,6 +21,12 @@ uv run python src/server.py
 
 ## Add to Claude Code
 
+**stdio (recommended — auto-start, no manual server management):**
+```bash
+claude mcp add second-opinion --transport stdio -- uv run --directory /path/to/claude-power-pack/mcp-second-opinion python src/server.py --stdio
+```
+
+**SSE (for systemd/docker deployments):**
 ```bash
 claude mcp add second-opinion --transport sse --url http://127.0.0.1:8080/sse
 ```

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -7,6 +7,7 @@ Powered by Google Gemini, OpenAI (Codex + GPT-5.2), and Anthropic Claude.
 Supports multi-model consultation for comparing responses from different LLMs.
 """
 
+import argparse
 import asyncio
 import logging
 from datetime import datetime, timedelta
@@ -1852,8 +1853,21 @@ async def list_fetch_domains() -> dict:
 
 def main():
     """Main entry point for the MCP server."""
-    logger.info(f"Starting {Config.SERVER_NAME} v{Config.SERVER_VERSION}")
-    logger.info(f"Transport: SSE on {Config.SERVER_HOST}:{Config.SERVER_PORT}")
+    parser = argparse.ArgumentParser(description=Config.SERVER_NAME)
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Run with stdio transport (for Claude Code auto-start)",
+    )
+    args = parser.parse_args()
+
+    if args.stdio:
+        logger.info(f"Starting {Config.SERVER_NAME} v{Config.SERVER_VERSION}")
+        logger.info("Transport: stdio")
+    else:
+        logger.info(f"Starting {Config.SERVER_NAME} v{Config.SERVER_VERSION}")
+        logger.info(f"Transport: SSE on {Config.SERVER_HOST}:{Config.SERVER_PORT}")
+
     logger.info(f"Context caching: {'enabled' if Config.ENABLE_CONTEXT_CACHING else 'disabled'}")
 
     if not Config.GEMINI_API_KEY:
@@ -1863,13 +1877,14 @@ def main():
             "Get your API key from https://aistudio.google.com/apikey"
         )
 
-    # Run the MCP server with SSE transport
-    # This keeps the server running continuously, eliminating cold starts
-    mcp.run(
-        transport="sse",
-        host=Config.SERVER_HOST,
-        port=Config.SERVER_PORT,
-    )
+    if args.stdio:
+        mcp.run(transport="stdio")
+    else:
+        mcp.run(
+            transport="sse",
+            host=Config.SERVER_HOST,
+            port=Config.SERVER_PORT,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Added `--stdio` CLI flag to all 3 MCP servers (second-opinion, playwright-persistent, coordination)
- When `--stdio` is passed, servers run with stdio transport for Claude Code auto-start
- Default behavior (no flag) remains SSE for backwards compatibility with systemd/docker
- Updated CLAUDE.md and both server READMEs with stdio setup instructions

## Changes

| File | Change |
|------|--------|
| `mcp-second-opinion/src/server.py` | Added `argparse` + `--stdio` flag |
| `mcp-playwright-persistent/src/server.py` | Added `argparse` + `--stdio` flag |
| `extras/redis-coordination/mcp-server/src/server.py` | Added `argparse` + `--stdio` flag |
| `CLAUDE.md` | Updated key conventions + setup docs for stdio |
| `mcp-second-opinion/README.md` | Added stdio setup instructions |
| `mcp-playwright-persistent/README.md` | Added stdio setup instructions |

## Usage

```bash
# stdio (recommended — auto-start)
claude mcp add second-opinion --transport stdio -- uv run --directory /path/to/mcp-second-opinion python src/server.py --stdio

# SSE (backwards compatible)
./start-server.sh
```

## Test plan

- [ ] `python src/server.py --stdio` starts without error (both servers)
- [ ] `python src/server.py` (no flag) still starts SSE mode
- [ ] `./start-server.sh` still works for standalone SSE usage
- [ ] `claude mcp list` shows servers as "Connected" when configured with stdio

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)