### PR TITLE
feat(cicd): Add /cicd:health and /cicd:smoke commands (Closes #146)

### DIFF
--- a/.claude/commands/cicd/health.md
+++ b/.claude/commands/cicd/health.md
@@ -1,0 +1,130 @@
+---
+description: Run health checks against configured endpoints and processes
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(curl:*), Bash(ss:*), Bash(lsof:*), Bash(ls:*), Bash(test:*), Bash(cat:*), Read
+---
+
+# /cicd:health — Health Checks
+
+Run health checks against configured endpoints and processes.
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: claude-power-pack not found"
+  exit 1
+fi
+```
+
+---
+
+## Step 2: Check for Configuration
+
+```bash
+if [ ! -f ".claude/cicd.yml" ]; then
+  echo "No .claude/cicd.yml found in $(pwd)"
+  echo ""
+  echo "Create one with:"
+  echo "  /cicd:init    — Auto-detect framework and generate"
+  echo ""
+  echo "Or add health checks manually to .claude/cicd.yml:"
+  echo ""
+  echo "  health:"
+  echo "    endpoints:"
+  echo "      - url: http://localhost:8000/health"
+  echo "        name: API Server"
+  echo "    processes:"
+  echo "      - name: uvicorn"
+  echo "        port: 8000"
+  exit 1
+fi
+```
+
+If `.claude/cicd.yml` exists but has no `health:` section, the CLI will report "no checks configured" and show configuration guidance. This is handled gracefully — no error.
+
+---
+
+## Step 3: Run Health Checks
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd health
+```
+
+---
+
+## Step 4: Present Results
+
+The CLI outputs a markdown table. Present it to the user as-is.
+
+The report includes:
+- **Check table**: Each check's name, type, status (PASS/FAIL), detail, and response time
+- **Summary**: Overall pass/fail count
+
+### Interpreting Results
+
+| Status | Meaning |
+|--------|---------|
+| `PASS` | Check succeeded — endpoint reachable or process running |
+| `FAIL` | Check failed — endpoint unreachable, wrong status, or process not found |
+
+### Check Types
+
+| Type | What It Checks |
+|------|---------------|
+| `endpoint` | HTTP request to URL — checks status code and optional response body |
+| `process` | Port listening — uses `ss` or `lsof` to verify process is bound to port |
+
+### No Checks Configured
+
+If the CLI reports "no checks configured", guide the user:
+
+```
+No health checks configured.
+
+Add checks to .claude/cicd.yml:
+
+  health:
+    endpoints:
+      - url: http://localhost:8000/health
+        name: API Server
+        expected_status: 200
+        timeout: 5
+    processes:
+      - name: uvicorn
+        port: 8000
+
+Then re-run: /cicd:health
+```
+
+---
+
+## Step 5: Interactive Fallback (No Config)
+
+If no `.claude/cicd.yml` exists, ask the user what to check:
+
+1. Use AskUserQuestion: "What endpoints should I check? (e.g., http://localhost:8000/health)"
+2. If the user provides URLs, run `curl -sf -o /dev/null -w "%{http_code}" <URL>` for each
+3. Report results in the same table format
+4. Offer to save the configuration to `.claude/cicd.yml`
+
+---
+
+## Notes
+
+- Health checks are designed for local development verification
+- Endpoint checks use `curl` with configurable timeouts (default 5s)
+- Process checks use `ss -tlnp` (preferred) or `lsof -i` as fallback
+- All checks run sequentially with timing for each
+- Use `--json` flag for machine-readable output
+- Use `--summary` flag for one-line pass/fail (useful in scripts)
+- Configure checks in `.claude/cicd.yml` under the `health:` section

--- a/.claude/commands/cicd/help.md
+++ b/.claude/commands/cicd/help.md
@@ -8,6 +8,8 @@ Build, verify, and deploy automation for Claude Code projects.
 |---------|---------|
 | `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
 | `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
 | `/cicd:help` | This help page |
 
 ## How It Works
@@ -15,10 +17,13 @@ Build, verify, and deploy automation for Claude Code projects.
 ```
 /cicd:init  →  Detect framework  →  Generate Makefile  →  Generate .claude/cicd.yml
                                           ↓
-/cicd:check →  Validate targets  →  Report gaps  →  Suggest fixes
+/cicd:check  →  Validate targets  →  Report gaps  →  Suggest fixes
                                           ↓
-/flow:finish → make lint + make test      (quality gates)
-/flow:deploy → make deploy                (deployment)
+/flow:finish  → make lint + make test     (quality gates)
+/flow:deploy  → make deploy               (deployment)
+                                          ↓
+/cicd:health  →  Check endpoints  →  Check processes  →  Report status
+/cicd:smoke   →  Run smoke tests  →  Check results    →  Report pass/fail
 ```
 
 ## Supported Frameworks
@@ -60,6 +65,27 @@ deploy:
       requires_confirmation: true
 ```
 
+### Health & Smoke Configuration
+
+```yaml
+health:
+  endpoints:
+    - url: http://localhost:8000/health
+      name: API Server
+      expected_status: 200
+      timeout: 5
+  processes:
+    - name: uvicorn
+      port: 8000
+  smoke_tests:
+    - name: API responds
+      command: "curl -sf http://localhost:8000/health"
+      expected_exit: 0
+    - name: CLI version
+      command: "python -m myapp --version"
+      expected_output: "v\\d+\\.\\d+"
+```
+
 See `templates/cicd.yml.example` for full documentation.
 
 ## Quick Start
@@ -70,6 +96,12 @@ See `templates/cicd.yml.example` for full documentation.
 
 # Validate your Makefile
 /cicd:check
+
+# Run health checks (after services are running)
+/cicd:health
+
+# Run smoke tests
+/cicd:smoke
 
 # Use with /flow
 /flow:finish    # Runs make lint + make test

--- a/.claude/commands/cicd/smoke.md
+++ b/.claude/commands/cicd/smoke.md
@@ -1,0 +1,153 @@
+---
+description: Run smoke tests from cicd.yml configuration
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(curl:*), Bash(ls:*), Bash(test:*), Bash(cat:*), Read
+---
+
+# /cicd:smoke — Smoke Tests
+
+Run smoke tests from `.claude/cicd.yml` configuration.
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: claude-power-pack not found"
+  exit 1
+fi
+```
+
+---
+
+## Step 2: Check for Configuration
+
+```bash
+if [ ! -f ".claude/cicd.yml" ]; then
+  echo "No .claude/cicd.yml found in $(pwd)"
+  echo ""
+  echo "Create one with:"
+  echo "  /cicd:init    — Auto-detect framework and generate"
+  echo ""
+  echo "Or add smoke tests manually to .claude/cicd.yml:"
+  echo ""
+  echo "  health:"
+  echo "    smoke_tests:"
+  echo "      - name: API responds"
+  echo "        command: \"curl -sf http://localhost:8000/health\""
+  echo "        expected_exit: 0"
+  echo "      - name: CLI version"
+  echo "        command: \"python -m myapp --version\""
+  echo "        expected_output: \"v\\\\d+\\\\.\\\\d+\""
+  exit 1
+fi
+```
+
+If `.claude/cicd.yml` exists but has no `smoke_tests:` section, the CLI will report "no tests configured" and show configuration guidance.
+
+---
+
+## Step 3: Run Smoke Tests
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd smoke
+```
+
+---
+
+## Step 4: Present Results
+
+The CLI outputs a markdown table. Present it to the user as-is.
+
+The report includes:
+- **Test table**: Each test's name, status (PASS/FAIL), detail, and execution time
+- **Summary**: Overall pass/fail count
+
+### Interpreting Results
+
+| Status | Meaning |
+|--------|---------|
+| `PASS` | Command exited with expected code and output matched (if configured) |
+| `FAIL` | Command failed — wrong exit code, output mismatch, or timeout |
+
+### Test Configuration
+
+Each smoke test in `.claude/cicd.yml` supports:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable test name |
+| `command` | Yes | Shell command to execute |
+| `expected_exit` | No | Expected exit code (default: 0) |
+| `expected_output` | No | Regex pattern to match in stdout |
+| `timeout` | No | Timeout in seconds (default: 30) |
+
+### No Tests Configured
+
+If the CLI reports "no tests configured", guide the user:
+
+```
+No smoke tests configured.
+
+Add tests to .claude/cicd.yml:
+
+  health:
+    smoke_tests:
+      - name: API responds
+        command: "curl -sf http://localhost:8000/health"
+        expected_exit: 0
+      - name: CLI version
+        command: "python -m myapp --version"
+        expected_output: "v\\d+\\.\\d+"
+      - name: Database connection
+        command: "python -c 'import myapp.db; myapp.db.ping()'"
+        expected_exit: 0
+        timeout: 10
+
+Then re-run: /cicd:smoke
+```
+
+---
+
+## Step 5: Handle Failures
+
+When smoke tests fail, provide remediation guidance:
+
+1. **Exit code mismatch**: Show actual vs expected exit code and stderr output
+2. **Output mismatch**: Show the expected pattern and actual output
+3. **Timeout**: Suggest increasing timeout or checking if the service is running
+4. **Command not found**: Suggest installing the dependency or activating the venv
+
+Example failure guidance:
+
+```
+Test "API responds" FAILED:
+  Command: curl -sf http://localhost:8000/health
+  Expected exit: 0, Got: 7
+  Detail: Connection refused
+
+  Fix: Ensure the API server is running:
+    make run    (if available)
+    uvicorn myapp:app --host 0.0.0.0 --port 8000
+```
+
+---
+
+## Notes
+
+- Smoke tests verify that a deployed/running system works end-to-end
+- Run after `make deploy` or service startup to validate
+- Commands run in the project root directory
+- Each test is independent — failures don't stop subsequent tests
+- Use `--json` flag for machine-readable output
+- Use `--summary` flag for one-line pass/fail (useful in scripts)
+- Configure tests in `.claude/cicd.yml` under `health.smoke_tests`
+- Pair with `/cicd:health` for comprehensive verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,12 @@ claude-power-pack/
 │   │   │   ├── init.md                         # Interactive setup wizard
 │   │   │   ├── status.md                       # Check installation state
 │   │   │   └── help.md                         # Command overview
+│   │   ├── cicd/                                # CI/CD & verification commands
+│   │   │   ├── init.md                         # Detect framework, generate Makefile
+│   │   │   ├── check.md                        # Validate Makefile targets
+│   │   │   ├── health.md                       # Run health checks (endpoints + processes)
+│   │   │   ├── smoke.md                        # Run smoke tests from cicd.yml
+│   │   │   └── help.md                         # CI/CD command overview
 │   │   ├── github/                             # GitHub issue management
 │   │   ├── spec/                               # Spec-Driven Development
 │   │   │   ├── help.md                         # SDD command overview


### PR DESCRIPTION
## Summary

- Create `.claude/commands/cicd/health.md` — health check command that delegates to `python3 -m lib.cicd health`
- Create `.claude/commands/cicd/smoke.md` — smoke test command that delegates to `python3 -m lib.cicd smoke`
- Update `.claude/commands/cicd/help.md` — add new commands to table and flow diagram
- Update `CLAUDE.md` — add cicd/ directory to repo structure tree

Both commands follow the established pattern from `cicd/check.md`: locate CPP_DIR, run via PYTHONPATH, present results. They handle missing config gracefully with interactive fallback guidance.

## Test plan

- [x] All 157 existing tests pass (lint failures are pre-existing)
- [ ] Run `/cicd:health` in a project with `.claude/cicd.yml` health config
- [ ] Run `/cicd:health` in a project without config — verify guidance output
- [ ] Run `/cicd:smoke` in a project with smoke tests configured
- [ ] Run `/cicd:smoke` in a project without config — verify guidance output

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)