### PR TITLE
feat(flow): Integrate post-deploy verification into /flow:deploy and /flow:finish (Closes #147)

### DIFF
--- a/.claude/commands/flow/deploy.md
+++ b/.claude/commands/flow/deploy.md
@@ -116,6 +116,67 @@ Deployment failed ❌
 Review the output above for errors.
 ```
 
+### Step 8: Post-Deploy Verification (optional)
+
+After a successful deployment, automatically run health checks and smoke tests if configured.
+
+**Condition:** Only run if `.claude/cicd.yml` exists AND contains `health.post_deploy: true`.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found and `.claude/cicd.yml` exists:
+
+1. **Check if post-deploy verification is enabled:**
+   ```bash
+   if grep -q "post_deploy:" .claude/cicd.yml 2>/dev/null; then
+       # Verification enabled
+   else
+       # Skip — not configured
+   fi
+   ```
+
+2. **Run health checks:**
+   ```bash
+   echo "Running post-deploy health checks..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd health --summary
+   HEALTH_EXIT=$?
+   ```
+
+3. **Run smoke tests:**
+   ```bash
+   echo "Running post-deploy smoke tests..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd smoke --summary
+   SMOKE_EXIT=$?
+   ```
+
+4. **Report results:**
+   - If all pass: `"Deploy verified ✅ — health checks and smoke tests passed"`
+   - If any fail: Report failures and suggest `/self-improvement:deployment`
+
+5. **Log verification results** (extends deploy.log format):
+   ```bash
+   HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
+   SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
+   echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS}" >> .claude/deploy.log
+   ```
+
+   Extended log format: `timestamp | target | commit | branch | deploy_exit | health:pass/fail | smoke:pass/fail`
+
+**Skip conditions:**
+- No `.claude/cicd.yml` → skip silently
+- No `post_deploy:` in config → skip silently
+- `lib/cicd` not available (no CPP_DIR) → skip with warning
+- Verification failures do NOT roll back the deployment — they only report
+
 ## Error Handling
 
 - **No Makefile:** Report error with guidance to create one

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -55,6 +55,39 @@ PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate
 - If the gate produces **warnings** (high findings): display them but proceed.
 - If `lib/security` is not available, skip this step (warn the user).
 
+### Step 2c: Makefile Completeness Check (optional, non-blocking)
+
+If `lib/cicd` is available, run a quick Makefile validation and report any gaps as warnings:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found and a Makefile exists:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary
+CHECK_EXIT=$?
+```
+
+- If check reports **missing required targets**: display as a warning but **do NOT block**.
+  ```
+  ⚠️  Makefile check: 1 required target missing (typecheck)
+      Run /cicd:check for details or /cicd:init to fix
+  ```
+- If check passes: report briefly — `"Makefile check: OK (6/6 targets present)"`
+- If `lib/cicd` is not available: skip silently
+- If no Makefile exists: skip silently (Step 2 already handles this)
+
+**This step never blocks the flow** — it is purely informational.
+
 ### Step 3: Check for Changes
 
 ```bash


### PR DESCRIPTION
## Summary

- Add **Step 8** to `/flow:deploy` — post-deploy verification that auto-runs health checks and smoke tests when `post_deploy` is configured in `.claude/cicd.yml`. Logs extended verification results to `deploy.log`.
- Add **Step 2c** to `/flow:finish` — non-blocking Makefile completeness check that warns about missing targets without stopping the flow.
- Both steps gracefully skip when `lib/cicd` is not available or config is absent.

## Test plan

- [x] All 157 existing tests pass
- [ ] Run `/flow:deploy` with `post_deploy: true` in cicd.yml — verify health/smoke checks run
- [ ] Run `/flow:deploy` without cicd.yml — verify Step 8 is silently skipped
- [ ] Run `/flow:finish` with Makefile — verify Step 2c reports gaps as warnings
- [ ] Run `/flow:finish` without Makefile — verify Step 2c is skipped

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)