### PR TITLE
docs(cicd): Create cicd-verification skill and update CLAUDE.md (Closes #154)

### DIFF
--- a/.claude/commands/cicd/help.md
+++ b/.claude/commands/cicd/help.md
@@ -10,6 +10,7 @@ Build, verify, and deploy automation for Claude Code projects.
 | `/cicd:check` | Validate Makefile against CPP standards |
 | `/cicd:health` | Run health checks (endpoints + processes) |
 | `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
 | `/cicd:help` | This help page |
 
 ## How It Works

--- a/.claude/commands/self-improvement/help.md
+++ b/.claude/commands/self-improvement/help.md
@@ -44,6 +44,11 @@ The self-improvement category may grow to include:
 - **review** — Analyze PR review feedback patterns, suggest code quality improvements
 - **session** — Analyze session patterns, suggest CLAUDE.md improvements
 
+## See Also
+
+- `/cicd:check` — Forward-looking Makefile validation against CPP standards
+- `/cicd:init` — Auto-detect framework and generate Makefile from templates
+
 ## Related Commands
 
 | Command | Relationship |

--- a/.claude/skills/best-practices.md
+++ b/.claude/skills/best-practices.md
@@ -23,6 +23,7 @@ Instead of loading 25K+ tokens, load only the relevant topic (~3K tokens).
 | **CLAUDE.md** | `claude-md-config` | CLAUDE.md, configuration, project setup |
 | **Code Quality** | `code-quality` | code review, quality, testing, production |
 | **Python Packaging** | `python-packaging` | pyproject.toml, PEP 621, PEP 723, setup.py, requirements.txt |
+| **CI/CD & Verification** | `cicd-verification` | CI/CD, pipeline, health check, smoke test, Makefile, verification |
 
 ## Routing Logic
 

--- a/.claude/skills/cicd-verification.md
+++ b/.claude/skills/cicd-verification.md
@@ -1,0 +1,45 @@
+---
+name: CI/CD & Verification
+description: Build system, health checks, CI/CD pipeline, and container patterns
+trigger: CI/CD, pipeline, health check, smoke test, Makefile generation, GitHub Actions, Dockerfile, docker-compose, verification, post-deploy
+---
+
+# CI/CD & Verification Skill
+
+When the user asks about CI/CD, build systems, health checks, smoke tests, pipelines, containers, or deployment verification, load the full reference:
+
+```
+Read docs/skills/cicd-verification.md
+```
+
+## Quick Reference
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
+| `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:help` | Overview of CI/CD commands |
+
+### The Verification Loop
+
+```
+code → lint/test → deploy → health check → smoke test → report
+```
+
+### CLI Usage
+
+```bash
+PYTHONPATH="$HOME/Projects/claude-power-pack/lib:$PYTHONPATH"
+python3 -m lib.cicd <command> [options]
+```
+
+Subcommands: `detect`, `check`, `health`, `smoke`, `pipeline`
+
+### Configuration
+
+Health checks and smoke tests are configured in `.claude/cicd.yml`. See `/cicd:help` for full configuration reference.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,18 @@ claude-power-pack/
 │   └── output/                                 # Output formatters
 │       ├── novice.py                           # Human-friendly output
 │       └── json_output.py                      # Machine-readable JSON
+├── lib/cicd/                                   # CI/CD & verification
+│   ├── __init__.py                             # Module exports
+│   ├── __main__.py                             # python -m lib.cicd entry
+│   ├── cli.py                                  # CLI (detect, check, health, smoke, pipeline)
+│   ├── config.py                               # CicdConfig from .claude/cicd.yml
+│   ├── detector.py                             # Framework + package manager detection
+│   ├── health.py                               # Health checks (endpoints + processes)
+│   ├── smoke.py                                # Smoke tests from cicd.yml
+│   ├── makefile.py                             # Makefile generation from templates
+│   ├── pipeline.py                             # CI pipeline generation (GitHub Actions)
+│   ├── container.py                            # Dockerfile + docker-compose generation
+│   └── models.py                               # Data models (Framework, Target, Result)
 ├── lib/spec_bridge/                            # Spec-to-Issue sync
 │   ├── __init__.py                             # Module exports
 │   ├── parser.py                               # Parse spec/tasks files
@@ -132,7 +144,10 @@ claude-power-pack/
 │   ├── status.py                               # Alignment checking
 │   └── cli.py                                  # Command-line interface
 ├── templates/
-│   └── Makefile.example                        # Starter Makefile for flow integration
+│   ├── Makefile.example                        # Starter Makefile for flow integration
+│   ├── makefiles/                              # Framework-specific Makefile templates
+│   ├── workflows/                              # GitHub Actions workflow templates
+│   └── containers/                             # Dockerfile + docker-compose templates
 ├── scripts/
 │   ├── prompt-context.sh                       # Shell prompt context
 │   ├── worktree-remove.sh                      # Safe worktree removal
@@ -164,6 +179,7 @@ claude-power-pack/
 │   │   │   ├── check.md                        # Validate Makefile targets
 │   │   │   ├── health.md                       # Run health checks (endpoints + processes)
 │   │   │   ├── smoke.md                        # Run smoke tests from cicd.yml
+│   │   │   ├── container.md                    # Generate Dockerfile + docker-compose
 │   │   │   └── help.md                         # CI/CD command overview
 │   │   ├── github/                             # GitHub issue management
 │   │   ├── spec/                               # Spec-Driven Development
@@ -208,6 +224,7 @@ claude-power-pack/
 │   │   ├── claude-md-config.md                 # → docs/skills/
 │   │   ├── code-quality.md                     # → docs/skills/
 │   │   ├── python-packaging.md                 # → docs/skills/
+│   │   ├── cicd-verification.md                # → docs/skills/
 │   │   └── secrets.md                          # Secrets skill
 │   └── hooks.json                              # Session hooks
 ├── .github/
@@ -232,6 +249,7 @@ To preserve context, documentation is NOT auto-loaded. Use topic-specific skills
 | CLAUDE.md Config | "CLAUDE.md", "configuration" |
 | Code Quality | "code review", "quality" |
 | Python Packaging | "pyproject.toml", "PEP 621", "PEP 723", "setup.py" |
+| CI/CD & Verification | "CI/CD", "pipeline", "health check", "smoke test", "verification" |
 | Build & Deploy | "Makefile", "uv", "deploy patterns" |
 
 **Commands:**
@@ -475,6 +493,7 @@ Commands for managing Claude Power Pack installation:
 | 1 | Minimal | Commands + Skills symlinks |
 | 2 | Standard | + Scripts, hooks, shell prompt |
 | 3 | Full | + MCP servers (uv, API keys, systemd), optional extras |
+| 4 | CI/CD | + Framework detection, Makefile generation, health/smoke, pipelines, containers |
 
 The wizard detects existing configuration and skips already-installed components (idempotent).
 
@@ -745,6 +764,44 @@ Run after failed deployments or builds to close the feedback loop:
 
 Pair with `/flow:doctor` for forward-looking health checks.
 
+## CI/CD & Verification (Tier 4)
+
+Framework-aware build system detection, verification, and deployment automation.
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
+| `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:help` | Overview of CI/CD commands |
+
+### The Verification Loop
+
+```
+code → lint/test → deploy → health check → smoke test → report
+```
+
+`/flow:deploy` runs post-deploy health checks and smoke tests when configured in `.claude/cicd.yml`.
+
+### Configuration
+
+Create `.claude/cicd.yml` for health checks, smoke tests, and deploy settings. See `/cicd:help` for full reference.
+
+### CLI Usage
+
+```bash
+PYTHONPATH="$HOME/Projects/claude-power-pack/lib:$PYTHONPATH"
+python3 -m lib.cicd detect     # Detect framework
+python3 -m lib.cicd check      # Validate Makefile
+python3 -m lib.cicd health     # Run health checks
+python3 -m lib.cicd smoke      # Run smoke tests
+python3 -m lib.cicd pipeline   # Generate CI pipeline
+```
+
 ## Makefile Integration
 
 The `/flow` commands use Makefile targets as the canonical way to run tests, lint, and deploy. This keeps build logic in one place and lets flow commands orchestrate without hardcoding commands.
@@ -754,7 +811,7 @@ The `/flow` commands use Makefile targets as the canonical way to run tests, lin
 | Command | Target | Behavior |
 |---------|--------|----------|
 | `/flow:finish` | `lint`, `test` | Auto-discovers and runs if targets exist; skips if no Makefile |
-| `/flow:deploy [target]` | `deploy` (default) | Runs specified target; lists available targets if not found |
+| `/flow:deploy [target]` | `deploy` (default) | Runs specified target + post-deploy health/smoke if configured |
 | `/flow:auto` | `deploy` | Runs after merge if target exists; skips otherwise |
 | `/flow:doctor` | all | Reports which standard targets are available |
 
@@ -1021,11 +1078,12 @@ Each Python component has its own `pyproject.toml`:
 - `mcp-second-opinion/pyproject.toml`
 - `mcp-playwright-persistent/pyproject.toml`
 - `extras/redis-coordination/mcp-server/pyproject.toml`
+- `lib/cicd/pyproject.toml`
 - `lib/creds/pyproject.toml`
 - `lib/security/pyproject.toml`
 - `lib/spec_bridge/pyproject.toml`
 
 ## Version
 
-Current version: 4.1.0
-Previous: 4.0.0 (Simplified Workflow)
+Current version: 4.2.0
+Previous: 4.1.0, 4.0.0 (Simplified Workflow)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This guides you through a tiered installation:
 | 1 | **Minimal** | Commands + Skills symlinks |
 | 2 | **Standard** | + Scripts, hooks, shell prompt |
 | 3 | **Full** | + MCP servers (uv, API keys, systemd), optional extras |
+| 4 | **CI/CD** | + Framework detection, Makefile generation, health/smoke, pipelines, containers |
 
 ### CPP Commands
 
@@ -654,6 +655,52 @@ suppressions:
 ```bash
 PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security scan
 PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security explain HARDCODED_PASSWORD
+```
+
+## 🔧 CI/CD & Verification (Tier 4)
+
+Framework-aware build system detection, verification, and deployment automation.
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
+| `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:help` | Overview of CI/CD commands |
+
+### The Verification Loop
+
+```
+code → lint/test → deploy → health check → smoke test → report
+```
+
+The CI/CD system auto-detects your project's framework (Python, Node.js, Go, Rust) and generates appropriate Makefiles, GitHub Actions workflows, and container configurations. Health checks and smoke tests verify deployments work end-to-end.
+
+### Configuration
+
+Configure health checks and smoke tests in `.claude/cicd.yml`:
+
+```yaml
+health:
+  endpoints:
+    - url: http://localhost:8000/health
+      name: API Server
+      expected_status: 200
+smoke_tests:
+  - name: API responds
+    command: "curl -sf http://localhost:8000/health"
+    expected_exit: 0
+```
+
+### CLI Usage
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.cicd detect
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.cicd health
 ```
 
 ## ⚡ Session Initialization

--- a/docs/skills/cicd-verification.md
+++ b/docs/skills/cicd-verification.md
@@ -1,0 +1,206 @@
+# CI/CD & Verification
+
+Build system detection, health checks, smoke tests, pipeline generation, container scaffolding, and the verification loop.
+
+## The Verification Loop
+
+```
+code → lint/test → deploy → health check → smoke test → report
+```
+
+This is the core pattern: every deployment should be **verified** before it's considered complete. The `/flow` commands orchestrate this automatically when configured.
+
+## Framework Detection
+
+The CI/CD system auto-detects your project's framework and package manager:
+
+| Framework | Package Managers | Detection |
+|-----------|-----------------|-----------|
+| Python | uv, pip | `pyproject.toml`, `setup.py`, `requirements.txt` |
+| Node.js | npm, yarn | `package.json` + lock files |
+| Go | go | `go.mod` |
+| Rust | cargo | `Cargo.toml` |
+| Multi-language | any | Multiple indicators |
+
+Run `/cicd:init` to detect and generate a Makefile from templates.
+
+## Makefile Conventions
+
+### Standard Targets
+
+| Target | Required | Used By | Purpose |
+|--------|----------|---------|---------|
+| `lint` | Yes | `/flow:finish` | Code linting |
+| `test` | Yes | `/flow:finish` | Test suite |
+| `format` | No | Manual/IDE | Code formatting |
+| `typecheck` | No | `/cicd:check` | Type checking |
+| `build` | No | Build step | Build artifacts |
+| `deploy` | No | `/flow:deploy` | Production deploy |
+| `clean` | No | Manual | Remove artifacts |
+| `verify` | No | Pre-deploy | lint + test + typecheck |
+
+### Best Practices
+
+1. **Always use `uv run`** for Python commands (environment isolation)
+2. **Declare `.PHONY`** for all non-file targets
+3. **Add dependencies** — `deploy` should depend on `test` and `lint`
+4. **Use `@` prefix** on informational `echo` commands to reduce noise
+5. **Keep targets idempotent** — safe to run multiple times
+
+### Example Makefile
+
+```makefile
+.PHONY: lint test format deploy clean verify
+
+lint:
+	uv run ruff check .
+
+test:
+	uv run pytest
+
+format:
+	uv run ruff format .
+
+deploy: verify
+	@echo "Deploying..."
+	# your deploy commands here
+
+verify: lint test
+
+clean:
+	rm -rf .pytest_cache __pycache__ dist/
+```
+
+## Health Check Configuration
+
+Configure in `.claude/cicd.yml`:
+
+```yaml
+health:
+  endpoints:
+    - url: http://localhost:8000/health
+      name: API Server
+      expected_status: 200
+      timeout: 5
+    - url: http://localhost:3000
+      name: Frontend
+      expected_status: 200
+  processes:
+    - name: uvicorn
+      port: 8000
+    - name: node
+      port: 3000
+```
+
+### Health Check Types
+
+| Type | What It Checks | How |
+|------|---------------|-----|
+| **Endpoint** | HTTP response | `curl` with status code + timeout |
+| **Process** | Service running | `ss`/`lsof` for port listening |
+
+### Best Practices
+
+- Check **both** endpoints and processes for critical services
+- Set reasonable timeouts (5s default, 30s max)
+- Use `/health` endpoints that verify dependencies (DB, cache)
+- Run health checks **after** deploy, not during
+
+## Smoke Test Configuration
+
+```yaml
+smoke_tests:
+  - name: API responds
+    command: "curl -sf http://localhost:8000/health"
+    expected_exit: 0
+  - name: CLI version
+    command: "python -m myapp --version"
+    expected_output: "v\\d+\\.\\d+"
+  - name: Database connected
+    command: "python -c 'from myapp.db import check; check()'"
+    expected_exit: 0
+```
+
+### Smoke vs Health
+
+| Aspect | Health Check | Smoke Test |
+|--------|-------------|------------|
+| Speed | Fast (< 5s each) | Slower (may do I/O) |
+| Scope | Is it running? | Does it work? |
+| When | Continuous / post-deploy | Post-deploy only |
+| Failure | Service down | Feature broken |
+
+## CI/CD Pipeline Patterns
+
+### GitHub Actions
+
+Generated via `/cicd:pipeline` using templates in `templates/workflows/`:
+
+```yaml
+# .github/workflows/ci.yml (generated)
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: make lint
+      - run: make test
+```
+
+### Template Selection
+
+Templates match detected framework:
+- `python-uv.yml` — Python with uv
+- `python-pip.yml` — Python with pip
+- `node-npm.yml` — Node.js with npm
+- `node-yarn.yml` — Node.js with yarn
+- `go.yml` — Go
+- `rust.yml` — Rust
+
+## Container Best Practices
+
+Generated via `/cicd:container` using templates in `templates/containers/`:
+
+### Dockerfile Patterns
+
+1. **Multi-stage builds** — separate build and runtime stages
+2. **Non-root user** — always run as non-root in production
+3. **Layer caching** — copy dependency files first, then source
+4. **Health checks** — include `HEALTHCHECK` instruction
+5. **Minimal base** — use slim/alpine variants
+
+### docker-compose Patterns
+
+1. **Named volumes** for persistent data
+2. **Health checks** with retries and intervals
+3. **Dependency ordering** with `depends_on` + `condition: service_healthy`
+4. **Environment files** — use `.env` files, never hardcode secrets
+
+## Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
+| `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:help` | Overview of CI/CD commands |
+
+## Integration with /flow
+
+| Flow Command | CI/CD Integration |
+|-------------|-------------------|
+| `/flow:finish` | Runs `make lint` + `make test` as quality gates |
+| `/flow:deploy` | Runs `make deploy`, then post-deploy health + smoke |
+| `/flow:auto` | Full lifecycle including deploy verification |
+| `/flow:doctor` | Reports Makefile target availability |
+
+## Related
+
+- `/self-improvement:deployment` — Analyze deploy failures, improve Makefile
+- `/flow:doctor` — Forward-looking health check of workflow environment
+- `/security:scan` — Security-focused analysis (complementary)


### PR DESCRIPTION
## Summary
- Created `.claude/skills/cicd-verification.md` skill loader with CI/CD triggers
- Created `docs/skills/cicd-verification.md` (~3K tokens) with full CI/CD reference
- Updated `best-practices.md` dispatcher to route CI/CD topics to new skill
- Updated `CLAUDE.md` with Tier 4 section, repo structure, installation tiers, topic skills table
- Updated `README.md` with Tier 4 in tiers table and new CI/CD section
- Updated `cicd/help.md` to include `/cicd:container` command
- Updated `self-improvement/help.md` with `/cicd:check` cross-references

## Test plan
- [ ] Verify skill activates on CI/CD-related triggers
- [ ] Verify `docs/skills/cicd-verification.md` is ~3K tokens
- [ ] Verify best-practices dispatcher routes to new skill
- [ ] Verify CLAUDE.md sections are correct and cross-referenced
- [ ] Verify README.md Tier 4 additions

Closes #154
Part of #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)