### PR TITLE
feat(cpp): Add Tier 4 CI/CD to /cpp:init, /cpp:status, /cpp:help (Closes #152)

### DIFF
--- a/.claude/commands/cicd/help.md
+++ b/.claude/commands/cicd/help.md
@@ -10,21 +10,25 @@ Build, verify, and deploy automation for Claude Code projects.
 | `/cicd:check` | Validate Makefile against CPP standards |
 | `/cicd:health` | Run health checks (endpoints + processes) |
 | `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:pipeline` | Generate GitHub Actions CI/CD workflows |
 | `/cicd:container` | Generate Dockerfile and docker-compose.yml |
 | `/cicd:help` | This help page |
 
 ## How It Works
 
 ```
-/cicd:init  →  Detect framework  →  Generate Makefile  →  Generate .claude/cicd.yml
-                                          ↓
-/cicd:check  →  Validate targets  →  Report gaps  →  Suggest fixes
-                                          ↓
-/flow:finish  → make lint + make test     (quality gates)
-/flow:deploy  → make deploy               (deployment)
-                                          ↓
-/cicd:health  →  Check endpoints  →  Check processes  →  Report status
-/cicd:smoke   →  Run smoke tests  →  Check results    →  Report pass/fail
+/cicd:init      →  Detect framework  →  Generate Makefile  →  Generate .claude/cicd.yml
+                                              ↓
+/cicd:check     →  Validate targets  →  Report gaps  →  Suggest fixes
+                                              ↓
+/flow:finish    → make lint + make test       (quality gates)
+/flow:deploy    → make deploy                 (deployment)
+                                              ↓
+/cicd:health    →  Check endpoints  →  Check processes  →  Report status
+/cicd:smoke     →  Run smoke tests  →  Check results    →  Report pass/fail
+                                              ↓
+/cicd:pipeline  →  Read Makefile targets  →  Generate .github/workflows/ci.yml
+/cicd:container →  Detect framework       →  Generate Dockerfile + docker-compose.yml
 ```
 
 ## Supported Frameworks

--- a/.claude/commands/cicd/pipeline.md
+++ b/.claude/commands/cicd/pipeline.md
@@ -1,0 +1,66 @@
+---
+description: Generate GitHub Actions CI/CD workflows
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(cat:*), Bash(ls:*), Bash(test:*), Bash(mkdir:*), Read, Write
+---
+
+# CI/CD Pipeline Generation
+
+Generate GitHub Actions CI/CD workflows from your Makefile targets.
+
+## Steps
+
+1. **Detect framework** using `lib/cicd`:
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/claude-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd detect --quiet
+```
+
+2. **Generate pipeline** (dry run first):
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/claude-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd pipeline
+```
+
+3. **Review output** with the user. Show the generated workflow YAML.
+
+4. **Check for existing files** before writing:
+   - If `.github/workflows/ci.yml` exists, ask before overwriting
+
+5. **Write files** if approved:
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/claude-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd pipeline --write
+```
+
+6. **Report results**:
+
+```
+## CI Pipeline Generated
+
+Framework: {framework} ({package_manager})
+
+Files created:
+  .github/workflows/ci.yml — CI pipeline with lint, test, build
+
+Triggers: push to main, pull requests
+Targets:  make lint, make test, make typecheck (if available)
+
+To view: cat .github/workflows/ci.yml
+```
+
+## Notes
+
+- Workflows use `make <target>` as steps (not direct tool commands)
+- This keeps CI in sync with local development commands
+- Caching is included for package managers (uv, npm, cargo, go)
+- Matrix builds are configured from `.claude/cicd.yml` if present
+- Configure pipeline settings in `.claude/cicd.yml`:
+  ```yaml
+  pipeline:
+    provider: github-actions
+    branches:
+      main: [lint, test, typecheck, build, deploy]
+      pr: [lint, test, typecheck]
+    matrix:
+      python: ["3.11", "3.12"]
+  ```

--- a/.claude/commands/cpp/help.md
+++ b/.claude/commands/cpp/help.md
@@ -24,6 +24,7 @@ CPP uses a tiered installation model:
 | 1 | **Minimal** | Commands + Skills symlinks |
 | 2 | **Standard** | + Scripts, hooks, shell prompt |
 | 3 | **Full** | + MCP servers (uv, API keys) |
+| 4 | **CI/CD** | + Build system, health checks, pipelines, containers |
 
 ## Quick Start
 
@@ -52,8 +53,27 @@ CPP uses a tiered installation model:
 - **MCP Playwright** (port 8081): Persistent browser automation
 - **Systemd services**: Auto-start on boot (optional)
 
+### Tier 4 - CI/CD
+- **Build System**: Framework detection, Makefile generation/validation (`/cicd:init`, `/cicd:check`)
+- **Health Checks**: Endpoint and process verification (`/cicd:health`)
+- **Smoke Tests**: Post-deploy command verification (`/cicd:smoke`)
+- **CI/CD Pipelines**: GitHub Actions workflow generation (`/cicd:pipeline`)
+- **Containers**: Dockerfile and docker-compose generation (`/cicd:container`)
+
 ### Optional Add-on
 - **Redis Coordination** (`extras/`): Distributed locking for team/multi-session use
+
+## CI/CD Commands (Tier 4)
+
+| Command | Purpose |
+|---------|---------|
+| `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
+| `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:pipeline` | Generate GitHub Actions CI/CD workflows |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:help` | CI/CD command overview |
 
 ## Related Documentation
 

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive setup wizard for Claude Power Pack
-allowed-tools: Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(cp:*), Bash(uv:*), Bash(claude mcp list:*), Bash(claude mcp add:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*)
+allowed-tools: Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(cp:*), Bash(uv:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(claude mcp list:*), Bash(claude mcp add:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*)
 ---
 
 # Claude Power Pack Setup Wizard
@@ -82,8 +82,9 @@ Ask the user which tier they want to install using the AskUserQuestion tool:
 | 1 | **Minimal** | Commands + Skills symlinks only |
 | 2 | **Standard** | + Scripts, hooks, shell prompt |
 | 3 | **Full** | + MCP servers (uv, API keys) |
+| 4 | **CI/CD** | + Build system, health checks, pipelines, containers |
 
-Default recommendation: **Standard** for most users, **Full** for MCP-powered workflows.
+Default recommendation: **Standard** for most users, **Full** for MCP-powered workflows, **CI/CD** for projects needing build automation.
 
 ---
 
@@ -290,6 +291,45 @@ This will make the following changes:
     rm -rf {CPP_DIR}/mcp-playwright-persistent/.venv
     claude mcp remove second-opinion
     claude mcp remove playwright-persistent
+
+Proceed? [y/N]
+```
+
+### Tier 4 Disclosure (CI/CD)
+
+```
+=== Tier 4: CI/CD Installation ===
+
+This will make the following changes:
+
+  [Tier 1 + 2 + 3 - All Full components]
+    (see above)
+
+  [Tier 4A - Build System]
+    • Detect project framework and package manager
+    • Generate/validate Makefile with standard targets
+    • Create .claude/cicd.yml configuration
+
+  [Tier 4B - Health Checks] (optional)
+    • Configure endpoint health checks in cicd.yml
+    • Configure process port checks
+
+  [Tier 4C - CI/CD Pipeline] (optional)
+    • Generate .github/workflows/ci.yml from Makefile targets
+    • Include caching, matrix builds, secrets references
+
+  [Tier 4D - Container] (optional)
+    • Generate Dockerfile (multi-stage, framework-specific)
+    • Generate docker-compose.yml
+    • Generate .dockerignore
+
+  Disk usage: ~0 MB (generated files only)
+
+  To undo:
+    # Tier 1+2+3 cleanup (see above)
+    rm .claude/cicd.yml
+    rm .github/workflows/ci.yml
+    rm Dockerfile docker-compose.yml .dockerignore
 
 Proceed? [y/N]
 ```
@@ -569,6 +609,144 @@ else
 fi
 ```
 
+### Tier 4 Execution (CI/CD)
+
+#### 4a. Framework Detection and Makefile
+
+```bash
+# Detect framework
+echo "Detecting project framework..."
+DETECT_JSON=$(PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect --json 2>/dev/null || echo "{}")
+FRAMEWORK=$(echo "$DETECT_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('framework','unknown'))" 2>/dev/null || echo "unknown")
+PKG_MGR=$(echo "$DETECT_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('package_manager','unknown'))" 2>/dev/null || echo "unknown")
+echo "Detected: $FRAMEWORK ($PKG_MGR)"
+```
+
+If no Makefile exists, offer to generate one:
+
+```bash
+if [ ! -f "Makefile" ]; then
+  echo ""
+  echo "No Makefile found. Generate one from the detected framework template?"
+  # Use AskUserQuestion to confirm
+  # If yes:
+  PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect --generate-makefile
+  echo "✓ Makefile generated"
+else
+  echo "→ Makefile already exists"
+  echo "  Run /cicd:check to validate targets"
+fi
+```
+
+If Makefile exists, run a quick check:
+
+```bash
+if [ -f "Makefile" ]; then
+  echo ""
+  echo "Validating Makefile..."
+  PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary 2>/dev/null || echo "  (validation skipped)"
+fi
+```
+
+#### 4b. Generate cicd.yml
+
+```bash
+if [ ! -f ".claude/cicd.yml" ]; then
+  mkdir -p .claude
+  # Generate cicd.yml with detected defaults
+  if [ -f "$CPP_DIR/templates/cicd.yml.example" ]; then
+    cp "$CPP_DIR/templates/cicd.yml.example" .claude/cicd.yml
+    echo "✓ .claude/cicd.yml created from template"
+    echo "  Edit to configure health checks and smoke tests"
+  else
+    cat > .claude/cicd.yml << 'CICD_EOF'
+build:
+  framework: auto
+  package_manager: auto
+  required_targets: [lint, test]
+  recommended_targets: [format, typecheck, build, deploy, clean, verify]
+
+health:
+  endpoints: []
+  processes: []
+  smoke_tests: []
+  post_deploy: false
+CICD_EOF
+    echo "✓ .claude/cicd.yml created with defaults"
+  fi
+else
+  echo "→ .claude/cicd.yml already exists (skipped)"
+fi
+```
+
+#### 4c. Health Check Configuration (Optional)
+
+Ask the user if they want to configure health checks:
+
+```
+=== Optional: Health Checks ===
+
+Configure endpoint health checks for post-deploy verification?
+
+This lets /cicd:health and /flow:deploy verify your services are running.
+
+Example:
+  health:
+    endpoints:
+      - url: http://localhost:8000/health
+        name: API Server
+
+Configure health checks? [y/N]
+```
+
+If yes, use AskUserQuestion to get endpoint URLs, then update `.claude/cicd.yml`.
+
+#### 4d. CI Pipeline Generation (Optional)
+
+Ask the user if they want to generate a CI pipeline:
+
+```
+=== Optional: CI Pipeline ===
+
+Generate a GitHub Actions CI workflow from your Makefile targets?
+
+This creates .github/workflows/ci.yml using `make lint`, `make test`, etc.
+
+Generate CI pipeline? [y/N]
+```
+
+If yes:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd pipeline --write 2>/dev/null
+if [ -f ".github/workflows/ci.yml" ]; then
+  echo "✓ .github/workflows/ci.yml generated"
+else
+  echo "⚠ Pipeline generation failed"
+fi
+```
+
+#### 4e. Container Generation (Optional)
+
+Ask the user if they want to generate container files:
+
+```
+=== Optional: Container Files ===
+
+Generate Dockerfile and docker-compose.yml for your project?
+
+Uses multi-stage builds with framework-specific optimization.
+
+Generate container files? [y/N]
+```
+
+If yes:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd container --write 2>/dev/null
+echo "✓ Container files generated"
+```
+
 ---
 
 ## Step 6: Systemd Services (Optional)
@@ -622,6 +800,7 @@ Installed:
   ✓ Tier 1: Commands + Skills symlinked
   ✓ Tier 2: Scripts, hooks, shell prompt
   ✓ Tier 3: uv, MCP servers, API keys
+  ✓ Tier 4: CI/CD build system, health checks, pipeline, containers
 
 Permission Profile: {PROFILE_NAME}
   Auto-approved: {AUTO_APPROVE_SUMMARY}
@@ -647,6 +826,7 @@ Next Steps:
      /project-next    - See what to work on
      /spec:help       - Spec-driven development
      /github:help     - Issue management
+     /cicd:help       - CI/CD build & verification
 
 Change Permissions Later:
   • Edit .claude/settings.local.json directly

--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -1,6 +1,6 @@
 ---
 description: Check Claude Power Pack installation state
-allowed-tools: Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(uv:*), Bash(claude mcp list:*), Bash(systemctl:*)
+allowed-tools: Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(uv:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(claude mcp list:*), Bash(systemctl:*), Bash(grep:*)
 ---
 
 # CPP Installation Status
@@ -242,7 +242,63 @@ for service in mcp-second-opinion mcp-playwright-persistent; do
 done
 ```
 
-## Step 5: Summary
+## Step 5: Check Tier 4 (CI/CD)
+
+Check CI/CD build system, health checks, pipeline, and container configuration:
+
+```bash
+echo ""
+echo "Tier 4 (CI/CD):"
+
+# Check cicd.yml
+if [ -f ".claude/cicd.yml" ]; then
+  echo "  [x] cicd.yml: configured"
+else
+  echo "  [ ] cicd.yml: not found"
+fi
+
+# Check framework detection
+if [ -n "$CPP_DIR" ] && [ -f "$CPP_DIR/lib/cicd/__init__.py" ]; then
+  FRAMEWORK=$(PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"{d.get('framework','unknown')} ({d.get('package_manager','unknown')})\")" 2>/dev/null || echo "detection unavailable")
+  echo "  [x] Framework detected: $FRAMEWORK"
+else
+  echo "  [ ] Framework detection: lib/cicd not available"
+fi
+
+# Check Makefile
+if [ -f "Makefile" ]; then
+  TARGET_COUNT=$(grep -cE '^[a-zA-Z_-]+:' Makefile 2>/dev/null || echo "0")
+  echo "  [x] Makefile: $TARGET_COUNT targets"
+else
+  echo "  [ ] Makefile: not found"
+fi
+
+# Check CI workflow
+if [ -f ".github/workflows/ci.yml" ] || [ -f ".github/workflows/ci.yaml" ]; then
+  echo "  [x] CI pipeline: .github/workflows/ci.yml"
+elif ls .github/workflows/*.yml 2>/dev/null | head -1 > /dev/null 2>&1; then
+  WF_COUNT=$(ls .github/workflows/*.yml 2>/dev/null | wc -l)
+  echo "  [~] CI pipeline: $WF_COUNT workflow(s) found (no ci.yml)"
+else
+  echo "  [ ] CI pipeline: no workflows found"
+fi
+
+# Check Dockerfile
+if [ -f "Dockerfile" ]; then
+  echo "  [x] Dockerfile: present"
+else
+  echo "  [ ] Dockerfile: not found"
+fi
+
+# Check docker-compose
+if [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ]; then
+  echo "  [x] docker-compose: present"
+else
+  echo "  [ ] docker-compose: not found"
+fi
+```
+
+## Step 6: Summary
 
 Based on the checks above, report:
 
@@ -277,9 +333,17 @@ Tier 3 (Full):
   [ ] Systemd: not installed
   Status: Partial
 
+Tier 4 (CI/CD):
+  [x] cicd.yml: configured
+  [x] Framework detected: python (uv)
+  [x] Makefile: 8 targets
+  [ ] CI pipeline: no workflows found
+  [ ] Dockerfile: not found
+  Status: Partial
+
 ---------------------------------
 Current Level: Tier 2 (Standard)
-Missing: Shell prompt, mcp-playwright-persistent, systemd
+Missing: Shell prompt, mcp-playwright-persistent, systemd, CI pipeline, Dockerfile
 
 Run /cpp:init to complete setup
 =================================


### PR DESCRIPTION
## Summary

- Add **Tier 4 (CI/CD)** as a fourth installation tier to the CPP wizard
- `/cpp:init` now offers Tier 4 with progressive sub-levels: Build System, Health Checks, Pipeline, Container
- `/cpp:status` reports Tier 4 state: cicd.yml, framework detection, Makefile targets, CI pipeline, Dockerfile
- `/cpp:help` documents Tier 4 in the tier table and lists all `/cicd:*` commands
- Created `/cicd:pipeline` command file for GitHub Actions workflow generation
- Updated `cicd/help.md` to include `/cicd:pipeline` and `/cicd:container` in command table

## Test plan

- [ ] Run `/cpp:help` — verify Tier 4 appears in tier table and CI/CD commands section
- [ ] Run `/cpp:status` — verify Tier 4 checks appear (cicd.yml, framework, Makefile, CI, Docker)
- [ ] Run `/cpp:init` — verify Tier 4 option appears in tier selection
- [ ] Run `/cicd:help` — verify pipeline and container commands listed
- [ ] All 157 tests pass

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)