### PR TITLE
fix(lint): Fix all 81 pre-existing ruff lint errors (Closes #175)

### DIFF
--- a/extras/redis-coordination/mcp-server/src/server.py
+++ b/extras/redis-coordination/mcp-server/src/server.py
@@ -14,11 +14,11 @@ Lock naming follows wave/issue pattern:
 - "pytest", "pr-create" - Resource locks
 """
 import argparse
-
-from fastmcp import FastMCP
+import logging
 
 from config import config
 from coordination import CoordinationManager
+from fastmcp import FastMCP
 from redis_client import RedisClient
 
 # Initialize FastMCP server
@@ -247,8 +247,6 @@ async def health_check() -> dict:
 # -----------------------------------------------------------------------------
 # Entry Point
 # -----------------------------------------------------------------------------
-
-import logging
 
 logging.basicConfig(
     level=logging.INFO,

--- a/fetch_reddit_posts.py
+++ b/fetch_reddit_posts.py
@@ -4,9 +4,11 @@ Fetch posts from r/ClaudeCode subreddit about Claude best practices.
 This script uses PRAW in read-only mode (no authentication required).
 """
 
-import praw
 import json
 from datetime import datetime
+
+import praw
+
 
 def fetch_claudecode_posts(limit=25):
     """

--- a/lib/cicd/detector.py
+++ b/lib/cicd/detector.py
@@ -17,7 +17,6 @@ from .models import (
     PackageManager,
 )
 
-
 # Marker files → (Framework, PackageManager or None)
 # Order matters: more specific markers first
 _FRAMEWORK_MARKERS: list[tuple[str, Framework, Optional[PackageManager]]] = [

--- a/lib/cicd/makefile.py
+++ b/lib/cicd/makefile.py
@@ -17,6 +17,7 @@ from .detector import detect_framework
 from .models import (
     FRAMEWORK_TARGETS,
     Framework,
+    FrameworkInfo,
     MakefileCheckResult,
     MakefileTarget,
     PackageManager,
@@ -335,7 +336,10 @@ def _generate_inline(info: FrameworkInfo) -> str:
 def _get_clean_command(framework: Framework) -> str:
     """Get the clean command for a framework."""
     commands = {
-        Framework.PYTHON: "rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache dist build *.egg-info .coverage htmlcov",
+        Framework.PYTHON: (
+            "rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache "
+            "dist build *.egg-info .coverage htmlcov"
+        ),
         Framework.NODE: "rm -rf node_modules dist build .next .nuxt coverage",
         Framework.GO: "rm -rf bin/ coverage.out",
         Framework.RUST: "cargo clean",

--- a/lib/cicd/pipeline.py
+++ b/lib/cicd/pipeline.py
@@ -12,7 +12,6 @@ from typing import Optional
 from .config import CICDConfig
 from .models import Framework, FrameworkInfo, PackageManager
 
-
 # Docker images for Woodpecker CI steps
 _WOODPECKER_IMAGES: dict[Framework, str] = {
     Framework.PYTHON: "python:3.12",

--- a/lib/creds/__init__.py
+++ b/lib/creds/__init__.py
@@ -39,17 +39,17 @@ Bundle Provider Priority:
 from .base import (
     BundleProvider,
     ProviderCaps,
-    SecretBundle,
-    SecretValue,
-    SecretsProvider,
-    SecretsError,
-    SecretNotFoundError,
     ProviderNotAvailableError,
+    SecretBundle,
+    SecretNotFoundError,
+    SecretsError,
+    SecretsProvider,
+    SecretValue,
 )
-from .credentials import DatabaseCredentials, APICredentials
-from .providers import EnvSecretsProvider, AWSSecretsProvider, DotEnvSecretsProvider
+from .credentials import APICredentials, DatabaseCredentials
 from .masking import OutputMasker, mask_output, scan_for_secrets
 from .permissions import AccessLevel, OperationType, PermissionConfig
+from .providers import AWSSecretsProvider, DotEnvSecretsProvider, EnvSecretsProvider
 
 __all__ = [
     # Base classes

--- a/lib/creds/cli.py
+++ b/lib/creds/cli.py
@@ -122,8 +122,8 @@ def cmd_set(args: argparse.Namespace) -> int:
 def cmd_list(args: argparse.Namespace) -> int:
     """Handle the 'list' subcommand."""
     from .project import get_project_id
-    from .providers.dotenv import DotEnvSecretsProvider
     from .providers.aws import AWSSecretsProvider
+    from .providers.dotenv import DotEnvSecretsProvider
 
     project_id = args.project or get_project_id()
 

--- a/lib/creds/config.py
+++ b/lib/creds/config.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/lib/creds/credentials.py
+++ b/lib/creds/credentials.py
@@ -278,7 +278,7 @@ class APICredentials:
 
     def __repr__(self) -> str:
         """Return masked representation."""
-        parts = [f"api_key=SecretValue('****')"]
+        parts = ["api_key=SecretValue('****')"]
         if self.base_url:
             parts.append(f"base_url='{self.base_url}'")
         if self.name:

--- a/lib/creds/masking.py
+++ b/lib/creds/masking.py
@@ -23,9 +23,9 @@ Pattern sources:
 
 from __future__ import annotations
 
-import re
 import logging
-from typing import List, Set, Tuple, Optional
+import re
+from typing import List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/lib/creds/providers/__init__.py
+++ b/lib/creds/providers/__init__.py
@@ -22,8 +22,8 @@ Usage:
     bundle = aws.get_bundle("my-project")
 """
 
-from .env import EnvSecretsProvider
 from .aws import AWSSecretsProvider
 from .dotenv import DotEnvSecretsProvider
+from .env import EnvSecretsProvider
 
 __all__ = ["EnvSecretsProvider", "AWSSecretsProvider", "DotEnvSecretsProvider"]

--- a/lib/creds/providers/aws.py
+++ b/lib/creds/providers/aws.py
@@ -29,11 +29,10 @@ from typing import Any, Dict, Literal, Optional, Tuple
 from ..base import (
     BundleProvider,
     ProviderCaps,
-    SecretBundle,
-    SecretsProvider,
-    SecretsError,
-    SecretNotFoundError,
     ProviderNotAvailableError,
+    SecretBundle,
+    SecretNotFoundError,
+    SecretsError,
 )
 
 logger = logging.getLogger(__name__)

--- a/lib/creds/providers/dotenv.py
+++ b/lib/creds/providers/dotenv.py
@@ -16,8 +16,6 @@ Usage:
 from __future__ import annotations
 
 import logging
-import os
-import re
 import shlex
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,7 +28,7 @@ from ..base import (
     SecretNotFoundError,
     SecretsError,
 )
-from ..project import ensure_secrets_dir, get_project_id
+from ..project import ensure_secrets_dir
 
 logger = logging.getLogger(__name__)
 

--- a/lib/creds/providers/env.py
+++ b/lib/creds/providers/env.py
@@ -23,13 +23,13 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from ..base import SecretsProvider, SecretNotFoundError
+from ..base import SecretNotFoundError, SecretsProvider
 
 logger = logging.getLogger(__name__)
 
 # Try to import dotenv, but it's optional
 try:
-    from dotenv import load_dotenv, dotenv_values
+    from dotenv import dotenv_values, load_dotenv
 
     DOTENV_AVAILABLE = True
 except ImportError:

--- a/lib/creds/run.py
+++ b/lib/creds/run.py
@@ -22,10 +22,8 @@ import os
 import shlex
 import subprocess
 import sys
-from typing import Optional
 
 from .audit import log_action
-from .base import SecretsError
 from .project import get_project_id
 
 logger = logging.getLogger(__name__)
@@ -33,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 def _get_bundle_provider(provider_name: str | None = None):
     """Get a bundle-capable provider."""
-    from .providers.dotenv import DotEnvSecretsProvider
     from .providers.aws import AWSSecretsProvider
+    from .providers.dotenv import DotEnvSecretsProvider
 
     if provider_name == "aws":
         return AWSSecretsProvider()

--- a/lib/creds/ui/app.py
+++ b/lib/creds/ui/app.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import secrets
 import sys
-from typing import Optional
 
 from ..audit import log_action
 from ..base import BundleProvider, SecretBundle, SecretNotFoundError
@@ -49,8 +48,8 @@ def _get_provider(
     config: SecretsConfig,
 ) -> BundleProvider:
     """Get the configured bundle provider."""
-    from ..providers.dotenv import DotEnvSecretsProvider
     from ..providers.aws import AWSSecretsProvider
+    from ..providers.dotenv import DotEnvSecretsProvider
 
     if config.default_provider == "aws":
         return AWSSecretsProvider(
@@ -84,9 +83,9 @@ def create_app(
     """
     _import_deps()
 
-    from fastapi import FastAPI, HTTPException, Depends, Request
-    from fastapi.responses import HTMLResponse, JSONResponse
-    from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+    from fastapi import Depends, FastAPI, HTTPException, Request
+    from fastapi.responses import HTMLResponse
+    from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
     if project_id is None:
         project_id = get_project_id()
@@ -445,10 +444,10 @@ def run_server(
 
     app, token = create_app(project_id, config)
 
-    print(f"\nSecrets Manager UI starting...")
+    print("\nSecrets Manager UI starting...")
     print(f"  URL:   http://{host}:{port}/")
     print(f"  Token: {token}")
-    print(f"  (Copy the token — it's required for API access)")
+    print("  (Copy the token — it's required for API access)")
     print()
 
     log_action("ui_start", project_id or "", f"host={host}, port={port}")

--- a/lib/security/cli.py
+++ b/lib/security/cli.py
@@ -61,7 +61,7 @@ def cmd_explain(args: argparse.Namespace) -> int:
         return 0
 
     print(f"Unknown finding ID: {args.finding_id}", file=sys.stderr)
-    print(f"\nAvailable finding IDs:", file=sys.stderr)
+    print("\nAvailable finding IDs:", file=sys.stderr)
     for fid in list_finding_ids():
         print(f"  - {fid}", file=sys.stderr)
     return 1

--- a/lib/security/config.py
+++ b/lib/security/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from .models import Severity, Suppression
 

--- a/lib/security/models.py
+++ b/lib/security/models.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from enum import IntEnum
-from pathlib import Path
 from typing import Optional
 
 

--- a/lib/security/modules/gitignore.py
+++ b/lib/security/modules/gitignore.py
@@ -37,7 +37,10 @@ def scan(project_root: str) -> ScanResult:
                 why="Without a .gitignore, `git add .` will stage all files "
                 "including secrets, keys, and environment files.",
                 fix="Create a .gitignore with standard exclusions.",
-                command='curl -sL https://www.toptal.com/developers/gitignore/api/python > .gitignore && echo ".env" >> .gitignore',
+                command=(
+                    'curl -sL https://www.toptal.com/developers/gitignore/api/python'
+                    ' > .gitignore && echo ".env" >> .gitignore'
+                ),
                 time_estimate="~2 minutes",
             )
         )

--- a/lib/security/modules/gitleaks.py
+++ b/lib/security/modules/gitleaks.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-from pathlib import Path
 
 from ..models import Finding, ScanResult, Severity
 
@@ -24,10 +23,17 @@ def scan(project_root: str, include_history: bool = False) -> ScanResult:
     result = ScanResult()
 
     if not is_available():
-        result.skipped.append("gitleaks not installed (run `brew install gitleaks` or see https://github.com/gitleaks/gitleaks)")
+        result.skipped.append(
+            "gitleaks not installed (run `brew install gitleaks` or "
+            "see https://github.com/gitleaks/gitleaks)"
+        )
         return result
 
-    cmd = ["gitleaks", "detect", "--source", project_root, "--report-format", "json", "--report-path", "/dev/stdout", "--no-banner"]
+    cmd = [
+        "gitleaks", "detect", "--source", project_root,
+        "--report-format", "json", "--report-path", "/dev/stdout",
+        "--no-banner",
+    ]
 
     if not include_history:
         cmd.append("--no-git")

--- a/lib/security/modules/permissions.py
+++ b/lib/security/modules/permissions.py
@@ -6,7 +6,6 @@ are not world-readable (chmod 600 or stricter).
 
 from __future__ import annotations
 
-import os
 import stat
 from pathlib import Path
 

--- a/lib/security/modules/pip_audit.py
+++ b/lib/security/modules/pip_audit.py
@@ -37,7 +37,10 @@ def scan(project_root: str) -> ScanResult:
         return result
 
     if not is_available():
-        result.skipped.append("pip-audit not installed (run `uv pip install pip-audit` for Python dependency CVE scanning)")
+        result.skipped.append(
+            "pip-audit not installed (run `uv pip install pip-audit` "
+            "for Python dependency CVE scanning)"
+        )
         return result
 
     cmd = ["pip-audit", "--format", "json", "--progress-spinner", "off"]

--- a/lib/security/orchestrator.py
+++ b/lib/security/orchestrator.py
@@ -6,8 +6,6 @@ Provides quick, standard, and deep scan modes.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from .config import SecurityConfig
 from .models import ScanResult
 from .modules import debug_flags, env_files, gitignore, gitleaks, npm_audit, permissions, pip_audit, secrets

--- a/lib/spec_bridge/__init__.py
+++ b/lib/spec_bridge/__init__.py
@@ -27,23 +27,23 @@ Based on GitHub Spec Kit (MIT License):
 https://github.com/github/spec-kit
 """
 
-from .parser import (
-    Task,
-    Wave,
-    SpecDocument,
-    parse_tasks,
-    parse_spec,
-    parse_plan,
-)
 from .issue_sync import (
     SyncResult,
-    sync_feature,
     sync_all_features,
+    sync_feature,
+)
+from .parser import (
+    SpecDocument,
+    Task,
+    Wave,
+    parse_plan,
+    parse_spec,
+    parse_tasks,
 )
 from .status import (
     FeatureStatus,
-    get_feature_status,
     get_all_status,
+    get_feature_status,
 )
 
 __all__ = [

--- a/lib/spec_bridge/__main__.py
+++ b/lib/spec_bridge/__main__.py
@@ -1,6 +1,7 @@
 """Allow running as python -m lib.spec_bridge."""
 
 import sys
+
 from .cli import main
 
 if __name__ == "__main__":

--- a/lib/spec_bridge/cli.py
+++ b/lib/spec_bridge/cli.py
@@ -14,8 +14,8 @@ import argparse
 import sys
 from pathlib import Path
 
-from .status import get_feature_status, get_all_status, format_feature_status, format_project_status
-from .issue_sync import sync_feature, sync_all_features
+from .issue_sync import sync_all_features, sync_feature
+from .status import format_feature_status, format_project_status, get_all_status, get_feature_status
 
 
 def cmd_status(args: argparse.Namespace) -> int:
@@ -121,7 +121,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     # Check for constitution
     constitution_path = base_dir / "memory" / "constitution.md"
     if not constitution_path.exists():
-        print(f"\nNote: Create your project constitution at:")
+        print("\nNote: Create your project constitution at:")
         print(f"  {constitution_path}")
 
     return 0
@@ -141,24 +141,56 @@ def cmd_create(args: argparse.Namespace) -> int:
     feature_path.mkdir(parents=True)
 
     # Create placeholder files
+    title = _title_case(feature_name)
     files = {
-        "spec.md": f"# Feature Specification: {_title_case(feature_name)}\n\n> **Status:** Draft\n\n## Overview\n\nTODO: Describe what this feature does.\n\n## User Stories\n\n### US1: TODO [P1]\n\n**As a** user,\n**I want** TODO,\n**So that** TODO.\n\n**Acceptance Criteria:**\n- [ ] TODO\n",
-        "plan.md": f"# Implementation Plan: {_title_case(feature_name)}\n\n> **Spec:** [spec.md](./spec.md)\n> **Status:** Draft\n\n## Summary\n\nTODO: Technical approach.\n\n## Architecture\n\nTODO: Component design.\n",
-        "tasks.md": f"# Tasks: {_title_case(feature_name)}\n\n> **Plan:** [plan.md](./plan.md)\n> **Status:** Draft\n\n## Wave 1: Core Implementation\n\n- [ ] **T001** [US1] TODO task description\n\n**Checkpoint:** Core functionality works\n\n## Issue Sync\n\n| Wave | Tasks | Issue | Status |\n|------|-------|-------|--------|\n| 1 | T001 | - | pending |\n",
+        "spec.md": (
+            f"# Feature Specification: {title}\n\n"
+            "> **Status:** Draft\n\n"
+            "## Overview\n\n"
+            "TODO: Describe what this feature does.\n\n"
+            "## User Stories\n\n"
+            "### US1: TODO [P1]\n\n"
+            "**As a** user,\n"
+            "**I want** TODO,\n"
+            "**So that** TODO.\n\n"
+            "**Acceptance Criteria:**\n"
+            "- [ ] TODO\n"
+        ),
+        "plan.md": (
+            f"# Implementation Plan: {title}\n\n"
+            "> **Spec:** [spec.md](./spec.md)\n"
+            "> **Status:** Draft\n\n"
+            "## Summary\n\n"
+            "TODO: Technical approach.\n\n"
+            "## Architecture\n\n"
+            "TODO: Component design.\n"
+        ),
+        "tasks.md": (
+            f"# Tasks: {title}\n\n"
+            "> **Plan:** [plan.md](./plan.md)\n"
+            "> **Status:** Draft\n\n"
+            "## Wave 1: Core Implementation\n\n"
+            "- [ ] **T001** [US1] TODO task description\n\n"
+            "**Checkpoint:** Core functionality works\n\n"
+            "## Issue Sync\n\n"
+            "| Wave | Tasks | Issue | Status |\n"
+            "|------|-------|-------|--------|\n"
+            "| 1 | T001 | - | pending |\n"
+        ),
     }
 
     for filename, content in files.items():
         (feature_path / filename).write_text(content)
 
     print(f"Created feature spec: {feature_name}")
-    print(f"\nFiles:")
+    print("\nFiles:")
     for filename in files:
         print(f"  {feature_path / filename}")
 
-    print(f"\nNext steps:")
-    print(f"  1. Edit spec.md with user stories")
-    print(f"  2. Edit plan.md with technical approach")
-    print(f"  3. Edit tasks.md with actionable items")
+    print("\nNext steps:")
+    print("  1. Edit spec.md with user stories")
+    print("  2. Edit plan.md with technical approach")
+    print("  3. Edit tasks.md with actionable items")
     print(f"  4. Run: python -m lib.spec_bridge sync {feature_name}")
 
     return 0

--- a/lib/spec_bridge/issue_sync.py
+++ b/lib/spec_bridge/issue_sync.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from .parser import Wave, parse_tasks, parse_spec
+from .parser import Wave, parse_tasks
 
 
 @dataclass
@@ -97,7 +97,7 @@ def list_issues(
                 number=item["number"],
                 title=item["title"],
                 state=item["state"],
-                labels=[l["name"] for l in item.get("labels", [])],
+                labels=[lbl["name"] for lbl in item.get("labels", [])],
             )
             issues.append(issue)
 

--- a/lib/spec_bridge/status.py
+++ b/lib/spec_bridge/status.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
-from .parser import parse_tasks, parse_spec, parse_plan, Wave, SpecDocument
-from .issue_sync import list_issues, IssueInfo
+from .issue_sync import IssueInfo, list_issues
+from .parser import Wave, parse_plan, parse_spec, parse_tasks
 
 
 @dataclass

--- a/mcp-evaluate/src/config.py
+++ b/mcp-evaluate/src/config.py
@@ -1,9 +1,9 @@
 """Configuration for the MCP Evaluate server."""
 
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
-from pathlib import Path
 
 _env_path = Path(__file__).parent.parent / ".env"
 if _env_path.exists():

--- a/mcp-evaluate/src/server.py
+++ b/mcp-evaluate/src/server.py
@@ -16,12 +16,11 @@ from pathlib import Path
 from typing import Optional
 
 import httpx
+from config import Config
+from domains import VALID_DOMAINS, get_domain_prompt, get_spec_focus
 from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
-
-from config import Config
-from domains import VALID_DOMAINS, get_domain_prompt, get_spec_focus
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/mcp-playwright-persistent/src/server.py
+++ b/mcp-playwright-persistent/src/server.py
@@ -14,7 +14,6 @@ Features:
 """
 
 import argparse
-import asyncio
 import base64
 import logging
 import os
@@ -24,7 +23,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
-from playwright.async_api import async_playwright, Browser, BrowserContext, Page
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -13,31 +13,30 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from google import genai
-from google.genai import types
 import anthropic
 import openai
+from config import Config
 from fastmcp import FastMCP
+from google import genai
+from google.genai import types
+from prompts import build_code_review_prompt, scan_for_secrets
+from sessions import get_session_manager
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
-from starlette.requests import Request
-from starlette.responses import JSONResponse
-
-from config import Config
-from prompts import build_code_review_prompt, scan_for_secrets
-from sessions import get_session_manager, Session
 from tools import (
-    web_search,
-    fetch_url,
-    WEB_SEARCH_DECLARATION,
     FETCH_URL_DECLARATION,
+    WEB_SEARCH_DECLARATION,
     approve_domain,
-    revoke_domain,
+    fetch_url,
     get_approved_domains,
+    revoke_domain,
+    web_search,
 )
 
 # Configure logging
@@ -407,7 +406,9 @@ async def _try_openai_chat_api(prompt: str, model_name: str, max_tokens: int = C
     return result, model_name
 
 
-async def _try_openai_responses_api(prompt: str, model_name: str, max_tokens: int = Config.MAX_TOKENS) -> tuple[str, str]:
+async def _try_openai_responses_api(
+    prompt: str, model_name: str, max_tokens: int = Config.MAX_TOKENS
+) -> tuple[str, str]:
     """Use Responses API for Codex models."""
     logger.info(f"Using Responses API for {model_name}")
 
@@ -912,7 +913,10 @@ async def get_code_second_opinion(
         # Resolve verbosity synonyms and get max_tokens
         verbosity, max_tokens = Config.resolve_verbosity(verbosity)
 
-        logger.info(f"Received code review request for {language}, verbosity={verbosity}, max_tokens={max_tokens}, has_image={has_image}")
+        logger.info(
+            f"Received code review request for {language}, "
+            f"verbosity={verbosity}, max_tokens={max_tokens}, has_image={has_image}"
+        )
 
         # Scan for potential secrets before sending to API
         potential_secrets = scan_for_secrets(code)
@@ -1192,7 +1196,10 @@ async def get_multi_model_second_opinion(
         # Resolve verbosity synonyms and get max_tokens
         verbosity, max_tokens = Config.resolve_verbosity(verbosity)
 
-        logger.info(f"Multi-model code review for {language}, models={models}, verbosity={verbosity}, max_tokens={max_tokens}")
+        logger.info(
+            f"Multi-model code review for {language}, models={models}, "
+            f"verbosity={verbosity}, max_tokens={max_tokens}"
+        )
 
         # Scan for potential secrets before sending to API
         potential_secrets = scan_for_secrets(code)
@@ -1365,7 +1372,10 @@ async def consult(
         history_context = ""
         for msg in session.messages:
             role_label = "You" if msg.role == "user" else "Gemini"
-            history_context += f"\n{role_label}: {msg.content[:500]}...\n" if len(msg.content) > 500 else f"\n{role_label}: {msg.content}\n"
+            if len(msg.content) > 500:
+                history_context += f"\n{role_label}: {msg.content[:500]}...\n"
+            else:
+                history_context += f"\n{role_label}: {msg.content}\n"
 
         prompt_parts = [
             f"This is turn {session.turn_count + 1} in a {session.purpose} session.",
@@ -1558,14 +1568,16 @@ async def close_session(
                 for m in session.messages
             ])
 
-            summary_prompt = f"""Summarize the key findings and conclusions from this {session.purpose} session in 2-3 bullet points:
-
-{conversation_text}
-
-Provide a concise summary focusing on:
-1. Main issues identified
-2. Recommended solutions
-3. Key decisions made"""
+            summary_prompt = (
+                f"Summarize the key findings and conclusions "
+                f"from this {session.purpose} session in "
+                f"2-3 bullet points:\n\n"
+                f"{conversation_text}\n\n"
+                f"Provide a concise summary focusing on:\n"
+                f"1. Main issues identified\n"
+                f"2. Recommended solutions\n"
+                f"3. Key decisions made"
+            )
 
             try:
                 summary_response, _ = await get_gemini_streaming_response(
@@ -1578,7 +1590,10 @@ Provide a concise summary focusing on:
                 summary_input = len(summary_prompt) // Config.CHARS_PER_TOKEN
                 summary_output = len(summary_response) // Config.CHARS_PER_TOKEN
                 pricing = Config.GEMINI_PRICING.get(Config.GEMINI_MODEL_PRIMARY)
-                summary_cost = (summary_input / 1_000_000) * pricing["input"] + (summary_output / 1_000_000) * pricing["output"]
+                summary_cost = (
+                    (summary_input / 1_000_000) * pricing["input"]
+                    + (summary_output / 1_000_000) * pricing["output"]
+                )
             except Exception as e:
                 logger.warning(f"Failed to generate summary: {e}")
                 summary = "Summary generation failed"
@@ -1775,7 +1790,11 @@ async def approve_fetch_domain(domain: str) -> dict:
             "approved": True,
             "domain": domain,
             "was_new": was_new,
-            "message": f"Domain '{domain}' approved for this session" if was_new else f"Domain '{domain}' was already approved",
+            "message": (
+                f"Domain '{domain}' approved for this session"
+                if was_new
+                else f"Domain '{domain}' was already approved"
+            ),
             "session_approved_domains": get_approved_domains(),
         }
 
@@ -1809,7 +1828,11 @@ async def revoke_fetch_domain(domain: str) -> dict:
         return {
             "revoked": was_approved,
             "domain": domain,
-            "message": f"Domain '{domain}' revoked" if was_approved else f"Domain '{domain}' was not in the approved list",
+            "message": (
+                f"Domain '{domain}' revoked"
+                if was_approved
+                else f"Domain '{domain}' was not in the approved list"
+            ),
             "session_approved_domains": get_approved_domains(),
         }
 

--- a/mcp-second-opinion/src/tools/__init__.py
+++ b/mcp-second-opinion/src/tools/__init__.py
@@ -5,14 +5,14 @@ These tools can be invoked by Gemini during multi-turn sessions to
 gather additional information needed to answer questions.
 """
 
-from tools.web_search import web_search, WEB_SEARCH_DECLARATION
 from tools.fetch_url import (
-    fetch_url,
     FETCH_URL_DECLARATION,
     approve_domain,
-    revoke_domain,
+    fetch_url,
     get_approved_domains,
+    revoke_domain,
 )
+from tools.web_search import WEB_SEARCH_DECLARATION, web_search
 
 __all__ = [
     "web_search",

--- a/mcp-second-opinion/src/tools/fetch_url.py
+++ b/mcp-second-opinion/src/tools/fetch_url.py
@@ -11,9 +11,8 @@ import re
 from typing import Any, Dict, List, Set
 
 import httpx
-from google.genai import types
-
 from config import Config
+from google.genai import types
 
 logger = logging.getLogger(__name__)
 

--- a/scrape_reddit.py
+++ b/scrape_reddit.py
@@ -4,14 +4,19 @@ Simple web scraper for r/ClaudeCode subreddit.
 Fetches posts without requiring Reddit API credentials.
 """
 
-import requests
 import json
 from datetime import datetime
-from typing import List, Dict
-import time
+from typing import Dict, List
+
+import requests
 
 
-def scrape_subreddit(subreddit_name: str = "ClaudeCode", limit: int = 25, sort: str = "hot", time_filter: str = "all") -> List[Dict]:
+def scrape_subreddit(
+    subreddit_name: str = "ClaudeCode",
+    limit: int = 25,
+    sort: str = "hot",
+    time_filter: str = "all",
+) -> List[Dict]:
     """
     Scrape posts from a subreddit using Reddit's old.reddit.com interface.
 
@@ -34,7 +39,10 @@ def scrape_subreddit(subreddit_name: str = "ClaudeCode", limit: int = 25, sort: 
         url = f"https://old.reddit.com/r/{subreddit_name}/.json"
 
     headers = {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        'User-Agent': (
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        )
     }
 
     params = {
@@ -102,7 +110,10 @@ def scrape_post_comments(post_id: str, subreddit_name: str = "ClaudeCode") -> Di
     url = f"https://old.reddit.com/r/{subreddit_name}/comments/{post_id}/.json"
 
     headers = {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        'User-Agent': (
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        )
     }
 
     try:

--- a/tests/test_cicd_health.py
+++ b/tests/test_cicd_health.py
@@ -6,9 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from lib.cicd.config import CICDConfig, HealthEndpoint, ProcessCheck, SmokeTest
 from lib.cicd.health import check_endpoint, check_process, run_health_checks
-from lib.cicd.models import HealthCheckEntry, HealthCheckResult
+from lib.cicd.models import HealthCheckEntry, HealthCheckResult, SmokeTestEntry, SmokeTestResult
 from lib.cicd.smoke import run_single_test, run_smoke_tests
-from lib.cicd.models import SmokeTestEntry, SmokeTestResult
 
 
 class TestHealthCheckModels:


### PR DESCRIPTION
## Summary
- Fixed all 81 pre-existing `ruff check` errors across 37 files
- Auto-fixed 59 errors: I001 (unsorted imports), F401 (unused imports), F541 (empty f-strings)
- Manually fixed 22 errors: F821 (missing `FrameworkInfo` import in `lib/cicd/makefile.py`), E501 (line length), E402 (import order), E741 (ambiguous variable name)
- `ruff check .` now passes with zero errors

## Test plan
- [x] `ruff check .` passes cleanly (0 errors)
- [ ] Verify no behavioral changes — lint-only cleanup
- [ ] Spot-check key files: `lib/cicd/makefile.py` (F821 fix), `mcp-second-opinion/src/server.py` (E501 fixes)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)