### PR TITLE
feat(flow): Add MCP server connectivity checks (Closes #120)

### DIFF
--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -206,7 +206,7 @@ fi
 # Check MCP server pyproject.toml files
 echo ""
 echo "MCP Server Projects:"
-for server in mcp-second-opinion mcp-playwright-persistent; do
+for server in mcp-second-opinion mcp-playwright-persistent extras/redis-coordination/mcp-server; do
   if [ -f "$CPP_DIR/$server/pyproject.toml" ]; then
     echo "  [x] $server: pyproject.toml found"
   else
@@ -218,11 +218,26 @@ done
 echo ""
 echo "MCP Servers (Claude Code):"
 MCP_LIST=$(claude mcp list 2>/dev/null || echo "")
-for server in second-opinion playwright-persistent; do
+for server in second-opinion playwright-persistent coordination; do
   if echo "$MCP_LIST" | grep -q "$server"; then
-    echo "  [x] $server"
+    echo "  [x] $server: registered"
   else
-    echo "  [ ] $server"
+    echo "  [ ] $server: not registered"
+  fi
+done
+
+# Check MCP server connectivity
+echo ""
+echo "MCP Server Connectivity:"
+for entry in "8080:second-opinion" "8081:playwright-persistent" "8082:coordination"; do
+  PORT="${entry%%:*}"
+  NAME="${entry#*:}"
+  if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "  [x] $NAME (port $PORT): reachable"
+  elif ss -tlnp 2>/dev/null | grep -q ":${PORT} " 2>/dev/null; then
+    echo "  [~] $NAME (port $PORT): port open (no /health endpoint)"
+  else
+    echo "  [ ] $NAME (port $PORT): not reachable"
   fi
 done
 
@@ -330,6 +345,10 @@ Tier 3 (Full):
   [x] uv: 0.5.x
   [x] mcp-second-opinion: pyproject.toml + registered
   [ ] mcp-playwright-persistent: not configured
+  MCP Connectivity:
+    [x] second-opinion (port 8080): reachable
+    [ ] playwright-persistent (port 8081): not reachable
+    [ ] coordination (port 8082): not reachable
   [ ] Systemd: not installed
   Status: Partial
 

--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -155,6 +155,35 @@ If `CPP_DIR` is not found, skip this entire section and note in the report:
 CI/CD Readiness: skipped (lib/cicd not available)
 ```
 
+### Step 7c: MCP Server Connectivity
+
+Check whether MCP servers are reachable on their expected ports:
+
+```bash
+echo ""
+echo "MCP Server Connectivity:"
+
+MCP_ISSUES=0
+for entry in "8080:second-opinion" "8081:playwright-persistent" "8082:coordination"; do
+  PORT="${entry%%:*}"
+  NAME="${entry#*:}"
+  if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "  [x] $NAME (port $PORT): reachable"
+  elif ss -tlnp 2>/dev/null | grep -q ":${PORT} " 2>/dev/null; then
+    echo "  [~] $NAME (port $PORT): port open (no /health endpoint)"
+  else
+    echo "  [ ] $NAME (port $PORT): not reachable"
+    MCP_ISSUES=$((MCP_ISSUES + 1))
+  fi
+done
+
+if (( MCP_ISSUES > 0 )); then
+  echo "  Status: $MCP_ISSUES server(s) not reachable"
+else
+  echo "  Status: All MCP servers reachable"
+fi
+```
+
 ### Step 8: Generate Report
 
 Output a single diagnostic report in this format:
@@ -190,6 +219,14 @@ Output a single diagnostic report in this format:
 | prompt-context.sh | ✅/❌ | Shell prompt context |
 | worktree-remove.sh | ✅/❌ | Safe worktree removal |
 | secrets-mask.sh | ✅/❌ | Output masking filter |
+
+### MCP Server Connectivity
+
+| Server | Port | Status | Details |
+|--------|------|--------|---------|
+| second-opinion | 8080 | ✅/⚠️/❌ | Reachable / Port open (no /health) / Not reachable |
+| playwright-persistent | 8081 | ✅/⚠️/❌ | Reachable / Port open (no /health) / Not reachable |
+| coordination | 8082 | ✅/⚠️/❌ | Reachable / Port open (no /health) / Not reachable |
 
 ### Active Worktrees
 
@@ -233,6 +270,7 @@ Output a single diagnostic report in this format:
 6. ❌ **No CI pipeline** — Run `/cicd:pipeline` to generate GitHub Actions or Woodpecker CI config
 7. ⚠️ **No health endpoints** — Add `health.endpoints` to `.claude/cicd.yml` for post-deploy verification
 8. ⚠️ **No smoke tests** — Add `health.smoke_tests` to `.claude/cicd.yml` for post-deploy testing
+9. ⚠️ **MCP server(s) not reachable** — Start servers: `cd mcp-second-opinion && ./start-server.sh` (or use stdio transport)
 
 *All checks passed!* → "Environment is ready for `/flow` workflow."
 ```


### PR DESCRIPTION
## Summary

- Add MCP server connectivity checks (ports 8080, 8081, 8082) to `/flow:doctor` as Step 7c
- Add MCP port connectivity section to `/cpp:status` Tier 3
- Checks use `curl /health` with fallback to `ss` port detection
- Include coordination server (extras/redis-coordination) alongside second-opinion and playwright

Closes #120

## Test plan

- [ ] Run `/flow:doctor` and verify MCP Server Connectivity section appears
- [ ] Run `/cpp:status` and verify MCP Connectivity section in Tier 3
- [ ] Verify reachable servers show `[x]`, port-only shows `[~]`, unreachable shows `[ ]`
- [ ] `make lint` passes
- [ ] `make test` passes (211 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)