### PR TITLE
docs(security): Document security gate behavior (Closes #123)

### DIFF
--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -55,6 +55,23 @@ PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate
 - If the gate produces **warnings** (high findings): display them but proceed.
 - If `lib/security` is not available, skip this step (warn the user).
 
+**Gate behavior by severity (defaults — configurable in `.claude/security.yml`):**
+
+| Severity | Effect on `/flow:finish` | What to do |
+|----------|--------------------------|------------|
+| CRITICAL | **BLOCKS** — flow stops, no PR created | Fix the finding, then re-run `/flow:finish` |
+| HIGH | **WARNS** — displayed, flow continues | Review finding; fix if real, suppress if false positive |
+| MEDIUM | Passes silently | No action needed |
+| LOW | Passes silently | No action needed |
+
+To suppress a known false positive, add it to `.claude/security.yml`:
+```yaml
+suppressions:
+  - id: HARDCODED_SECRET
+    path: tests/fixtures/.*
+    reason: "Test fixtures with fake credentials"
+```
+
 ### Step 2c: Makefile Completeness Check (optional, non-blocking)
 
 If `lib/cicd` is available, run a quick Makefile validation and report any gaps as warnings:

--- a/.claude/commands/flow/help.md
+++ b/.claude/commands/flow/help.md
@@ -36,6 +36,39 @@ Machine A: /flow:start 42  →  work  →  /flow:sync
 Machine B: /flow:start 42  →  picks up remote branch  →  continue working
 ```
 
+## Security Gates
+
+`/flow:finish` and `/flow:deploy` run automatic security scans as quality gates. Gate behavior is controlled by `.claude/security.yml`:
+
+| Severity | `/flow:finish` (default) | `/flow:deploy` (default) |
+|----------|--------------------------|--------------------------|
+| CRITICAL | **Blocks** — must fix before PR | **Blocks** — must fix before deploy |
+| HIGH | **Warns** — shows findings, proceeds | **Blocks** — must fix before deploy |
+| MEDIUM | Passes | **Warns** — shows findings, proceeds |
+| LOW | Passes | Passes |
+
+**What happens when blocked:**
+- The flow stops and displays all blocking findings with remediation hints
+- You fix the issue, then re-run `/flow:finish` or `/flow:deploy`
+- To suppress known false positives, add entries to `.claude/security.yml` `suppressions:`
+
+**Configuration** (`.claude/security.yml`):
+```yaml
+gates:
+  flow_finish:
+    block_on: [critical]       # Severities that stop the flow
+    warn_on: [high]            # Severities shown as warnings
+  flow_deploy:
+    block_on: [critical, high]
+    warn_on: [medium]
+suppressions:
+  - id: HARDCODED_SECRET       # Finding type to suppress
+    path: tests/fixtures/.*    # Regex for file path (optional)
+    reason: "Test fixtures with fake credentials"
+```
+
+If no `.claude/security.yml` exists, the defaults above are used. If `lib/security` is not available, the gate is skipped with a warning.
+
 ## Conventions
 
 - **Worktree directory:** `../{repo}-issue-{N}` (sibling to main repo)

--- a/.claude/commands/security/help.md
+++ b/.claude/commands/security/help.md
@@ -45,18 +45,52 @@ Novice-friendly security scanning for Claude Code projects.
 
 ## Configuration
 
-Create `.claude/security.yml` to customize:
+Create `.claude/security.yml` to customize gate behavior and suppress known findings.
+
+If this file does not exist, sensible defaults are used (see below).
+
+### Annotated Example
 
 ```yaml
+# .claude/security.yml — Security gate configuration
+# All sections are optional. Missing sections use defaults.
+
+# Gates control how /flow:finish and /flow:deploy respond to findings.
+# Each gate has two lists:
+#   block_on: severities that STOP the flow (must fix before proceeding)
+#   warn_on:  severities that DISPLAY a warning but allow the flow to continue
+# Severities not in either list pass silently.
 gates:
   flow_finish:
-    block_on: [critical]
-    warn_on: [high]
+    block_on: [critical]         # CRITICAL findings block PR creation
+    warn_on: [high]              # HIGH findings shown as warnings
+    # MEDIUM and LOW pass silently
   flow_deploy:
-    block_on: [critical, high]
-    warn_on: [medium]
+    block_on: [critical, high]   # Both CRITICAL and HIGH block deployment
+    warn_on: [medium]            # MEDIUM findings shown as warnings
+    # LOW passes silently
+
+# Suppressions hide known false positives from scan results.
+# Each entry must have an 'id' matching the finding type.
+# 'path' is an optional regex — if provided, only findings in matching
+# files are suppressed. 'reason' documents why the suppression exists.
 suppressions:
-  - id: HARDCODED_SECRET
-    path: tests/fixtures/.*
+  - id: HARDCODED_SECRET         # Finding type (from /security:explain)
+    path: tests/fixtures/.*      # Only suppress in test fixtures
     reason: "Test fixtures with fake credentials"
+
+  - id: DEBUG_FLAG_ENABLED
+    path: docs/examples/.*
+    reason: "Example code intentionally shows debug configuration"
 ```
+
+### Default Behavior (no security.yml)
+
+| Gate | Blocks on | Warns on |
+|------|-----------|----------|
+| `flow_finish` | CRITICAL | HIGH |
+| `flow_deploy` | CRITICAL, HIGH | MEDIUM |
+
+### Finding Types
+
+Use `/security:explain <ID>` to see details about any finding type (e.g., `HARDCODED_SECRET`, `ENV_FILE_TRACKED`, `DEBUG_FLAG_ENABLED`). The ID is shown in scan output next to each finding.


### PR DESCRIPTION
## Summary

- Add **Security Gates** section to `/flow:help` with severity/gate behavior table, config example, and suppression guidance
- Expand `/flow:finish` Step 2b with detailed gate behavior table and suppression example
- Replace minimal `/security:help` config section with fully annotated `.claude/security.yml` example, defaults table, and finding type reference

Closes #123

## Test plan

- [ ] Run `/flow:help` and verify Security Gates section appears between Golden Path and Conventions
- [ ] Run `/security:help` and verify annotated security.yml example with defaults table
- [ ] Verify `/flow:finish` docs explain CRITICAL blocks and HIGH warns with remediation
- [ ] `make lint` passes
- [ ] `make test` passes (211 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)