### PR TITLE
feat(secrets): Add /secrets:delete command with audit logging (Closes #121)

### DIFF
--- a/.claude/commands/secrets/delete.md
+++ b/.claude/commands/secrets/delete.md
@@ -1,0 +1,27 @@
+# Delete a Secret
+
+Remove a secret key from the project's store. Logs the deletion
+to the audit log (never the value).
+
+## Arguments
+
+- `KEY` (required): Secret key name to delete (e.g., `DB_PASSWORD`)
+
+## Instructions
+
+When the user invokes `/secrets:delete KEY`, run:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds delete "$KEY" --force
+```
+
+If `--project` is specified, add it:
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib:${PYTHONPATH}" python3 -m lib.creds delete "$KEY" --force --project "$PROJECT"
+```
+
+**Note:** `--force` skips the interactive confirmation prompt since Claude Code is non-interactive.
+
+**IMPORTANT:** Never echo or display secret values in output. Only confirm the key name was deleted.
+
+Report the result to the user.

--- a/.claude/commands/secrets/help.md
+++ b/.claude/commands/secrets/help.md
@@ -11,6 +11,7 @@ Secrets Management Commands
 
   /secrets:get [ID]        Get credentials (masked output)
   /secrets:set KEY VALUE   Set or update a secret value
+  /secrets:delete KEY      Delete a secret key (with confirmation)
   /secrets:list            List all secret keys (values masked)
   /secrets:run -- CMD      Run command with secrets injected as env vars
   /secrets:validate        Validate credential configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ claude-power-pack/
 │   ├── __init__.py                             # Main exports + get_bundle_provider()
 │   ├── __main__.py                             # python -m lib.creds entry
 │   ├── base.py                                 # SecretValue, SecretBundle, BundleProvider
-│   ├── cli.py                                  # CLI (get, set, list, run, ui, rotate)
+│   ├── cli.py                                  # CLI (get, set, delete, list, run, ui, rotate)
 │   ├── project.py                              # Project identity (git-based)
 │   ├── config.py                               # SecretsConfig from .claude/secrets.yml
 │   ├── audit.py                                # Audit logging (actions only, never values)
@@ -206,6 +206,7 @@ claude-power-pack/
 │   │   ├── secrets/                            # Secrets management commands
 │   │   │   ├── get.md                          # Get credentials (masked)
 │   │   │   ├── set.md                          # Set a secret value
+│   │   │   ├── delete.md                       # Delete a secret key
 │   │   │   ├── list.md                         # List secret keys
 │   │   │   ├── run.md                          # Run command with secrets
 │   │   │   ├── validate.md                     # Validate configuration
@@ -1049,6 +1050,9 @@ ln -sf ~/Projects/claude-power-pack/scripts/secrets-mask.sh ~/.claude/scripts/
 # Set a secret
 python -m lib.creds set DB_PASSWORD my-secret-value
 
+# Delete a secret
+python -m lib.creds delete DB_PASSWORD
+
 # List all secrets (masked)
 python -m lib.creds list
 
@@ -1074,6 +1078,7 @@ python -m lib.creds validate
 |---------|---------|
 | `/secrets:get [id]` | Get credentials (masked output) |
 | `/secrets:set KEY VALUE` | Set or update a secret |
+| `/secrets:delete KEY` | Delete a secret key |
 | `/secrets:list` | List all secret keys (masked) |
 | `/secrets:run -- CMD` | Run command with secrets injected |
 | `/secrets:validate` | Test credential configuration |

--- a/lib/creds/cli.py
+++ b/lib/creds/cli.py
@@ -3,6 +3,7 @@
 Usage:
     python -m lib.creds get [OPTIONS] [SECRET_ID]
     python -m lib.creds set KEY VALUE [--project PROJECT]
+    python -m lib.creds delete KEY [--project PROJECT] [--force]
     python -m lib.creds list [--project PROJECT]
     python -m lib.creds run -- COMMAND [ARGS...]
     python -m lib.creds validate [OPTIONS]
@@ -15,6 +16,9 @@ Examples:
 
     # Set a secret
     python -m lib.creds set DB_PASSWORD my-secret-value
+
+    # Delete a secret
+    python -m lib.creds delete DB_PASSWORD
 
     # List all secrets for current project
     python -m lib.creds list
@@ -194,6 +198,41 @@ def cmd_ui(args: argparse.Namespace) -> int:
         )
     except KeyboardInterrupt:
         print("\nUI server stopped.")
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    """Handle the 'delete' subcommand."""
+    from .audit import log_action
+    from .base import SecretNotFoundError
+    from .project import get_project_id
+    from .providers.dotenv import DotEnvSecretsProvider
+
+    project_id = args.project or get_project_id()
+    provider = DotEnvSecretsProvider()
+
+    # Check key exists first
+    bundle = provider.get_bundle(project_id)
+    if args.key not in bundle.secrets:
+        print_status("fail", f"Key '{args.key}' not found in project '{project_id}'")
+        return 1
+
+    # Confirm unless --force
+    if not args.force:
+        response = input(f"Delete '{args.key}' from project '{project_id}'? [y/N] ")
+        if response.lower() not in ("y", "yes"):
+            print("Cancelled.")
+            return 0
+
+    try:
+        provider.delete_key(project_id, args.key)
+    except SecretNotFoundError:
+        print_status("fail", f"Key '{args.key}' not found in project '{project_id}'")
+        return 1
+
+    log_action("delete", project_id, f"key={args.key}")
+
+    print_status("ok", f"Deleted {args.key} from project '{project_id}'")
     return 0
 
 
@@ -472,6 +511,25 @@ def create_parser() -> argparse.ArgumentParser:
         help="Override auto-detected project ID",
     )
 
+    # 'delete' subcommand
+    delete_parser = subparsers.add_parser(
+        "delete",
+        help="Delete a secret key",
+        description="Remove a secret from the project's store. "
+        "Requires confirmation unless --force is used.",
+    )
+    delete_parser.add_argument("key", help="Secret key name to delete (e.g., DB_PASSWORD)")
+    delete_parser.add_argument(
+        "--project",
+        help="Override auto-detected project ID",
+    )
+    delete_parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+
     # 'list' subcommand
     list_parser = subparsers.add_parser(
         "list",
@@ -590,6 +648,7 @@ def main(argv: list[str] | None = None) -> int:
     commands = {
         "get": cmd_get,
         "set": cmd_set,
+        "delete": cmd_delete,
         "list": cmd_list,
         "run": cmd_run,
         "validate": cmd_validate,


### PR DESCRIPTION
## Summary
- Add `delete` subcommand to the creds CLI (`lib/creds/cli.py`) with confirmation prompt and `--force` flag
- Create `/secrets:delete` command file (`.claude/commands/secrets/delete.md`)
- Wire up audit logging for delete operations (`log_action("delete", ...)`)
- Both `DotEnvSecretsProvider.delete_key()` and `AWSSecretsProvider.delete_key()` were already implemented

Closes #121

## Test plan
- [x] `python -m lib.creds delete TEST_KEY --force` removes secret and prints success
- [x] Deleting non-existent key returns exit code 1 with error message
- [x] Audit log records delete action with key name (never value)
- [x] `make lint` passes (ruff)
- [x] `make test` passes (211 tests)
- [x] `python -m lib.creds --help` shows delete in command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)