### PR TITLE
feat(cicd): Add Django Makefile template and framework-aware template suggestions (Closes #122)

### DIFF
--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -60,6 +60,27 @@ fi
 
 Report which of these standard targets exist: `lint`, `test`, `format`, `deploy`.
 
+**If no Makefile found:** Detect the framework and suggest the matching template:
+
+```bash
+# Only if CPP lib is available
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir/lib/cicd" ]; then CPP_DIR="$dir"; break; fi
+done
+
+if [ -n "$CPP_DIR" ] && [ ! -f "Makefile" ]; then
+  DETECTED=$(PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -c "
+from lib.cicd.detector import detect_framework
+info = detect_framework('.')
+print(f'{info.framework.value}:{info.package_manager.value}')
+" 2>/dev/null)
+  echo "Detected: $DETECTED"
+fi
+```
+
+Use the detection result to suggest the specific template file in the Actions Needed section (e.g., `django-uv.mk` for Django projects, `python-uv.mk` for Python+uv).
+
 ### Step 4: Hooks Configuration
 
 ```bash
@@ -262,7 +283,15 @@ Output a single diagnostic report in this format:
 
 (Only if there are failures or warnings)
 
-1. ❌ **Makefile missing** — Create a Makefile with `lint`, `test`, and `deploy` targets for `/flow:finish` and `/flow:deploy`
+1. ❌ **Makefile missing** — Create a Makefile with `lint`, `test`, and `deploy` targets for `/flow:finish` and `/flow:deploy`. Run `/cicd:init` to auto-generate from a stack-specific template, or copy one manually:
+   - Python (uv): `cp ~/Projects/claude-power-pack/templates/makefiles/python-uv.mk Makefile`
+   - Python (pip): `cp ~/Projects/claude-power-pack/templates/makefiles/python-pip.mk Makefile`
+   - Django (uv): `cp ~/Projects/claude-power-pack/templates/makefiles/django-uv.mk Makefile`
+   - Node (npm): `cp ~/Projects/claude-power-pack/templates/makefiles/node-npm.mk Makefile`
+   - Node (yarn): `cp ~/Projects/claude-power-pack/templates/makefiles/node-yarn.mk Makefile`
+   - Go: `cp ~/Projects/claude-power-pack/templates/makefiles/go.mk Makefile`
+   - Rust: `cp ~/Projects/claude-power-pack/templates/makefiles/rust.mk Makefile`
+   - Monorepo: `cp ~/Projects/claude-power-pack/templates/makefiles/multi.mk Makefile`
 2. ❌ **worktree-remove.sh not found** — Run: `ln -sf ~/Projects/claude-power-pack/scripts/worktree-remove.sh ~/.claude/scripts/`
 3. ⚠️ **uv not installed** — Install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 4. ❌ **cicd.yml missing** — Run `/cicd:init` to auto-detect framework and generate configuration

--- a/lib/cicd/detector.py
+++ b/lib/cicd/detector.py
@@ -17,6 +17,9 @@ from .models import (
     PackageManager,
 )
 
+# Django markers checked separately (requires manage.py + Python)
+_DJANGO_MARKER = "manage.py"
+
 # Marker files → (Framework, PackageManager or None)
 # Order matters: more specific markers first
 _FRAMEWORK_MARKERS: list[tuple[str, Framework, Optional[PackageManager]]] = [
@@ -114,6 +117,11 @@ def detect_framework(project_root: str | Path) -> FrameworkInfo:
     else:
         primary = unique_frameworks[0]
         secondary = []
+
+    # Promote Python → Django if manage.py exists
+    if primary == Framework.PYTHON and (root / _DJANGO_MARKER).exists():
+        detected_files.append(_DJANGO_MARKER)
+        primary = Framework.DJANGO
 
     # Determine package manager
     if detected_pm is None:

--- a/lib/cicd/makefile.py
+++ b/lib/cicd/makefile.py
@@ -224,6 +224,9 @@ def _get_template_path(info: FrameworkInfo, template_dir: Path) -> Optional[Path
         (Framework.PYTHON, PackageManager.UV): "python-uv.mk",
         (Framework.PYTHON, PackageManager.PIP): "python-pip.mk",
         (Framework.PYTHON, PackageManager.POETRY): "python-pip.mk",
+        (Framework.DJANGO, PackageManager.UV): "django-uv.mk",
+        (Framework.DJANGO, PackageManager.PIP): "django-uv.mk",
+        (Framework.DJANGO, PackageManager.POETRY): "django-uv.mk",
         (Framework.NODE, PackageManager.NPM): "node-npm.mk",
         (Framework.NODE, PackageManager.YARN): "node-yarn.mk",
         (Framework.NODE, PackageManager.PNPM): "node-npm.mk",
@@ -239,6 +242,7 @@ def _get_template_path(info: FrameworkInfo, template_dir: Path) -> Optional[Path
     # Fallback: try just the framework
     fw_mapping = {
         Framework.PYTHON: "python-uv.mk",
+        Framework.DJANGO: "django-uv.mk",
         Framework.NODE: "node-npm.mk",
         Framework.GO: "go.mk",
         Framework.RUST: "rust.mk",
@@ -339,6 +343,10 @@ def _get_clean_command(framework: Framework) -> str:
         Framework.PYTHON: (
             "rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache "
             "dist build *.egg-info .coverage htmlcov"
+        ),
+        Framework.DJANGO: (
+            "rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache "
+            "dist build *.egg-info .venv staticfiles .coverage htmlcov"
         ),
         Framework.NODE: "rm -rf node_modules dist build .next .nuxt coverage",
         Framework.GO: "rm -rf bin/ coverage.out",

--- a/lib/cicd/models.py
+++ b/lib/cicd/models.py
@@ -21,6 +21,7 @@ class Framework(Enum):
     """Detected project framework."""
 
     PYTHON = "python"
+    DJANGO = "django"
     NODE = "node"
     GO = "go"
     RUST = "rust"
@@ -31,6 +32,7 @@ class Framework(Enum):
     def label(self) -> str:
         labels = {
             Framework.PYTHON: "Python",
+            Framework.DJANGO: "Django",
             Framework.NODE: "Node.js",
             Framework.GO: "Go",
             Framework.RUST: "Rust",
@@ -66,6 +68,10 @@ RECOMMENDED_TARGETS = ["format", "typecheck", "build", "deploy", "clean", "verif
 # Framework-specific recommended targets
 FRAMEWORK_TARGETS: dict[Framework, list[str]] = {
     Framework.PYTHON: ["lint", "test", "typecheck", "format", "build", "deploy", "clean", "verify"],
+    Framework.DJANGO: [
+        "lint", "test", "typecheck", "format", "build", "deploy", "clean", "verify",
+        "migrate", "collectstatic", "check", "runserver",
+    ],
     Framework.NODE: ["lint", "test", "typecheck", "build", "deploy", "clean", "dev", "verify"],
     Framework.GO: ["lint", "test", "vet", "build", "deploy", "clean", "verify"],
     Framework.RUST: ["lint", "test", "build", "build-release", "deploy", "clean", "verify"],
@@ -88,6 +94,28 @@ FRAMEWORK_RUNNERS: dict[tuple[Framework, PackageManager], dict[str, str]] = {
         "typecheck": "python -m mypy .",
         "format": "python -m ruff format .",
         "build": "python -m build",
+    },
+    (Framework.DJANGO, PackageManager.UV): {
+        "lint": "uv run ruff check .",
+        "test": "uv run python manage.py test --verbosity=2",
+        "typecheck": "uv run mypy .",
+        "format": "uv run ruff format .",
+        "build": "uv build",
+        "migrate": "uv run python manage.py migrate",
+        "collectstatic": "uv run python manage.py collectstatic --noinput",
+        "check": "uv run python manage.py check --deploy",
+        "runserver": "uv run python manage.py runserver",
+    },
+    (Framework.DJANGO, PackageManager.PIP): {
+        "lint": "python -m ruff check .",
+        "test": "python manage.py test --verbosity=2",
+        "typecheck": "python -m mypy .",
+        "format": "python -m ruff format .",
+        "build": "python -m build",
+        "migrate": "python manage.py migrate",
+        "collectstatic": "python manage.py collectstatic --noinput",
+        "check": "python manage.py check --deploy",
+        "runserver": "python manage.py runserver",
     },
     (Framework.NODE, PackageManager.NPM): {
         "lint": "npm run lint",

--- a/templates/makefiles/django-uv.mk
+++ b/templates/makefiles/django-uv.mk
@@ -1,0 +1,78 @@
+# Makefile — Django + uv (Claude Power Pack)
+#
+# CPP /flow integration:
+#   /flow:finish  → runs `make lint` and `make test`
+#   /flow:deploy  → runs `make deploy`
+#   /flow:doctor  → reports which targets are available
+#
+# All commands use `uv run` for dependency isolation.
+# Copy to your project root as "Makefile" and customize.
+#
+# Django-specific targets: migrate, collectstatic, runserver, shell, createsuperuser
+
+.PHONY: lint test typecheck format build deploy clean verify ci-local
+.PHONY: migrate collectstatic runserver shell createsuperuser check showmigrations
+
+## Quality gates (used by /flow:finish)
+
+lint:
+	uv run ruff check .
+
+test:
+	uv run python manage.py test --verbosity=2
+
+## Recommended targets
+
+typecheck:
+	uv run mypy .
+
+format:
+	uv run ruff format .
+
+build:
+	uv build
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test typecheck check
+
+## Django management commands
+
+migrate:
+	uv run python manage.py migrate
+
+showmigrations:
+	uv run python manage.py showmigrations
+
+collectstatic:
+	uv run python manage.py collectstatic --noinput
+
+check:
+	uv run python manage.py check --deploy
+
+runserver:
+	uv run python manage.py runserver
+
+shell:
+	uv run python manage.py shell
+
+createsuperuser:
+	uv run python manage.py createsuperuser
+
+## Deployment (used by /flow:deploy)
+
+deploy: verify migrate collectstatic
+	@echo "TODO: Define your deploy steps here"
+	@echo "Examples:"
+	@echo "  ssh prod 'cd /app && git pull && uv sync && python manage.py migrate && systemctl restart gunicorn'"
+	@echo "  docker compose up -d --build"
+
+## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
+
+ci-local:
+	woodpecker exec
+
+## Utilities
+
+clean:
+	rm -rf .pytest_cache __pycache__ .ruff_cache .mypy_cache dist build *.egg-info .venv staticfiles


### PR DESCRIPTION
## Summary

- Add `django-uv.mk` Makefile template with Django-specific targets (migrate, collectstatic, check, runserver, shell, createsuperuser)
- Add Django framework detection to `lib/cicd/detector.py` — promotes Python→Django when `manage.py` is present
- Wire Django into models (Framework enum, targets, runner commands) and template selection in `makefile.py`
- Update `/flow:doctor` to suggest stack-specific template files when no Makefile is found

Closes #122

## Test plan

- [x] All 211 existing tests pass
- [x] Lint passes (ruff check clean)
- [x] Django detection works: Python project with `manage.py` detected as Django
- [x] Regular Python project without `manage.py` still detected as Python
- [x] `generate_makefile()` selects `django-uv.mk` for Django projects
- [x] Template includes all Django management targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)