### PR TITLE
feat(cicd): Add typecheck/verify targets and cicd.yml

### DIFF
--- a/.claude/cicd.yml
+++ b/.claude/cicd.yml
@@ -1,0 +1,15 @@
+# .claude/cicd.yml — CI/CD configuration for Claude Power Pack
+#
+# Framework and package manager are auto-detected (Python + uv).
+# This file configures quality gates and recommendations.
+
+build:
+  required_targets:
+    - lint
+    - test
+
+  recommended_targets:
+    - format
+    - typecheck
+    - verify
+    - clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint format clean
+.PHONY: test lint format typecheck verify clean
 
 ## Quality gates (used by /flow:finish)
 
@@ -10,6 +10,13 @@ format:
 
 test:
 	uv run --extra dev pytest
+
+typecheck:
+	uv run --extra dev mypy .
+
+## Pre-deploy gate (runs all quality checks)
+
+verify: lint test typecheck
 
 ## Utilities
 


### PR DESCRIPTION
## Summary
- Added `typecheck` (mypy) and `verify` (lint+test+typecheck) targets to Makefile
- Generated `.claude/cicd.yml` with required/recommended target config for `/flow` integration
- Skipped `build`/`deploy` targets — not useful for a developer tooling project

## Test plan
- [ ] `make typecheck` runs mypy successfully
- [ ] `make verify` runs lint, test, and typecheck in sequence
- [ ] `/cicd:check` reports 6/8 targets present

🤖 Generated with [Claude Code](https://claude.com/claude-code)