### PR TITLE
docs: Add Docker deployment docs and MCP vs Skills guide (Closes #197)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,14 @@ This repository contains five core components and optional extras:
 
 - Python 3.11+
 - Use uv for dependency management (pyproject.toml)
-- MCP servers support both stdio (recommended) and SSE transport
-- MCP Second Opinion: port 8080 (SSE) or `--stdio`
-- MCP Playwright: port 8081 (SSE) or `--stdio`
-- MCP Coordination: port 8082 (SSE) or `--stdio`
+- MCP servers support three deployment modes: stdio (recommended), SSE, or Docker
+- MCP Second Opinion: port 8080 (SSE/Docker) or `--stdio`
+- MCP Playwright: port 8081 (SSE/Docker) or `--stdio`
+- MCP Coordination: port 8082 (SSE/Docker) or `--stdio`
 - MCP Evaluate: DEPRECATED (absorbed into /evaluate:issue command + evaluate skill)
-- MCP Nano-Banana: port 8084 (SSE) or `--stdio`
+- MCP Nano-Banana: port 8084 (SSE/Docker) or `--stdio`
+- Docker Compose profiles: `core`, `browser`, `coord` (see Docker Deployment section)
+- Woodpecker CI for pipeline automation (`.woodpecker.yml`)
 - All documentation uses progressive disclosure principles
 
 ## Environment Variables
@@ -250,8 +252,64 @@ claude-power-pack/
 │   └── hooks.json                              # Session hooks
 ├── .github/
 │   └── ISSUE_TEMPLATE/                         # Structured issue templates
+├── docker-compose.yml                           # MCP server orchestration (profiles)
+├── .woodpecker.yml                              # Woodpecker CI pipeline
+├── docs/architecture/
+│   └── mcp-vs-skills.md                        # MCP vs Skills decision boundary
 └── README.md                                    # Quick start guide
 ```
+
+## Docker Deployment
+
+MCP servers can be run via Docker Compose with profile-based selection.
+
+### Profiles
+
+| Profile | Services | Use Case |
+|---------|----------|----------|
+| `core` | second-opinion, nano-banana | Default: code review + diagrams |
+| `browser` | playwright-persistent | Browser automation (2GB shm) |
+| `coord` | coordination + redis | Multi-session locking (teams) |
+
+### Quick Start
+
+```bash
+# Create .env with API keys (never commit)
+echo "GEMINI_API_KEY=..." > .env
+echo "OPENAI_API_KEY=..." >> .env
+
+# Start core services
+make docker-up PROFILE=core
+
+# Start all profiles
+make docker-up PROFILE="core browser coord"
+
+# View logs / status / stop
+make docker-logs
+make docker-ps
+make docker-down
+```
+
+### Secrets Flow
+
+Docker containers read API keys from a root `.env` file via `env_file` in docker-compose.yml. The `.env` file is gitignored. For production, use AWS Secrets Manager via `lib/creds`.
+
+### Connecting Claude Code to Docker MCP Servers
+
+```bash
+# SSE transport (containers expose ports)
+claude mcp add second-opinion --transport sse --url http://127.0.0.1:8080/sse
+claude mcp add nano-banana --transport sse --url http://127.0.0.1:8084/sse
+claude mcp add playwright-persistent --transport sse --url http://127.0.0.1:8081/sse
+```
+
+### Woodpecker CI
+
+The `.woodpecker.yml` pipeline runs on push/PR:
+1. **lint** — `uv run ruff check .`
+2. **test** — `uv run pytest`
+3. **typecheck** — `uv run mypy .`
+4. **Docker builds** — conditional per-server builds (only when server files change)
 
 ## On-Demand Documentation Loading
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A comprehensive repository combining:
 ## 🎯 Quick Navigation
 
 - [Quick Start: /cpp:init](#-quick-start-cppinit) - **START HERE** - Interactive setup wizard
+- [Quick Start: Docker](#-quick-start-docker) - Run MCP servers as containers
 - [Claude Best Practices](#claude-best-practices) - Community insights & tips
 - [Token-Efficient Tool Organization](#-token-efficient-tool-organization) - Progressive disclosure
 - [Shell Prompt Context](#-shell-prompt-context) - Visual session management
@@ -84,6 +85,51 @@ mkdir -p ~/Projects/.claude
 ln -s /path/to/claude-power-pack/.claude/commands ~/Projects/.claude/commands
 ln -s /path/to/claude-power-pack/.claude/skills ~/Projects/.claude/skills
 ```
+
+## 🐳 Quick Start: Docker
+
+Run MCP servers as Docker containers with profile-based selection:
+
+```bash
+# Create .env with API keys (never commit this file)
+echo "GEMINI_API_KEY=your-key" > .env
+
+# Start core services (Second Opinion + Nano-Banana)
+make docker-up PROFILE=core
+
+# Or start multiple profiles
+make docker-up PROFILE="core browser"
+```
+
+### Docker Compose Profiles
+
+| Profile | Services | Ports |
+|---------|----------|-------|
+| `core` | second-opinion, nano-banana | 8080, 8084 |
+| `browser` | playwright-persistent | 8081 |
+| `coord` | coordination + redis | 8082 |
+
+### Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make docker-up PROFILE=core` | Start services |
+| `make docker-down` | Stop all services |
+| `make docker-build PROFILE=core` | Build images |
+| `make docker-logs` | Tail logs |
+| `make docker-ps` | Show running containers |
+
+### Connect Claude Code to Docker MCP Servers
+
+```bash
+claude mcp add second-opinion --transport sse --url http://127.0.0.1:8080/sse
+claude mcp add nano-banana --transport sse --url http://127.0.0.1:8084/sse
+claude mcp add playwright-persistent --transport sse --url http://127.0.0.1:8081/sse
+```
+
+### CI Pipeline (Woodpecker)
+
+The `.woodpecker.yml` pipeline runs lint, test, typecheck, and conditional Docker builds per server on push/PR.
 
 ---
 

--- a/docs/architecture/mcp-vs-skills.md
+++ b/docs/architecture/mcp-vs-skills.md
@@ -1,0 +1,75 @@
+# MCP vs Skills: Decision Boundary
+
+When adding new functionality to Claude Power Pack, choose between MCP tools and Skills based on these criteria.
+
+## Decision Tree
+
+```
+Does the feature need real-time external access (APIs, browsers, databases)?
+  YES -> MCP Tool
+  NO  -> Does it teach a procedure or workflow?
+    YES -> Skill
+    NO  -> Does it need to run frequently with low latency?
+      YES -> MCP Tool
+      NO  -> Skill
+```
+
+## Comparison
+
+| Criteria | MCP Tool | Skill |
+|----------|----------|-------|
+| **Token cost** | Always loaded (~200-2K tokens/tool) | Loaded on demand (~0 idle) |
+| **External access** | Yes (APIs, filesystem, network) | No (prompt-only) |
+| **Latency** | Fast (direct function call) | None (injected into prompt) |
+| **State** | Can maintain state (sessions, caches) | Stateless |
+| **Deployment** | Server process (stdio/SSE/Docker) | Markdown file in `.claude/skills/` |
+| **Complexity** | Python code, dependencies, tests | Markdown with instructions |
+| **Discoverability** | Auto-listed by Claude Code | Triggered by keywords |
+
+## When to Use MCP
+
+- Calling external LLM APIs (Gemini, OpenAI, Anthropic)
+- Browser automation (Playwright sessions)
+- Diagram rendering (HTML generation, screenshot capture)
+- Distributed locking (Redis coordination)
+- Any operation requiring network I/O or persistent state
+
+## When to Use Skills
+
+- Teaching Claude a workflow (e.g., `/flow:auto`, `/spec:sync`)
+- Loading reference documentation on demand
+- Domain-specific prompting (e.g., evaluation domain types)
+- Procedures that compose existing tools
+- Anything that would bloat idle token usage if always loaded
+
+## Token Budget Policy
+
+| Category | Budget | Rationale |
+|----------|--------|-----------|
+| MCP server (always loaded) | <10K tokens | Per MCP_TOKEN_AUDIT_CHECKLIST |
+| Per-tool description | <200 chars | Minimize idle overhead |
+| Skill (on demand) | <5K tokens | Only loaded when triggered |
+| CLAUDE.md | <30K tokens | Always in context |
+
+## Migration Checklist
+
+Moving functionality from MCP to Skill (or vice versa):
+
+1. Identify whether the feature needs real-time external access
+2. Measure current token overhead (`/context`)
+3. If converting MCP -> Skill: extract procedure into markdown, remove tool
+4. If converting Skill -> MCP: implement as FastMCP tool, add to server
+5. Update CLAUDE.md references
+6. Verify no functionality lost
+
+## Examples
+
+| Feature | Type | Why |
+|---------|------|-----|
+| Code review via Gemini | MCP | Calls external Gemini API |
+| Browser screenshots | MCP | Controls Chromium process |
+| Diagram generation | MCP | Renders HTML, captures images |
+| `/evaluate:issue` workflow | Skill | Orchestrates existing MCP tools |
+| Best practices loading | Skill | Loads reference docs on demand |
+| Security scanning | Skill + lib | Runs local Python modules |
+| `/flow:auto` lifecycle | Skill | Composes git + gh + make commands |


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added Docker Deployment section (profiles, make targets, secrets flow, Woodpecker CI), updated Key Conventions, added docker-compose.yml and .woodpecker.yml to repo structure
- **README.md**: Added Docker Quick Start section with profile table, Makefile targets, and Claude Code connection instructions
- **docs/architecture/mcp-vs-skills.md**: New decision boundary document — when to use MCP tools vs Skills, with decision tree, comparison table, and token budget policy

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (211 tests)
- [x] Markdown renders correctly (verified structure)
- [x] All links and references consistent with existing docs

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)