### PR TITLE
fix(docker): Fix health checks, host binding, and deployment conventions (Closes #196)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ This repository contains five core components and optional extras:
 - MCP Nano-Banana: port 8084 (SSE) or `--stdio`
 - All documentation uses progressive disclosure principles
 
+## Deployment Conventions
+
+- If deploying, or testing deployment, use CI/CD protocols (Makefile targets like `make docker-build`, `make docker-up`, etc.)
+- If composing Docker, utilize CI/CD process (`make docker-*` targets, not raw `docker compose`)
+- If errors encountered, correct code, and correct CI/CD process (Makefile, Dockerfile, docker-compose.yml)
+
 ## Environment Variables
 
 | Variable | Purpose | Example |

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,13 @@ docker-up:
 	$(foreach p,$(PROFILE),docker compose --profile $(p) up -d;)
 
 docker-down:
-	docker compose --profile core --profile eval --profile browser --profile coord down
+	docker compose --profile core --profile browser --profile coord down
 
 docker-logs:
-	docker compose --profile core --profile eval --profile browser --profile coord logs -f
+	docker compose --profile core --profile browser --profile coord logs -f
 
 docker-ps:
-	docker compose --profile core --profile eval --profile browser --profile coord ps
+	docker compose --profile core --profile browser --profile coord ps
 
 ## Utilities
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      - MCP_SERVER_HOST=0.0.0.0
     restart: unless-stopped
     profiles: ["core"]
     deploy:
@@ -42,6 +44,8 @@ services:
     container_name: mcp-nano-banana
     ports:
       - "8084:8084"
+    environment:
+      - MCP_SERVER_HOST=0.0.0.0
     restart: unless-stopped
     profiles: ["core"]
     deploy:
@@ -91,6 +95,8 @@ services:
     ports:
       - "8081:8081"
     shm_size: "2gb"
+    environment:
+      - SERVER_HOST=0.0.0.0
     restart: unless-stopped
     profiles: ["browser"]
     deploy:
@@ -127,6 +133,7 @@ services:
       - redis
     environment:
       - REDIS_URL=redis://redis:6379/0
+      - MCP_SERVER_HOST=0.0.0.0
     restart: unless-stopped
     profiles: ["coord"]
     deploy:

--- a/extras/redis-coordination/mcp-server/deploy/Dockerfile
+++ b/extras/redis-coordination/mcp-server/deploy/Dockerfile
@@ -46,7 +46,7 @@ EXPOSE 8082
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8082/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8082/')" || exit 1
 
 # Run the MCP server
 ENTRYPOINT ["python", "server.py"]

--- a/extras/redis-coordination/mcp-server/src/server.py
+++ b/extras/redis-coordination/mcp-server/src/server.py
@@ -15,11 +15,14 @@ Lock naming follows wave/issue pattern:
 """
 import argparse
 import logging
+import os
 
 from config import config
 from coordination import CoordinationManager
 from fastmcp import FastMCP
 from redis_client import RedisClient
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 # Initialize FastMCP server
 mcp = FastMCP(
@@ -40,6 +43,15 @@ mcp = FastMCP(
     - Locks auto-expire based on timeout (default 5 minutes)
     """,
 )
+
+@mcp.custom_route("/", methods=["GET"])
+async def root_health_check(request: Request) -> JSONResponse:
+    """Health check endpoint."""
+    return JSONResponse({
+        "status": "healthy",
+        "server": config.SERVER_NAME,
+    })
+
 
 # Global coordinator instance
 coord = CoordinationManager()
@@ -270,10 +282,11 @@ def main():
         mcp.run(transport="stdio")
     else:
         logger.info(f"Starting {config.SERVER_NAME}")
-        logger.info(f"Transport: SSE on 127.0.0.1:{config.SERVER_PORT}")
+        host = os.getenv("MCP_SERVER_HOST", "127.0.0.1")
+        logger.info(f"Transport: SSE on {host}:{config.SERVER_PORT}")
         mcp.run(
             transport="sse",
-            host="127.0.0.1",
+            host=host,
             port=config.SERVER_PORT,
         )
 

--- a/mcp-nano-banana/deploy/Dockerfile
+++ b/mcp-nano-banana/deploy/Dockerfile
@@ -47,7 +47,7 @@ EXPOSE 8084
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8084/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8084/')" || exit 1
 
 # Run the MCP server
 ENTRYPOINT ["python", "server.py"]

--- a/mcp-playwright-persistent/deploy/Dockerfile
+++ b/mcp-playwright-persistent/deploy/Dockerfile
@@ -57,7 +57,7 @@ EXPOSE 8081
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/')" || exit 1
 
 # Run the MCP server
 ENTRYPOINT ["python", "server.py"]

--- a/mcp-second-opinion/deploy/Dockerfile
+++ b/mcp-second-opinion/deploy/Dockerfile
@@ -45,7 +45,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import sys; from config import Config; sys.exit(0 if Config.GEMINI_API_KEY else 1)"
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/')" || exit 1
 
 # Expose SSE port
 EXPOSE 8080


### PR DESCRIPTION
## Summary

- Fixed all 4 Dockerfile health checks to use correct `/` endpoint (was `/health` or API key check)
- Added `MCP_SERVER_HOST=0.0.0.0` environment variable to all services in docker-compose.yml for container host binding
- Added health check endpoint (`custom_route("/")`) to coordination server
- Made coordination server host configurable via `MCP_SERVER_HOST` env var
- Removed deprecated `eval` profile from Makefile docker targets
- Documented deployment conventions in CLAUDE.md

## Fixes Applied

| Issue | Fix |
|-------|-----|
| Health check 404s | Changed `/health` → `/` in all Dockerfiles |
| Second-opinion health check | Replaced API key check with HTTP health check |
| Containers unreachable | Added `MCP_SERVER_HOST=0.0.0.0` / `SERVER_HOST=0.0.0.0` |
| Coordination no health endpoint | Added `@mcp.custom_route("/")` handler |
| Coordination hardcoded host | Changed to `os.getenv("MCP_SERVER_HOST", "127.0.0.1")` |
| Stale eval profile | Removed from Makefile docker-down/logs/ps targets |

## Validation

All 5 containers built, running, and reporting healthy:
- mcp-second-opinion (8080) ✓
- mcp-playwright-persistent (8081) ✓
- mcp-coordination (8082) ✓
- mcp-nano-banana (8084) ✓
- mcp-redis (6379) ✓

## Test plan

- [ ] `make docker-build PROFILE="core browser coord"` succeeds
- [ ] `make docker-up PROFILE="core browser coord"` starts all containers
- [ ] `make docker-ps` shows all containers healthy
- [ ] Each service responds on its port (curl localhost:8080/, etc.)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)