### PR TITLE
fix(second-opinion): Add --diagnose flag and troubleshooting for -32602 errors (Closes #207)

### DIFF
--- a/.claude/commands/second-opinion/help.md
+++ b/.claude/commands/second-opinion/help.md
@@ -51,6 +51,24 @@ You can also invoke the MCP tools directly without commands:
 
 ## Requirements
 
-- MCP Second Opinion server running on port 8080
+- MCP Second Opinion server configured (stdio recommended, or SSE on port 8080)
 - At least one API key configured (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)
 - All three recommended for cross-provider comparison
+
+## Troubleshooting
+
+**Error `-32602: Invalid request parameters`** usually means the server isn't running, not that parameters are wrong.
+
+**Fix:** Switch from SSE to stdio transport (auto-starts the server):
+
+```bash
+claude mcp remove second-opinion
+claude mcp add second-opinion --transport stdio -- uv run --directory /path/to/claude-power-pack/mcp-second-opinion python src/server.py --stdio
+```
+
+**Diagnose configuration:**
+
+```bash
+cd /path/to/claude-power-pack/mcp-second-opinion
+./start-server.sh --diagnose
+```

--- a/mcp-second-opinion/README.md
+++ b/mcp-second-opinion/README.md
@@ -58,6 +58,54 @@ Copy `.env.example` to `.env` and configure:
 | `list_fetch_domains` | Show approved domains |
 | `health_check` | Server status |
 
+## Troubleshooting
+
+### Error: `-32602: Invalid request parameters`
+
+This usually means Claude Code cannot reach the server, not that your parameters are wrong.
+
+**Fix: Switch to stdio transport (recommended)**
+
+```bash
+# Remove the SSE configuration
+claude mcp remove second-opinion
+
+# Add with stdio (auto-starts, no manual server management)
+claude mcp add second-opinion --transport stdio -- uv run --directory /path/to/claude-power-pack/mcp-second-opinion python src/server.py --stdio
+```
+
+**If using SSE:** Ensure the server is running before starting Claude Code:
+
+```bash
+# Check if server is running
+curl -s http://127.0.0.1:8080/ | jq .
+
+# Start if not running
+cd /path/to/claude-power-pack/mcp-second-opinion
+./start-server.sh
+```
+
+### Diagnosing Configuration Issues
+
+```bash
+# Run pre-flight diagnostics
+./start-server.sh --diagnose
+
+# Or directly
+uv run python src/server.py --diagnose
+```
+
+This checks API keys, .env file, port availability, and available models.
+
+### No API keys configured
+
+The server starts but all LLM calls will fail. Add at least one key:
+
+```bash
+cp .env.example .env
+# Edit .env — add GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY
+```
+
 ## License
 
 MIT

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -1671,6 +1671,92 @@ async def list_fetch_domains() -> dict:
         }
 
 
+def _run_diagnose() -> int:
+    """Run pre-flight diagnostics and report server readiness.
+
+    Returns exit code: 0 = ready, 1 = warnings, 2 = errors.
+    """
+    import socket
+    from pathlib import Path
+
+    print(f"Second Opinion MCP Server v{Config.SERVER_VERSION}")
+    print("=" * 50)
+    errors = []
+    warnings = []
+
+    # Check API keys
+    has_gemini = bool(Config.GEMINI_API_KEY)
+    has_openai = bool(Config.OPENAI_API_KEY)
+    has_anthropic = bool(Config.ANTHROPIC_API_KEY)
+
+    if has_gemini:
+        print(f"  Gemini API key:    configured")
+    else:
+        warnings.append("GEMINI_API_KEY not set")
+        print(f"  Gemini API key:    NOT SET")
+
+    if has_openai:
+        print(f"  OpenAI API key:    configured")
+    else:
+        warnings.append("OPENAI_API_KEY not set")
+        print(f"  OpenAI API key:    NOT SET")
+
+    if has_anthropic:
+        print(f"  Anthropic API key: configured")
+    else:
+        warnings.append("ANTHROPIC_API_KEY not set")
+        print(f"  Anthropic API key: NOT SET")
+
+    if not (has_gemini or has_openai or has_anthropic):
+        errors.append("No API keys configured — server will start but all tool calls will fail")
+
+    # Check .env file
+    env_path = Path(__file__).parent.parent / ".env"
+    if env_path.exists():
+        print(f"  .env file:         {env_path}")
+    else:
+        print(f"  .env file:         not found (using environment variables)")
+
+    # Check port availability (SSE mode)
+    port = Config.SERVER_PORT
+    host = Config.SERVER_HOST
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(1)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        if result == 0:
+            print(f"  Port {port}:           IN USE (another server already running?)")
+            warnings.append(f"Port {port} already in use — SSE mode may fail to bind")
+        else:
+            print(f"  Port {port}:           available")
+    except Exception:
+        print(f"  Port {port}:           unable to check")
+
+    # Check available models
+    available = Config.get_available_model_keys()
+    print(f"  Available models:  {len(available)} ({', '.join(available[:5])}{'...' if len(available) > 5 else ''})")
+
+    # Summary
+    print()
+    if errors:
+        for e in errors:
+            print(f"  ERROR: {e}")
+    if warnings:
+        for w in warnings:
+            print(f"  WARNING: {w}")
+
+    if not errors and not warnings:
+        print("  Status: READY")
+        return 0
+    elif errors:
+        print(f"\n  Status: NOT READY ({len(errors)} error(s), {len(warnings)} warning(s))")
+        return 2
+    else:
+        print(f"\n  Status: READY with warnings ({len(warnings)} warning(s))")
+        return 1
+
+
 def main():
     """Main entry point for the MCP server."""
     parser = argparse.ArgumentParser(description=Config.SERVER_NAME)
@@ -1679,7 +1765,17 @@ def main():
         action="store_true",
         help="Run with stdio transport (for Claude Code auto-start)",
     )
+    parser.add_argument(
+        "--diagnose",
+        action="store_true",
+        help="Run pre-flight diagnostics and exit (check config, ports, API keys)",
+    )
     args = parser.parse_args()
+
+    if args.diagnose:
+        logging.disable(logging.CRITICAL)  # Suppress log noise during diagnostics
+        exit_code = _run_diagnose()
+        raise SystemExit(exit_code)
 
     if args.stdio:
         logger.info(f"Starting {Config.SERVER_NAME} v{Config.SERVER_VERSION}")

--- a/mcp-second-opinion/start-server.sh
+++ b/mcp-second-opinion/start-server.sh
@@ -7,6 +7,29 @@ set -euo pipefail
 # Change to the server directory
 cd "$(dirname "$0")"
 
+# Pre-flight: check uv is available
+if ! command -v uv &>/dev/null; then
+    echo "ERROR: 'uv' not found. Install it: curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+    exit 1
+fi
+
+# Pre-flight: check .env or environment variables
+if [[ ! -f .env ]] && [[ -z "${GEMINI_API_KEY:-}" ]] && [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    echo "WARNING: No .env file and no API keys in environment." >&2
+    echo "  The server will start but all tool calls will fail." >&2
+    echo "  Copy .env.example to .env and add at least one API key:" >&2
+    echo "    cp .env.example .env" >&2
+    echo "    # Edit .env with your API keys" >&2
+    echo "" >&2
+fi
+
+# Handle --diagnose flag
+if [[ "${1:-}" == "--diagnose" ]]; then
+    echo "Running diagnostics..."
+    uv run python src/server.py --diagnose
+    exit $?
+fi
+
 # Start the server using uv
 echo "Starting Second Opinion MCP Server..."
-uv run python src/server.py
+uv run python src/server.py "$@"


### PR DESCRIPTION
## Summary

- Add `--diagnose` CLI flag to `server.py` for pre-flight configuration checks (API keys, port availability, .env detection, model count)
- Update `start-server.sh` with pre-flight validation (uv check, .env detection, passthrough for `--diagnose`)
- Add troubleshooting section to `README.md` explaining the `-32602` error and recommending stdio transport
- Update `second-opinion:help.md` with troubleshooting guidance

The root cause: when the server is configured as SSE but not running, Claude Code's MCP client reports a misleading `-32602: Invalid request parameters` error instead of a clear "server not reachable" message. The fix makes it easier to diagnose and prevent this scenario.

## Test plan

- [ ] `uv run python src/server.py --diagnose` reports configuration status and exits
- [ ] `./start-server.sh --diagnose` runs pre-flight checks
- [ ] `./start-server.sh` warns when no .env and no API keys
- [ ] Server still starts normally with `./start-server.sh` and `--stdio`
- [ ] Troubleshooting docs are clear and actionable

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)