### PR TITLE
feat(claude-md): Add /claude-md:lint for CLAUDE.md governance auditing (Closes #205)

### DIFF
--- a/.claude/commands/cicd/check.md
+++ b/.claude/commands/cicd/check.md
@@ -88,6 +88,7 @@ The report includes:
 | `deploy` | Deployment (`/flow:deploy`) |
 | `clean` | Remove build artifacts |
 | `verify` | Pre-deploy gate (lint + test + typecheck) |
+| `troubleshoot` | Diagnostic pass (clean + lint + test) |
 
 ---
 

--- a/.claude/commands/cicd/help.md
+++ b/.claude/commands/cicd/help.md
@@ -53,6 +53,7 @@ Build, verify, and deploy automation for Claude Code projects.
 | `deploy` | No | `/flow:deploy` |
 | `clean` | No | Cleanup |
 | `verify` | No | Pre-deploy gate (lint + test + typecheck) |
+| `troubleshoot` | No | Diagnostic pass (clean + lint + test) |
 
 ## Configuration
 
@@ -115,6 +116,7 @@ See `templates/cicd.yml.example` for full documentation.
 
 ## Related
 
+- `/claude-md:lint` — Audit CLAUDE.md for CI/CD and troubleshooting directives
 - `/flow:doctor` — Reports Makefile target availability
 - `/flow:deploy` — Runs deploy target
 - `/self-improvement:deployment` — Analyze deploy failures and improve Makefile

--- a/.claude/commands/claude-md/help.md
+++ b/.claude/commands/claude-md/help.md
@@ -1,0 +1,56 @@
+---
+description: Overview of CLAUDE.md management commands
+---
+
+# CLAUDE.md Commands
+
+Audit and manage your project's CLAUDE.md governance directives.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/claude-md:lint` | Audit CLAUDE.md for CI/CD, Docker, and troubleshooting directives |
+| `/claude-md:help` | This help page |
+
+## Why CLAUDE.md Governance Matters
+
+CLAUDE.md is the primary mechanism for directing Claude Code agent behavior. Without explicit CI/CD and troubleshooting directives, agents default to ad-hoc approaches that bypass your project's build pipeline.
+
+`/claude-md:lint` checks that your CLAUDE.md includes:
+
+| Category | What It Checks |
+|----------|----------------|
+| CI/CD Protocol | Makefile targets referenced for build/test/deploy |
+| Troubleshooting Protocol | Directives to fix CI/CD alongside code |
+| Quality Gates | `make lint`, `make test`, `make verify` mentioned |
+| Docker Conventions | `make docker-*` targets (if Docker files exist) |
+| Deployment Protocol | `make deploy` or deployment workflow |
+| Available Commands | Makefile targets listed for reference |
+
+## Scoring
+
+| Score | Rating |
+|-------|--------|
+| 5-6 / 6 | HEALTHY |
+| 3-4 / 6 | NEEDS ATTENTION |
+| 0-2 / 6 | UNHEALTHY |
+
+## Quick Start
+
+```bash
+# Audit your CLAUDE.md
+/claude-md:lint
+
+# Fix gaps in your Makefile first
+/cicd:check
+
+# Full project health: Makefile + CLAUDE.md
+/cicd:check && /claude-md:lint
+```
+
+## Related
+
+- `/cicd:check` — Validate Makefile targets
+- `/cicd:init` — Generate Makefile from detected framework
+- `/project:init` — Full project scaffolding (generates CLAUDE.md with directives)

--- a/.claude/commands/claude-md/lint.md
+++ b/.claude/commands/claude-md/lint.md
@@ -1,0 +1,261 @@
+---
+description: Lint CLAUDE.md for missing CI/CD, Docker, and troubleshooting directives
+allowed-tools: Bash(cat:*), Bash(grep:*), Bash(test:*), Bash(ls:*), Bash(PYTHONPATH=*), Bash(python3:*), Read, Glob, Grep
+---
+
+# /claude-md:lint — CLAUDE.md Health Check
+
+Audit a project's CLAUDE.md to ensure it includes essential directives for CI/CD protocols, Docker conventions, and troubleshooting workflows.
+
+## Why This Matters
+
+CLAUDE.md governs agent behavior. Without explicit CI/CD directives, Claude Code agents will:
+- Run raw `docker compose` instead of `make docker-*` targets
+- Debug ad-hoc without following Makefile pipelines
+- Skip lint/test gates when troubleshooting
+- Make manual fixes that break CI/CD alignment
+
+---
+
+## Step 1: Detect Project Context
+
+```bash
+# Check for CLAUDE.md
+if [ ! -f "CLAUDE.md" ]; then
+    echo "NO CLAUDE.md FOUND"
+    echo ""
+    echo "This project has no CLAUDE.md. Create one with /project:init or manually."
+    exit 1
+fi
+
+# Detect framework
+HAS_MAKEFILE="no"
+HAS_DOCKER="no"
+HAS_CICD_YML="no"
+FRAMEWORK="unknown"
+
+[ -f "Makefile" ] && HAS_MAKEFILE="yes"
+[ -f "Dockerfile" ] || [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ] && HAS_DOCKER="yes"
+[ -f ".claude/cicd.yml" ] && HAS_CICD_YML="yes"
+
+# Detect framework from markers
+[ -f "pyproject.toml" ] || [ -f "setup.py" ] && FRAMEWORK="python"
+[ -f "package.json" ] && FRAMEWORK="node"
+[ -f "go.mod" ] && FRAMEWORK="go"
+[ -f "Cargo.toml" ] && FRAMEWORK="rust"
+```
+
+---
+
+## Step 2: Read and Audit CLAUDE.md
+
+Read the project's CLAUDE.md and check for the presence of each required directive category.
+
+### Required Sections
+
+Check for these directive categories (case-insensitive, flexible matching):
+
+| Category | Check For | Weight |
+|----------|-----------|--------|
+| **CI/CD Protocol** | Mentions Makefile targets for build/test/deploy | REQUIRED |
+| **Troubleshooting Protocol** | Mentions running lint/test before debugging, fixing CI/CD alongside code | REQUIRED |
+| **Quality Gates** | Mentions `make lint`, `make test`, `make verify`, or equivalent | REQUIRED |
+| **Docker Conventions** | Mentions `make docker-*` targets (only if Docker files exist) | CONDITIONAL |
+| **Deployment Protocol** | Mentions `make deploy` or deployment workflow | RECOMMENDED |
+| **Available Commands** | Lists Makefile targets or build commands | RECOMMENDED |
+
+### Detection Patterns
+
+For each category, search CLAUDE.md for these patterns:
+
+**CI/CD Protocol** (any of):
+- `make lint`, `make test`, `make build`, `make deploy`
+- `Makefile target`
+- `CI/CD protocol` or `cicd`
+- `quality gate`
+
+**Troubleshooting Protocol** (any of):
+- `troubleshoot`
+- `before debugging`
+- `fix.*CI/CD` or `fix.*Makefile` or `fix.*pipeline`
+- `root cause`
+- `never bypass`
+
+**Quality Gates** (any of):
+- `make lint`
+- `make test`
+- `make verify`
+- `quality gate`
+- `/flow:finish`
+
+**Docker Conventions** (any of, only checked if Docker files exist):
+- `make docker`
+- `docker-build`, `docker-up`, `docker-down`
+- `not raw.*docker`
+
+**Deployment Protocol** (any of):
+- `make deploy`
+- `deployment`
+- `/flow:deploy`
+
+**Available Commands** (any of):
+- A table or list containing `make` targets
+- `## Commands` or `## Makefile` or `## Available`
+
+---
+
+## Step 3: Score and Report
+
+Present results as a health report:
+
+```markdown
+## CLAUDE.md Lint Report
+
+**Project:** {project name from directory}
+**Framework:** {detected framework}
+**Makefile:** {yes/no}
+**Docker:** {yes/no}
+**cicd.yml:** {yes/no}
+
+### Directive Coverage
+
+| Category | Status | Details |
+|----------|--------|---------|
+| CI/CD Protocol | PASS/FAIL | {what was found or missing} |
+| Troubleshooting Protocol | PASS/FAIL | {what was found or missing} |
+| Quality Gates | PASS/FAIL | {what was found or missing} |
+| Docker Conventions | PASS/FAIL/SKIP | {what was found, or "No Docker files"} |
+| Deployment Protocol | PASS/WARN | {what was found or missing} |
+| Available Commands | PASS/WARN | {what was found or missing} |
+
+### Score: {N}/6 ({percentage}%)
+
+### {HEALTHY / NEEDS ATTENTION / UNHEALTHY}
+```
+
+**Scoring:**
+- PASS on REQUIRED = 1 point each (3 total)
+- PASS on CONDITIONAL (Docker) = 1 point if applicable, auto-PASS if no Docker
+- PASS on RECOMMENDED = 1 point each (2 total)
+- **HEALTHY:** 5-6 points
+- **NEEDS ATTENTION:** 3-4 points
+- **UNHEALTHY:** 0-2 points
+
+---
+
+## Step 4: Generate Fix Suggestions
+
+For each FAIL or WARN, provide the exact text block to add to CLAUDE.md.
+
+### If CI/CD Protocol is FAIL:
+
+```markdown
+**Add to CLAUDE.md:**
+
+## CI/CD Protocol
+
+- Use Makefile targets for all build, test, and deploy operations
+- Never run raw build commands — use `make lint`, `make test`, `make build`, `make deploy`
+- The Makefile is the single source of truth for project commands
+- If a Makefile target is missing for your operation, ADD the target rather than running raw commands
+```
+
+### If Troubleshooting Protocol is FAIL:
+
+```markdown
+**Add to CLAUDE.md:**
+
+## Troubleshooting Protocol
+
+- Before debugging manually, run `make lint` and `make test` to surface known issues
+- When fixing errors, fix BOTH the application code AND the CI/CD process (Makefile, Dockerfile, docker-compose.yml)
+- After any fix, verify through the full pipeline: `make verify`
+- Never bypass quality gates — if `make lint` or `make test` fails, fix the root cause
+- Use `make troubleshoot` for a single-command diagnostic pass (clean + lint + test)
+```
+
+### If Quality Gates is FAIL:
+
+```markdown
+**Add to CLAUDE.md:**
+
+## Quality Gates
+
+| Target | Purpose | When to Run |
+|--------|---------|-------------|
+| `make lint` | Run linter | Before every commit |
+| `make test` | Run tests | Before every commit |
+| `make verify` | Full check (lint + test + typecheck) | Before deployment |
+| `make troubleshoot` | Diagnostic pass (clean + lint + test) | When debugging issues |
+```
+
+### If Docker Conventions is FAIL (and Docker files exist):
+
+```markdown
+**Add to CLAUDE.md:**
+
+## Docker Conventions
+
+- Build images: `make docker-build` (not raw `docker build`)
+- Start services: `make docker-up` (not raw `docker compose up`)
+- Stop services: `make docker-down`
+- View logs: `make docker-logs`
+- Check status: `make docker-ps`
+- If Docker errors occur, check Dockerfile and docker-compose.yml alongside application code
+```
+
+### If Deployment Protocol is WARN:
+
+```markdown
+**Add to CLAUDE.md:**
+
+## Deployment
+
+- Deploy: `make deploy` (runs verify first)
+- The deploy target should be customized in the Makefile for your environment
+- Post-deploy: run `/cicd:health` to verify endpoints
+```
+
+### If Available Commands is WARN:
+
+```markdown
+**Add to CLAUDE.md:**
+
+## Available Makefile Targets
+
+Run `make help` or see the Makefile for all targets. Key targets:
+
+| Target | Purpose |
+|--------|---------|
+| `make lint` | Run linter |
+| `make test` | Run tests |
+| `make verify` | Full quality gate |
+| `make deploy` | Deploy (after verify) |
+| `make clean` | Remove build artifacts |
+| `make troubleshoot` | Diagnostic pass |
+```
+
+---
+
+## Step 5: Offer to Apply Fixes
+
+After presenting the report, ask:
+
+1. **Apply all fixes** — Add all missing sections to CLAUDE.md
+2. **Apply selectively** — Choose which sections to add
+3. **View only** — Just see the report, make changes manually
+
+If the user chooses to apply:
+- Read the current CLAUDE.md
+- Append missing sections at an appropriate location (after existing conventions, before detailed/reference sections)
+- Show the diff of what was added
+
+---
+
+## Notes
+
+- This command is read-only by default — it only modifies CLAUDE.md if the user opts in
+- Patterns are intentionally flexible — projects can phrase directives differently
+- Docker section is only checked if Dockerfile or docker-compose.yml exists
+- Run this after `/project:init` or `/cicd:init` to verify completeness
+- Pair with `/cicd:check` for full project health: `/cicd:check` validates the Makefile, `/claude-md:lint` validates the CLAUDE.md

--- a/.claude/commands/project/help.md
+++ b/.claude/commands/project/help.md
@@ -13,6 +13,7 @@ Commands for creating and managing projects.
 | `/project:init <name>` | Full project scaffolding — zero to GitHub repo |
 | `/project-next` | Scan issues and worktrees to recommend next steps |
 | `/project-lite` | Quick project reference with minimal context |
+| `/claude-md:lint` | Audit CLAUDE.md for CI/CD and troubleshooting directives |
 
 ## /project:init
 

--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -403,7 +403,81 @@ if [ -n "$CPP_DIR" ]; then
 fi
 ```
 
-### 4c: Spec Init
+### 4c: Generate CLAUDE.md
+
+If no CLAUDE.md exists yet, generate one with CI/CD governance directives:
+
+```bash
+if [ ! -f "CLAUDE.md" ]; then
+    # Detect Docker presence
+    HAS_DOCKER="no"
+    [ -f "Dockerfile" ] || [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ] && HAS_DOCKER="yes"
+
+    cat > CLAUDE.md << 'CLAUDEEOF'
+# $PROJECT_NAME
+
+## Overview
+
+{Brief project description.}
+
+## Key Conventions
+
+- {Framework} project
+- {Package manager} for dependency management
+
+## CI/CD Protocol
+
+- Use Makefile targets for all build, test, and deploy operations
+- Never run raw build commands — use `make lint`, `make test`, `make build`, `make deploy`
+- The Makefile is the single source of truth for project commands
+- If a Makefile target is missing for your operation, ADD the target rather than running raw commands
+
+## Troubleshooting Protocol
+
+- Before debugging manually, run `make lint` and `make test` to surface known issues
+- When fixing errors, fix BOTH the application code AND the CI/CD process (Makefile, Dockerfile, docker-compose.yml)
+- After any fix, verify through the full pipeline: `make verify`
+- Never bypass quality gates — if `make lint` or `make test` fails, fix the root cause
+- Use `make troubleshoot` for a single-command diagnostic pass (clean + lint + test)
+
+## Quality Gates
+
+| Target | Purpose | When to Run |
+|--------|---------|-------------|
+| `make lint` | Run linter | Before every commit |
+| `make test` | Run tests | Before every commit |
+| `make verify` | Full check (lint + test + typecheck) | Before deployment |
+| `make troubleshoot` | Diagnostic pass (clean + lint + test) | When debugging issues |
+
+## Deployment
+
+- Deploy: `make deploy` (runs verify first)
+- Customize the deploy target in the Makefile for your environment
+- Post-deploy: run `/cicd:health` to verify endpoints
+CLAUDEEOF
+
+    # Append Docker section if Docker files detected
+    if [ "$HAS_DOCKER" = "yes" ]; then
+        cat >> CLAUDE.md << 'DOCKEREOF'
+
+## Docker Conventions
+
+- Build images: `make docker-build` (not raw `docker build`)
+- Start services: `make docker-up` (not raw `docker compose up`)
+- Stop services: `make docker-down`
+- View logs: `make docker-logs`
+- Check status: `make docker-ps`
+- If Docker errors occur, check Dockerfile and docker-compose.yml alongside application code
+DOCKEREOF
+    fi
+
+    echo "Generated CLAUDE.md with CI/CD governance directives"
+fi
+```
+
+Fill in the framework/package-manager placeholders based on what was detected in Step 2.
+
+### 4d: Spec Init
 
 ```bash
 if [ ! -d ".specify" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@ This repository contains five core components and optional extras:
 - If composing Docker, utilize CI/CD process (`make docker-*` targets, not raw `docker compose`)
 - If errors encountered, correct code, and correct CI/CD process (Makefile, Dockerfile, docker-compose.yml)
 
+## Troubleshooting Protocol
+
+- Before debugging manually, run `make lint` and `make test` to surface known issues
+- When fixing errors, fix BOTH the application code AND the CI/CD process (Makefile, Dockerfile, docker-compose.yml)
+- After any fix, verify through the full pipeline: `make verify`
+- Never bypass quality gates — if `make lint` or `make test` fails, fix the root cause
+- If a Makefile target is missing for your operation, ADD the target rather than running raw commands
+
 ## Environment Variables
 
 | Variable | Purpose | Example |

--- a/README.md
+++ b/README.md
@@ -757,6 +757,8 @@ Framework-aware build system detection, verification, and deployment automation.
 | `/cicd:pipeline` | Generate GitHub Actions CI/CD workflows |
 | `/cicd:container` | Generate Dockerfile and docker-compose.yml |
 | `/cicd:help` | Overview of CI/CD commands |
+| `/claude-md:lint` | Audit CLAUDE.md for CI/CD and troubleshooting directives |
+| `/claude-md:help` | Overview of CLAUDE.md governance commands |
 
 ### The Verification Loop
 

--- a/templates/makefiles/django-uv.mk
+++ b/templates/makefiles/django-uv.mk
@@ -10,7 +10,7 @@
 #
 # Django-specific targets: migrate, collectstatic, runserver, shell, createsuperuser
 
-.PHONY: lint test typecheck format build deploy clean verify ci-local
+.PHONY: lint test typecheck format build deploy clean verify troubleshoot ci-local
 .PHONY: migrate collectstatic runserver shell createsuperuser check showmigrations
 
 ## Quality gates (used by /flow:finish)
@@ -66,6 +66,11 @@ deploy: verify migrate collectstatic
 	@echo "Examples:"
 	@echo "  ssh prod 'cd /app && git pull && uv sync && python manage.py migrate && systemctl restart gunicorn'"
 	@echo "  docker compose up -d --build"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test check
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/go.mk
+++ b/templates/makefiles/go.mk
@@ -11,7 +11,7 @@
 BINARY_NAME ?= $(shell basename $(CURDIR))
 BUILD_DIR   ?= bin
 
-.PHONY: lint test vet build deploy clean verify tidy ci-local
+.PHONY: lint test vet build deploy clean verify troubleshoot tidy ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -43,6 +43,11 @@ deploy: verify build
 	@echo "Examples:"
 	@echo "  scp $(BUILD_DIR)/$(BINARY_NAME) prod:/usr/local/bin/"
 	@echo "  docker build -t $(BINARY_NAME) . && docker push $(BINARY_NAME)"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test vet
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/multi.mk
+++ b/templates/makefiles/multi.mk
@@ -12,7 +12,7 @@
 # List sub-projects (directories containing their own Makefile)
 PROJECTS := backend frontend
 
-.PHONY: lint test build deploy clean verify ci-local $(PROJECTS)
+.PHONY: lint test build deploy clean verify troubleshoot ci-local $(PROJECTS)
 
 ## Quality gates (used by /flow:finish)
 ## Runs target in each sub-project that defines it
@@ -54,6 +54,11 @@ deploy: verify build
 	@echo "Examples:"
 	@echo "  docker compose up -d --build"
 	@echo "  $(MAKE) -C backend deploy && $(MAKE) -C frontend deploy"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/node-npm.mk
+++ b/templates/makefiles/node-npm.mk
@@ -8,7 +8,7 @@
 # Assumes package.json scripts: "lint", "test", "build", "dev".
 # Copy to your project root as "Makefile" and customize.
 
-.PHONY: lint test typecheck build deploy clean verify dev install ci-local
+.PHONY: lint test typecheck build deploy clean verify troubleshoot dev install ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -46,6 +46,11 @@ deploy: verify build
 	@echo "  npx wrangler deploy          # Cloudflare"
 	@echo "  npx vercel --prod            # Vercel"
 	@echo "  aws s3 sync dist/ s3://bucket # S3 static"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/node-yarn.mk
+++ b/templates/makefiles/node-yarn.mk
@@ -8,7 +8,7 @@
 # Assumes package.json scripts: "lint", "test", "build", "dev".
 # Copy to your project root as "Makefile" and customize.
 
-.PHONY: lint test typecheck build deploy clean verify dev install ci-local
+.PHONY: lint test typecheck build deploy clean verify troubleshoot dev install ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -46,6 +46,11 @@ deploy: verify build
 	@echo "  npx wrangler deploy          # Cloudflare"
 	@echo "  npx vercel --prod            # Vercel"
 	@echo "  aws s3 sync dist/ s3://bucket # S3 static"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/python-pip.mk
+++ b/templates/makefiles/python-pip.mk
@@ -9,7 +9,7 @@
 # or adjust commands to use `python -m` prefix.
 # Copy to your project root as "Makefile" and customize.
 
-.PHONY: lint test typecheck format build deploy clean verify venv ci-local
+.PHONY: lint test typecheck format build deploy clean verify troubleshoot venv ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -47,6 +47,11 @@ deploy: verify
 	@echo "Examples:"
 	@echo "  ssh prod 'cd /app && git pull && systemctl restart app'"
 	@echo "  docker compose up -d --build"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/python-uv.mk
+++ b/templates/makefiles/python-uv.mk
@@ -8,7 +8,7 @@
 # All commands use `uv run` for dependency isolation.
 # Copy to your project root as "Makefile" and customize.
 
-.PHONY: lint test typecheck format build deploy clean verify ci-local
+.PHONY: lint test typecheck format build deploy clean verify troubleshoot ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -40,6 +40,11 @@ deploy: verify
 	@echo "Examples:"
 	@echo "  ssh prod 'cd /app && git pull && systemctl restart app'"
 	@echo "  docker compose up -d --build"
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 

--- a/templates/makefiles/rust.mk
+++ b/templates/makefiles/rust.mk
@@ -8,7 +8,7 @@
 # Requires: cargo, clippy, rustfmt
 # Copy to your project root as "Makefile" and customize.
 
-.PHONY: lint test format build build-release deploy clean verify ci-local
+.PHONY: lint test format build build-release deploy clean verify troubleshoot ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -40,6 +40,11 @@ deploy: verify build-release
 	@echo "Examples:"
 	@echo "  scp target/release/$(shell basename $(CURDIR)) prod:/usr/local/bin/"
 	@echo "  docker build -t $(shell basename $(CURDIR)) ."
+
+## Troubleshooting (single-command diagnostic pass)
+
+troubleshoot: clean lint test
+	@echo "All checks passed — issue may be environmental"
 
 ## Local CI (requires: woodpecker-cli — https://woodpecker-ci.org/)
 


### PR DESCRIPTION
## Summary

- New `/claude-md:lint` command that audits CLAUDE.md for CI/CD, Docker, and troubleshooting directives
- Scores projects on 6 governance categories (CI/CD Protocol, Troubleshooting Protocol, Quality Gates, Docker Conventions, Deployment Protocol, Available Commands)
- Offers to auto-fix missing sections with ready-to-paste directive blocks
- Updated `/project:init` to generate CLAUDE.md with governance directives for new projects
- Added `make troubleshoot` target (clean + lint + test) to all 8 Makefile templates
- Expanded CPP's own CLAUDE.md with Troubleshooting Protocol section (dogfooding)
- Cross-referenced from `cicd:help`, `cicd:check`, `project:help`, and README

## Files Changed (16)

| Area | Files |
|------|-------|
| New command | `.claude/commands/claude-md/lint.md`, `.claude/commands/claude-md/help.md` |
| Project init | `.claude/commands/project/init.md` |
| CI/CD refs | `.claude/commands/cicd/check.md`, `.claude/commands/cicd/help.md` |
| Docs | `CLAUDE.md`, `README.md`, `.claude/commands/project/help.md` |
| Makefiles (8) | All templates in `templates/makefiles/` |

## Test plan

- [ ] Run `/claude-md:lint` in CPP repo — should score HEALTHY
- [ ] Run `/claude-md:lint` in a project without CI/CD directives — should score UNHEALTHY and offer fixes
- [ ] Verify `make troubleshoot` target works in a Python/uv project
- [ ] Run `/project:init test-project` and verify generated CLAUDE.md includes governance sections

Closes #205

Generated with [Claude Code](https://claude.com/claude-code)