### PR TITLE
feat(cicd): Add Infrastructure as Code tiered pipeline support (Closes #211)

### DIFF
--- a/.claude/commands/cicd/help.md
+++ b/.claude/commands/cicd/help.md
@@ -12,6 +12,9 @@ Build, verify, and deploy automation for Claude Code projects.
 | `/cicd:smoke` | Run smoke tests from cicd.yml |
 | `/cicd:pipeline` | Generate GitHub Actions CI/CD workflows |
 | `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:infra-init` | Scaffold IaC directory with tiered structure (foundation/platform/app) |
+| `/cicd:infra-discover` | Generate cloud resource discovery script for IaC import |
+| `/cicd:infra-pipeline` | Generate CI/CD pipelines for infrastructure tiers with approval gates |
 | `/cicd:help` | This help page |
 
 ## How It Works
@@ -112,6 +115,40 @@ See `templates/cicd.yml.example` for full documentation.
 # Use with /flow
 /flow:finish    # Runs make lint + make test
 /flow:deploy    # Runs make deploy
+```
+
+## Infrastructure as Code
+
+Three-tier IaC model with separate pipelines and approval gates:
+
+```
+/cicd:infra-init      →  Scaffold infra/ directory  →  foundation/ + platform/ + app/
+                                    ↓
+/cicd:infra-discover  →  Audit cloud resources  →  Generate terraform import commands
+                                    ↓
+/cicd:infra-pipeline  →  Generate per-tier workflows  →  Approval gates for foundation
+```
+
+Supported IaC providers: Terraform (default), Pulumi, Bicep
+Supported clouds: AWS, Azure, GCP
+
+Configuration in `.claude/cicd.yml`:
+
+```yaml
+infrastructure:
+  provider: terraform
+  cloud: aws
+  state_backend:
+    type: s3
+    bucket: my-tf-state
+    lock: true
+  tiers:
+    foundation:
+      approval_required: true
+    platform:
+      approval_required: false
+    app:
+      approval_required: false
 ```
 
 ## Related

--- a/.claude/commands/cicd/infra-discover.md
+++ b/.claude/commands/cicd/infra-discover.md
@@ -1,0 +1,41 @@
+---
+description: Generate cloud resource discovery script for IaC import
+allowed-tools: Bash(PYTHONPATH=*), Bash(python3:*), Bash(bash:*), Bash(ls:*), Read, AskUserQuestion
+---
+
+# /cicd:infra-discover — Cloud Resource Discovery
+
+Generate a discovery script that audits existing cloud resources and outputs them in a format suitable for IaC import (`terraform import`, etc.).
+
+## Instructions
+
+1. **Detect cloud provider** from `.claude/cicd.yml` or ask the user (aws/azure/gcp).
+
+2. **Generate the discovery script:**
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-discover --path "$(pwd)" --cloud aws --write
+```
+
+3. **Optionally run the script** if the user has CLI tools configured:
+
+```bash
+bash infra/scripts/discover-aws.sh
+```
+
+4. **Report findings** and suggest which resources to import first (most critical/fragile).
+
+## When to Use
+
+- Starting IaC from scratch ("no documentation exists yet")
+- Auditing what exists before codifying it
+- Building a manifest for `terraform import`
+
+## Key Principle
+
+Even if you only plan to run infrastructure changes once, codify them. The value is having an executable runbook, not a stale wiki page.
+
+## Related
+
+- `/cicd:infra-init` — Scaffold IaC directory structure
+- `/cicd:infra-pipeline` — Generate CI/CD pipelines with approval gates

--- a/.claude/commands/cicd/infra-init.md
+++ b/.claude/commands/cicd/infra-init.md
@@ -1,0 +1,69 @@
+---
+description: Scaffold IaC directory with tiered structure (foundation/platform/app)
+allowed-tools: Bash(PYTHONPATH=*), Bash(python3:*), Bash(ls:*), Bash(cat:*), Read, AskUserQuestion
+---
+
+# /cicd:infra-init — Scaffold Infrastructure as Code
+
+Generate a tiered IaC directory structure for your project.
+
+## Instructions
+
+1. **Check for existing IaC** by running detection:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-init --path "$(pwd)" --json
+```
+
+2. **If no `.claude/cicd.yml` exists**, ask the user for:
+   - IaC provider: terraform (default), pulumi, or bicep
+   - Cloud provider: aws (default), azure, or gcp
+   - Remote state backend type (s3, azure-storage, gcs)
+   - Tagging conventions (managed-by, repo, owner)
+
+3. **If `.claude/cicd.yml` exists** with an `infrastructure` section, use those settings.
+
+4. **Generate the scaffold:**
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-init --path "$(pwd)" --write
+```
+
+5. **Report what was created** and suggest next steps.
+
+## Three-Tier Model
+
+- **foundation/** — Run once, touch rarely. DNS zones, resource groups, networking, identity. Manual approval gates.
+- **platform/** — Shared services. Container registries, key vaults, shared databases. Less frequent deploys.
+- **app/** — Application-specific infrastructure. Deployed with application CI/CD.
+
+## Configuration
+
+Add to `.claude/cicd.yml`:
+
+```yaml
+infrastructure:
+  provider: terraform
+  cloud: aws
+  state_backend:
+    type: s3
+    bucket: my-tf-state
+    lock: true
+  tagging:
+    managed-by: terraform
+    repo: my-project
+    owner: platform-team
+  tiers:
+    foundation:
+      approval_required: true
+      separate_credentials: true
+    platform:
+      approval_required: false
+    app:
+      approval_required: false
+```
+
+## Related
+
+- `/cicd:infra-discover` — Audit existing cloud resources
+- `/cicd:infra-pipeline` — Generate CI/CD pipelines with approval gates

--- a/.claude/commands/cicd/infra-pipeline.md
+++ b/.claude/commands/cicd/infra-pipeline.md
@@ -1,0 +1,44 @@
+---
+description: Generate CI/CD pipelines for infrastructure tiers with approval gates
+allowed-tools: Bash(PYTHONPATH=*), Bash(python3:*), Bash(ls:*), Read, AskUserQuestion
+---
+
+# /cicd:infra-pipeline — Infrastructure CI/CD Pipelines
+
+Generate separate CI/CD pipelines for each infrastructure tier with appropriate approval gates.
+
+## Instructions
+
+1. **Read configuration** from `.claude/cicd.yml` infrastructure section.
+
+2. **Generate pipelines:**
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-pipeline --path "$(pwd)" --write
+```
+
+3. **Report what was generated** and explain the approval model:
+   - Foundation: requires environment approval in GitHub (or manual in Woodpecker)
+   - Platform: auto-deploy on merge (configurable)
+   - App: auto-deploy on merge
+
+## Pipeline Model
+
+Each tier gets its own workflow file, triggered only by changes to that tier's directory:
+
+- `.github/workflows/infra-foundation.yml` — Manual approval required
+- `.github/workflows/infra-platform.yml` — Auto-deploy (configurable)
+- `.github/workflows/infra-app.yml` — Auto-deploy
+
+### Approval Gates
+
+Foundation tier uses GitHub Environments with required reviewers. Set up:
+1. Go to repo Settings > Environments
+2. Create `infra-foundation` environment
+3. Add required reviewers
+
+## Related
+
+- `/cicd:infra-init` — Scaffold IaC directory structure
+- `/cicd:infra-discover` — Audit existing cloud resources
+- `/cicd:pipeline` — Application-layer pipeline generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,9 @@ Docker containers read API keys from a root `.env` file (gitignored) via `env_fi
 - `/cicd:smoke` — Run smoke tests from cicd.yml
 - `/cicd:pipeline` — Generate GitHub Actions workflows
 - `/cicd:container` — Generate Dockerfile and docker-compose.yml
+- `/cicd:infra-init` — Scaffold IaC directory (foundation/platform/app tiers)
+- `/cicd:infra-discover` — Generate cloud resource discovery script for IaC import
+- `/cicd:infra-pipeline` — Generate per-tier CI/CD pipelines with approval gates
 
 ### Security
 - `/security:scan` — Full scan: native + external tools

--- a/lib/cicd/__init__.py
+++ b/lib/cicd/__init__.py
@@ -32,14 +32,19 @@ Quick Start:
 
 from .config import CICDConfig
 from .container import generate_compose, generate_container_files, generate_dockerfile, generate_dockerignore
-from .detector import detect_framework
+from .detector import detect_framework, detect_infrastructure
 from .health import check_endpoint, check_process, run_health_checks
+from .infrastructure import generate_discovery_script, generate_infra_pipeline, scaffold_infrastructure
 from .makefile import check_makefile, generate_makefile, parse_makefile
 from .models import (
+    CloudProvider,
     Framework,
     FrameworkInfo,
     HealthCheckEntry,
     HealthCheckResult,
+    IaCProvider,
+    InfrastructureInfo,
+    InfraTier,
     MakefileCheckResult,
     MakefileTarget,
     PackageManager,
@@ -54,6 +59,7 @@ __all__ = [
     "CICDConfig",
     # Detector
     "detect_framework",
+    "detect_infrastructure",
     # Health
     "run_health_checks",
     "check_endpoint",
@@ -73,7 +79,15 @@ __all__ = [
     "generate_pipeline",
     "generate_github_actions",
     "generate_woodpecker",
+    # Infrastructure
+    "scaffold_infrastructure",
+    "generate_infra_pipeline",
+    "generate_discovery_script",
     # Models
+    "CloudProvider",
+    "IaCProvider",
+    "InfraTier",
+    "InfrastructureInfo",
     "Framework",
     "FrameworkInfo",
     "HealthCheckEntry",

--- a/lib/cicd/cli.py
+++ b/lib/cicd/cli.py
@@ -28,8 +28,9 @@ from typing import NoReturn
 
 from .config import CICDConfig
 from .container import generate_container_files
-from .detector import detect_framework
+from .detector import detect_framework, detect_infrastructure
 from .health import run_health_checks
+from .infrastructure import generate_discovery_script, generate_infra_pipeline, scaffold_infrastructure
 from .makefile import check_makefile
 from .pipeline import generate_pipeline
 from .smoke import run_smoke_tests
@@ -289,6 +290,115 @@ def cmd_container(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_infra_init(args: argparse.Namespace) -> int:
+    """Scaffold IaC directory structure."""
+    config = CICDConfig.load(args.path)
+
+    # Check if infra already exists
+    infra_dir = os.path.join(args.path, "infra")
+    if os.path.isdir(infra_dir) and not args.force:
+        print(f"infra/ directory already exists at {infra_dir}")
+        print("Use --force to overwrite.")
+        return 1
+
+    if args.json:
+        files = scaffold_infrastructure(args.path, config.infrastructure)
+        print(json.dumps({"files": list(files.keys())}, indent=2))
+        return 0
+
+    if args.write:
+        files = scaffold_infrastructure(args.path, config.infrastructure, output_dir=args.path)
+        print(f"IaC Provider: {config.infrastructure.provider}")
+        print(f"Cloud: {config.infrastructure.cloud}")
+        print()
+        for filepath in sorted(files.keys()):
+            print(f"  Created: {filepath}")
+        print()
+        print("Next steps:")
+        print("  1. Edit infra/foundation/variables.tf with your values")
+        print("  2. Configure state backend in each tier's main.tf")
+        print("  3. Run: cd infra && make init-all")
+    else:
+        files = scaffold_infrastructure(args.path, config.infrastructure)
+        for filepath, content in sorted(files.items()):
+            print(f"--- {filepath} ---")
+            print(content)
+        print("(dry run — use --write to create files)")
+
+    return 0
+
+
+def cmd_infra_discover(args: argparse.Namespace) -> int:
+    """Generate cloud resource discovery script."""
+    config = CICDConfig.load(args.path)
+    cloud = args.cloud or config.infrastructure.cloud
+
+    # Also run detection
+    infra_info = detect_infrastructure(args.path)
+    if infra_info.iac_provider.value != "none":
+        print(f"Existing IaC detected: {infra_info.iac_provider.label}")
+        if infra_info.detected_files:
+            print(f"  Files: {', '.join(infra_info.detected_files)}")
+        print()
+
+    if args.json:
+        files = generate_discovery_script(cloud)
+        result = {
+            "cloud": cloud,
+            "detection": infra_info.to_dict(),
+            "files": list(files.keys()),
+        }
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.write:
+        files = generate_discovery_script(cloud, output_dir=args.path)
+        for filepath in files:
+            print(f"  Created: {filepath}")
+        print()
+        print("Run the discovery script:")
+        print(f"  bash {list(files.keys())[0]}")
+    else:
+        files = generate_discovery_script(cloud)
+        for filepath, content in files.items():
+            print(f"--- {filepath} ---")
+            print(content)
+        print("(dry run — use --write to create files)")
+
+    return 0
+
+
+def cmd_infra_pipeline(args: argparse.Namespace) -> int:
+    """Generate CI/CD pipelines for infrastructure tiers."""
+    config = CICDConfig.load(args.path)
+    provider = args.provider or config.pipeline.provider
+
+    if args.json:
+        files = generate_infra_pipeline(config.infrastructure, provider)
+        print(json.dumps({"provider": provider, "files": list(files.keys())}, indent=2))
+        return 0
+
+    if args.write:
+        files = generate_infra_pipeline(config.infrastructure, provider, output_dir=args.path)
+        print(f"Pipeline provider: {provider}")
+        print(f"IaC: {config.infrastructure.provider}")
+        print()
+        for filepath in sorted(files.keys()):
+            print(f"  Created: {filepath}")
+        print()
+        for tier_name, tier_cfg in config.infrastructure.tiers.items():
+            approval = "manual approval required" if tier_cfg.approval_required else "auto-deploy"
+            print(f"  {tier_name}: {approval}")
+    else:
+        files = generate_infra_pipeline(config.infrastructure, provider)
+        for filepath, content in sorted(files.items()):
+            print(f"--- {filepath} ---")
+            print(content)
+        print("(dry run — use --write to create files)")
+
+    return 0
+
+
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add common arguments to a parser."""
     parser.add_argument(
@@ -398,6 +508,52 @@ def create_parser() -> argparse.ArgumentParser:
         help="Write files to disk (default: dry run to stdout)",
     )
 
+    # 'infra-init' subcommand
+    infra_init_parser = subparsers.add_parser(
+        "infra-init",
+        help="Scaffold IaC directory with tiered structure (foundation/platform/app)",
+    )
+    _add_common_args(infra_init_parser)
+    infra_init_parser.add_argument(
+        "--write", "-w", action="store_true",
+        help="Write files to disk (default: dry run to stdout)",
+    )
+    infra_init_parser.add_argument(
+        "--force", "-f", action="store_true",
+        help="Overwrite existing infra/ directory",
+    )
+
+    # 'infra-discover' subcommand
+    infra_discover_parser = subparsers.add_parser(
+        "infra-discover",
+        help="Generate cloud resource discovery script for IaC import",
+    )
+    _add_common_args(infra_discover_parser)
+    infra_discover_parser.add_argument(
+        "--cloud", choices=["aws", "azure", "gcp"], default=None,
+        help="Cloud provider (overrides cicd.yml)",
+    )
+    infra_discover_parser.add_argument(
+        "--write", "-w", action="store_true",
+        help="Write script to disk (default: dry run to stdout)",
+    )
+
+    # 'infra-pipeline' subcommand
+    infra_pipeline_parser = subparsers.add_parser(
+        "infra-pipeline",
+        help="Generate CI/CD pipelines for infrastructure tiers with approval gates",
+    )
+    _add_common_args(infra_pipeline_parser)
+    infra_pipeline_parser.add_argument(
+        "--provider", choices=["github-actions", "woodpecker"],
+        default=None,
+        help="Pipeline provider (overrides cicd.yml)",
+    )
+    infra_pipeline_parser.add_argument(
+        "--write", "-w", action="store_true",
+        help="Write files to disk (default: dry run to stdout)",
+    )
+
     return parser
 
 
@@ -417,6 +573,9 @@ def main(argv: list[str] | None = None) -> int:
         "smoke": cmd_smoke,
         "container": cmd_container,
         "pipeline": cmd_pipeline,
+        "infra-init": cmd_infra_init,
+        "infra-discover": cmd_infra_discover,
+        "infra-pipeline": cmd_infra_pipeline,
     }
 
     handler = commands.get(args.command)

--- a/lib/cicd/config.py
+++ b/lib/cicd/config.py
@@ -98,6 +98,51 @@ class BranchProtection:
 
 
 @dataclass
+class InfraTaggingConfig:
+    """Tagging conventions for IaC resources."""
+
+    managed_by: str = "terraform"
+    repo: str = ""
+    owner: str = ""
+    extra_tags: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class InfraTierConfig:
+    """Configuration for a single infrastructure tier."""
+
+    approval_required: bool = False
+    separate_credentials: bool = False
+
+
+@dataclass
+class InfraStateBackend:
+    """Remote state backend configuration."""
+
+    type: str = ""  # s3, azure-storage, gcs
+    bucket: str = ""
+    lock: bool = True
+    region: str = ""
+
+
+@dataclass
+class InfrastructureConfig:
+    """Infrastructure as Code configuration."""
+
+    provider: str = "terraform"  # terraform, pulumi, bicep
+    cloud: str = "aws"  # aws, azure, gcp
+    state_backend: InfraStateBackend = field(default_factory=InfraStateBackend)
+    tagging: InfraTaggingConfig = field(default_factory=InfraTaggingConfig)
+    tiers: dict[str, InfraTierConfig] = field(
+        default_factory=lambda: {
+            "foundation": InfraTierConfig(approval_required=True, separate_credentials=True),
+            "platform": InfraTierConfig(approval_required=False),
+            "app": InfraTierConfig(approval_required=False),
+        }
+    )
+
+
+@dataclass
 class ContainerConfig:
     """Container configuration."""
 
@@ -115,6 +160,7 @@ class CICDConfig:
     health: HealthConfig = field(default_factory=HealthConfig)
     pipeline: PipelineConfig = field(default_factory=PipelineConfig)
     container: ContainerConfig = field(default_factory=ContainerConfig)
+    infrastructure: InfrastructureConfig = field(default_factory=InfrastructureConfig)
 
     @classmethod
     def load(cls, project_root: Optional[str] = None) -> CICDConfig:
@@ -211,5 +257,41 @@ class CICDConfig:
                 config.container.expose_ports = container_data["expose_ports"]
             if "compose_services" in container_data:
                 config.container.compose_services = container_data["compose_services"]
+
+        # Parse infrastructure section
+        infra_data = data.get("infrastructure", {})
+        if infra_data:
+            config.infrastructure.provider = infra_data.get("provider", "terraform")
+            config.infrastructure.cloud = infra_data.get("cloud", "aws")
+
+            state_data = infra_data.get("state_backend", {})
+            if state_data:
+                config.infrastructure.state_backend = InfraStateBackend(
+                    type=state_data.get("type", ""),
+                    bucket=state_data.get("bucket", ""),
+                    lock=state_data.get("lock", True),
+                    region=state_data.get("region", ""),
+                )
+
+            tagging_data = infra_data.get("tagging", {})
+            if tagging_data:
+                config.infrastructure.tagging = InfraTaggingConfig(
+                    managed_by=tagging_data.get("managed-by", "terraform"),
+                    repo=tagging_data.get("repo", ""),
+                    owner=tagging_data.get("owner", ""),
+                    extra_tags={
+                        k: v for k, v in tagging_data.items()
+                        if k not in ("managed-by", "repo", "owner")
+                    },
+                )
+
+            tiers_data = infra_data.get("tiers", {})
+            if tiers_data:
+                config.infrastructure.tiers = {}
+                for tier_name, tier_cfg in tiers_data.items():
+                    config.infrastructure.tiers[tier_name] = InfraTierConfig(
+                        approval_required=tier_cfg.get("approval_required", False),
+                        separate_credentials=tier_cfg.get("separate_credentials", False),
+                    )
 
         return config

--- a/lib/cicd/detector.py
+++ b/lib/cicd/detector.py
@@ -12,8 +12,12 @@ from typing import Optional
 from .models import (
     FRAMEWORK_RUNNERS,
     FRAMEWORK_TARGETS,
+    CloudProvider,
     Framework,
     FrameworkInfo,
+    IaCProvider,
+    InfrastructureInfo,
+    InfraTier,
     PackageManager,
 )
 
@@ -155,4 +159,116 @@ def detect_framework(project_root: str | Path) -> FrameworkInfo:
         recommended_targets=recommended,
         runner_commands=runners,
         secondary_frameworks=secondary,
+    )
+
+
+# IaC marker files -> IaCProvider
+_IAC_MARKERS: list[tuple[str, IaCProvider]] = [
+    ("main.tf", IaCProvider.TERRAFORM),
+    ("terraform.tf", IaCProvider.TERRAFORM),
+    ("providers.tf", IaCProvider.TERRAFORM),
+    ("Pulumi.yaml", IaCProvider.PULUMI),
+    ("Pulumi.yml", IaCProvider.PULUMI),
+    ("main.bicep", IaCProvider.BICEP),
+    ("template.json", IaCProvider.CLOUDFORMATION),
+    ("template.yaml", IaCProvider.CLOUDFORMATION),
+]
+
+# Cloud provider markers
+_CLOUD_MARKERS: list[tuple[str, CloudProvider]] = [
+    ("aws", CloudProvider.AWS),
+    ("azurerm", CloudProvider.AZURE),
+    ("azure", CloudProvider.AZURE),
+    ("google", CloudProvider.GCP),
+    ("gcp", CloudProvider.GCP),
+]
+
+# Tier directory names
+_TIER_DIRS: dict[str, InfraTier] = {
+    "foundation": InfraTier.FOUNDATION,
+    "platform": InfraTier.PLATFORM,
+    "app": InfraTier.APP,
+    "application": InfraTier.APP,
+}
+
+
+def detect_infrastructure(project_root: str | Path) -> InfrastructureInfo:
+    """Detect IaC provider, cloud provider, and tier structure.
+
+    Checks the project root and common subdirectories (infra/, infrastructure/)
+    for IaC marker files.
+
+    Args:
+        project_root: Path to project root directory.
+
+    Returns:
+        InfrastructureInfo with detection results.
+    """
+    root = Path(project_root)
+    detected_files: list[str] = []
+    iac_provider = IaCProvider.NONE
+    cloud_provider = CloudProvider.UNKNOWN
+    has_state_backend = False
+    tiers_present: list[InfraTier] = []
+
+    # Directories to scan for IaC files
+    scan_dirs = [root]
+    for subdir in ("infra", "infrastructure", "iac", "terraform", "pulumi"):
+        candidate = root / subdir
+        if candidate.is_dir():
+            scan_dirs.append(candidate)
+            # Check for tier subdirectories
+            for tier_name, tier_enum in _TIER_DIRS.items():
+                if (candidate / tier_name).is_dir() and tier_enum not in tiers_present:
+                    tiers_present.append(tier_enum)
+
+    for scan_dir in scan_dirs:
+        # Check IaC markers
+        for filename, provider in _IAC_MARKERS:
+            filepath = scan_dir / filename
+            if filepath.exists():
+                rel = str(filepath.relative_to(root))
+                detected_files.append(rel)
+                if iac_provider == IaCProvider.NONE:
+                    iac_provider = provider
+
+        # Check for Terraform files by extension
+        if iac_provider == IaCProvider.NONE:
+            tf_files = list(scan_dir.glob("*.tf"))
+            if tf_files:
+                iac_provider = IaCProvider.TERRAFORM
+                for tf in tf_files[:3]:  # Cap at 3 for brevity
+                    detected_files.append(str(tf.relative_to(root)))
+
+        # Check for state backend
+        if (scan_dir / "backend.tf").exists():
+            has_state_backend = True
+            detected_files.append(str((scan_dir / "backend.tf").relative_to(root)))
+        if (scan_dir / ".terraform.lock.hcl").exists():
+            has_state_backend = True
+        if (scan_dir / "Pulumi.yaml").exists():
+            # Pulumi uses its own state management
+            has_state_backend = True
+
+    # Detect cloud provider from file contents (check provider blocks)
+    if iac_provider == IaCProvider.TERRAFORM:
+        for scan_dir in scan_dirs:
+            for tf_file in scan_dir.glob("*.tf"):
+                try:
+                    content = tf_file.read_text(errors="ignore")
+                    for marker, cp in _CLOUD_MARKERS:
+                        if marker in content:
+                            cloud_provider = cp
+                            break
+                    if cloud_provider != CloudProvider.UNKNOWN:
+                        break
+                except OSError:
+                    continue
+
+    return InfrastructureInfo(
+        iac_provider=iac_provider,
+        cloud_provider=cloud_provider,
+        detected_files=detected_files,
+        has_state_backend=has_state_backend,
+        tiers_present=tiers_present,
     )

--- a/lib/cicd/infrastructure.py
+++ b/lib/cicd/infrastructure.py
@@ -1,0 +1,849 @@
+"""Infrastructure as Code scaffold generation and discovery.
+
+Provides:
+- Scaffold generation for tiered IaC directories (foundation/platform/app)
+- Cloud resource discovery via CLI tools (aws/az/gcloud)
+- IaC pipeline generation with approval gates
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .config import InfrastructureConfig
+from .models import CloudProvider, IaCProvider
+
+
+def scaffold_infrastructure(
+    project_root: str | Path,
+    config: Optional[InfrastructureConfig] = None,
+    output_dir: Optional[str | Path] = None,
+) -> dict[str, str]:
+    """Generate IaC scaffold with tiered directory structure.
+
+    Creates:
+        infra/
+            foundation/  (subscriptions, resource groups, DNS, networking)
+            platform/    (registries, key vaults, shared DBs)
+            app/         (app-specific infra)
+
+    Args:
+        project_root: Path to project root.
+        config: Infrastructure configuration (defaults used if None).
+        output_dir: Where to write files (None = dry run, returns content).
+
+    Returns:
+        Dict mapping filepath to content for each generated file.
+    """
+    if config is None:
+        config = InfrastructureConfig()
+
+    provider = IaCProvider(config.provider)
+    cloud = CloudProvider(config.cloud)
+
+    generators = {
+        IaCProvider.TERRAFORM: _scaffold_terraform,
+        IaCProvider.PULUMI: _scaffold_pulumi,
+        IaCProvider.BICEP: _scaffold_bicep,
+    }
+
+    generator = generators.get(provider, _scaffold_terraform)
+    files = generator(config, cloud)
+
+    if output_dir:
+        root = Path(output_dir)
+        for filepath, content in files.items():
+            full_path = root / filepath
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
+
+    return files
+
+
+def generate_infra_pipeline(
+    config: Optional[InfrastructureConfig] = None,
+    provider: str = "github-actions",
+    output_dir: Optional[str | Path] = None,
+) -> dict[str, str]:
+    """Generate CI/CD pipelines for infrastructure tiers.
+
+    Foundation tier gets manual approval gates.
+    Platform tier may or may not require approval.
+    App tier runs automatically.
+
+    Args:
+        config: Infrastructure configuration.
+        provider: Pipeline provider (github-actions or woodpecker).
+        output_dir: Where to write files (None = dry run).
+
+    Returns:
+        Dict mapping filepath to content.
+    """
+    if config is None:
+        config = InfrastructureConfig()
+
+    iac = IaCProvider(config.provider)
+
+    if provider == "github-actions":
+        files = _generate_gh_infra_pipeline(config, iac)
+    else:
+        files = _generate_woodpecker_infra_pipeline(config, iac)
+
+    if output_dir:
+        root = Path(output_dir)
+        for filepath, content in files.items():
+            full_path = root / filepath
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
+
+    return files
+
+
+def generate_discovery_script(
+    cloud: str = "aws",
+    output_dir: Optional[str | Path] = None,
+) -> dict[str, str]:
+    """Generate a cloud resource discovery script.
+
+    Creates a shell script that audits existing cloud resources
+    and outputs them in a format suitable for IaC import.
+
+    Args:
+        cloud: Cloud provider (aws, azure, gcp).
+        output_dir: Where to write files (None = dry run).
+
+    Returns:
+        Dict mapping filepath to content.
+    """
+    generators = {
+        "aws": _generate_aws_discovery,
+        "azure": _generate_azure_discovery,
+        "gcp": _generate_gcp_discovery,
+    }
+
+    generator = generators.get(cloud, _generate_aws_discovery)
+    files = generator()
+
+    if output_dir:
+        root = Path(output_dir)
+        for filepath, content in files.items():
+            full_path = root / filepath
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
+            if filepath.endswith(".sh"):
+                full_path.chmod(0o755)
+
+    return files
+
+
+# --- Terraform scaffolding ---
+
+
+def _scaffold_terraform(config: InfrastructureConfig, cloud: CloudProvider) -> dict[str, str]:
+    """Generate Terraform scaffold."""
+    files: dict[str, str] = {}
+
+    # Provider block
+    provider_block = _tf_provider_block(cloud)
+    backend_block = _tf_backend_block(config)
+    tags_block = _tf_tags_block(config)
+
+    # Foundation tier
+    files["infra/foundation/main.tf"] = f"""\
+# Foundation Layer — run once, touch rarely
+# Resources: subscriptions, resource groups, DNS zones, networking, identity
+#
+# Deploy with approval: terraform plan -> review -> terraform apply
+{provider_block}
+{backend_block}
+
+# Add foundation resources here:
+# - DNS zones
+# - Resource groups / VPCs
+# - Identity providers
+# - Networking (VNets, subnets, peering)
+"""
+
+    files["infra/foundation/variables.tf"] = """\
+# Foundation variables
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (prod, staging, dev)"
+  type        = string
+  default     = "prod"
+}
+
+variable "region" {
+  description = "Primary cloud region"
+  type        = string
+}
+"""
+
+    files["infra/foundation/outputs.tf"] = """\
+# Foundation outputs — consumed by platform and app tiers
+# Use terraform_remote_state to reference these from other tiers
+"""
+
+    files["infra/foundation/tags.tf"] = tags_block
+
+    # Platform tier
+    files["infra/platform/main.tf"] = f"""\
+# Platform Layer — shared services
+# Resources: container registries, key vaults, log analytics, shared DBs
+{provider_block}
+{backend_block}
+
+# Reference foundation outputs:
+# data "terraform_remote_state" "foundation" {{
+#   backend = "{config.state_backend.type or 's3'}"
+#   config = {{
+#     bucket = "{config.state_backend.bucket or 'my-tf-state'}"
+#     key    = "foundation/terraform.tfstate"
+#   }}
+# }}
+"""
+
+    files["infra/platform/variables.tf"] = """\
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (prod, staging, dev)"
+  type        = string
+  default     = "prod"
+}
+"""
+
+    # App tier
+    files["infra/app/main.tf"] = f"""\
+# Application Layer — app-specific infrastructure
+# Resources: app services, functions, storage, app databases
+{provider_block}
+{backend_block}
+
+# Reference platform outputs:
+# data "terraform_remote_state" "platform" {{
+#   backend = "{config.state_backend.type or 's3'}"
+#   config = {{
+#     bucket = "{config.state_backend.bucket or 'my-tf-state'}"
+#     key    = "platform/terraform.tfstate"
+#   }}
+# }}
+"""
+
+    files["infra/app/variables.tf"] = """\
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (prod, staging, dev)"
+  type        = string
+  default     = "prod"
+}
+"""
+
+    # Root Makefile for infra operations
+    files["infra/Makefile"] = """\
+.PHONY: init-foundation plan-foundation apply-foundation \\
+        init-platform plan-platform apply-platform \\
+        init-app plan-app apply-app
+
+## Foundation (manual approval required)
+
+init-foundation:
+\tcd foundation && terraform init
+
+plan-foundation:
+\tcd foundation && terraform plan -out=tfplan
+
+apply-foundation:
+\t@echo "FOUNDATION TIER: Requires manual review of plan output."
+\t@echo "Run 'make plan-foundation' first, then approve below."
+\tcd foundation && terraform apply tfplan
+
+## Platform (shared services)
+
+init-platform:
+\tcd platform && terraform init
+
+plan-platform:
+\tcd platform && terraform plan -out=tfplan
+
+apply-platform:
+\tcd platform && terraform apply tfplan
+
+## App (application-specific)
+
+init-app:
+\tcd app && terraform init
+
+plan-app:
+\tcd app && terraform plan -out=tfplan
+
+apply-app:
+\tcd app && terraform apply tfplan
+
+## All tiers
+
+init-all: init-foundation init-platform init-app
+
+plan-all: plan-foundation plan-platform plan-app
+"""
+
+    # .gitignore for infra
+    files["infra/.gitignore"] = """\
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+tfplan
+.terraform.lock.hcl
+crash.log
+
+# Secrets
+*.tfvars
+!example.tfvars
+"""
+
+    # README
+    files["infra/README.md"] = f"""\
+# Infrastructure as Code
+
+Three-tier infrastructure managed by {config.provider.capitalize()}.
+
+## Tiers
+
+- **foundation/** — Run once, touch rarely. DNS, networking, identity. Manual approval required.
+- **platform/** — Shared services. Container registries, key vaults, shared DBs.
+- **app/** — Application-specific infrastructure. Deployed with application CI/CD.
+
+## Quick Start
+
+```bash
+# Initialize all tiers
+make init-all
+
+# Plan and apply foundation (requires manual approval)
+make plan-foundation
+# Review the plan output carefully
+make apply-foundation
+
+# Plan and apply platform
+make plan-platform
+make apply-platform
+
+# Plan and apply app
+make plan-app
+make apply-app
+```
+
+## State
+
+Remote state backend: {config.state_backend.type or 'configure in backend block'}
+Each tier has its own state file to minimize blast radius.
+
+## Tagging
+
+All resources are tagged with:
+- `managed-by: {config.tagging.managed_by}`
+- `repo: {config.tagging.repo or '<your-repo>'}`
+- `owner: {config.tagging.owner or '<your-team>'}`
+"""
+
+    return files
+
+
+def _tf_provider_block(cloud: CloudProvider) -> str:
+    providers = {
+        CloudProvider.AWS: 'provider "aws" {\n  region = var.region\n}',
+        CloudProvider.AZURE: 'provider "azurerm" {\n  features {}\n}',
+        CloudProvider.GCP: 'provider "google" {\n  project = var.project_id\n  region  = var.region\n}',
+    }
+    return providers.get(cloud, providers[CloudProvider.AWS])
+
+
+def _tf_backend_block(config: InfrastructureConfig) -> str:
+    if not config.state_backend.type:
+        return "# Configure remote state backend:\n# terraform {\n#   backend \"s3\" { ... }\n# }"
+
+    backends = {
+        "s3": f"""\
+terraform {{
+  backend "s3" {{
+    bucket = "{config.state_backend.bucket}"
+    key    = "TIER/terraform.tfstate"  # Replace TIER with foundation/platform/app
+    region = "{config.state_backend.region or 'us-east-1'}"
+    encrypt = true
+    dynamodb_table = "{config.state_backend.bucket}-locks"
+  }}
+}}""",
+        "azure-storage": f"""\
+terraform {{
+  backend "azurerm" {{
+    storage_account_name = "{config.state_backend.bucket}"
+    container_name       = "tfstate"
+    key                  = "TIER/terraform.tfstate"
+  }}
+}}""",
+        "gcs": f"""\
+terraform {{
+  backend "gcs" {{
+    bucket = "{config.state_backend.bucket}"
+    prefix = "TIER"
+  }}
+}}""",
+    }
+    return backends.get(config.state_backend.type, backends["s3"])
+
+
+def _tf_tags_block(config: InfrastructureConfig) -> str:
+    tags = {
+        "managed-by": config.tagging.managed_by,
+        "repo": config.tagging.repo or "REPO_NAME",
+        "owner": config.tagging.owner or "TEAM_NAME",
+    }
+    tags.update(config.tagging.extra_tags)
+
+    tag_lines = "\n".join(f'    "{k}" = "{v}"' for k, v in tags.items())
+    return f"""\
+# Default tags applied to all resources
+locals {{
+  default_tags = {{
+{tag_lines}
+  }}
+}}
+"""
+
+
+# --- Pulumi scaffolding ---
+
+
+def _scaffold_pulumi(config: InfrastructureConfig, cloud: CloudProvider) -> dict[str, str]:
+    """Generate Pulumi scaffold (Python)."""
+    files: dict[str, str] = {}
+
+    runtime = "python"
+    cloud_pkg = {
+        CloudProvider.AWS: "pulumi-aws",
+        CloudProvider.AZURE: "pulumi-azure-native",
+        CloudProvider.GCP: "pulumi-gcp",
+    }.get(cloud, "pulumi-aws")
+
+    for tier in ("foundation", "platform", "app"):
+        files[f"infra/{tier}/Pulumi.yaml"] = f"""\
+name: {tier}
+runtime: {runtime}
+description: {tier.capitalize()} tier infrastructure
+"""
+
+        files[f"infra/{tier}/__main__.py"] = f"""\
+\"\"\"
+{tier.capitalize()} tier infrastructure.
+\"\"\"
+import pulumi
+
+# Add {tier} resources here
+pulumi.export("tier", "{tier}")
+"""
+
+        files[f"infra/{tier}/requirements.txt"] = f"""\
+pulumi>=3.0.0
+{cloud_pkg}
+"""
+
+    files["infra/README.md"] = f"""\
+# Infrastructure as Code (Pulumi)
+
+Three-tier infrastructure managed by Pulumi ({runtime}).
+
+## Tiers
+
+- **foundation/** — DNS, networking, identity. Manual approval required.
+- **platform/** — Shared services.
+- **app/** — Application-specific infrastructure.
+
+## Quick Start
+
+```bash
+cd infra/foundation && pulumi up --yes
+cd infra/platform && pulumi up --yes
+cd infra/app && pulumi up --yes
+```
+"""
+
+    files["infra/.gitignore"] = """\
+# Pulumi
+*.pyc
+__pycache__/
+venv/
+"""
+
+    return files
+
+
+# --- Bicep scaffolding ---
+
+
+def _scaffold_bicep(config: InfrastructureConfig, cloud: CloudProvider) -> dict[str, str]:
+    """Generate Bicep scaffold."""
+    files: dict[str, str] = {}
+
+    for tier in ("foundation", "platform", "app"):
+        files[f"infra/{tier}/main.bicep"] = f"""\
+// {tier.capitalize()} tier infrastructure
+// Deploy: az deployment sub create --location <region> --template-file main.bicep
+
+targetScope = 'subscription'
+
+param location string = 'canadacentral'
+param projectName string
+
+// Add {tier} resources here
+"""
+
+        files[f"infra/{tier}/parameters.json"] = """\
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "projectName": {
+      "value": "my-project"
+    }
+  }
+}
+"""
+
+    files["infra/README.md"] = """\
+# Infrastructure as Code (Bicep)
+
+Three-tier infrastructure managed by Azure Bicep.
+
+## Tiers
+
+- **foundation/** — Resource groups, DNS, VNets. Manual approval required.
+- **platform/** — Key Vault, ACR, Log Analytics.
+- **app/** — App Service, Functions, Storage.
+
+## Quick Start
+
+```bash
+az deployment sub create --location canadacentral --template-file infra/foundation/main.bicep
+az deployment sub create --location canadacentral --template-file infra/platform/main.bicep
+az deployment sub create --location canadacentral --template-file infra/app/main.bicep
+```
+"""
+
+    files["infra/.gitignore"] = """\
+# Bicep
+*.json.bak
+"""
+
+    return files
+
+
+# --- Pipeline generation ---
+
+
+def _generate_gh_infra_pipeline(
+    config: InfrastructureConfig,
+    iac: IaCProvider,
+) -> dict[str, str]:
+    """Generate GitHub Actions workflows for infrastructure tiers."""
+    files: dict[str, str] = {}
+
+    plan_cmd = {
+        IaCProvider.TERRAFORM: "terraform plan -out=tfplan",
+        IaCProvider.PULUMI: "pulumi preview",
+        IaCProvider.BICEP: "az deployment sub what-if --location ${{ vars.AZURE_LOCATION }} --template-file main.bicep",
+    }.get(iac, "terraform plan -out=tfplan")
+
+    apply_cmd = {
+        IaCProvider.TERRAFORM: "terraform apply tfplan",
+        IaCProvider.PULUMI: "pulumi up --yes",
+        IaCProvider.BICEP: "az deployment sub create --location ${{ vars.AZURE_LOCATION }} --template-file main.bicep",
+    }.get(iac, "terraform apply tfplan")
+
+    init_cmd = {
+        IaCProvider.TERRAFORM: "terraform init",
+        IaCProvider.PULUMI: "pip install -r requirements.txt",
+        IaCProvider.BICEP: "az bicep install",
+    }.get(iac, "terraform init")
+
+    for tier_name, tier_cfg in config.tiers.items():
+        lines: list[str] = []
+        lines.append(f"# Infrastructure: {tier_name} tier")
+        lines.append("# Generated by Claude Power Pack /cicd:infra-pipeline")
+        lines.append("")
+        lines.append(f"name: 'Infra: {tier_name.capitalize()}'")
+        lines.append("")
+        lines.append("on:")
+        lines.append("  push:")
+        lines.append(f"    paths: ['infra/{tier_name}/**']")
+        lines.append("    branches: [main]")
+        lines.append("  pull_request:")
+        lines.append(f"    paths: ['infra/{tier_name}/**']")
+        lines.append("    branches: [main]")
+        lines.append("  workflow_dispatch:")
+        lines.append("")
+        lines.append("jobs:")
+
+        # Plan job (always runs)
+        lines.append("  plan:")
+        lines.append("    runs-on: ubuntu-latest")
+        lines.append("    steps:")
+        lines.append("      - uses: actions/checkout@v4")
+        lines.append("      - name: Init")
+        lines.append(f"        working-directory: infra/{tier_name}")
+        lines.append(f"        run: {init_cmd}")
+        lines.append("      - name: Plan")
+        lines.append(f"        working-directory: infra/{tier_name}")
+        lines.append(f"        run: {plan_cmd}")
+        lines.append("")
+
+        # Apply job
+        lines.append("  apply:")
+        lines.append("    needs: plan")
+        lines.append("    runs-on: ubuntu-latest")
+        lines.append("    if: github.ref == 'refs/heads/main' && github.event_name == 'push'")
+
+        if tier_cfg.approval_required:
+            lines.append(f"    environment: infra-{tier_name}")  # Requires environment approval
+
+        lines.append("    steps:")
+        lines.append("      - uses: actions/checkout@v4")
+        lines.append("      - name: Init")
+        lines.append(f"        working-directory: infra/{tier_name}")
+        lines.append(f"        run: {init_cmd}")
+        lines.append("      - name: Plan")
+        lines.append(f"        working-directory: infra/{tier_name}")
+        lines.append(f"        run: {plan_cmd}")
+        lines.append("      - name: Apply")
+        lines.append(f"        working-directory: infra/{tier_name}")
+        lines.append(f"        run: {apply_cmd}")
+        lines.append("")
+
+        files[f".github/workflows/infra-{tier_name}.yml"] = "\n".join(lines)
+
+    return files
+
+
+def _generate_woodpecker_infra_pipeline(
+    config: InfrastructureConfig,
+    iac: IaCProvider,
+) -> dict[str, str]:
+    """Generate Woodpecker CI pipeline for infrastructure."""
+    files: dict[str, str] = {}
+
+    image = {
+        IaCProvider.TERRAFORM: "hashicorp/terraform:latest",
+        IaCProvider.PULUMI: "pulumi/pulumi-python:latest",
+        IaCProvider.BICEP: "mcr.microsoft.com/azure-cli:latest",
+    }.get(iac, "hashicorp/terraform:latest")
+
+    for tier_name, tier_cfg in config.tiers.items():
+        lines = [
+            f"# Infrastructure: {tier_name} tier",
+            "# Generated by Claude Power Pack /cicd:infra-pipeline",
+            "",
+            "when:",
+            f"  path: 'infra/{tier_name}/**'",
+            "  branch: main",
+            "  event: [push, pull_request]",
+            "",
+            "steps:",
+            f"  - name: plan-{tier_name}",
+            f"    image: {image}",
+            "    commands:",
+            f"      - cd infra/{tier_name}",
+            "      - terraform init",
+            "      - terraform plan -out=tfplan",
+            "",
+        ]
+
+        if not tier_cfg.approval_required:
+            lines.extend([
+                f"  - name: apply-{tier_name}",
+                f"    image: {image}",
+                "    commands:",
+                f"      - cd infra/{tier_name}",
+                "      - terraform init",
+                "      - terraform apply tfplan",
+                "    when:",
+                "      branch: main",
+                "      event: push",
+                "",
+            ])
+
+        files[f".woodpecker/infra-{tier_name}.yml"] = "\n".join(lines)
+
+    return files
+
+
+# --- Discovery scripts ---
+
+
+def _generate_aws_discovery() -> dict[str, str]:
+    return {
+        "infra/scripts/discover-aws.sh": """\
+#!/usr/bin/env bash
+# AWS Resource Discovery Script
+# Generated by Claude Power Pack /cicd:infra-discover
+#
+# Outputs a manifest of existing AWS resources for IaC import.
+# Requires: aws CLI configured with appropriate permissions.
+
+set -euo pipefail
+
+echo "=== AWS Resource Discovery ==="
+echo "Account: $(aws sts get-caller-identity --query Account --output text)"
+echo "Region: $(aws configure get region)"
+echo ""
+
+echo "--- VPCs ---"
+aws ec2 describe-vpcs --query 'Vpcs[].{ID:VpcId,CIDR:CidrBlock,Name:Tags[?Key==`Name`].Value|[0]}' --output table
+
+echo ""
+echo "--- Route53 Hosted Zones ---"
+aws route53 list-hosted-zones --query 'HostedZones[].{Name:Name,ID:Id,Records:ResourceRecordSetCount}' --output table
+
+echo ""
+echo "--- IAM Roles ---"
+aws iam list-roles \\
+  --query 'Roles[?starts_with(RoleName,`custom-`)||starts_with(RoleName,`app-`)].{Name:RoleName,Created:CreateDate}' \\
+  --output table
+
+echo ""
+echo "--- RDS Instances ---"
+aws rds describe-db-instances \\
+  --query 'DBInstances[].{ID:DBInstanceIdentifier,Engine:Engine,Status:DBInstanceStatus,Class:DBInstanceClass}' \\
+  --output table
+
+echo ""
+echo "--- S3 Buckets ---"
+aws s3api list-buckets --query 'Buckets[].{Name:Name,Created:CreationDate}' --output table
+
+echo ""
+echo "--- ECS Clusters ---"
+aws ecs list-clusters --query 'clusterArns' --output table
+
+echo ""
+echo "--- ElastiCache ---"
+aws elasticache describe-cache-clusters \\
+  --query 'CacheClusters[].{ID:CacheClusterId,Engine:Engine,Status:CacheClusterStatus}' \\
+  --output table
+
+echo ""
+echo "=== Discovery Complete ==="
+echo "To import resources into Terraform:"
+echo "  terraform import aws_vpc.main <vpc-id>"
+echo "  terraform import aws_route53_zone.main <zone-id>"
+""",
+    }
+
+
+def _generate_azure_discovery() -> dict[str, str]:
+    return {
+        "infra/scripts/discover-azure.sh": """\
+#!/usr/bin/env bash
+# Azure Resource Discovery Script
+# Generated by Claude Power Pack /cicd:infra-discover
+#
+# Outputs a manifest of existing Azure resources for IaC import.
+# Requires: az CLI logged in with appropriate permissions.
+
+set -euo pipefail
+
+echo "=== Azure Resource Discovery ==="
+echo "Subscription: $(az account show --query name -o tsv)"
+echo ""
+
+echo "--- Resource Groups ---"
+az group list --query '[].{Name:name,Location:location,Tags:tags}' -o table
+
+echo ""
+echo "--- DNS Zones ---"
+az network dns zone list --query '[].{Name:name,ResourceGroup:resourceGroup,Records:numberOfRecordSets}' -o table
+
+echo ""
+echo "--- Virtual Networks ---"
+az network vnet list \\
+  --query '[].{Name:name,ResourceGroup:resourceGroup,AddressSpace:addressSpace.addressPrefixes[0]}' \\
+  -o table
+
+echo ""
+echo "--- Key Vaults ---"
+az keyvault list --query '[].{Name:name,ResourceGroup:resourceGroup,Location:location}' -o table
+
+echo ""
+echo "--- App Services ---"
+az webapp list --query '[].{Name:name,ResourceGroup:resourceGroup,State:state,URL:defaultHostName}' -o table
+
+echo ""
+echo "--- Container Registries ---"
+az acr list --query '[].{Name:name,ResourceGroup:resourceGroup,SKU:sku.name}' -o table
+
+echo ""
+echo "--- SQL Servers ---"
+az sql server list --query '[].{Name:name,ResourceGroup:resourceGroup,FQDN:fullyQualifiedDomainName}' -o table
+
+echo ""
+echo "=== Discovery Complete ==="
+echo "To import resources into Terraform:"
+echo '  terraform import azurerm_resource_group.main /subscriptions/<sub>/resourceGroups/<rg>'
+""",
+    }
+
+
+def _generate_gcp_discovery() -> dict[str, str]:
+    return {
+        "infra/scripts/discover-gcp.sh": """\
+#!/usr/bin/env bash
+# GCP Resource Discovery Script
+# Generated by Claude Power Pack /cicd:infra-discover
+#
+# Outputs a manifest of existing GCP resources for IaC import.
+# Requires: gcloud CLI configured.
+
+set -euo pipefail
+
+PROJECT=$(gcloud config get-value project)
+echo "=== GCP Resource Discovery ==="
+echo "Project: $PROJECT"
+echo ""
+
+echo "--- VPC Networks ---"
+gcloud compute networks list --format="table(name,subnetMode,autoCreateSubnetworks)"
+
+echo ""
+echo "--- Cloud DNS Zones ---"
+gcloud dns managed-zones list --format="table(name,dnsName,visibility)"
+
+echo ""
+echo "--- GKE Clusters ---"
+gcloud container clusters list --format="table(name,location,status,currentNodeCount)"
+
+echo ""
+echo "--- Cloud SQL ---"
+gcloud sql instances list --format="table(name,databaseVersion,region,state)"
+
+echo ""
+echo "--- Cloud Storage ---"
+gsutil ls -L 2>/dev/null | grep -E "^gs://" || echo "No buckets found"
+
+echo ""
+echo "=== Discovery Complete ==="
+echo "To import resources into Terraform:"
+echo "  terraform import google_compute_network.main projects/$PROJECT/global/networks/<name>"
+""",
+    }

--- a/lib/cicd/models.py
+++ b/lib/cicd/models.py
@@ -17,6 +17,63 @@ from enum import Enum
 from typing import Optional
 
 
+class IaCProvider(Enum):
+    """Infrastructure as Code provider."""
+
+    TERRAFORM = "terraform"
+    PULUMI = "pulumi"
+    BICEP = "bicep"
+    CLOUDFORMATION = "cloudformation"
+    NONE = "none"
+
+    @property
+    def label(self) -> str:
+        labels = {
+            IaCProvider.TERRAFORM: "Terraform",
+            IaCProvider.PULUMI: "Pulumi",
+            IaCProvider.BICEP: "Bicep",
+            IaCProvider.CLOUDFORMATION: "CloudFormation",
+            IaCProvider.NONE: "None",
+        }
+        return labels[self]
+
+
+class CloudProvider(Enum):
+    """Cloud provider."""
+
+    AWS = "aws"
+    AZURE = "azure"
+    GCP = "gcp"
+    UNKNOWN = "unknown"
+
+    @property
+    def label(self) -> str:
+        labels = {
+            CloudProvider.AWS: "AWS",
+            CloudProvider.AZURE: "Azure",
+            CloudProvider.GCP: "GCP",
+            CloudProvider.UNKNOWN: "Unknown",
+        }
+        return labels[self]
+
+
+class InfraTier(Enum):
+    """Infrastructure tier."""
+
+    FOUNDATION = "foundation"
+    PLATFORM = "platform"
+    APP = "app"
+
+    @property
+    def label(self) -> str:
+        labels = {
+            InfraTier.FOUNDATION: "Foundation (run once, touch rarely)",
+            InfraTier.PLATFORM: "Platform (shared services)",
+            InfraTier.APP: "Application (app-specific)",
+        }
+        return labels[self]
+
+
 class Framework(Enum):
     """Detected project framework."""
 
@@ -307,6 +364,26 @@ class SmokeTestEntry:
             "output": self.output,
             "detail": self.detail,
             "elapsed_ms": round(self.elapsed_ms, 1),
+        }
+
+
+@dataclass
+class InfrastructureInfo:
+    """Results from IaC provider detection."""
+
+    iac_provider: IaCProvider = IaCProvider.NONE
+    cloud_provider: CloudProvider = CloudProvider.UNKNOWN
+    detected_files: list[str] = field(default_factory=list)
+    has_state_backend: bool = False
+    tiers_present: list[InfraTier] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "iac_provider": self.iac_provider.value,
+            "cloud_provider": self.cloud_provider.value,
+            "detected_files": self.detected_files,
+            "has_state_backend": self.has_state_backend,
+            "tiers_present": [t.value for t in self.tiers_present],
         }
 
 


### PR DESCRIPTION
## Summary

- Add three-tier IaC model (foundation/platform/app) with configurable approval gates
- New `scaffold_infrastructure()` generates Terraform/Pulumi/Bicep directory structures with state backend, tagging, and per-tier Makefiles
- New `generate_infra_pipeline()` creates GitHub Actions/Woodpecker workflows with manual approval for foundation tier
- New `generate_discovery_script()` produces AWS/Azure/GCP resource audit scripts for `terraform import` workflows
- Three new CLI subcommands: `infra-init`, `infra-discover`, `infra-pipeline`
- Three new slash commands: `/cicd:infra-init`, `/cicd:infra-discover`, `/cicd:infra-pipeline`
- Updated `cicd/help.md` with Infrastructure as Code section
- Updated `CLAUDE.md` Commands Reference with new commands

## Files Changed

- `lib/cicd/models.py` — Added `IaCProvider`, `CloudProvider`, `InfraTier` enums + `InfrastructureInfo` dataclass
- `lib/cicd/config.py` — Added `InfrastructureConfig` with YAML parsing
- `lib/cicd/detector.py` — Added `detect_infrastructure()` function
- `lib/cicd/infrastructure.py` — New module (~850 lines): scaffold, pipelines, discovery
- `lib/cicd/cli.py` — Three new subcommand handlers
- `lib/cicd/__init__.py` — New exports
- `.claude/commands/cicd/infra-*.md` — Three new command files
- `.claude/commands/cicd/help.md` — IaC section added
- `CLAUDE.md` — Commands Reference updated

## Test plan

- [x] All 211 existing tests pass
- [x] Lint passes on all changed files
- [ ] Manual: `/cicd:infra-init` scaffolds correct directory structure
- [ ] Manual: `/cicd:infra-discover` generates runnable discovery script
- [ ] Manual: `/cicd:infra-pipeline` generates valid workflow YAML

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)