### PR TITLE
feat(woodpecker): Add Woodpecker CI config

### DIFF
--- a/woodpecker/bootstrap-secrets.py
+++ b/woodpecker/bootstrap-secrets.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Pull Woodpecker secrets from AWS Secrets Manager and write docker .env"""
+import json
+import os
+
+import boto3
+
+
+def main():
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+    )
+    client = session.client("secretsmanager")
+    resp = client.get_secret_value(SecretId="essent-ai")
+    secrets = json.loads(resp["SecretString"])
+
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "docker.env")
+    with open(env_path, "w") as f:
+        for key in [
+            "WOODPECKER_GITHUB_CLIENT",
+            "WOODPECKER_GITHUB_SECRET",
+            "WOODPECKER_AGENT_SECRET",
+            "WOODPECKER_HOST",
+        ]:
+            if key in secrets:
+                f.write(f"{key}={secrets[key]}\n")
+    print(f"Wrote {env_path} with secrets from essent-ai")
+
+
+if __name__ == "__main__":
+    main()

--- a/woodpecker/docker-compose.yml
+++ b/woodpecker/docker-compose.yml
@@ -1,0 +1,36 @@
+# Woodpecker CI - Server + Agent
+# Secrets pulled from AWS Secrets Manager via bootstrap-secrets.py -> docker.env
+# Start: docker compose up -d
+
+services:
+  woodpecker-server:
+    image: woodpeckerci/woodpecker-server:v3.13.0
+    container_name: woodpecker-server
+    ports:
+      - "9000:8000"
+      - "9001:9000"
+    volumes:
+      - woodpecker-server-data:/var/lib/woodpecker/
+    env_file: docker.env
+    environment:
+      - WOODPECKER_OPEN=true
+      - WOODPECKER_HOST=${WOODPECKER_HOST:?Set WOODPECKER_HOST in docker.env}
+      - WOODPECKER_GITHUB=true
+      - WOODPECKER_ADMIN=cooneycw
+    restart: unless-stopped
+
+  woodpecker-agent:
+    image: woodpeckerci/woodpecker-agent:v3.13.0
+    container_name: woodpecker-agent
+    depends_on:
+      - woodpecker-server
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    env_file: docker.env
+    environment:
+      - WOODPECKER_SERVER=woodpecker-server:9000
+      - WOODPECKER_MAX_WORKFLOWS=2
+    restart: unless-stopped
+
+volumes:
+  woodpecker-server-data:


### PR DESCRIPTION
## Summary
- Adds `woodpecker/docker-compose.yml` template for Woodpecker CI v3.13.0 (server + agent)
- Adds `woodpecker/bootstrap-secrets.py` to pull credentials from AWS Secrets Manager
- Domain/host kept out of version control - sourced from `WOODPECKER_HOST` via docker.env

Closes #232

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (211 tests)
- [ ] Verify bootstrap script generates valid docker.env on target VM
- [ ] Verify `docker compose up` starts Woodpecker successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)