### PR TITLE
feat(woodpecker): Add MCP server auto-deploy pipeline (Closes #235)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,5 +1,9 @@
 # Claude Power Pack - Woodpecker CI Pipeline
-# Runs quality gates and builds Docker containers for MCP servers
+# Runs quality gates, builds Docker containers, and deploys MCP servers
+#
+# Pipeline:
+#   PR/push   -> lint, test, typecheck, dry-run builds
+#   main push -> above + deploy-mcp (rebuild + restart containers)
 
 steps:
   lint:
@@ -67,4 +71,26 @@ steps:
     when:
       - event: [push, pull_request]
         path: "mcp-evaluate/**"
+
+  deploy-mcp:
+    image: docker:cli
+    commands:
+      - apk add --no-cache docker-compose
+      - echo "Deploying MCP containers..."
+      - cd /cpp && docker compose --profile core --profile browser build
+      - docker compose --profile core --profile browser up -d
+      - sleep 5
+      - docker compose --profile core --profile browser ps
+      - echo "Deploy complete."
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /home/cooneycw/Projects/claude-power-pack:/cpp
+    when:
+      - event: push
+        branch: main
+        path:
+          - "mcp-second-opinion/**"
+          - "mcp-playwright-persistent/**"
+          - "mcp-nano-banana/**"
+          - "docker-compose.yml"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Docker containers read API keys from a root `.env` file (gitignored) via `env_fi
 - **Status/logs/stop:** `make docker-ps`, `make docker-logs`, `make docker-down`
 - **MCP connections:** Defined in project `.mcp.json` pointing to `127.0.0.1:{port}/sse` (SSE transport)
 - **Woodpecker CI** runs on push/PR: lint, test, typecheck, conditional Docker builds
+- **Auto-deploy:** On push to main, if `mcp-*/` or `docker-compose.yml` changed, Woodpecker rebuilds and restarts MCP containers via the local agent
 
 ## Commands Reference
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test lint format typecheck verify update_docs clean \
-       docker-build docker-check-env docker-up docker-down docker-logs docker-ps
+       docker-build docker-check-env docker-up docker-down docker-logs docker-ps deploy
 
 ## Quality gates (used by /flow:finish)
 
@@ -65,6 +65,12 @@ docker-logs:
 
 docker-ps:
 	docker compose --profile core --profile browser --profile coord ps
+
+## Deploy (used by Woodpecker CI and /flow:deploy)
+
+deploy: docker-build docker-up
+	@sleep 5
+	@$(MAKE) docker-ps
 
 ## Utilities
 


### PR DESCRIPTION
## Summary
- Added `deploy-mcp` step to `.woodpecker.yml` - triggers on push to main when `mcp-*/` or `docker-compose.yml` changes
- Uses `docker:cli` image with docker.sock to rebuild and restart MCP containers on the agent machine
- Added `deploy` Makefile target wrapping docker-build + docker-up + docker-ps
- Documented auto-deploy behavior in CLAUDE.md

Closes #235

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (211 tests)
- [ ] Push an MCP change to main and verify Woodpecker triggers deploy-mcp step
- [ ] Verify containers restart with updated images

🤖 Generated with [Claude Code](https://claude.com/claude-code)