### PR TITLE
perf(ci): consolidate pipeline, health-based deploys, extended CI polling

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -323,8 +323,8 @@ if [[ -n "$WOODPECKER_API_TOKEN" ]]; then
     if [[ -z "$REPO_ID" || "$REPO_ID" == "null" ]]; then
         echo "WARNING: Could not resolve Woodpecker repo ID for $REPO_FULL. Skipping CI verification."
     else
-        # Poll up to 5 minutes (30 attempts, 10s apart)
-        for i in $(seq 1 30); do
+        # Poll up to 10 minutes (60 attempts, 10s apart)
+        for i in $(seq 1 60); do
             PIPELINE_JSON=$(curl -s -H "Authorization: Bearer $WOODPECKER_API_TOKEN" \
                 -H "Accept: application/json" \
                 "$WOODPECKER_SERVER/api/repos/$REPO_ID/pipelines?per_page=5" | \
@@ -346,13 +346,13 @@ if [[ -n "$WOODPECKER_API_TOKEN" ]]; then
                         exit 1
                         ;;
                     *)
-                        echo "Pipeline #$PIPELINE_NUM status: $STATUS (attempt $i/30)..."
+                        echo "Pipeline #$PIPELINE_NUM status: $STATUS (attempt $i/60)..."
                         sleep 10
                         ;;
                 esac
             else
-                if [[ $i -ge 30 ]]; then
-                    echo "WARNING: No Woodpecker pipeline found for $SHORT_SHA after 5 minutes."
+                if [[ $i -ge 60 ]]; then
+                    echo "WARNING: No Woodpecker pipeline found for $SHORT_SHA after 10 minutes."
                     break
                 fi
                 sleep 10
@@ -368,7 +368,7 @@ fi
 if [[ -z "$WOODPECKER_API_TOKEN" ]]; then
     echo "Polling GitHub Actions for commit $SHORT_SHA..."
 
-    for i in $(seq 1 30); do
+    for i in $(seq 1 60); do
         RUN_JSON=$(gh run list --commit "$COMMIT_SHA" --json status,conclusion,databaseId,name --jq '.[0]' 2>/dev/null)
 
         if [[ -n "$RUN_JSON" && "$RUN_JSON" != "null" ]]; then
@@ -386,12 +386,12 @@ if [[ -z "$WOODPECKER_API_TOKEN" ]]; then
                     exit 1
                 fi
             else
-                echo "Run #$RUN_ID status: $GH_STATUS (attempt $i/30)..."
+                echo "Run #$RUN_ID status: $GH_STATUS (attempt $i/60)..."
                 sleep 10
             fi
         else
-            if [[ $i -ge 30 ]]; then
-                echo "WARNING: No GitHub Actions run found for $SHORT_SHA after 5 minutes."
+            if [[ $i -ge 60 ]]; then
+                echo "WARNING: No GitHub Actions run found for $SHORT_SHA after 10 minutes."
                 break
             fi
             sleep 10

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,29 +2,19 @@
 # Runs quality gates, builds Docker containers, and deploys MCP servers
 #
 # Pipeline:
-#   PR/push   -> lint, test, typecheck, dry-run builds
+#   PR/push   -> validate (lint+test+typecheck), dry-run builds
 #   main push -> above + deploy-mcp (rebuild + restart containers)
 
 when:
   - event: [push, pull_request]
 
 steps:
-  lint:
+  validate:
     image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
     commands:
       - uv sync --extra dev --frozen
       - uv run ruff check .
-
-  test:
-    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
-    commands:
-      - uv sync --extra dev --frozen
       - uv run pytest
-
-  typecheck:
-    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
-    commands:
-      - uv sync --extra dev --frozen
       - uv run mypy .
 
   build-second-opinion:
@@ -70,10 +60,9 @@ steps:
     commands:
       - apk add --no-cache docker-compose
       - echo "Deploying MCP containers..."
-      - docker compose --profile core --profile browser build
-      - docker compose --profile core --profile browser up -d
-      - sleep 5
+      - docker compose --profile core --profile browser up -d --build --wait
       - docker compose --profile core --profile browser ps
+      - docker image prune -f
       - echo "Deploy complete."
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary

Based on three-model consensus review (Gemini 3.1 Pro, GPT-5.3 Codex, o4-mini):

- **Consolidate validate step** - merge lint/test/typecheck into one pipeline step, eliminating 2x redundant `uv sync` calls (saves ~30s per run)
- **Health-based deploy verification** - replace `sleep 5` + `docker compose ps` with `docker compose up -d --build --wait`, which blocks until all healthchecks report healthy
- **Disk cleanup** - add `docker image prune -f` after deploys to prevent dangling image accumulation
- **Extended CI polling** - increase flow:auto CI verification timeout from 5 to 10 minutes (60x10s) to handle Docker build times

## Test plan

- [x] `make verify` passes (211 tests, lint, typecheck)
- [ ] Woodpecker pipeline runs validate step successfully
- [ ] Deploy step uses `--wait` and reports healthy containers

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)