### PR TITLE
feat(cicd): typed task manifest with Pydantic v2 validation (Closes #245)

### DIFF
--- a/.claude/cicd_tasks.yml
+++ b/.claude/cicd_tasks.yml
@@ -1,0 +1,78 @@
+# .claude/cicd_tasks.yml - Task manifest for CI/CD runner
+#
+# Defines steps (what to run) and plans (which steps to run together).
+# The runner loads this manifest when present; falls back to built-in defaults otherwise.
+#
+# Reference:
+#   steps.<name>.command     - Shell command to execute
+#   steps.<name>.timeout     - Max seconds (default: 600)
+#   steps.<name>.max_attempts - Retry count (default: 1)
+#   steps.<name>.idempotent  - Safe to retry? (default: true)
+#   steps.<name>.skip_if     - Shell expression; skip if exits 0
+#   steps.<name>.artifacts   - Output files to preserve
+#   steps.<name>.rollback    - Command to run on failure
+#   plans.<name>.steps       - Ordered list of step names
+#
+
+version: "1"
+
+steps:
+  lint:
+    command: make lint
+    description: Run ruff linter
+    timeout: 300
+    skip_if: '! grep -q "^lint:" Makefile 2>/dev/null'
+
+  test:
+    command: make test
+    description: Run pytest suite
+    timeout: 600
+    skip_if: '! grep -q "^test:" Makefile 2>/dev/null'
+
+  typecheck:
+    command: make typecheck
+    description: Run mypy type checker
+    timeout: 300
+    skip_if: '! grep -q "^typecheck:" Makefile 2>/dev/null'
+
+  security_scan:
+    command: >-
+      PYTHONPATH="${HOME}/Projects/claude-power-pack/lib"
+      python3 -m lib.security gate flow_finish
+    description: Run security quick scan
+    timeout: 120
+    skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
+
+  deploy_security_scan:
+    command: >-
+      PYTHONPATH="${HOME}/Projects/claude-power-pack/lib"
+      python3 -m lib.security gate flow_deploy
+    description: Run security scan before deploy
+    timeout: 120
+    skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
+
+  deploy:
+    command: make deploy
+    description: Run deployment
+    timeout: 1800
+    idempotent: false
+
+plans:
+  finish:
+    description: Quality gates for /flow:finish
+    steps:
+      - lint
+      - test
+      - security_scan
+
+  check:
+    description: Quick quality check for /flow:check
+    steps:
+      - lint
+      - test
+
+  deploy:
+    description: Deployment pipeline for /flow:deploy
+    steps:
+      - deploy_security_scan
+      - deploy

--- a/lib/cicd/__init__.py
+++ b/lib/cicd/__init__.py
@@ -36,6 +36,14 @@ from .detector import detect_framework, detect_infrastructure
 from .health import check_endpoint, check_process, run_health_checks
 from .infrastructure import generate_discovery_script, generate_infra_pipeline, scaffold_infrastructure
 from .makefile import check_makefile, generate_makefile, parse_makefile
+from .manifest import (
+    PlanModel,
+    StepModel,
+    TaskManifest,
+    generate_manifest,
+    load_manifest,
+    write_manifest,
+)
 from .models import (
     CloudProvider,
     Framework,
@@ -100,6 +108,13 @@ __all__ = [
     "PackageManager",
     "SmokeTestEntry",
     "SmokeTestResult",
+    # Manifest
+    "TaskManifest",
+    "StepModel",
+    "PlanModel",
+    "load_manifest",
+    "generate_manifest",
+    "write_manifest",
     # Runner
     "DeterministicRunner",
     "RunResult",

--- a/lib/cicd/cli.py
+++ b/lib/cicd/cli.py
@@ -32,6 +32,7 @@ from .detector import detect_framework, detect_infrastructure
 from .health import run_health_checks
 from .infrastructure import generate_discovery_script, generate_infra_pipeline, scaffold_infrastructure
 from .makefile import check_makefile
+from .manifest import generate_manifest, load_manifest, write_manifest
 from .pipeline import generate_pipeline
 from .runner import resume_run, run_plan, show_status
 from .smoke import run_smoke_tests
@@ -400,6 +401,85 @@ def cmd_infra_pipeline(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_init_manifest(args: argparse.Namespace) -> int:
+    """Generate a default cicd_tasks.yml manifest."""
+    import os
+
+    manifest_path = os.path.join(args.path, ".claude", "cicd_tasks.yml")
+
+    if os.path.exists(manifest_path) and not args.force:
+        print(f"Manifest already exists: {manifest_path}")
+        print("Use --force to overwrite.")
+        return 1
+
+    manifest = generate_manifest(args.path)
+
+    if args.json:
+        print(json.dumps({"steps": list(manifest.steps.keys()), "plans": list(manifest.plans.keys())}, indent=2))
+        if not args.write:
+            return 0
+
+    if args.write:
+        path = write_manifest(manifest, args.path)
+        print(f"Wrote manifest: {path}")
+        print()
+        print(f"Steps: {', '.join(sorted(manifest.steps.keys()))}")
+        print(f"Plans: {', '.join(sorted(manifest.plans.keys()))}")
+        print()
+        print("The runner will now load plans from this manifest.")
+        print("Edit .claude/cicd_tasks.yml to customize steps and plans.")
+    else:
+        print("# .claude/cicd_tasks.yml (dry run)")
+        print()
+        print(manifest.to_yaml())
+        print("(dry run - use --write to create file)")
+
+    return 0
+
+
+def cmd_validate_manifest(args: argparse.Namespace) -> int:
+    """Validate an existing cicd_tasks.yml manifest."""
+    try:
+        manifest = load_manifest(args.path)
+    except ValueError as e:
+        if args.json:
+            print(json.dumps({"valid": False, "errors": [str(e)]}, indent=2))
+        else:
+            print(f"INVALID: {e}")
+        return 1
+
+    if manifest is None:
+        if args.json:
+            print(json.dumps({"valid": False, "errors": ["No manifest found"]}, indent=2))
+        else:
+            print("No manifest found at .claude/cicd_tasks.yml")
+            print("Generate one with: python -m lib.cicd init-manifest --write")
+        return 1
+
+    ref_errors = manifest.validate_plan_references()
+    if ref_errors:
+        if args.json:
+            print(json.dumps({"valid": False, "errors": ref_errors}, indent=2))
+        else:
+            print("INVALID manifest:")
+            for err in ref_errors:
+                print(f"  - {err}")
+        return 1
+
+    if args.json:
+        print(json.dumps({
+            "valid": True,
+            "steps": list(manifest.steps.keys()),
+            "plans": list(manifest.plans.keys()),
+        }, indent=2))
+    else:
+        print("Manifest OK")
+        print(f"  Steps: {', '.join(sorted(manifest.steps.keys()))}")
+        print(f"  Plans: {', '.join(sorted(manifest.plans.keys()))}")
+
+    return 0
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     """Execute a CI/CD plan deterministically."""
     return run_plan(
@@ -450,6 +530,28 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # 'init-manifest' subcommand
+    init_manifest_parser = subparsers.add_parser(
+        "init-manifest",
+        help="Generate a default cicd_tasks.yml manifest from detected framework",
+    )
+    _add_common_args(init_manifest_parser)
+    init_manifest_parser.add_argument(
+        "--write", "-w", action="store_true",
+        help="Write manifest to disk (default: dry run to stdout)",
+    )
+    init_manifest_parser.add_argument(
+        "--force", "-f", action="store_true",
+        help="Overwrite existing manifest",
+    )
+
+    # 'validate-manifest' subcommand
+    validate_manifest_parser = subparsers.add_parser(
+        "validate-manifest",
+        help="Validate an existing cicd_tasks.yml manifest",
+    )
+    _add_common_args(validate_manifest_parser)
 
     # 'run' subcommand
     run_parser = subparsers.add_parser(
@@ -638,6 +740,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     commands = {
+        "init-manifest": cmd_init_manifest,
+        "validate-manifest": cmd_validate_manifest,
         "run": cmd_run,
         "resume": cmd_resume,
         "status": cmd_status,

--- a/lib/cicd/manifest.py
+++ b/lib/cicd/manifest.py
@@ -1,0 +1,389 @@
+"""Typed task manifest with Pydantic v2 validation.
+
+Defines the schema for `.claude/cicd_tasks.yml` - a declarative manifest
+that lets projects customize CI/CD plans and steps without modifying code.
+
+The manifest is separate from `cicd.yml` (which handles build/health/pipeline config)
+to avoid breaking changes. When present, the runner loads plans from the manifest;
+when absent, it falls back to built-in defaults.
+
+Schema:
+    version: "1"
+    steps:
+      lint:
+        command: "make lint"
+        timeout: 300
+        ...
+    plans:
+      finish:
+        steps: [lint, test, security_scan]
+      deploy:
+        steps: [security_scan, deploy]
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    from pydantic import BaseModel, Field, ValidationError, field_validator
+except ImportError:
+    raise ImportError(
+        "pydantic>=2.0 is required for manifest support. "
+        "Install it with: uv add --dev pydantic"
+    )
+
+import yaml
+
+from .detector import detect_framework
+from .makefile import parse_makefile
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = "cicd_tasks.yml"
+MANIFEST_PATH = ".claude/cicd_tasks.yml"
+SUPPORTED_VERSIONS = {"1"}
+
+
+class StepModel(BaseModel):
+    """Pydantic model for a single CI/CD step definition."""
+
+    command: str
+    description: str = ""
+    timeout: int = Field(default=600, ge=1, le=7200)
+    max_attempts: int = Field(default=1, ge=1, le=10)
+    backoff_seconds: float = Field(default=2.0, ge=0.1, le=60.0)
+    idempotent: bool = True
+    skip_if: Optional[str] = None
+    depends_on: list[str] = Field(default_factory=list)
+    artifacts: list[str] = Field(default_factory=list)
+    rollback: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class PlanModel(BaseModel):
+    """Pydantic model for a named plan that composes steps."""
+
+    steps: list[str]
+    description: str = ""
+
+    model_config = {"extra": "ignore"}
+
+    @field_validator("steps")
+    @classmethod
+    def steps_not_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("Plan must have at least one step")
+        return v
+
+
+class TaskManifest(BaseModel):
+    """Root Pydantic model for `.claude/cicd_tasks.yml`.
+
+    Defines steps (what to run) and plans (which steps to run together).
+    """
+
+    version: str = "1"
+    steps: dict[str, StepModel] = Field(default_factory=dict)
+    plans: dict[str, PlanModel] = Field(default_factory=dict)
+
+    model_config = {"extra": "ignore"}
+
+    @field_validator("version")
+    @classmethod
+    def version_supported(cls, v: str) -> str:
+        if v not in SUPPORTED_VERSIONS:
+            supported = ", ".join(sorted(SUPPORTED_VERSIONS))
+            raise ValueError(f"Unsupported manifest version '{v}'. Supported: {supported}")
+        return v
+
+    def validate_plan_references(self) -> list[str]:
+        """Check that all plan step references point to defined steps.
+
+        Returns list of error messages (empty if valid).
+        """
+        errors: list[str] = []
+        for plan_name, plan in self.plans.items():
+            for step_name in plan.steps:
+                if step_name not in self.steps:
+                    errors.append(
+                        f"Plan '{plan_name}' references undefined step '{step_name}'. "
+                        f"Available steps: {', '.join(sorted(self.steps.keys()))}"
+                    )
+        return errors
+
+    def get_plan_step_models(self, plan_name: str) -> list[tuple[str, StepModel]]:
+        """Get ordered step models for a plan.
+
+        Returns list of (step_id, StepModel) tuples.
+
+        Raises:
+            ValueError: If plan not found or references undefined steps.
+        """
+        if plan_name not in self.plans:
+            available = ", ".join(sorted(self.plans.keys()))
+            raise ValueError(f"Unknown plan '{plan_name}' in manifest. Available: {available}")
+
+        plan = self.plans[plan_name]
+        result: list[tuple[str, StepModel]] = []
+        for step_name in plan.steps:
+            if step_name not in self.steps:
+                raise ValueError(
+                    f"Plan '{plan_name}' references undefined step '{step_name}'"
+                )
+            result.append((step_name, self.steps[step_name]))
+        return result
+
+    def to_yaml(self) -> str:
+        """Serialize manifest to YAML string."""
+        data: dict[str, Any] = {"version": self.version}
+
+        if self.steps:
+            steps_dict: dict[str, Any] = {}
+            for name, step in self.steps.items():
+                step_data = step.model_dump(exclude_defaults=True)
+                steps_dict[name] = step_data
+            data["steps"] = steps_dict
+
+        if self.plans:
+            plans_dict: dict[str, Any] = {}
+            for name, plan in self.plans.items():
+                plan_data = plan.model_dump(exclude_defaults=True)
+                plans_dict[name] = plan_data
+            data["plans"] = plans_dict
+
+        return yaml.dump(data, default_flow_style=False, sort_keys=False)
+
+
+def load_manifest(project_root: str | Path) -> Optional[TaskManifest]:
+    """Load and validate a task manifest from `.claude/cicd_tasks.yml`.
+
+    Returns None if no manifest file exists (backwards compatible).
+
+    Raises:
+        ValueError: If manifest exists but is invalid.
+    """
+    root = Path(project_root)
+    manifest_path = root / MANIFEST_PATH
+
+    if not manifest_path.exists():
+        return None
+
+    try:
+        raw = yaml.safe_load(manifest_path.read_text())
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in {MANIFEST_PATH}: {e}") from e
+
+    if raw is None:
+        return None
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"{MANIFEST_PATH} must be a YAML mapping, got {type(raw).__name__}")
+
+    try:
+        manifest = TaskManifest.model_validate(raw)
+    except ValidationError as e:
+        errors = []
+        for err in e.errors():
+            loc = " -> ".join(str(x) for x in err["loc"])
+            errors.append(f"  {loc}: {err['msg']}")
+        raise ValueError(
+            f"Invalid manifest {MANIFEST_PATH}:\n" + "\n".join(errors)
+        ) from e
+
+    # Validate cross-references
+    ref_errors = manifest.validate_plan_references()
+    if ref_errors:
+        raise ValueError(
+            f"Invalid manifest {MANIFEST_PATH}:\n" + "\n".join(f"  {e}" for e in ref_errors)
+        )
+
+    return manifest
+
+
+def step_model_to_step_def(step_id: str, model: StepModel) -> Any:
+    """Convert a Pydantic StepModel to a dataclass StepDef for the runner.
+
+    This bridges the manifest layer (Pydantic) with the execution layer (dataclasses).
+    """
+    from .steps import StepDef
+
+    return StepDef(
+        id=step_id,
+        command=model.command,
+        description=model.description,
+        timeout_seconds=model.timeout,
+        max_attempts=model.max_attempts,
+        backoff_seconds=model.backoff_seconds,
+        idempotent=model.idempotent,
+        skip_if=model.skip_if,
+        depends_on=list(model.depends_on),
+    )
+
+
+def get_manifest_plan_steps(
+    manifest: TaskManifest, plan_name: str
+) -> list[Any]:
+    """Get StepDef list for a plan from the manifest.
+
+    Converts Pydantic models to dataclass StepDefs for runner consumption.
+    """
+    pairs = manifest.get_plan_step_models(plan_name)
+    return [step_model_to_step_def(step_id, model) for step_id, model in pairs]
+
+
+def generate_manifest(
+    project_root: str | Path,
+    include_existing_makefile: bool = True,
+) -> TaskManifest:
+    """Auto-generate a TaskManifest from detected framework and existing Makefile.
+
+    Inspects the project to build a sensible default manifest:
+    1. Detects framework and package manager
+    2. Parses existing Makefile targets (if any)
+    3. Generates steps from framework runner commands + Makefile targets
+    4. Creates standard plans (finish, check, deploy)
+
+    Args:
+        project_root: Path to project root.
+        include_existing_makefile: If True, incorporate existing Makefile targets.
+
+    Returns:
+        A TaskManifest ready to be serialized to YAML.
+    """
+    root = Path(project_root)
+    info = detect_framework(root)
+
+    steps: dict[str, StepModel] = {}
+    runners = info.runner_commands
+
+    # Build steps from Makefile targets if present
+    makefile_targets: set[str] = set()
+    if include_existing_makefile:
+        parsed = parse_makefile(root)
+        makefile_targets = {t.name for t in parsed}
+
+    # Standard step definitions from framework runners
+    standard_steps = {
+        "lint": ("Run linter", 300),
+        "test": ("Run tests", 600),
+        "typecheck": ("Run type checker", 300),
+        "format": ("Run formatter", 120),
+        "build": ("Build project", 600),
+        "deploy": ("Run deployment", 1800),
+        "clean": ("Clean build artifacts", 60),
+    }
+
+    for step_name, (desc, timeout) in standard_steps.items():
+        # Use framework runner command if available, otherwise use make target
+        if step_name in runners:
+            command = runners[step_name]
+        elif step_name in makefile_targets:
+            command = f"make {step_name}"
+        else:
+            continue
+
+        skip_if = None
+        if step_name in ("lint", "test", "typecheck", "format", "build", "clean"):
+            skip_if = f'! grep -q "^{step_name}:" Makefile 2>/dev/null'
+
+        idempotent = step_name != "deploy"
+
+        steps[step_name] = StepModel(
+            command=command,
+            description=desc,
+            timeout=timeout,
+            idempotent=idempotent,
+            skip_if=skip_if,
+        )
+
+    # Add security_scan step if lib.security is available
+    steps["security_scan"] = StepModel(
+        command=(
+            'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '
+            "python3 -m lib.security gate flow_finish"
+        ),
+        description="Run security quick scan",
+        timeout=120,
+        skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+    )
+
+    # Add any extra Makefile targets not already covered
+    for target_name in sorted(makefile_targets - set(steps.keys())):
+        if target_name.startswith(".") or target_name == "verify":
+            continue
+        steps[target_name] = StepModel(
+            command=f"make {target_name}",
+            description=f"Run {target_name}",
+            timeout=600,
+            skip_if=f'! grep -q "^{target_name}:" Makefile 2>/dev/null',
+        )
+
+    # Build standard plans
+    plans: dict[str, PlanModel] = {}
+
+    # finish plan: lint -> test -> security_scan
+    finish_steps = [s for s in ["lint", "test", "security_scan"] if s in steps]
+    if finish_steps:
+        plans["finish"] = PlanModel(
+            steps=finish_steps,
+            description="Quality gates for /flow:finish",
+        )
+
+    # check plan: lint -> test
+    check_steps = [s for s in ["lint", "test"] if s in steps]
+    if check_steps:
+        plans["check"] = PlanModel(
+            steps=check_steps,
+            description="Quick quality check for /flow:check",
+        )
+
+    # deploy plan: security_scan -> deploy
+    deploy_steps = [s for s in ["security_scan", "deploy"] if s in steps]
+    if deploy_steps:
+        plans["deploy"] = PlanModel(
+            steps=deploy_steps,
+            description="Deployment pipeline for /flow:deploy",
+        )
+
+    return TaskManifest(version="1", steps=steps, plans=plans)
+
+
+def write_manifest(manifest: TaskManifest, project_root: str | Path) -> Path:
+    """Write a TaskManifest to `.claude/cicd_tasks.yml`.
+
+    Returns the path to the written file.
+    """
+    root = Path(project_root)
+    manifest_dir = root / ".claude"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / MANIFEST_FILENAME
+
+    yaml_content = manifest.to_yaml()
+
+    header = (
+        "# .claude/cicd_tasks.yml - Task manifest for CI/CD runner\n"
+        "#\n"
+        "# Defines steps (what to run) and plans (which steps to run together).\n"
+        "# The runner loads this manifest when present; falls back to built-in defaults otherwise.\n"
+        "#\n"
+        "# Auto-generated by: python -m lib.cicd init-manifest\n"
+        "# Edit freely - this file is yours to customize.\n"
+        "#\n"
+        "# Reference:\n"
+        "#   steps.<name>.command     - Shell command to execute\n"
+        "#   steps.<name>.timeout     - Max seconds (default: 600)\n"
+        "#   steps.<name>.max_attempts - Retry count (default: 1)\n"
+        "#   steps.<name>.idempotent  - Safe to retry? (default: true)\n"
+        "#   steps.<name>.skip_if     - Shell expression; skip if exits 0\n"
+        "#   steps.<name>.artifacts   - Output files to preserve\n"
+        "#   steps.<name>.rollback    - Command to run on failure\n"
+        "#   plans.<name>.steps       - Ordered list of step names\n"
+        "#\n\n"
+    )
+
+    manifest_path.write_text(header + yaml_content)
+    return manifest_path

--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -85,7 +85,7 @@ class DeterministicRunner:
 
         # Load step definitions
         if step_defs is None:
-            step_defs = get_plan_steps(plan_name)
+            step_defs = get_plan_steps(plan_name, project_root=str(self.project_root))
 
         # Create new run state
         step_ids = [s.id for s in step_defs]
@@ -118,7 +118,7 @@ class DeterministicRunner:
         state.status = "running"
 
         # Load step definitions for the plan
-        step_defs = get_plan_steps(state.plan_name)
+        step_defs = get_plan_steps(state.plan_name, project_root=str(self.project_root))
 
         return self._execute(state, step_defs)
 
@@ -130,7 +130,7 @@ class DeterministicRunner:
     def _execute(self, state: RunState, step_defs: Optional[list[StepDef]] = None) -> RunResult:
         """Execute steps from the current state index."""
         if step_defs is None:
-            step_defs = get_plan_steps(state.plan_name)
+            step_defs = get_plan_steps(state.plan_name, project_root=str(self.project_root))
 
         context = {
             "project_root": str(self.project_root),

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -244,12 +244,28 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
 }
 
 
-def get_plan_steps(plan_name: str) -> list[StepDef]:
-    """Get step definitions for a built-in plan.
+def get_plan_steps(plan_name: str, project_root: Optional[str] = None) -> list[StepDef]:
+    """Get step definitions for a plan.
 
-    Returns built-in plan steps. In future, this will also load
-    from cicd_tasks.yml manifest.
+    Loads from `.claude/cicd_tasks.yml` manifest if present,
+    otherwise falls back to built-in plan definitions.
     """
+    from pathlib import Path
+
+    root = Path(project_root) if project_root else Path(".")
+
+    # Try loading from manifest first
+    try:
+        from .manifest import get_manifest_plan_steps, load_manifest
+
+        manifest = load_manifest(root)
+        if manifest is not None and plan_name in manifest.plans:
+            return get_manifest_plan_steps(manifest, plan_name)
+    except (ImportError, ValueError):
+        # Pydantic not installed or manifest invalid - fall back to built-in
+        pass
+
+    # Fall back to built-in plans
     if plan_name not in BUILTIN_PLANS:
         available = ", ".join(sorted(BUILTIN_PLANS.keys()))
         raise ValueError(f"Unknown plan: {plan_name}. Available: {available}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["mypy>=1.10", "pytest>=8.0", "pyyaml>=6.0", "ruff>=0.4", "types-PyYAML>=6.0", "types-requests>=2.31"]
+dev = ["mypy>=1.10", "pydantic>=2.0", "pytest>=8.0", "pyyaml>=6.0", "ruff>=0.4", "types-PyYAML>=6.0", "types-requests>=2.31"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,471 @@
+"""Tests for the typed task manifest (cicd_tasks.yml).
+
+Covers:
+- Pydantic model validation (StepModel, PlanModel, TaskManifest)
+- YAML loading and validation
+- Auto-generation from detected framework + Makefile
+- Cross-reference validation (plans referencing undefined steps)
+- Backwards compatibility (no manifest = built-in plans)
+- Runner integration (manifest plans consumed by get_plan_steps)
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.cicd.manifest import (
+    PlanModel,
+    StepModel,
+    TaskManifest,
+    generate_manifest,
+    load_manifest,
+    step_model_to_step_def,
+    write_manifest,
+)
+from lib.cicd.steps import StepDef, get_plan_steps
+
+# -- StepModel validation tests --
+
+
+class TestStepModel:
+    def test_minimal_step(self):
+        step = StepModel(command="make lint")
+        assert step.command == "make lint"
+        assert step.timeout == 600
+        assert step.max_attempts == 1
+        assert step.idempotent is True
+        assert step.skip_if is None
+        assert step.artifacts == []
+        assert step.rollback is None
+
+    def test_full_step(self):
+        step = StepModel(
+            command="make test",
+            description="Run pytest",
+            timeout=300,
+            max_attempts=3,
+            backoff_seconds=5.0,
+            idempotent=True,
+            skip_if='! grep -q "^test:" Makefile 2>/dev/null',
+            depends_on=["lint"],
+            artifacts=["coverage.xml", "htmlcov/"],
+            rollback="make clean",
+        )
+        assert step.timeout == 300
+        assert step.max_attempts == 3
+        assert step.artifacts == ["coverage.xml", "htmlcov/"]
+        assert step.rollback == "make clean"
+
+    def test_timeout_bounds(self):
+        with pytest.raises(Exception):
+            StepModel(command="x", timeout=0)
+
+        with pytest.raises(Exception):
+            StepModel(command="x", timeout=8000)
+
+    def test_max_attempts_bounds(self):
+        with pytest.raises(Exception):
+            StepModel(command="x", max_attempts=0)
+
+        with pytest.raises(Exception):
+            StepModel(command="x", max_attempts=11)
+
+    def test_extra_fields_ignored(self):
+        step = StepModel(command="make lint", unknown_field="ignored")
+        assert step.command == "make lint"
+        assert not hasattr(step, "unknown_field")
+
+
+# -- PlanModel validation tests --
+
+
+class TestPlanModel:
+    def test_valid_plan(self):
+        plan = PlanModel(steps=["lint", "test"])
+        assert plan.steps == ["lint", "test"]
+
+    def test_empty_steps_rejected(self):
+        with pytest.raises(Exception):
+            PlanModel(steps=[])
+
+    def test_description(self):
+        plan = PlanModel(steps=["lint"], description="Quality check")
+        assert plan.description == "Quality check"
+
+
+# -- TaskManifest validation tests --
+
+
+class TestTaskManifest:
+    def test_minimal_manifest(self):
+        manifest = TaskManifest(version="1")
+        assert manifest.version == "1"
+        assert manifest.steps == {}
+        assert manifest.plans == {}
+
+    def test_unsupported_version(self):
+        with pytest.raises(Exception):
+            TaskManifest(version="99")
+
+    def test_full_manifest(self):
+        manifest = TaskManifest(
+            version="1",
+            steps={
+                "lint": StepModel(command="make lint"),
+                "test": StepModel(command="make test"),
+            },
+            plans={
+                "check": PlanModel(steps=["lint", "test"]),
+            },
+        )
+        assert "lint" in manifest.steps
+        assert "check" in manifest.plans
+
+    def test_validate_plan_references_valid(self):
+        manifest = TaskManifest(
+            version="1",
+            steps={
+                "lint": StepModel(command="make lint"),
+                "test": StepModel(command="make test"),
+            },
+            plans={
+                "check": PlanModel(steps=["lint", "test"]),
+            },
+        )
+        errors = manifest.validate_plan_references()
+        assert errors == []
+
+    def test_validate_plan_references_invalid(self):
+        manifest = TaskManifest(
+            version="1",
+            steps={
+                "lint": StepModel(command="make lint"),
+            },
+            plans={
+                "check": PlanModel(steps=["lint", "nonexistent"]),
+            },
+        )
+        errors = manifest.validate_plan_references()
+        assert len(errors) == 1
+        assert "nonexistent" in errors[0]
+
+    def test_get_plan_step_models(self):
+        manifest = TaskManifest(
+            version="1",
+            steps={
+                "lint": StepModel(command="make lint", timeout=300),
+                "test": StepModel(command="make test", timeout=600),
+            },
+            plans={
+                "check": PlanModel(steps=["lint", "test"]),
+            },
+        )
+        pairs = manifest.get_plan_step_models("check")
+        assert len(pairs) == 2
+        assert pairs[0] == ("lint", manifest.steps["lint"])
+        assert pairs[1] == ("test", manifest.steps["test"])
+
+    def test_get_plan_step_models_unknown_plan(self):
+        manifest = TaskManifest(version="1")
+        with pytest.raises(ValueError, match="Unknown plan"):
+            manifest.get_plan_step_models("nonexistent")
+
+    def test_to_yaml_roundtrip(self):
+        manifest = TaskManifest(
+            version="1",
+            steps={
+                "lint": StepModel(command="make lint", timeout=300),
+                "test": StepModel(command="make test"),
+            },
+            plans={
+                "check": PlanModel(steps=["lint", "test"]),
+            },
+        )
+        yaml_str = manifest.to_yaml()
+        data = yaml.safe_load(yaml_str)
+        restored = TaskManifest.model_validate(data)
+        assert restored.version == "1"
+        assert "lint" in restored.steps
+        assert restored.steps["lint"].timeout == 300
+        assert restored.plans["check"].steps == ["lint", "test"]
+
+
+# -- step_model_to_step_def conversion tests --
+
+
+class TestStepModelToStepDef:
+    def test_conversion(self):
+        model = StepModel(
+            command="make test",
+            description="Run tests",
+            timeout=300,
+            max_attempts=3,
+            backoff_seconds=5.0,
+            idempotent=True,
+            skip_if='! grep -q "^test:" Makefile 2>/dev/null',
+            depends_on=["lint"],
+        )
+        step_def = step_model_to_step_def("test", model)
+        assert isinstance(step_def, StepDef)
+        assert step_def.id == "test"
+        assert step_def.command == "make test"
+        assert step_def.timeout_seconds == 300
+        assert step_def.max_attempts == 3
+        assert step_def.backoff_seconds == 5.0
+        assert step_def.idempotent is True
+        assert step_def.skip_if == '! grep -q "^test:" Makefile 2>/dev/null'
+        assert step_def.depends_on == ["lint"]
+
+
+# -- load_manifest tests --
+
+
+class TestLoadManifest:
+    def test_no_manifest_returns_none(self, tmp_path):
+        result = load_manifest(tmp_path)
+        assert result is None
+
+    def test_valid_manifest(self, tmp_path):
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text(textwrap.dedent("""\
+            version: "1"
+            steps:
+              lint:
+                command: make lint
+                timeout: 300
+              test:
+                command: make test
+            plans:
+              check:
+                steps: [lint, test]
+        """))
+
+        manifest = load_manifest(tmp_path)
+        assert manifest is not None
+        assert manifest.version == "1"
+        assert "lint" in manifest.steps
+        assert manifest.steps["lint"].timeout == 300
+        assert "check" in manifest.plans
+
+    def test_invalid_yaml(self, tmp_path):
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text("{{invalid yaml")
+
+        with pytest.raises(ValueError, match="Invalid YAML"):
+            load_manifest(tmp_path)
+
+    def test_invalid_schema(self, tmp_path):
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text(textwrap.dedent("""\
+            version: "99"
+            steps: {}
+            plans: {}
+        """))
+
+        with pytest.raises(ValueError, match="Unsupported manifest version"):
+            load_manifest(tmp_path)
+
+    def test_invalid_cross_reference(self, tmp_path):
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text(textwrap.dedent("""\
+            version: "1"
+            steps:
+              lint:
+                command: make lint
+            plans:
+              check:
+                steps: [lint, nonexistent]
+        """))
+
+        with pytest.raises(ValueError, match="nonexistent"):
+            load_manifest(tmp_path)
+
+    def test_empty_file_returns_none(self, tmp_path):
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text("")
+
+        result = load_manifest(tmp_path)
+        assert result is None
+
+    def test_non_dict_yaml(self, tmp_path):
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text("- item1\n- item2\n")
+
+        with pytest.raises(ValueError, match="must be a YAML mapping"):
+            load_manifest(tmp_path)
+
+
+# -- generate_manifest tests --
+
+
+class TestGenerateManifest:
+    def test_python_project(self, tmp_path):
+        # Create minimal Python project markers
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+        (tmp_path / "uv.lock").write_text("")
+        (tmp_path / "Makefile").write_text(
+            ".PHONY: lint test\n\nlint:\n\tuv run ruff check .\n\ntest:\n\tuv run pytest\n"
+        )
+
+        manifest = generate_manifest(tmp_path)
+        assert manifest.version == "1"
+        assert "lint" in manifest.steps
+        assert "test" in manifest.steps
+        assert "finish" in manifest.plans
+        assert "check" in manifest.plans
+
+    def test_no_makefile(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+        (tmp_path / "uv.lock").write_text("")
+
+        manifest = generate_manifest(tmp_path)
+        # Should still generate steps from framework runner commands
+        assert manifest.version == "1"
+        assert len(manifest.steps) > 0
+
+    def test_unknown_framework(self, tmp_path):
+        # Empty directory - no framework markers
+        manifest = generate_manifest(tmp_path)
+        assert manifest.version == "1"
+        # Should still have security_scan at minimum
+        assert "security_scan" in manifest.steps
+
+
+# -- write_manifest tests --
+
+
+class TestWriteManifest:
+    def test_write_and_reload(self, tmp_path):
+        manifest = TaskManifest(
+            version="1",
+            steps={
+                "lint": StepModel(command="make lint"),
+                "test": StepModel(command="make test", timeout=300),
+            },
+            plans={
+                "check": PlanModel(steps=["lint", "test"]),
+            },
+        )
+
+        path = write_manifest(manifest, tmp_path)
+        assert path.exists()
+        assert path.name == "cicd_tasks.yml"
+
+        # Reload and verify
+        reloaded = load_manifest(tmp_path)
+        assert reloaded is not None
+        assert reloaded.version == "1"
+        assert "lint" in reloaded.steps
+        assert "test" in reloaded.steps
+        assert reloaded.steps["test"].timeout == 300
+        assert reloaded.plans["check"].steps == ["lint", "test"]
+
+    def test_write_creates_directory(self, tmp_path):
+        manifest = TaskManifest(
+            version="1",
+            steps={"lint": StepModel(command="make lint")},
+            plans={"check": PlanModel(steps=["lint"])},
+        )
+        path = write_manifest(manifest, tmp_path)
+        assert (tmp_path / ".claude").is_dir()
+        assert path.exists()
+
+
+# -- get_plan_steps integration tests --
+
+
+class TestGetPlanStepsIntegration:
+    def test_no_manifest_uses_builtin(self, tmp_path):
+        """Without a manifest, get_plan_steps returns built-in plan."""
+        steps = get_plan_steps("finish", project_root=str(tmp_path))
+        assert len(steps) > 0
+        assert steps[0].id == "lint"
+
+    def test_manifest_overrides_builtin(self, tmp_path):
+        """With a manifest, get_plan_steps uses manifest plans."""
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text(textwrap.dedent("""\
+            version: "1"
+            steps:
+              custom_lint:
+                command: "custom-linter run ."
+                timeout: 120
+              custom_test:
+                command: "custom-test run ."
+                timeout: 300
+            plans:
+              finish:
+                steps: [custom_lint, custom_test]
+        """))
+
+        steps = get_plan_steps("finish", project_root=str(tmp_path))
+        assert len(steps) == 2
+        assert steps[0].id == "custom_lint"
+        assert steps[0].command == "custom-linter run ."
+        assert steps[1].id == "custom_test"
+
+    def test_manifest_plan_not_found_falls_back(self, tmp_path):
+        """If manifest exists but plan not in it, fall back to built-in."""
+        manifest_dir = tmp_path / ".claude"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text(textwrap.dedent("""\
+            version: "1"
+            steps:
+              lint:
+                command: make lint
+            plans:
+              custom_only:
+                steps: [lint]
+        """))
+
+        # 'finish' not in manifest, should fall back to built-in
+        steps = get_plan_steps("finish", project_root=str(tmp_path))
+        assert len(steps) > 0
+        assert steps[0].id == "lint"
+        assert steps[0].command == "make lint"  # built-in
+
+
+# -- CPP's own manifest validation --
+
+
+class TestCPPManifest:
+    def test_cpp_manifest_loads(self):
+        """Validate that CPP's own .claude/cicd_tasks.yml is valid."""
+        cpp_root = Path(__file__).parent.parent
+        manifest = load_manifest(cpp_root)
+        assert manifest is not None
+        assert manifest.version == "1"
+
+        # Verify expected steps exist
+        assert "lint" in manifest.steps
+        assert "test" in manifest.steps
+        assert "security_scan" in manifest.steps
+        assert "deploy" in manifest.steps
+
+        # Verify expected plans exist
+        assert "finish" in manifest.plans
+        assert "check" in manifest.plans
+        assert "deploy" in manifest.plans
+
+        # Verify cross-references are valid
+        errors = manifest.validate_plan_references()
+        assert errors == [], f"CPP manifest has reference errors: {errors}"

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "claude-power-pack"
 version = "5.1.0"
 source = { virtual = "." }
@@ -10,6 +19,7 @@ source = { virtual = "." }
 [package.optional-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pyyaml" },
     { name = "ruff" },
@@ -20,6 +30,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
@@ -195,6 +206,118 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +450,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `lib/cicd/manifest.py` with Pydantic v2 models (`TaskManifest`, `PlanModel`, `StepModel`) for typed `.claude/cicd_tasks.yml` manifest
- Runner loads plans from manifest when present, falls back to built-in defaults (full backwards compatibility)
- Add `init-manifest` and `validate-manifest` CLI subcommands for auto-generating and validating manifests
- Create CPP's own `.claude/cicd_tasks.yml` manifest (dogfooding)
- 33 unit/integration tests covering validation, loading, generation, cross-references, and runner integration
- Add `pydantic>=2.0` to dev dependencies

## Test plan

- [x] All 33 new tests pass (`tests/test_manifest.py`)
- [x] All 269 tests pass (full suite - no regressions)
- [x] Lint passes (ruff check clean)
- [x] CPP's own manifest loads and validates correctly
- [x] Backwards compatibility: projects without manifest use built-in plans
- [x] Manifest plans override built-in when present

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)