### PR TITLE
feat(cicd): deployment strategies with readiness gates and rollback (Closes #246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Core components and their locations:
 - `extras/sequential-thinking/` - Optional: structured reasoning (stdio, npm)
 - `lib/creds/` - Secrets management (dotenv/AWS SM, FastAPI UI, audit logging)
 - `lib/security/` - Security scanning (native + external tools)
-- `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks
+- `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deployment strategies
 - `lib/spec_bridge/` - Spec-to-GitHub-issue sync
 - `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks)
 - `templates/` - Makefile, workflow, container templates

--- a/lib/cicd/__init__.py
+++ b/lib/cicd/__init__.py
@@ -32,6 +32,16 @@ Quick Start:
 
 from .config import CICDConfig
 from .container import generate_compose, generate_container_files, generate_dockerfile, generate_dockerignore
+from .deploy import (
+    DeployConfig,
+    DeploymentStrategy,
+    DockerComposeStrategy,
+    ReadinessPolicy,
+    ReadinessResult,
+    get_strategy,
+    poll_readiness,
+    register_strategy,
+)
 from .detector import detect_framework, detect_infrastructure
 from .health import check_endpoint, check_process, run_health_checks
 from .infrastructure import generate_discovery_script, generate_infra_pipeline, scaffold_infrastructure
@@ -63,7 +73,7 @@ from .pipeline import generate_github_actions, generate_pipeline, generate_woodp
 from .runner import DeterministicRunner, RunResult, resume_run, run_plan
 from .smoke import run_smoke_tests
 from .state import RunState, StepRecord, StepStatus
-from .steps import ShellStep, StepDef, StepResult
+from .steps import DeployStep, ShellStep, StepDef, StepResult
 
 __all__ = [
     # Config
@@ -108,6 +118,16 @@ __all__ = [
     "PackageManager",
     "SmokeTestEntry",
     "SmokeTestResult",
+    # Deploy
+    "DeployConfig",
+    "DeploymentStrategy",
+    "DeployStep",
+    "DockerComposeStrategy",
+    "ReadinessPolicy",
+    "ReadinessResult",
+    "get_strategy",
+    "poll_readiness",
+    "register_strategy",
     # Manifest
     "TaskManifest",
     "StepModel",

--- a/lib/cicd/deploy/__init__.py
+++ b/lib/cicd/deploy/__init__.py
@@ -1,0 +1,30 @@
+"""Deployment strategies with readiness gates and rollback.
+
+Provides a pluggable strategy system for CI/CD deployments:
+- DeploymentStrategy Protocol for custom strategies
+- DockerComposeStrategy for docker compose deployments
+- ReadinessPolicy for polling health endpoints after deploy
+- Automatic rollback on readiness failure
+"""
+
+from .docker_compose import DockerComposeStrategy
+from .strategy import (
+    DeployConfig,
+    DeploymentStrategy,
+    ReadinessPolicy,
+    ReadinessResult,
+    get_strategy,
+    poll_readiness,
+    register_strategy,
+)
+
+__all__ = [
+    "DeployConfig",
+    "DeploymentStrategy",
+    "DockerComposeStrategy",
+    "ReadinessPolicy",
+    "ReadinessResult",
+    "get_strategy",
+    "poll_readiness",
+    "register_strategy",
+]

--- a/lib/cicd/deploy/docker_compose.py
+++ b/lib/cicd/deploy/docker_compose.py
@@ -1,0 +1,230 @@
+"""Docker Compose deployment strategy.
+
+Handles deploy, rollback, and readiness checking for services
+managed by docker compose. This is the primary deployment strategy
+for Claude Power Pack MCP servers.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+from ..state import StepStatus
+from ..steps import StepResult
+from .strategy import DeployConfig, register_strategy
+
+
+class DockerComposeStrategy:
+    """Deploy via docker compose with optional profiles and services."""
+
+    name = "docker_compose"
+
+    def _compose_base_cmd(self, config: DeployConfig) -> list[str]:
+        """Build the base docker compose command with file and profiles."""
+        cmd = ["docker", "compose", "-f", config.compose_file]
+        for profile in config.profiles:
+            cmd.extend(["--profile", profile])
+        return cmd
+
+    def deploy(self, context: dict[str, Any], config: DeployConfig) -> StepResult:
+        """Pull images and start/restart services.
+
+        Uses `docker compose up -d` with optional profiles and services.
+        If a custom deploy_command is set in config, uses that instead.
+        """
+        cwd = context.get("project_root")
+        env = context.get("env")
+
+        if config.deploy_command:
+            return self._run_shell(config.deploy_command, cwd=cwd, env=env,
+                                   timeout=config.timeout_seconds)
+
+        base = self._compose_base_cmd(config)
+        # Pull first, then up
+        pull_cmd = base + ["pull"]
+        if config.services:
+            pull_cmd.extend(config.services)
+
+        pull_result = self._run_cmd(pull_cmd, cwd=cwd, env=env, timeout=300)
+        if not pull_result.success:
+            return pull_result
+
+        up_cmd = base + ["up", "-d", "--remove-orphans"]
+        if config.services:
+            up_cmd.extend(config.services)
+
+        return self._run_cmd(up_cmd, cwd=cwd, env=env,
+                             timeout=config.timeout_seconds)
+
+    def rollback(self, context: dict[str, Any], config: DeployConfig) -> StepResult:
+        """Roll back by stopping and restarting services.
+
+        If a custom rollback_command is set, uses that instead.
+        Default: docker compose down + up (forces fresh start).
+        """
+        cwd = context.get("project_root")
+        env = context.get("env")
+
+        if config.rollback_command:
+            return self._run_shell(config.rollback_command, cwd=cwd, env=env,
+                                   timeout=config.timeout_seconds)
+
+        base = self._compose_base_cmd(config)
+
+        # Down first
+        down_cmd = base + ["down"]
+        if config.services:
+            down_cmd.extend(config.services)
+        down_result = self._run_cmd(down_cmd, cwd=cwd, env=env, timeout=120)
+        if not down_result.success:
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=down_result.exit_code,
+                output=down_result.output,
+                error=f"Rollback failed during 'down': {down_result.error}",
+            )
+
+        # Up again
+        up_cmd = base + ["up", "-d"]
+        if config.services:
+            up_cmd.extend(config.services)
+        return self._run_cmd(up_cmd, cwd=cwd, env=env,
+                             timeout=config.timeout_seconds)
+
+    def check_readiness(self, context: dict[str, Any], config: DeployConfig) -> bool:
+        """Check if all target services are running and healthy.
+
+        Uses `docker compose ps` to verify service status.
+        """
+        cwd = context.get("project_root")
+        env = context.get("env")
+
+        base = self._compose_base_cmd(config)
+        ps_cmd = base + ["ps", "--format", "json"]
+        if config.services:
+            ps_cmd.extend(config.services)
+
+        try:
+            proc = subprocess.run(
+                ps_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=cwd,
+                env=env,
+            )
+            if proc.returncode != 0:
+                return False
+
+            # docker compose ps --format json outputs one JSON object per line
+            # Check that all services are "running"
+            output = proc.stdout.strip()
+            if not output:
+                return False
+
+            import json
+            for line in output.splitlines():
+                try:
+                    svc = json.loads(line)
+                    state = svc.get("State", "").lower()
+                    if state != "running":
+                        return False
+                except (json.JSONDecodeError, AttributeError):
+                    return False
+
+            return True
+
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+
+    def _run_cmd(
+        self,
+        cmd: list[str],
+        cwd: Any = None,
+        env: Any = None,
+        timeout: int = 600,
+    ) -> StepResult:
+        """Run a command list and return StepResult."""
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=cwd,
+                env=env,
+            )
+            if proc.returncode == 0:
+                return StepResult(
+                    status=StepStatus.SUCCESS,
+                    exit_code=0,
+                    output=proc.stdout,
+                )
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=proc.returncode,
+                output=proc.stdout,
+                error=proc.stderr,
+            )
+        except subprocess.TimeoutExpired as e:
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=124,
+                output=e.stdout or "" if isinstance(e.stdout, str) else "",
+                error=f"Command timed out after {timeout}s",
+            )
+        except OSError as e:
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=1,
+                error=str(e),
+            )
+
+    def _run_shell(
+        self,
+        command: str,
+        cwd: Any = None,
+        env: Any = None,
+        timeout: int = 600,
+    ) -> StepResult:
+        """Run a shell command string and return StepResult."""
+        try:
+            proc = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=cwd,
+                env=env,
+            )
+            if proc.returncode == 0:
+                return StepResult(
+                    status=StepStatus.SUCCESS,
+                    exit_code=0,
+                    output=proc.stdout,
+                )
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=proc.returncode,
+                output=proc.stdout,
+                error=proc.stderr,
+            )
+        except subprocess.TimeoutExpired as e:
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=124,
+                output=e.stdout or "" if isinstance(e.stdout, str) else "",
+                error=f"Command timed out after {timeout}s",
+            )
+        except OSError as e:
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=1,
+                error=str(e),
+            )
+
+
+# Auto-register on import
+register_strategy("docker_compose", DockerComposeStrategy)

--- a/lib/cicd/deploy/strategy.py
+++ b/lib/cicd/deploy/strategy.py
@@ -1,0 +1,311 @@
+"""Deployment strategy protocol and readiness polling.
+
+Defines the DeploymentStrategy Protocol that all strategy implementations
+must follow, plus the ReadinessPolicy for health endpoint polling with
+exponential backoff and consecutive success thresholds.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol
+
+from ..steps import StepResult
+
+
+class DeploymentStrategy(Protocol):
+    """Protocol for deployment strategy implementations.
+
+    Each strategy knows how to deploy, rollback, and check readiness
+    for a specific deployment target (docker compose, AWS ECS, etc.)
+    """
+
+    name: str
+
+    def deploy(self, context: dict[str, Any], config: DeployConfig) -> StepResult:
+        """Execute the deployment.
+
+        Args:
+            context: Runner context (project_root, run_id, plan, env).
+            config: Deployment configuration.
+
+        Returns:
+            StepResult with deploy outcome.
+        """
+        ...
+
+    def rollback(self, context: dict[str, Any], config: DeployConfig) -> StepResult:
+        """Roll back a failed deployment.
+
+        Args:
+            context: Runner context.
+            config: Deployment configuration.
+
+        Returns:
+            StepResult with rollback outcome.
+        """
+        ...
+
+    def check_readiness(self, context: dict[str, Any], config: DeployConfig) -> bool:
+        """Single readiness check (not polling).
+
+        Args:
+            context: Runner context.
+            config: Deployment configuration.
+
+        Returns:
+            True if the deployment target is ready.
+        """
+        ...
+
+
+@dataclass
+class ReadinessPolicy:
+    """Configuration for readiness gate polling.
+
+    Polls a URL until N consecutive successful responses or timeout.
+    Uses exponential backoff between attempts.
+    """
+
+    url: str
+    interval_seconds: float = 5.0
+    timeout_seconds: float = 120.0
+    consecutive_successes: int = 3
+    backoff_multiplier: float = 1.5
+    expected_status: int = 200
+
+    def validate(self) -> list[str]:
+        """Return validation errors, if any."""
+        errors = []
+        if not self.url:
+            errors.append("readiness url is required")
+        if self.interval_seconds <= 0:
+            errors.append("interval_seconds must be positive")
+        if self.timeout_seconds <= 0:
+            errors.append("timeout_seconds must be positive")
+        if self.consecutive_successes < 1:
+            errors.append("consecutive_successes must be >= 1")
+        if self.backoff_multiplier < 1.0:
+            errors.append("backoff_multiplier must be >= 1.0")
+        return errors
+
+
+@dataclass
+class DeployConfig:
+    """Configuration for a deployment step.
+
+    Loaded from the task manifest or constructed programmatically.
+    """
+
+    strategy: str = "docker_compose"
+    compose_file: str = "docker-compose.yml"
+    profiles: list[str] = field(default_factory=list)
+    services: list[str] = field(default_factory=list)
+    readiness: Optional[ReadinessPolicy] = None
+    rollback_command: Optional[str] = None
+    deploy_command: Optional[str] = None
+    timeout_seconds: int = 900
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeployConfig:
+        """Create from a dictionary (e.g., manifest config section)."""
+        readiness_data = data.pop("readiness", None)
+        readiness = ReadinessPolicy(**readiness_data) if readiness_data else None
+        profiles = data.pop("profiles", [])
+        services = data.pop("services", [])
+        extra = {}
+        known_keys = {
+            "strategy", "compose_file", "readiness", "rollback_command",
+            "deploy_command", "timeout_seconds", "profiles", "services",
+        }
+        for k, v in list(data.items()):
+            if k not in known_keys:
+                extra[k] = v
+                data.pop(k)
+
+        return cls(
+            strategy=data.get("strategy", "docker_compose"),
+            compose_file=data.get("compose_file", "docker-compose.yml"),
+            profiles=profiles,
+            services=services,
+            readiness=readiness,
+            rollback_command=data.get("rollback_command"),
+            deploy_command=data.get("deploy_command"),
+            timeout_seconds=data.get("timeout_seconds", 900),
+            extra=extra,
+        )
+
+
+@dataclass
+class ReadinessResult:
+    """Result of a readiness polling session."""
+
+    ready: bool
+    attempts: int = 0
+    consecutive_ok: int = 0
+    elapsed_seconds: float = 0.0
+    last_status: Optional[int] = None
+    last_error: Optional[str] = None
+
+    @property
+    def summary(self) -> str:
+        if self.ready:
+            return (
+                f"Ready after {self.attempts} attempts "
+                f"({self.elapsed_seconds:.1f}s, "
+                f"{self.consecutive_ok} consecutive OK)"
+            )
+        reason = self.last_error or f"HTTP {self.last_status}"
+        return (
+            f"Not ready after {self.attempts} attempts "
+            f"({self.elapsed_seconds:.1f}s): {reason}"
+        )
+
+
+def poll_readiness(
+    policy: ReadinessPolicy,
+    sleep_fn: Any = None,
+) -> ReadinessResult:
+    """Poll a readiness URL until success threshold or timeout.
+
+    Uses curl for HTTP checks (matching health.py pattern, no new deps).
+
+    Args:
+        policy: Readiness polling configuration.
+        sleep_fn: Optional sleep function for testing (default: time.sleep).
+
+    Returns:
+        ReadinessResult with polling outcome.
+    """
+    if sleep_fn is None:
+        sleep_fn = time.sleep
+
+    curl_path = shutil.which("curl")
+    if not curl_path:
+        return ReadinessResult(
+            ready=False,
+            last_error="curl not found in PATH",
+        )
+
+    errors = policy.validate()
+    if errors:
+        return ReadinessResult(
+            ready=False,
+            last_error=f"Invalid policy: {'; '.join(errors)}",
+        )
+
+    start = time.monotonic()
+    attempts = 0
+    consecutive_ok = 0
+    interval = policy.interval_seconds
+    last_status: Optional[int] = None
+    last_error: Optional[str] = None
+
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= policy.timeout_seconds:
+            return ReadinessResult(
+                ready=False,
+                attempts=attempts,
+                consecutive_ok=consecutive_ok,
+                elapsed_seconds=elapsed,
+                last_status=last_status,
+                last_error=last_error or "Timeout exceeded",
+            )
+
+        attempts += 1
+
+        try:
+            proc = subprocess.run(
+                [
+                    curl_path,
+                    "-sf",
+                    "-o", "/dev/null",
+                    "-w", "%{http_code}",
+                    "--max-time", "5",
+                    policy.url,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            # Parse status code from curl output
+            try:
+                status_code = int(proc.stdout.strip())
+            except (ValueError, TypeError):
+                status_code = 0
+
+            last_status = status_code
+            last_error = None
+
+            if status_code == policy.expected_status:
+                consecutive_ok += 1
+                if consecutive_ok >= policy.consecutive_successes:
+                    return ReadinessResult(
+                        ready=True,
+                        attempts=attempts,
+                        consecutive_ok=consecutive_ok,
+                        elapsed_seconds=time.monotonic() - start,
+                        last_status=status_code,
+                    )
+            else:
+                consecutive_ok = 0
+                last_error = f"HTTP {status_code} (expected {policy.expected_status})"
+
+        except subprocess.TimeoutExpired:
+            consecutive_ok = 0
+            last_error = "Request timed out"
+        except OSError as e:
+            consecutive_ok = 0
+            last_error = str(e)
+
+        # Check timeout before sleeping
+        elapsed = time.monotonic() - start
+        if elapsed + interval >= policy.timeout_seconds:
+            # One last check: if we've already exceeded, break
+            if elapsed >= policy.timeout_seconds:
+                return ReadinessResult(
+                    ready=False,
+                    attempts=attempts,
+                    consecutive_ok=consecutive_ok,
+                    elapsed_seconds=elapsed,
+                    last_status=last_status,
+                    last_error=last_error or "Timeout exceeded",
+                )
+
+        sleep_fn(interval)
+        # Apply backoff
+        interval = min(interval * policy.backoff_multiplier, 30.0)
+
+
+# --- Strategy registry ---
+
+_STRATEGY_REGISTRY: dict[str, type] = {}
+
+
+def register_strategy(name: str, strategy_cls: type) -> None:
+    """Register a deployment strategy by name."""
+    _STRATEGY_REGISTRY[name] = strategy_cls
+
+
+def get_strategy(name: str) -> DeploymentStrategy:
+    """Look up and instantiate a strategy by name.
+
+    Args:
+        name: Strategy name (e.g., "docker_compose").
+
+    Returns:
+        An instance of the named strategy.
+
+    Raises:
+        ValueError: If the strategy name is not registered.
+    """
+    if name not in _STRATEGY_REGISTRY:
+        available = ", ".join(sorted(_STRATEGY_REGISTRY.keys())) or "(none)"
+        raise ValueError(f"Unknown deployment strategy: {name}. Available: {available}")
+    return _STRATEGY_REGISTRY[name]()

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -244,6 +244,68 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
 }
 
 
+class DeployStep:
+    """Execute a deployment with readiness gate and automatic rollback.
+
+    Wraps a DeploymentStrategy to provide:
+    1. Deploy via the configured strategy
+    2. Poll readiness URL until success threshold or timeout
+    3. Automatic rollback if readiness check fails
+
+    Usage:
+        config = DeployConfig(strategy="docker_compose", ...)
+        step = DeployStep(config)
+        result = step.execute(context)
+    """
+
+    def __init__(self, config: Optional[Any] = None):
+        from .deploy.strategy import DeployConfig, get_strategy
+
+        if config is None:
+            config = DeployConfig()
+        elif isinstance(config, dict):
+            config = DeployConfig.from_dict(config)
+
+        self.config: DeployConfig = config
+        self.id = "deploy"
+        self.timeout_seconds = config.timeout_seconds
+        self.max_attempts = 1
+        self.idempotent = False
+
+        self.strategy = get_strategy(config.strategy)
+
+    def execute(self, context: dict[str, Any]) -> StepResult:
+        """Execute deploy, check readiness, rollback on failure."""
+        from .deploy.strategy import poll_readiness
+
+        # Step 1: Deploy
+        deploy_result = self.strategy.deploy(context, self.config)
+        if not deploy_result.success:
+            return deploy_result
+
+        # Step 2: Readiness gate (if configured)
+        if self.config.readiness:
+            readiness = poll_readiness(self.config.readiness)
+            if not readiness.ready:
+                # Step 3: Auto-rollback on readiness failure
+                rollback_result = self.strategy.rollback(context, self.config)
+                rollback_info = (
+                    "rollback succeeded" if rollback_result.success
+                    else f"rollback also failed: {rollback_result.error}"
+                )
+                return StepResult(
+                    status=StepStatus.FAILED,
+                    exit_code=1,
+                    output=deploy_result.output,
+                    error=(
+                        f"Readiness check failed: {readiness.summary}. "
+                        f"Rollback: {rollback_info}"
+                    ),
+                )
+
+        return deploy_result
+
+
 def get_plan_steps(plan_name: str, project_root: Optional[str] = None) -> list[StepDef]:
     """Get step definitions for a plan.
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,485 @@
+"""Unit tests for deployment strategies and readiness polling."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.cicd.deploy.docker_compose import DockerComposeStrategy
+from lib.cicd.deploy.strategy import (
+    DeployConfig,
+    ReadinessPolicy,
+    ReadinessResult,
+    get_strategy,
+    poll_readiness,
+    register_strategy,
+)
+from lib.cicd.state import StepStatus
+from lib.cicd.steps import DeployStep, StepResult
+
+# --- ReadinessPolicy tests ---
+
+
+class TestReadinessPolicy:
+    def test_defaults(self):
+        policy = ReadinessPolicy(url="http://localhost:8080/health")
+        assert policy.interval_seconds == 5.0
+        assert policy.timeout_seconds == 120.0
+        assert policy.consecutive_successes == 3
+        assert policy.backoff_multiplier == 1.5
+        assert policy.expected_status == 200
+
+    def test_validate_ok(self):
+        policy = ReadinessPolicy(url="http://localhost:8080/health")
+        assert policy.validate() == []
+
+    def test_validate_empty_url(self):
+        policy = ReadinessPolicy(url="")
+        errors = policy.validate()
+        assert any("url" in e for e in errors)
+
+    def test_validate_bad_interval(self):
+        policy = ReadinessPolicy(url="http://localhost/health", interval_seconds=0)
+        errors = policy.validate()
+        assert any("interval" in e for e in errors)
+
+    def test_validate_bad_consecutive(self):
+        policy = ReadinessPolicy(url="http://localhost/health", consecutive_successes=0)
+        errors = policy.validate()
+        assert any("consecutive" in e for e in errors)
+
+    def test_validate_bad_backoff(self):
+        policy = ReadinessPolicy(url="http://localhost/health", backoff_multiplier=0.5)
+        errors = policy.validate()
+        assert any("backoff" in e for e in errors)
+
+
+# --- DeployConfig tests ---
+
+
+class TestDeployConfig:
+    def test_defaults(self):
+        config = DeployConfig()
+        assert config.strategy == "docker_compose"
+        assert config.compose_file == "docker-compose.yml"
+        assert config.readiness is None
+        assert config.profiles == []
+        assert config.services == []
+
+    def test_from_dict_basic(self):
+        data = {
+            "strategy": "docker_compose",
+            "compose_file": "docker-compose.prod.yml",
+            "profiles": ["core", "browser"],
+        }
+        config = DeployConfig.from_dict(data)
+        assert config.strategy == "docker_compose"
+        assert config.compose_file == "docker-compose.prod.yml"
+        assert config.profiles == ["core", "browser"]
+
+    def test_from_dict_with_readiness(self):
+        data = {
+            "strategy": "docker_compose",
+            "readiness": {
+                "url": "http://localhost:8080/health",
+                "consecutive_successes": 5,
+                "timeout_seconds": 60,
+            },
+        }
+        config = DeployConfig.from_dict(data)
+        assert config.readiness is not None
+        assert config.readiness.url == "http://localhost:8080/health"
+        assert config.readiness.consecutive_successes == 5
+        assert config.readiness.timeout_seconds == 60
+
+    def test_from_dict_extra_keys(self):
+        data = {
+            "strategy": "docker_compose",
+            "custom_key": "custom_value",
+        }
+        config = DeployConfig.from_dict(data)
+        assert config.extra == {"custom_key": "custom_value"}
+
+
+# --- poll_readiness tests ---
+
+
+class TestPollReadiness:
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value=None)
+    def test_no_curl(self, mock_which: MagicMock):
+        policy = ReadinessPolicy(url="http://localhost/health")
+        result = poll_readiness(policy)
+        assert not result.ready
+        assert "curl not found" in (result.last_error or "")
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    def test_immediate_success(self, mock_run: MagicMock, mock_which: MagicMock):
+        """3 consecutive 200s should succeed."""
+        mock_run.return_value = MagicMock(
+            stdout="200",
+            stderr="",
+            returncode=0,
+        )
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            consecutive_successes=3,
+            interval_seconds=0.01,
+            timeout_seconds=5,
+        )
+        sleeps: list[float] = []
+        result = poll_readiness(policy, sleep_fn=lambda s: sleeps.append(s))
+        assert result.ready
+        assert result.consecutive_ok == 3
+        assert result.attempts == 3
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    def test_intermittent_failures(self, mock_run: MagicMock, mock_which: MagicMock):
+        """Failures reset consecutive count but don't stop polling."""
+        # 200, 503, 200, 200, 200 -> should succeed on 5th attempt
+        statuses = ["200", "503", "200", "200", "200"]
+        returncodes = [0, 0, 0, 0, 0]
+        mock_run.side_effect = [
+            MagicMock(stdout=s, stderr="", returncode=r)
+            for s, r in zip(statuses, returncodes)
+        ]
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            consecutive_successes=3,
+            interval_seconds=0.01,
+            timeout_seconds=5,
+            backoff_multiplier=1.0,  # no backoff for test
+        )
+        result = poll_readiness(policy, sleep_fn=lambda s: None)
+        assert result.ready
+        assert result.attempts == 5
+        assert result.consecutive_ok == 3
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    @patch("lib.cicd.deploy.strategy.time.monotonic")
+    def test_timeout(self, mock_time: MagicMock, mock_run: MagicMock, mock_which: MagicMock):
+        """Should fail after timeout."""
+        # Simulate time advancing past timeout
+        call_count = [0]
+
+        def advancing_time():
+            call_count[0] += 1
+            # Return increasing timestamps to eventually exceed timeout
+            return call_count[0] * 10.0  # 10s per call
+
+        mock_time.side_effect = advancing_time
+        mock_run.return_value = MagicMock(stdout="503", stderr="", returncode=0)
+
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            timeout_seconds=5,
+            interval_seconds=0.01,
+        )
+        result = poll_readiness(policy, sleep_fn=lambda s: None)
+        assert not result.ready
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    def test_connection_refused(self, mock_run: MagicMock, mock_which: MagicMock):
+        """OSError during curl should count as failure."""
+        mock_run.side_effect = OSError("Connection refused")
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            timeout_seconds=0.05,
+            interval_seconds=0.01,
+            backoff_multiplier=1.0,
+        )
+        result = poll_readiness(policy, sleep_fn=lambda s: None)
+        assert not result.ready
+        assert "Connection refused" in (result.last_error or "")
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    def test_curl_timeout(self, mock_run: MagicMock, mock_which: MagicMock):
+        """subprocess.TimeoutExpired should count as failure."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="curl", timeout=10)
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            timeout_seconds=0.05,
+            interval_seconds=0.01,
+            backoff_multiplier=1.0,
+        )
+        result = poll_readiness(policy, sleep_fn=lambda s: None)
+        assert not result.ready
+        assert "timed out" in (result.last_error or "").lower()
+
+    def test_invalid_policy(self):
+        """Invalid policy should return immediately."""
+        policy = ReadinessPolicy(url="", timeout_seconds=0)
+        result = poll_readiness(policy)
+        assert not result.ready
+        assert "Invalid policy" in (result.last_error or "")
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    def test_backoff_applied(self, mock_run: MagicMock, mock_which: MagicMock):
+        """Sleep intervals should increase with backoff multiplier."""
+        mock_run.return_value = MagicMock(stdout="503", stderr="", returncode=0)
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            timeout_seconds=0.1,
+            interval_seconds=0.01,
+            backoff_multiplier=2.0,
+        )
+        sleeps: list[float] = []
+        poll_readiness(policy, sleep_fn=lambda s: sleeps.append(s))
+
+        if len(sleeps) >= 2:
+            # Second interval should be 2x the first
+            assert sleeps[1] == pytest.approx(sleeps[0] * 2.0)
+
+
+# --- ReadinessResult tests ---
+
+
+class TestReadinessResult:
+    def test_ready_summary(self):
+        result = ReadinessResult(
+            ready=True, attempts=5, consecutive_ok=3, elapsed_seconds=12.5
+        )
+        s = result.summary
+        assert "Ready" in s
+        assert "5 attempts" in s
+        assert "3 consecutive OK" in s
+
+    def test_not_ready_summary(self):
+        result = ReadinessResult(
+            ready=False, attempts=10, consecutive_ok=1,
+            elapsed_seconds=120.0, last_error="Timeout exceeded",
+        )
+        s = result.summary
+        assert "Not ready" in s
+        assert "Timeout exceeded" in s
+
+
+# --- Strategy registry tests ---
+
+
+class TestStrategyRegistry:
+    def test_docker_compose_registered(self):
+        strategy = get_strategy("docker_compose")
+        assert strategy.name == "docker_compose"
+        assert isinstance(strategy, DockerComposeStrategy)
+
+    def test_unknown_strategy_raises(self):
+        with pytest.raises(ValueError, match="Unknown deployment strategy"):
+            get_strategy("nonexistent_strategy")
+
+    def test_register_custom(self):
+        class CustomStrategy:
+            name = "custom"
+            def deploy(self, ctx: Any, config: Any) -> StepResult:
+                return StepResult(status=StepStatus.SUCCESS)
+            def rollback(self, ctx: Any, config: Any) -> StepResult:
+                return StepResult(status=StepStatus.SUCCESS)
+            def check_readiness(self, ctx: Any, config: Any) -> bool:
+                return True
+
+        register_strategy("custom", CustomStrategy)
+        strategy = get_strategy("custom")
+        assert strategy.name == "custom"
+
+
+# --- DockerComposeStrategy tests ---
+
+
+class TestDockerComposeStrategy:
+    def test_compose_base_cmd_default(self):
+        strategy = DockerComposeStrategy()
+        config = DeployConfig()
+        cmd = strategy._compose_base_cmd(config)
+        assert cmd == ["docker", "compose", "-f", "docker-compose.yml"]
+
+    def test_compose_base_cmd_with_profiles(self):
+        strategy = DockerComposeStrategy()
+        config = DeployConfig(profiles=["core", "browser"])
+        cmd = strategy._compose_base_cmd(config)
+        assert cmd == [
+            "docker", "compose", "-f", "docker-compose.yml",
+            "--profile", "core", "--profile", "browser",
+        ]
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_deploy_custom_command(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            stdout="deployed", stderr="", returncode=0,
+        )
+        strategy = DockerComposeStrategy()
+        config = DeployConfig(deploy_command="make deploy")
+        result = strategy.deploy({"project_root": "/tmp"}, config)
+        assert result.success
+        mock_run.assert_called_once()
+        # Should have been called with shell=True for custom command
+        assert mock_run.call_args[1].get("shell") is True
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_rollback_custom_command(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            stdout="rolled back", stderr="", returncode=0,
+        )
+        strategy = DockerComposeStrategy()
+        config = DeployConfig(rollback_command="docker compose down && docker compose up -d")
+        result = strategy.rollback({"project_root": "/tmp"}, config)
+        assert result.success
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_deploy_failure(self, mock_run: MagicMock):
+        # Pull succeeds, up fails
+        mock_run.side_effect = [
+            MagicMock(stdout="pulled", stderr="", returncode=0),
+            MagicMock(stdout="", stderr="error starting", returncode=1),
+        ]
+        strategy = DockerComposeStrategy()
+        config = DeployConfig()
+        result = strategy.deploy({"project_root": "/tmp"}, config)
+        assert not result.success
+        assert result.exit_code == 1
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_deploy_pull_failure(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            stdout="", stderr="pull failed", returncode=1,
+        )
+        strategy = DockerComposeStrategy()
+        config = DeployConfig()
+        result = strategy.deploy({"project_root": "/tmp"}, config)
+        assert not result.success
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_deploy_timeout(self, mock_run: MagicMock):
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd="docker compose up", timeout=900,
+        )
+        strategy = DockerComposeStrategy()
+        config = DeployConfig()
+        result = strategy.deploy({"project_root": "/tmp"}, config)
+        assert not result.success
+        assert result.exit_code == 124
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_check_readiness_running(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            stdout='{"Name":"svc","State":"running"}\n',
+            stderr="",
+            returncode=0,
+        )
+        strategy = DockerComposeStrategy()
+        config = DeployConfig()
+        assert strategy.check_readiness({"project_root": "/tmp"}, config) is True
+
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_check_readiness_not_running(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            stdout='{"Name":"svc","State":"exited"}\n',
+            stderr="",
+            returncode=0,
+        )
+        strategy = DockerComposeStrategy()
+        config = DeployConfig()
+        assert strategy.check_readiness({"project_root": "/tmp"}, config) is False
+
+
+# --- DeployStep tests ---
+
+
+class TestDeployStep:
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_deploy_without_readiness(self, mock_run: MagicMock):
+        """Deploy succeeds without readiness config."""
+        mock_run.return_value = MagicMock(
+            stdout="ok", stderr="", returncode=0,
+        )
+        config = DeployConfig(readiness=None)
+        step = DeployStep(config)
+        result = step.execute({"project_root": "/tmp"})
+        assert result.success
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    def test_deploy_with_readiness_success(
+        self, mock_compose_run: MagicMock, mock_curl_run: MagicMock,
+        mock_which: MagicMock,
+    ):
+        """Deploy + readiness both succeed."""
+        # compose pull + up succeed
+        mock_compose_run.return_value = MagicMock(
+            stdout="ok", stderr="", returncode=0,
+        )
+        # curl returns 200
+        mock_curl_run.return_value = MagicMock(
+            stdout="200", stderr="", returncode=0,
+        )
+        config = DeployConfig(
+            readiness=ReadinessPolicy(
+                url="http://localhost:8080/health",
+                consecutive_successes=2,
+                interval_seconds=0.01,
+                timeout_seconds=5,
+            ),
+        )
+        step = DeployStep(config)
+        result = step.execute({"project_root": "/tmp"})
+        assert result.success
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    @patch("lib.cicd.deploy.docker_compose.subprocess.run")
+    @patch("lib.cicd.deploy.strategy.time.monotonic")
+    def test_deploy_readiness_fails_triggers_rollback(
+        self, mock_time: MagicMock, mock_compose_run: MagicMock,
+        mock_curl_run: MagicMock, mock_which: MagicMock,
+    ):
+        """Readiness failure triggers automatic rollback."""
+        # Simulate time advancing past timeout
+        call_count = [0]
+        def advancing_time():
+            call_count[0] += 1
+            return call_count[0] * 10.0
+        mock_time.side_effect = advancing_time
+
+        # compose commands succeed (deploy + rollback)
+        mock_compose_run.return_value = MagicMock(
+            stdout="ok", stderr="", returncode=0,
+        )
+        # curl always returns 503
+        mock_curl_run.return_value = MagicMock(
+            stdout="503", stderr="", returncode=0,
+        )
+
+        config = DeployConfig(
+            readiness=ReadinessPolicy(
+                url="http://localhost:8080/health",
+                timeout_seconds=5,
+                interval_seconds=0.01,
+            ),
+        )
+        step = DeployStep(config)
+        result = step.execute({"project_root": "/tmp"})
+
+        assert not result.success
+        assert "Readiness check failed" in result.error
+        assert "rollback succeeded" in result.error
+
+    def test_deploy_step_from_dict(self):
+        """DeployStep can be created from a dict config."""
+        config_dict = {
+            "strategy": "docker_compose",
+            "compose_file": "docker-compose.yml",
+            "profiles": ["core"],
+        }
+        step = DeployStep(config_dict)
+        assert step.config.strategy == "docker_compose"
+        assert step.config.profiles == ["core"]
+        assert step.id == "deploy"
+        assert step.idempotent is False

--- a/tests/test_deploy_integration.py
+++ b/tests/test_deploy_integration.py
@@ -1,0 +1,322 @@
+"""Integration tests for deploy + readiness gate + rollback scenarios.
+
+These tests verify the full flow through DeployStep using the
+DockerComposeStrategy with mocked subprocess calls to simulate
+real deployment scenarios.
+
+Note: Both docker_compose.py and strategy.py import subprocess, but Python
+shares a single module object. We mock subprocess.run once and use
+command-aware side_effect routing for integration tests that need both
+compose and curl behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from lib.cicd.deploy.strategy import (
+    DeployConfig,
+    ReadinessPolicy,
+    register_strategy,
+)
+from lib.cicd.state import StepStatus
+from lib.cicd.steps import DeployStep, StepResult
+
+
+def _is_curl_cmd(args: Any) -> bool:
+    """Check if a subprocess call is a curl command."""
+    if isinstance(args, list):
+        return len(args) > 0 and "curl" in str(args[0])
+    if isinstance(args, str):
+        return "curl" in args
+    return False
+
+
+class TestDeployReadinessRollbackFlow:
+    """Full deploy -> readiness -> rollback integration tests."""
+
+    def _make_context(self, tmp_path: Path) -> dict[str, Any]:
+        return {"project_root": str(tmp_path)}
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("subprocess.run")
+    def test_full_success_flow(
+        self, mock_run: MagicMock, mock_which: MagicMock, tmp_path: Path,
+    ):
+        """Deploy succeeds, readiness passes -> overall success."""
+        compose_calls = []
+
+        def route_cmd(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if _is_curl_cmd(cmd):
+                return MagicMock(stdout="200", stderr="", returncode=0)
+            compose_calls.append(cmd)
+            return MagicMock(stdout="ok", stderr="", returncode=0)
+
+        mock_run.side_effect = route_cmd
+
+        config = DeployConfig(
+            readiness=ReadinessPolicy(
+                url="http://localhost:8080/health",
+                consecutive_successes=2,
+                interval_seconds=0.01,
+                timeout_seconds=5,
+            ),
+        )
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert result.success
+        assert result.status == StepStatus.SUCCESS
+        # compose should have been called for pull + up
+        assert len(compose_calls) == 2
+
+    @patch("subprocess.run")
+    def test_deploy_fails_no_rollback(
+        self, mock_run: MagicMock, tmp_path: Path,
+    ):
+        """If deploy itself fails, no rollback is attempted."""
+        call_log = []
+
+        def route_cmd(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            call_log.append(cmd)
+            return MagicMock(stdout="", stderr="pull failed: auth error", returncode=1)
+
+        mock_run.side_effect = route_cmd
+
+        config = DeployConfig()
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert not result.success
+        # Only pull was called, no rollback
+        assert len(call_log) == 1
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("subprocess.run")
+    @patch("lib.cicd.deploy.strategy.time.monotonic")
+    def test_readiness_timeout_triggers_rollback(
+        self, mock_time: MagicMock, mock_run: MagicMock,
+        mock_which: MagicMock, tmp_path: Path,
+    ):
+        """Readiness timeout triggers rollback via strategy."""
+        call_count = [0]
+
+        def advancing_time():
+            call_count[0] += 1
+            return call_count[0] * 10.0
+
+        mock_time.side_effect = advancing_time
+
+        compose_calls = []
+
+        def route_cmd(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if _is_curl_cmd(cmd):
+                return MagicMock(stdout="503", stderr="", returncode=0)
+            compose_calls.append(cmd)
+            return MagicMock(stdout="ok", stderr="", returncode=0)
+
+        mock_run.side_effect = route_cmd
+
+        config = DeployConfig(
+            readiness=ReadinessPolicy(
+                url="http://localhost:8080/health",
+                timeout_seconds=5,
+                interval_seconds=0.01,
+            ),
+        )
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert not result.success
+        assert "Readiness check failed" in result.error
+        assert "rollback succeeded" in result.error
+        # compose called: pull + up (deploy) + down + up (rollback) = 4
+        assert len(compose_calls) == 4
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("subprocess.run")
+    @patch("lib.cicd.deploy.strategy.time.monotonic")
+    def test_readiness_fails_rollback_also_fails(
+        self, mock_time: MagicMock, mock_run: MagicMock,
+        mock_which: MagicMock, tmp_path: Path,
+    ):
+        """When both readiness and rollback fail, error includes both."""
+        time_count = [0]
+
+        def advancing_time():
+            time_count[0] += 1
+            return time_count[0] * 10.0
+
+        mock_time.side_effect = advancing_time
+
+        compose_calls = [0]
+
+        def route_cmd(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if _is_curl_cmd(cmd):
+                return MagicMock(stdout="503", stderr="", returncode=0)
+            compose_calls[0] += 1
+            # First 2 compose calls (pull + up) succeed, 3rd (down for rollback) fails
+            if compose_calls[0] <= 2:
+                return MagicMock(stdout="ok", stderr="", returncode=0)
+            return MagicMock(stdout="", stderr="rollback error", returncode=1)
+
+        mock_run.side_effect = route_cmd
+
+        config = DeployConfig(
+            readiness=ReadinessPolicy(
+                url="http://localhost:8080/health",
+                timeout_seconds=5,
+                interval_seconds=0.01,
+            ),
+        )
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert not result.success
+        assert "rollback also failed" in result.error
+
+    @patch("subprocess.run")
+    def test_deploy_with_profiles_and_services(
+        self, mock_run: MagicMock, tmp_path: Path,
+    ):
+        """Profiles and services are passed to docker compose commands."""
+        call_log = []
+
+        def route_cmd(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            call_log.append(cmd)
+            return MagicMock(stdout="ok", stderr="", returncode=0)
+
+        mock_run.side_effect = route_cmd
+
+        config = DeployConfig(
+            profiles=["core", "browser"],
+            services=["second-opinion", "playwright"],
+        )
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert result.success
+        # Check that profiles were included in the pull command
+        pull_cmd = call_log[0]
+        assert "--profile" in pull_cmd
+        assert "core" in pull_cmd
+        assert "browser" in pull_cmd
+        assert "second-opinion" in pull_cmd
+
+    @patch("subprocess.run")
+    def test_deploy_with_custom_commands(
+        self, mock_run: MagicMock, tmp_path: Path,
+    ):
+        """Custom deploy/rollback commands are used when specified."""
+        mock_run.return_value = MagicMock(
+            stdout="ok", stderr="", returncode=0,
+        )
+
+        config = DeployConfig(
+            deploy_command="make deploy-prod",
+        )
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert result.success
+        # Should use shell=True for custom command
+        assert mock_run.call_count == 1
+        assert mock_run.call_args[1].get("shell") is True
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("subprocess.run")
+    def test_readiness_recovers_after_initial_failures(
+        self, mock_run: MagicMock, mock_which: MagicMock, tmp_path: Path,
+    ):
+        """Service starts slow but eventually becomes ready."""
+        curl_call_count = [0]
+        # First 3 curl calls fail, then 3 succeed
+        curl_responses = [
+            OSError("Connection refused"),
+            OSError("Connection refused"),
+            OSError("Connection refused"),
+            MagicMock(stdout="200", stderr="", returncode=0),
+            MagicMock(stdout="200", stderr="", returncode=0),
+            MagicMock(stdout="200", stderr="", returncode=0),
+        ]
+
+        def route_cmd(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if _is_curl_cmd(cmd):
+                idx = curl_call_count[0]
+                curl_call_count[0] += 1
+                resp = curl_responses[idx]
+                if isinstance(resp, Exception):
+                    raise resp
+                return resp
+            return MagicMock(stdout="ok", stderr="", returncode=0)
+
+        mock_run.side_effect = route_cmd
+
+        config = DeployConfig(
+            readiness=ReadinessPolicy(
+                url="http://localhost:8080/health",
+                consecutive_successes=3,
+                interval_seconds=0.01,
+                timeout_seconds=10,
+                backoff_multiplier=1.0,
+            ),
+        )
+        step = DeployStep(config)
+        result = step.execute(self._make_context(tmp_path))
+
+        assert result.success
+
+    def test_no_readiness_config_skips_gate(self, tmp_path: Path):
+        """Without readiness config, deploy result is returned directly."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="deployed ok", stderr="", returncode=0,
+            )
+
+            config = DeployConfig(readiness=None)
+            step = DeployStep(config)
+            result = step.execute(self._make_context(tmp_path))
+
+            assert result.success
+            assert result.output == "deployed ok"
+
+
+class TestCustomStrategyIntegration:
+    """Test that custom strategies work with DeployStep."""
+
+    def test_custom_strategy_full_flow(self, tmp_path: Path):
+        """Register and use a custom strategy through DeployStep."""
+        deploy_called = False
+        readiness_count = [0]
+
+        class MockStrategy:
+            name = "mock_test"
+
+            def deploy(self, ctx: dict[str, Any], config: DeployConfig) -> StepResult:
+                nonlocal deploy_called
+                deploy_called = True
+                return StepResult(status=StepStatus.SUCCESS, output="mock deployed")
+
+            def rollback(self, ctx: dict[str, Any], config: DeployConfig) -> StepResult:
+                return StepResult(status=StepStatus.SUCCESS)
+
+            def check_readiness(self, ctx: dict[str, Any], config: DeployConfig) -> bool:
+                readiness_count[0] += 1
+                return readiness_count[0] >= 3
+
+        register_strategy("mock_test", MockStrategy)
+
+        config = DeployConfig(strategy="mock_test")
+        step = DeployStep(config)
+        result = step.execute({"project_root": str(tmp_path)})
+
+        assert result.success
+        assert deploy_called


### PR DESCRIPTION
## Summary

- Add `DeploymentStrategy` Protocol with `deploy/rollback/check_readiness` methods and pluggable strategy registry
- Implement `DockerComposeStrategy` with compose pull/up, down/up rollback, and service status checking
- Add `ReadinessPolicy` with URL polling, exponential backoff, consecutive success threshold, and timeout
- Add `DeployStep` that orchestrates deploy -> readiness gate -> automatic rollback on failure
- 36 unit tests + 9 integration tests covering all acceptance criteria

Closes #246

## Test plan

- [x] `make lint` passes (ruff check clean)
- [x] `make test` passes (281 tests, 0 failures)
- [x] Unit tests cover: ReadinessPolicy validation, poll_readiness (success, timeout, intermittent failures, backoff), DockerComposeStrategy (deploy, rollback, custom commands, timeout), DeployStep (with/without readiness, auto-rollback), strategy registry
- [x] Integration tests cover: full success flow, deploy failure (no rollback), readiness timeout (triggers rollback), rollback failure reporting, profiles/services passthrough, recovery after initial failures, custom strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)