### PR TITLE
feat(cicd): schema validation + flow prompt integration (Closes #247)

### DIFF
--- a/.claude/commands/cicd/pipeline.md
+++ b/.claude/commands/cicd/pipeline.md
@@ -9,30 +9,46 @@ Generate GitHub Actions CI/CD workflows from your Makefile targets.
 
 ## Steps
 
-1. **Detect framework** using `lib/cicd`:
+1. **Check for task manifest** - if `.claude/cicd_tasks.yml` exists, use it to inform pipeline generation:
+
+```bash
+if [ -f ".claude/cicd_tasks.yml" ]; then
+    echo "Found cicd_tasks.yml manifest - pipeline will use manifest-defined steps"
+    # The manifest defines plan steps (lint, test, deploy, etc.) with exact commands.
+    # Pipeline generation should use these commands instead of defaults.
+fi
+```
+
+When a manifest is present, the generated pipeline YAML should:
+- Use the exact commands from the manifest's step definitions
+- Include timeout values from the manifest
+- Respect skip_if conditions as conditional steps
+- Fall back to `make <target>` for steps not in the manifest
+
+2. **Detect framework** using `lib/cicd`:
 
 ```bash
 PYTHONPATH="$PWD/lib:$HOME/Projects/claude-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd detect --quiet
 ```
 
-2. **Generate pipeline** (dry run first):
+3. **Generate pipeline** (dry run first):
 
 ```bash
 PYTHONPATH="$PWD/lib:$HOME/Projects/claude-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd pipeline
 ```
 
-3. **Review output** with the user. Show the generated workflow YAML.
+4. **Review output** with the user. Show the generated workflow YAML.
 
-4. **Check for existing files** before writing:
+5. **Check for existing files** before writing:
    - If `.github/workflows/ci.yml` exists, ask before overwriting
 
-5. **Write files** if approved:
+6. **Write files** if approved:
 
 ```bash
 PYTHONPATH="$PWD/lib:$HOME/Projects/claude-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd pipeline --write
 ```
 
-6. **Report results**:
+7. **Report results**:
 
 ```
 ## CI Pipeline Generated

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -203,9 +203,28 @@ BRANCH=$(git branch --show-current)
 ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
 ```
 
-1. **Quality gates** - if Makefile exists:
-   - Run `make lint` (if target exists)
-   - Run `make test` (if target exists)
+1. **Quality gates** - use the deterministic runner as primary path:
+
+   **Primary path:** Call the CI/CD runner for reproducible quality gates:
+   ```bash
+   CPP_DIR=""
+   for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+     if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+       CPP_DIR="$dir"
+       break
+     fi
+   done
+
+   if [ -n "$CPP_DIR" ]; then
+       PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+       RUNNER_EXIT=$?
+   fi
+   ```
+
+   - If runner succeeds (exit 0): quality gates passed, proceed to commit.
+   - If runner fails: parse JSON output, report the failed step, **STOP**.
+
+   **Fallback** (only if runner unavailable): Run `make lint` and `make test` directly.
    - If either fails: **STOP**. Report the failure and exit.
 
 2. **Commit** - if there are uncommitted changes:

--- a/.claude/commands/flow/deploy.md
+++ b/.claude/commands/flow/deploy.md
@@ -62,7 +62,31 @@ targets:
 - If `requires_confirmation: true`, ask the user to confirm before proceeding
 - If no deploy.yaml, proceed without extra confirmation
 
-### Step 4b: Run Security Check
+### Step 4b: Run Deploy via Deterministic Runner (primary path)
+
+**Primary path:** Use the deterministic CI/CD runner for reproducible deploy with security gate:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan deploy
+    RUNNER_EXIT=$?
+fi
+```
+
+- If runner **succeeds** (exit 0): deploy completed (includes security scan + make deploy), skip to Step 6.
+- If runner **fails** (exit non-zero): parse JSON output, report the failed step, and **stop**.
+- If runner is **not available**: fall back to manual execution below.
+
+**Fallback path** (only if runner unavailable):
 
 Run security scan before deploying:
 
@@ -74,7 +98,11 @@ PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate
 - If the gate produces **warnings** (medium findings): display them but proceed.
 - If `lib/security` is not available, skip this step.
 
-### Step 5: Run Deploy
+### Step 5: Run Deploy (fallback only - runner includes this)
+
+**Skip this step if the deterministic runner was used above** (it already runs make deploy).
+
+Only run manually if the runner was unavailable:
 
 ```bash
 echo "Running: make $TARGET"

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -20,9 +20,31 @@ fi
 ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
 ```
 
-### Step 2: Run Quality Gates (if Makefile targets exist)
+### Step 2: Run Quality Gates via Deterministic Runner (primary path)
 
-Check for standard Makefile targets and run them:
+**Primary path:** Use the deterministic CI/CD runner for reproducible quality gates:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+    RUNNER_EXIT=$?
+fi
+```
+
+- If runner **succeeds** (exit 0): quality gates passed, skip to Step 2d.
+- If runner **fails** (exit non-zero): parse the JSON output for the failed step, report it, and **stop**.
+- If runner is **not available** (no CPP_DIR or import error): fall back to manual execution below.
+
+**Fallback path** (only if runner unavailable):
 
 ```bash
 if [[ -f "Makefile" ]]; then
@@ -43,9 +65,11 @@ fi
 - If tests or lint fail, **stop and report**. Do not proceed to PR creation.
 - If no Makefile exists, skip quality gates (warn the user).
 
-### Step 2b: Run Security Quick Scan
+### Step 2b: Run Security Quick Scan (fallback only - runner includes this)
 
-Run the native security scanner as a quality gate:
+**Skip this step if the deterministic runner was used above** (it already includes security_scan).
+
+Only run manually if the runner was unavailable:
 
 ```bash
 PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate flow_finish

--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -19,7 +19,7 @@ Create a new project from zero to pushed GitHub repo in one command.
   Step 2: Select framework, generate scaffold
   Step 3: Initialize git, push to GitHub
   Step 4: Run /cicd:init, /cpp:init, /spec:init
-  Step 5: Optional initial spec + sync
+  Step 5: Initial spec (mandatory) + sync
   Step 6: Summary
 ```
 
@@ -532,17 +532,17 @@ Report: `Step 4/6: CPP setup complete - Makefile, commands, skills, hooks, .spec
 
 ---
 
-## Step 5: Optional Initial Spec
+## Step 5: Initial Spec (Mandatory)
+
+Create an initial feature specification for the project. This step is mandatory to
+ensure every project starts with a spec-driven foundation. The spec can be minimal
+and refined later.
 
 Ask the user with `AskUserQuestion`:
 
-**Question:** "Create an initial feature specification for this project?"
+**Question:** "What is the first feature or MVP for this project? (Enter a name or press enter to use the project name)"
 
-**Options:**
-- **Yes** - Create a feature spec with the project name
-- **Skip** - Set up specs later with `/spec:create`
-
-If yes:
+Use the project name as the default feature name if the user doesn't provide one.
 
 ```bash
 FEATURE_NAME="$PROJECT_NAME"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Core components and their locations:
 - `extras/sequential-thinking/` - Optional: structured reasoning (stdio, npm)
 - `lib/creds/` - Secrets management (dotenv/AWS SM, FastAPI UI, audit logging)
 - `lib/security/` - Security scanning (native + external tools)
-- `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deployment strategies
+- `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
 - `lib/spec_bridge/` - Spec-to-GitHub-issue sync
 - `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks)
 - `templates/` - Makefile, workflow, container templates
@@ -88,11 +88,14 @@ Docker containers read API keys from a root `.env` file (gitignored) via `env_fi
 - `/cicd:check` - Validate Makefile against CPP standards
 - `/cicd:health` - Run health checks (endpoints + processes)
 - `/cicd:smoke` - Run smoke tests from cicd.yml
-- `/cicd:pipeline` - Generate GitHub Actions workflows
+- `/cicd:pipeline` - Generate GitHub Actions workflows (consults cicd_tasks.yml manifest if present)
 - `/cicd:container` - Generate Dockerfile and docker-compose.yml
 - `/cicd:infra-init` - Scaffold IaC directory (foundation/platform/app tiers)
 - `/cicd:infra-discover` - Generate cloud resource discovery script for IaC import
 - `/cicd:infra-pipeline` - Generate per-tier CI/CD pipelines with approval gates
+- `python -m lib.cicd validate` - Validate .claude/cicd.yml with fix suggestions (Pydantic v2)
+- `python -m lib.cicd validate --schema` - Generate JSON Schema for IDE autocompletion
+- `python -m lib.cicd run --plan <name>` - Execute CI/CD plan deterministically (finish, check, deploy)
 
 ### Security
 - `/security:scan` - Full scan: native + external tools
@@ -130,8 +133,8 @@ Docker containers read API keys from a root `.env` file (gitignored) via `env_fi
 
 Flow commands use Makefile targets as the canonical build interface:
 
-- `/flow:check` and `/flow:finish` run `make lint` and `make test`
-- `/flow:deploy` runs `make deploy` (or specified target) + post-deploy health/smoke
+- `/flow:check` and `/flow:finish` use `python -m lib.cicd run --plan finish` (deterministic runner) with fallback to `make lint` / `make test`
+- `/flow:deploy` uses `python -m lib.cicd run --plan deploy` (deterministic runner) with fallback to `make deploy` + post-deploy health/smoke
 - `/flow:auto` runs `make update_docs` after implement, verifies CI after merge, then `make deploy`
 - `/flow:doctor` reports which standard targets are available
 - Deploy metadata in `.claude/deploy.yaml` (optional `requires_confirmation: true`)

--- a/lib/cicd/cli.py
+++ b/lib/cicd/cli.py
@@ -24,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 from typing import NoReturn
 
 from .config import CICDConfig
@@ -480,6 +481,52 @@ def cmd_validate_manifest(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_validate(args: argparse.Namespace) -> int:
+    """Validate CI/CD configuration file."""
+    config_path = Path(args.path) / ".claude" / "cicd.yml"
+
+    if args.schema:
+        # Output JSON Schema for IDE autocompletion
+        print(CICDConfig.json_schema())
+        return 0
+
+    if not config_path.exists():
+        if args.json:
+            print(json.dumps({"valid": False, "issues": ["No .claude/cicd.yml found"], "path": str(config_path)}))
+        else:
+            print(f"No config file found at {config_path}")
+            print()
+            print("  Create one with /cicd:init or copy a template:")
+            print("    cp ~/Projects/claude-power-pack/templates/cicd.yml.example .claude/cicd.yml")
+        return 1
+
+    issues = CICDConfig.validate_file(config_path)
+
+    if args.json:
+        print(json.dumps({"valid": len(issues) == 0, "issues": issues, "path": str(config_path)}, indent=2))
+        return 0 if not issues else 1
+
+    if not issues:
+        print(f"Config valid: {config_path}")
+        # Also show loaded config summary
+        config = CICDConfig.load(args.path)
+        print(f"  Build: framework={config.build.framework}, pm={config.build.package_manager}")
+        print(f"  Pipeline: provider={config.pipeline.provider}")
+        if config.health.endpoints:
+            print(f"  Health: {len(config.health.endpoints)} endpoint(s)")
+        if config.health.smoke_tests:
+            print(f"  Smoke: {len(config.health.smoke_tests)} test(s)")
+        return 0
+
+    print(f"Config issues in {config_path}:")
+    print()
+    for i, issue in enumerate(issues, 1):
+        print(f"  {i}. {issue}")
+    print()
+    print(f"Found {len(issues)} issue(s). Fix them and re-run: python -m lib.cicd validate")
+    return 1
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     """Execute a CI/CD plan deterministically."""
     return run_plan(
@@ -552,6 +599,18 @@ def create_parser() -> argparse.ArgumentParser:
         help="Validate an existing cicd_tasks.yml manifest",
     )
     _add_common_args(validate_manifest_parser)
+
+    # 'validate' subcommand
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate .claude/cicd.yml configuration with fix suggestions",
+    )
+    _add_common_args(validate_parser)
+    validate_parser.add_argument(
+        "--schema",
+        action="store_true",
+        help="Output JSON Schema for IDE autocompletion instead of validating",
+    )
 
     # 'run' subcommand
     run_parser = subparsers.add_parser(
@@ -742,6 +801,7 @@ def main(argv: list[str] | None = None) -> int:
     commands = {
         "init-manifest": cmd_init_manifest,
         "validate-manifest": cmd_validate_manifest,
+        "validate": cmd_validate,
         "run": cmd_run,
         "resume": cmd_resume,
         "status": cmd_status,

--- a/lib/cicd/config.py
+++ b/lib/cicd/config.py
@@ -2,31 +2,39 @@
 
 Loads configuration from .claude/cicd.yml if present,
 otherwise uses sensible defaults.
+
+Uses Pydantic v2 for validation with extra="ignore" for backwards
+compatibility - existing configs load without errors even if they
+contain unknown keys.
 """
 
 from __future__ import annotations
 
+import json
 import os
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from pydantic import BaseModel, ConfigDict, Field
 
-@dataclass
-class BuildConfig:
+
+class BuildConfig(BaseModel):
     """Build system configuration."""
+
+    model_config = ConfigDict(extra="ignore")
 
     framework: str = "auto"
     package_manager: str = "auto"
-    required_targets: list[str] = field(default_factory=lambda: ["lint", "test"])
-    recommended_targets: list[str] = field(
+    required_targets: list[str] = Field(default_factory=lambda: ["lint", "test"])
+    recommended_targets: list[str] = Field(
         default_factory=lambda: ["format", "typecheck", "build", "deploy", "clean", "verify"]
     )
 
 
-@dataclass
-class HealthEndpoint:
+class HealthEndpoint(BaseModel):
     """A single health check endpoint."""
+
+    model_config = ConfigDict(extra="ignore")
 
     url: str
     name: str = ""
@@ -35,17 +43,19 @@ class HealthEndpoint:
     timeout: int = 5
 
 
-@dataclass
-class ProcessCheck:
+class ProcessCheck(BaseModel):
     """A process health check."""
+
+    model_config = ConfigDict(extra="ignore")
 
     name: str
     port: int
 
 
-@dataclass
-class SmokeTest:
+class SmokeTest(BaseModel):
     """A smoke test definition."""
+
+    model_config = ConfigDict(extra="ignore")
 
     name: str
     command: str
@@ -54,70 +64,77 @@ class SmokeTest:
     timeout: int = 10
 
 
-@dataclass
-class HealthConfig:
+class HealthConfig(BaseModel):
     """Health check and smoke test configuration."""
 
-    endpoints: list[HealthEndpoint] = field(default_factory=list)
-    processes: list[ProcessCheck] = field(default_factory=list)
-    smoke_tests: list[SmokeTest] = field(default_factory=list)
+    model_config = ConfigDict(extra="ignore")
+
+    endpoints: list[HealthEndpoint] = Field(default_factory=list)
+    processes: list[ProcessCheck] = Field(default_factory=list)
+    smoke_tests: list[SmokeTest] = Field(default_factory=list)
     post_deploy: bool = False
     startup_delay: int = 0
 
 
-@dataclass
-class WoodpeckerConfig:
+class WoodpeckerConfig(BaseModel):
     """Woodpecker CI-specific configuration."""
+
+    model_config = ConfigDict(extra="ignore")
 
     local: bool = True  # Use woodpecker exec for local runs
 
 
-@dataclass
-class PipelineConfig:
+class PipelineConfig(BaseModel):
     """CI/CD pipeline configuration."""
 
+    model_config = ConfigDict(extra="ignore")
+
     provider: str = "github-actions"  # github-actions | woodpecker | both
-    branches: dict[str, list[str]] = field(
+    branches: dict[str, list[str]] = Field(
         default_factory=lambda: {
             "main": ["lint", "test", "typecheck", "build"],
             "pr": ["lint", "test", "typecheck"],
         }
     )
-    matrix: dict[str, list[str]] = field(default_factory=dict)
-    secrets_needed: list[str] = field(default_factory=list)
-    woodpecker: WoodpeckerConfig = field(default_factory=WoodpeckerConfig)
+    matrix: dict[str, list[str]] = Field(default_factory=dict)
+    secrets_needed: list[str] = Field(default_factory=list)
+    woodpecker: WoodpeckerConfig = Field(default_factory=WoodpeckerConfig)
 
 
-@dataclass
-class BranchProtection:
+class BranchProtection(BaseModel):
     """Branch protection rule suggestions."""
 
+    model_config = ConfigDict(extra="ignore")
+
     require_pr_review: bool = True
-    require_status_checks: list[str] = field(default_factory=lambda: ["lint", "test"])
+    require_status_checks: list[str] = Field(default_factory=lambda: ["lint", "test"])
     require_up_to_date: bool = True
 
 
-@dataclass
-class InfraTaggingConfig:
+class InfraTaggingConfig(BaseModel):
     """Tagging conventions for IaC resources."""
+
+    model_config = ConfigDict(extra="ignore")
 
     managed_by: str = "terraform"
     repo: str = ""
     owner: str = ""
-    extra_tags: dict[str, str] = field(default_factory=dict)
+    extra_tags: dict[str, str] = Field(default_factory=dict)
 
 
-@dataclass
-class InfraTierConfig:
+class InfraTierConfig(BaseModel):
     """Configuration for a single infrastructure tier."""
+
+    model_config = ConfigDict(extra="ignore")
 
     approval_required: bool = False
     separate_credentials: bool = False
 
 
-@dataclass
-class InfraStateBackend:
+class InfraStateBackend(BaseModel):
     """Remote state backend configuration."""
+
+    model_config = ConfigDict(extra="ignore")
 
     type: str = ""  # s3, azure-storage, gcs
     bucket: str = ""
@@ -125,15 +142,16 @@ class InfraStateBackend:
     region: str = ""
 
 
-@dataclass
-class InfrastructureConfig:
+class InfrastructureConfig(BaseModel):
     """Infrastructure as Code configuration."""
+
+    model_config = ConfigDict(extra="ignore")
 
     provider: str = "terraform"  # terraform, pulumi, bicep
     cloud: str = "aws"  # aws, azure, gcp
-    state_backend: InfraStateBackend = field(default_factory=InfraStateBackend)
-    tagging: InfraTaggingConfig = field(default_factory=InfraTaggingConfig)
-    tiers: dict[str, InfraTierConfig] = field(
+    state_backend: InfraStateBackend = Field(default_factory=InfraStateBackend)
+    tagging: InfraTaggingConfig = Field(default_factory=InfraTaggingConfig)
+    tiers: dict[str, InfraTierConfig] = Field(
         default_factory=lambda: {
             "foundation": InfraTierConfig(approval_required=True, separate_credentials=True),
             "platform": InfraTierConfig(approval_required=False),
@@ -142,25 +160,27 @@ class InfrastructureConfig:
     )
 
 
-@dataclass
-class ContainerConfig:
+class ContainerConfig(BaseModel):
     """Container configuration."""
+
+    model_config = ConfigDict(extra="ignore")
 
     enabled: bool = False
     base_image: str = "auto"
-    expose_ports: list[int] = field(default_factory=list)
-    compose_services: list[dict[str, Any]] = field(default_factory=list)
+    expose_ports: list[int] = Field(default_factory=list)
+    compose_services: list[dict[str, Any]] = Field(default_factory=list)
 
 
-@dataclass
-class CICDConfig:
+class CICDConfig(BaseModel):
     """Full CI/CD configuration."""
 
-    build: BuildConfig = field(default_factory=BuildConfig)
-    health: HealthConfig = field(default_factory=HealthConfig)
-    pipeline: PipelineConfig = field(default_factory=PipelineConfig)
-    container: ContainerConfig = field(default_factory=ContainerConfig)
-    infrastructure: InfrastructureConfig = field(default_factory=InfrastructureConfig)
+    model_config = ConfigDict(extra="ignore")
+
+    build: BuildConfig = Field(default_factory=BuildConfig)
+    health: HealthConfig = Field(default_factory=HealthConfig)
+    pipeline: PipelineConfig = Field(default_factory=PipelineConfig)
+    container: ContainerConfig = Field(default_factory=ContainerConfig)
+    infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
 
     @classmethod
     def load(cls, project_root: Optional[str] = None) -> CICDConfig:
@@ -180,7 +200,11 @@ class CICDConfig:
 
     @classmethod
     def _from_yaml(cls, path: Path) -> CICDConfig:
-        """Parse YAML config file."""
+        """Parse YAML config file using Pydantic model_validate.
+
+        With extra="ignore" on all models, unknown keys are silently
+        dropped - ensuring backwards compatibility with older configs.
+        """
         try:
             import yaml
         except ImportError:
@@ -189,109 +213,143 @@ class CICDConfig:
         with open(path) as f:
             data = yaml.safe_load(f) or {}
 
-        config = cls._defaults()
-
-        # Parse build section
-        build_data = data.get("build", {})
-        if build_data:
-            config.build.framework = build_data.get("framework", "auto")
-            config.build.package_manager = build_data.get("package_manager", "auto")
-            if "required_targets" in build_data:
-                config.build.required_targets = build_data["required_targets"]
-            if "recommended_targets" in build_data:
-                config.build.recommended_targets = build_data["recommended_targets"]
-
-        # Parse health section
-        health_data = data.get("health", {})
-        if health_data:
-            config.health.post_deploy = health_data.get("post_deploy", False)
-            config.health.startup_delay = health_data.get("startup_delay", 0)
-
-            for ep in health_data.get("endpoints", []):
-                config.health.endpoints.append(
-                    HealthEndpoint(
-                        url=ep["url"],
-                        name=ep.get("name", ""),
-                        expected_status=ep.get("expected_status", 200),
-                        expected_body=ep.get("expected_body", ""),
-                        timeout=ep.get("timeout", 5),
-                    )
-                )
-
-            for proc in health_data.get("processes", []):
-                config.health.processes.append(
-                    ProcessCheck(name=proc["name"], port=proc["port"])
-                )
-
-            for st in health_data.get("smoke_tests", []):
-                config.health.smoke_tests.append(
-                    SmokeTest(
-                        name=st["name"],
-                        command=st["command"],
-                        expected_exit=st.get("expected_exit", 0),
-                        expected_output=st.get("expected_output", ""),
-                        timeout=st.get("timeout", 10),
-                    )
-                )
-
-        # Parse pipeline section
-        pipeline_data = data.get("pipeline", {})
-        if pipeline_data:
-            config.pipeline.provider = pipeline_data.get("provider", "github-actions")
-            if "branches" in pipeline_data:
-                config.pipeline.branches = pipeline_data["branches"]
-            if "matrix" in pipeline_data:
-                config.pipeline.matrix = pipeline_data["matrix"]
-            if "secrets_needed" in pipeline_data:
-                config.pipeline.secrets_needed = pipeline_data["secrets_needed"]
-            wp_data = pipeline_data.get("woodpecker", {})
-            if wp_data:
-                config.pipeline.woodpecker.local = wp_data.get("local", True)
-
-        # Parse container section
-        container_data = data.get("container", {})
-        if container_data:
-            config.container.enabled = container_data.get("enabled", False)
-            config.container.base_image = container_data.get("base_image", "auto")
-            if "expose_ports" in container_data:
-                config.container.expose_ports = container_data["expose_ports"]
-            if "compose_services" in container_data:
-                config.container.compose_services = container_data["compose_services"]
-
-        # Parse infrastructure section
+        # Handle tagging key mapping (managed-by -> managed_by)
         infra_data = data.get("infrastructure", {})
         if infra_data:
-            config.infrastructure.provider = infra_data.get("provider", "terraform")
-            config.infrastructure.cloud = infra_data.get("cloud", "aws")
-
-            state_data = infra_data.get("state_backend", {})
-            if state_data:
-                config.infrastructure.state_backend = InfraStateBackend(
-                    type=state_data.get("type", ""),
-                    bucket=state_data.get("bucket", ""),
-                    lock=state_data.get("lock", True),
-                    region=state_data.get("region", ""),
-                )
-
             tagging_data = infra_data.get("tagging", {})
-            if tagging_data:
-                config.infrastructure.tagging = InfraTaggingConfig(
-                    managed_by=tagging_data.get("managed-by", "terraform"),
-                    repo=tagging_data.get("repo", ""),
-                    owner=tagging_data.get("owner", ""),
-                    extra_tags={
-                        k: v for k, v in tagging_data.items()
-                        if k not in ("managed-by", "repo", "owner")
-                    },
+            if tagging_data and "managed-by" in tagging_data:
+                tagging_data["managed_by"] = tagging_data.pop("managed-by")
+                # Collect extra tags (non-standard keys)
+                known_keys = {"managed_by", "repo", "owner", "extra_tags"}
+                extra = {k: v for k, v in tagging_data.items() if k not in known_keys}
+                if extra:
+                    tagging_data["extra_tags"] = extra
+                    for k in extra:
+                        del tagging_data[k]
+
+        return cls.model_validate(data)
+
+    @classmethod
+    def validate_file(cls, path: Path) -> list[str]:
+        """Validate a config file and return a list of issues with fix suggestions.
+
+        Returns an empty list if the config is valid.
+        """
+        try:
+            import yaml
+        except ImportError:
+            return ["PyYAML not installed - run: uv pip install pyyaml"]
+
+        if not path.exists():
+            return [f"Config file not found: {path}"]
+
+        with open(path) as f:
+            raw = f.read()
+
+        # Check YAML syntax
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError as e:
+            return [f"YAML syntax error: {e}"]
+
+        if not isinstance(data, dict):
+            return ["Config must be a YAML mapping (dict), not a scalar or list"]
+
+        issues: list[str] = []
+
+        # Validate known sections
+        known_sections = {"build", "health", "pipeline", "container", "infrastructure"}
+        unknown = set(data.keys()) - known_sections
+        if unknown:
+            issues.append(
+                f"Unknown top-level keys: {', '.join(sorted(unknown))}. "
+                f"Valid keys: {', '.join(sorted(known_sections))}"
+            )
+
+        # Validate build section
+        build_data = data.get("build", {})
+        if build_data and isinstance(build_data, dict):
+            if "provider" in build_data:
+                issues.append(
+                    "build.provider is not valid here. "
+                    "Did you mean pipeline.provider? Move it to the 'pipeline' section."
                 )
 
-            tiers_data = infra_data.get("tiers", {})
-            if tiers_data:
-                config.infrastructure.tiers = {}
-                for tier_name, tier_cfg in tiers_data.items():
-                    config.infrastructure.tiers[tier_name] = InfraTierConfig(
-                        approval_required=tier_cfg.get("approval_required", False),
-                        separate_credentials=tier_cfg.get("separate_credentials", False),
-                    )
+        # Validate pipeline section
+        pipeline_data = data.get("pipeline", {})
+        if pipeline_data and isinstance(pipeline_data, dict):
+            provider = pipeline_data.get("provider", "")
+            valid_providers = {"github-actions", "woodpecker", "both"}
+            if provider and provider not in valid_providers:
+                issues.append(
+                    f"pipeline.provider '{provider}' is invalid. "
+                    f"Valid values: {', '.join(sorted(valid_providers))}"
+                )
 
-        return config
+        # Validate health section
+        health_data = data.get("health", {})
+        if health_data and isinstance(health_data, dict):
+            for i, ep in enumerate(health_data.get("endpoints", [])):
+                if isinstance(ep, dict) and "url" not in ep:
+                    issues.append(f"health.endpoints[{i}] is missing required field 'url'")
+
+            for i, proc in enumerate(health_data.get("processes", [])):
+                if isinstance(proc, dict):
+                    if "name" not in proc:
+                        issues.append(f"health.processes[{i}] is missing required field 'name'")
+                    if "port" not in proc:
+                        issues.append(f"health.processes[{i}] is missing required field 'port'")
+
+            for i, st in enumerate(health_data.get("smoke_tests", [])):
+                if isinstance(st, dict):
+                    if "name" not in st:
+                        issues.append(f"health.smoke_tests[{i}] is missing required field 'name'")
+                    if "command" not in st:
+                        issues.append(f"health.smoke_tests[{i}] is missing required field 'command'")
+
+        # Validate infrastructure section
+        infra_data = data.get("infrastructure", {})
+        if infra_data and isinstance(infra_data, dict):
+            provider = infra_data.get("provider", "")
+            valid_iac = {"terraform", "pulumi", "bicep"}
+            if provider and provider not in valid_iac:
+                issues.append(
+                    f"infrastructure.provider '{provider}' is invalid. "
+                    f"Valid values: {', '.join(sorted(valid_iac))}"
+                )
+
+            cloud = infra_data.get("cloud", "")
+            valid_clouds = {"aws", "azure", "gcp"}
+            if cloud and cloud not in valid_clouds:
+                issues.append(
+                    f"infrastructure.cloud '{cloud}' is invalid. "
+                    f"Valid values: {', '.join(sorted(valid_clouds))}"
+                )
+
+        # Try Pydantic validation for type errors
+        try:
+            # Handle tagging mapping
+            if infra_data:
+                tagging_data = infra_data.get("tagging", {})
+                if tagging_data and "managed-by" in tagging_data:
+                    tagging_data = dict(tagging_data)
+                    tagging_data["managed_by"] = tagging_data.pop("managed-by")
+                    known_keys = {"managed_by", "repo", "owner", "extra_tags"}
+                    extra = {k: v for k, v in tagging_data.items() if k not in known_keys}
+                    if extra:
+                        tagging_data["extra_tags"] = extra
+                        for k in extra:
+                            del tagging_data[k]
+                    data = dict(data)
+                    data["infrastructure"] = dict(data["infrastructure"])
+                    data["infrastructure"]["tagging"] = tagging_data
+            cls.model_validate(data)
+        except Exception as e:
+            issues.append(f"Validation error: {e}")
+
+        return issues
+
+    @classmethod
+    def json_schema(cls) -> str:
+        """Generate JSON Schema for IDE autocompletion."""
+        return json.dumps(cls.model_json_schema(), indent=2)

--- a/lib/cicd/pyproject.toml
+++ b/lib/cicd/pyproject.toml
@@ -7,11 +7,11 @@ license = {text = "MIT"}
 authors = [
     {name = "cooneycw"}
 ]
-dependencies = []
+dependencies = ["pydantic>=2.0"]
 
 [project.optional-dependencies]
 yaml = ["pyyaml>=6.0"]
-all = ["pyyaml>=6.0"]
+all = ["pydantic>=2.0", "pyyaml>=6.0"]
 
 [project.scripts]
 cicd = "cicd.cli:main"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,401 @@
+"""Tests for CI/CD config validation (T018, T019, T020).
+
+Tests Pydantic v2 migration, backwards compatibility, validate command,
+and JSON Schema generation.
+"""
+
+from __future__ import annotations
+
+import json
+
+from lib.cicd.config import (
+    BuildConfig,
+    CICDConfig,
+    ContainerConfig,
+    HealthConfig,
+    HealthEndpoint,
+    InfrastructureConfig,
+    PipelineConfig,
+    ProcessCheck,
+    SmokeTest,
+)
+
+
+class TestPydanticMigration:
+    """Test that dataclass -> Pydantic v2 migration preserves all behavior."""
+
+    def test_default_config(self):
+        config = CICDConfig()
+        assert config.build.framework == "auto"
+        assert config.build.package_manager == "auto"
+        assert config.build.required_targets == ["lint", "test"]
+        assert config.pipeline.provider == "github-actions"
+        assert config.health.post_deploy is False
+        assert config.container.enabled is False
+        assert config.infrastructure.provider == "terraform"
+        assert config.infrastructure.cloud == "aws"
+
+    def test_build_config_defaults(self):
+        build = BuildConfig()
+        assert build.framework == "auto"
+        assert build.required_targets == ["lint", "test"]
+        assert "format" in build.recommended_targets
+        assert "deploy" in build.recommended_targets
+
+    def test_health_endpoint(self):
+        ep = HealthEndpoint(url="http://localhost:8000/health", name="API")
+        assert ep.url == "http://localhost:8000/health"
+        assert ep.name == "API"
+        assert ep.expected_status == 200
+        assert ep.timeout == 5
+
+    def test_process_check(self):
+        proc = ProcessCheck(name="uvicorn", port=8000)
+        assert proc.name == "uvicorn"
+        assert proc.port == 8000
+
+    def test_smoke_test(self):
+        st = SmokeTest(name="api", command="curl -sf http://localhost:8000/health")
+        assert st.expected_exit == 0
+        assert st.timeout == 10
+
+    def test_pipeline_config_defaults(self):
+        pipeline = PipelineConfig()
+        assert "main" in pipeline.branches
+        assert "pr" in pipeline.branches
+        assert pipeline.woodpecker.local is True
+
+    def test_infrastructure_tiers_defaults(self):
+        infra = InfrastructureConfig()
+        assert "foundation" in infra.tiers
+        assert infra.tiers["foundation"].approval_required is True
+        assert infra.tiers["foundation"].separate_credentials is True
+        assert infra.tiers["platform"].approval_required is False
+        assert infra.tiers["app"].approval_required is False
+
+    def test_container_config(self):
+        container = ContainerConfig(enabled=True, expose_ports=[8000, 8080])
+        assert container.enabled is True
+        assert container.expose_ports == [8000, 8080]
+
+
+class TestBackwardsCompatibility:
+    """Test extra='ignore' ensures existing configs load without errors."""
+
+    def test_extra_fields_ignored_build(self):
+        build = BuildConfig.model_validate({"framework": "python", "unknown_field": "value"})
+        assert build.framework == "python"
+
+    def test_extra_fields_ignored_health(self):
+        health = HealthConfig.model_validate({"post_deploy": True, "new_option": 42})
+        assert health.post_deploy is True
+
+    def test_extra_fields_ignored_pipeline(self):
+        pipeline = PipelineConfig.model_validate(
+            {"provider": "woodpecker", "future_feature": True}
+        )
+        assert pipeline.provider == "woodpecker"
+
+    def test_extra_fields_ignored_nested(self):
+        config = CICDConfig.model_validate(
+            {
+                "build": {"framework": "python", "extra_key": "ignored"},
+                "pipeline": {"provider": "both", "new_setting": 123},
+                "unknown_section": {"data": True},
+            }
+        )
+        assert config.build.framework == "python"
+        assert config.pipeline.provider == "both"
+
+    def test_full_config_with_extras(self):
+        data = {
+            "build": {
+                "framework": "python",
+                "package_manager": "uv",
+                "required_targets": ["lint", "test", "typecheck"],
+                "future_option": True,
+            },
+            "health": {
+                "endpoints": [{"url": "http://localhost:8000/health", "name": "API"}],
+                "processes": [{"name": "uvicorn", "port": 8000}],
+                "smoke_tests": [{"name": "api", "command": "curl -sf localhost:8000"}],
+                "post_deploy": True,
+            },
+            "pipeline": {
+                "provider": "woodpecker",
+                "branches": {"main": ["lint", "test"]},
+            },
+            "container": {"enabled": True, "expose_ports": [8000]},
+            "infrastructure": {
+                "provider": "terraform",
+                "cloud": "aws",
+                "tiers": {
+                    "foundation": {"approval_required": True},
+                    "platform": {"approval_required": False},
+                },
+            },
+        }
+        config = CICDConfig.model_validate(data)
+        assert config.build.required_targets == ["lint", "test", "typecheck"]
+        assert len(config.health.endpoints) == 1
+        assert config.health.endpoints[0].url == "http://localhost:8000/health"
+        assert config.pipeline.provider == "woodpecker"
+        assert config.container.enabled is True
+        assert config.infrastructure.tiers["foundation"].approval_required is True
+
+
+class TestYamlLoading:
+    """Test loading from YAML files."""
+
+    def test_load_defaults_no_file(self, tmp_path):
+        config = CICDConfig.load(str(tmp_path))
+        assert config.build.framework == "auto"
+        assert config.pipeline.provider == "github-actions"
+
+    def test_load_from_yaml(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        config_file = claude_dir / "cicd.yml"
+        config_file.write_text(
+            """
+build:
+  framework: python
+  package_manager: uv
+  required_targets:
+    - lint
+    - test
+    - typecheck
+pipeline:
+  provider: woodpecker
+health:
+  post_deploy: true
+  endpoints:
+    - url: http://localhost:8000/health
+      name: API Server
+"""
+        )
+        config = CICDConfig.load(str(tmp_path))
+        assert config.build.framework == "python"
+        assert config.build.package_manager == "uv"
+        assert config.pipeline.provider == "woodpecker"
+        assert config.health.post_deploy is True
+        assert len(config.health.endpoints) == 1
+        assert config.health.endpoints[0].name == "API Server"
+
+    def test_load_yaml_with_unknown_keys(self, tmp_path):
+        """Backwards compat: unknown keys silently ignored."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        config_file = claude_dir / "cicd.yml"
+        config_file.write_text(
+            """
+build:
+  framework: python
+  new_future_field: true
+pipeline:
+  provider: github-actions
+  experimental: true
+brand_new_section:
+  key: value
+"""
+        )
+        config = CICDConfig.load(str(tmp_path))
+        assert config.build.framework == "python"
+        assert config.pipeline.provider == "github-actions"
+
+    def test_load_yaml_with_tagging_managed_by(self, tmp_path):
+        """Test managed-by -> managed_by mapping."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        config_file = claude_dir / "cicd.yml"
+        config_file.write_text(
+            """
+infrastructure:
+  provider: terraform
+  cloud: aws
+  tagging:
+    managed-by: terraform
+    repo: my-repo
+    owner: my-team
+    environment: prod
+"""
+        )
+        config = CICDConfig.load(str(tmp_path))
+        assert config.infrastructure.tagging.managed_by == "terraform"
+        assert config.infrastructure.tagging.repo == "my-repo"
+        assert config.infrastructure.tagging.extra_tags == {"environment": "prod"}
+
+
+class TestValidation:
+    """Test the validate_file method."""
+
+    def test_validate_valid_config(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+build:
+  framework: python
+pipeline:
+  provider: github-actions
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert issues == []
+
+    def test_validate_missing_file(self, tmp_path):
+        issues = CICDConfig.validate_file(tmp_path / "missing.yml")
+        assert len(issues) == 1
+        assert "not found" in issues[0]
+
+    def test_validate_invalid_yaml(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text("build: [invalid: yaml: syntax")
+        issues = CICDConfig.validate_file(config_file)
+        assert any("syntax" in i.lower() or "error" in i.lower() for i in issues)
+
+    def test_validate_unknown_top_level_keys(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+build:
+  framework: python
+unknown_key: value
+another_unknown: true
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("unknown_key" in i for i in issues)
+
+    def test_validate_invalid_provider(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+pipeline:
+  provider: jenkins
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("jenkins" in i and "invalid" in i for i in issues)
+
+    def test_validate_missing_endpoint_url(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+health:
+  endpoints:
+    - name: API Server
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("url" in i for i in issues)
+
+    def test_validate_missing_process_fields(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+health:
+  processes:
+    - port: 8000
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("name" in i for i in issues)
+
+    def test_validate_misplaced_provider(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+build:
+  framework: python
+  provider: github-actions
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("pipeline.provider" in i for i in issues)
+
+    def test_validate_invalid_iac_provider(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+infrastructure:
+  provider: ansible
+  cloud: aws
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("ansible" in i for i in issues)
+
+    def test_validate_invalid_cloud(self, tmp_path):
+        config_file = tmp_path / "cicd.yml"
+        config_file.write_text(
+            """
+infrastructure:
+  provider: terraform
+  cloud: digitalocean
+"""
+        )
+        issues = CICDConfig.validate_file(config_file)
+        assert any("digitalocean" in i for i in issues)
+
+
+class TestJsonSchema:
+    """Test JSON Schema generation for IDE autocompletion."""
+
+    def test_json_schema_output(self):
+        schema_str = CICDConfig.json_schema()
+        schema = json.loads(schema_str)
+        assert schema["title"] == "CICDConfig"
+        assert "properties" in schema
+        assert "build" in schema["properties"]
+        assert "health" in schema["properties"]
+        assert "pipeline" in schema["properties"]
+        assert "container" in schema["properties"]
+        assert "infrastructure" in schema["properties"]
+
+    def test_json_schema_nested_refs(self):
+        schema_str = CICDConfig.json_schema()
+        schema = json.loads(schema_str)
+        # Pydantic v2 uses $defs for nested models
+        assert "$defs" in schema
+        assert "BuildConfig" in schema["$defs"]
+        assert "HealthConfig" in schema["$defs"]
+
+
+class TestCliValidate:
+    """Test the validate CLI subcommand."""
+
+    def test_validate_no_config(self, tmp_path):
+        from lib.cicd.cli import main
+
+        result = main(["validate", "--path", str(tmp_path)])
+        assert result == 1
+
+    def test_validate_valid_config(self, tmp_path):
+        from lib.cicd.cli import main
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "cicd.yml").write_text("build:\n  framework: python\n")
+        result = main(["validate", "--path", str(tmp_path)])
+        assert result == 0
+
+    def test_validate_json_output(self, tmp_path, capsys):
+        from lib.cicd.cli import main
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "cicd.yml").write_text("build:\n  framework: python\n")
+        result = main(["validate", "--path", str(tmp_path), "--json"])
+        assert result == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["valid"] is True
+        assert output["issues"] == []
+
+    def test_validate_schema_output(self, tmp_path, capsys):
+        from lib.cicd.cli import main
+
+        result = main(["validate", "--path", str(tmp_path), "--schema"])
+        assert result == 0
+        schema = json.loads(capsys.readouterr().out)
+        assert "title" in schema
+        assert schema["title"] == "CICDConfig"


### PR DESCRIPTION
## Summary

- **T018:** Migrated `lib/cicd/config.py` from dataclasses to Pydantic v2 models with `extra="ignore"` for backwards compatibility
- **T019:** Added `validate` subcommand to CLI with fix suggestions and `--schema` flag for JSON Schema generation
- **T020:** Created 33 unit tests covering Pydantic migration, backwards compat, YAML loading, validation, JSON Schema, and CLI
- **T021-T023:** Updated `/flow:finish`, `/flow:auto`, `/flow:deploy` prompts to call deterministic runner as primary path with fallback to manual execution
- **T032:** Made `/spec:create` a mandatory step in `/project:init` (Step 5)
- **T033:** Made `/cicd:pipeline` consult `cicd_tasks.yml` manifest before generating pipeline YAML

## Test plan

- [x] 33 new config validation tests pass
- [x] All 269 existing tests pass (no regressions)
- [x] Ruff lint passes
- [x] Pydantic v2 added to project dependencies
- [x] Backwards compat verified: unknown YAML keys silently ignored
- [x] `python -m lib.cicd validate --schema` generates valid JSON Schema

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)