### PR TITLE
fix(docs): remove save_path from c4 skill for Docker MCP compatibility

### DIFF
--- a/.claude/commands/documentation/c4.md
+++ b/.claude/commands/documentation/c4.md
@@ -42,6 +42,8 @@ mkdir -p "$DOCS_DIR"
 
 Generate each level using the `generate_diagram` MCP tool with `diagram_type: "c4"`.
 
+**IMPORTANT:** Do NOT pass `save_path` to `generate_diagram`. The MCP tool runs in Docker and cannot write to host paths. Instead, capture the returned `html` string and save it using the `Write` tool.
+
 **C4 Node Types:**
 
 | Node Type | C4 Concept | When to Use |
@@ -58,7 +60,7 @@ Generate each level using the `generate_diagram` MCP tool with `diagram_type: "c
 Focus on: actors + external systems + the system of interest. Keep it high-level (5-10 nodes max).
 
 ```
-generate_diagram(
+result = generate_diagram(
     diagram_type="c4",
     title="L1 System Context - {Project Name}",
     description="Who uses the system and what it connects to",
@@ -71,8 +73,9 @@ generate_diagram(
         {"source": "user", "target": "system", "label": "Uses"},
         {"source": "system", "target": "ext1", "label": "Calls API"},
     ],
-    save_path="{DOCS_DIR}/c4-l1-context.html"
 )
+# Save HTML using Write tool
+Write(file_path="{DOCS_DIR}/c4-l1-context.html", content=result.html)
 ```
 
 #### Level 2: Container
@@ -80,7 +83,7 @@ generate_diagram(
 Focus on: applications, databases, services within the system boundary. Show technology choices.
 
 ```
-generate_diagram(
+result = generate_diagram(
     diagram_type="c4",
     title="L2 Container - {Project Name}",
     description="Applications, data stores, and services",
@@ -90,8 +93,8 @@ generate_diagram(
         {"id": "db", "label": "Database", "type": "container", "description": "PostgreSQL"},
     ],
     edges=[...],
-    save_path="{DOCS_DIR}/c4-l2-container.html"
 )
+Write(file_path="{DOCS_DIR}/c4-l2-container.html", content=result.html)
 ```
 
 #### Level 3: Component
@@ -99,7 +102,7 @@ generate_diagram(
 Focus on: major components within the most important containers. Show how responsibilities are divided.
 
 ```
-generate_diagram(
+result = generate_diagram(
     diagram_type="c4",
     title="L3 Component - {Container Name}",
     description="Components within {container}",
@@ -108,8 +111,8 @@ generate_diagram(
         {"id": "router", "label": "Router", "type": "component", "description": "FastAPI routes"},
     ],
     edges=[...],
-    save_path="{DOCS_DIR}/c4-l3-{container-slug}.html"
 )
+Write(file_path="{DOCS_DIR}/c4-l3-{container-slug}.html", content=result.html)
 ```
 
 #### Level 4: Code
@@ -117,7 +120,7 @@ generate_diagram(
 Focus on: key classes, interfaces, and modules within the most critical components.
 
 ```
-generate_diagram(
+result = generate_diagram(
     diagram_type="c4",
     title="L4 Code - {Component Name}",
     description="Classes and modules in {component}",
@@ -126,8 +129,8 @@ generate_diagram(
         {"id": "cls2", "label": "AuthMiddleware", "type": "code", "description": "class"},
     ],
     edges=[...],
-    save_path="{DOCS_DIR}/c4-l4-{component-slug}.html"
 )
+Write(file_path="{DOCS_DIR}/c4-l4-{component-slug}.html", content=result.html)
 ```
 
 ### Step 4: Screenshot (if Playwright available)


### PR DESCRIPTION
## Summary
- Removed `save_path` parameter from all `generate_diagram` calls in the `/documentation:c4` skill
- Skill now captures returned HTML and saves via Claude Code's `Write` tool
- Added explicit warning not to pass `save_path` to Dockerized MCP tools

## Context
The nano-banana MCP server runs in Docker without host volume mounts. Passing host filesystem paths as `save_path` always triggers a `PermissionError`. The tool's graceful fallback (returning HTML + error message) works, but the skill should follow the standard MCP pattern: tool = compute, Claude Code = I/O.

Closes #252

## Test plan
- [ ] Run `/documentation:c4` on a project and verify HTML files are saved correctly via Write tool
- [ ] Confirm no `save_path_error` messages in generate_diagram responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)