### PR TITLE
security(nano-banana): HTML-escape all user content in diagram generators (Closes #256)

### DIFF
--- a/mcp-nano-banana/src/diagrams/architecture.py
+++ b/mcp-nano-banana/src/diagrams/architecture.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _node_color
+from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
 
 
 def generate_architecture_diagram(
@@ -21,16 +21,16 @@ def generate_architecture_diagram(
     nodes_html = []
     for i, node in enumerate(spec.nodes):
         bg, border, text = _node_color(node.type)
-        icon_html = f'<div class="node-icon">{node.icon}</div>' if node.icon else ""
-        desc_html = f'<div class="node-desc">{node.description}</div>' if node.description else ""
+        icon_html = f'<div class="node-icon">{_esc(node.icon)}</div>' if node.icon else ""
+        desc_html = f'<div class="node-desc">{_esc(node.description)}</div>' if node.description else ""
         nodes_html.append(f"""
-        <div class="arch-node" id="node-{node.id}" style="
+        <div class="arch-node" id="node-{_esc(node.id)}" style="
             background: {bg};
             border: 2px solid {border};
             color: {text};
         ">
             {icon_html}
-            <div class="node-label">{node.label}</div>
+            <div class="node-label">{_esc(node.label)}</div>
             {desc_html}
         </div>
         """)
@@ -42,14 +42,14 @@ def generate_architecture_diagram(
         edges_svg += '<defs><marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/></marker></defs>'
         edges_svg += "</svg>"
 
-    subtitle = spec.description or "System Architecture"
+    subtitle = _esc(spec.description) if spec.description else "System Architecture"
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .arch-grid {{
@@ -97,7 +97,7 @@ def generate_architecture_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body">
         {edges_svg}

--- a/mcp-nano-banana/src/diagrams/base.py
+++ b/mcp-nano-banana/src/diagrams/base.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+import html as _html_mod
 from dataclasses import dataclass, field
+
+
+def _esc(text: str) -> str:
+    """HTML-escape user-provided text to prevent XSS injection.
+
+    Must be applied to all node labels, descriptions, icons, edge labels,
+    spec titles, and spec descriptions before embedding in HTML output.
+    """
+    return _html_mod.escape(str(text), quote=True)
 
 
 DIAGRAM_TYPES = [

--- a/mcp-nano-banana/src/diagrams/c4.py
+++ b/mcp-nano-banana/src/diagrams/c4.py
@@ -19,7 +19,7 @@ Use the ``description`` field for technology labels (e.g., "Python / FastAPI").
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset
+from diagrams.base import DiagramSpec, _css_reset, _esc
 
 
 # C4-specific color palette
@@ -84,18 +84,18 @@ def generate_c4_diagram(
 
         icon_html = _person_svg(text) if is_person else ""
         tech_html = (
-            f'<div class="c4-tech">[{node.description}]</div>'
+            f'<div class="c4-tech">[{_esc(node.description)}]</div>'
             if node.description else ""
         )
 
         shape_class = "c4-person" if is_person else "c4-box"
 
         all_nodes_html.append(f"""
-        <div class="c4-node {shape_class}" id="node-{node.id}"
-             data-type="{node.type}"
+        <div class="c4-node {shape_class}" id="node-{_esc(node.id)}"
+             data-type="{_esc(node.type)}"
              style="background:{bg}; border-color:{border}; color:{text};">
             {icon_html}
-            <div class="c4-label">{node.label}</div>
+            <div class="c4-label">{_esc(node.label)}</div>
             {tech_html}
         </div>
         """)
@@ -170,20 +170,20 @@ def generate_c4_diagram(
             dash = "stroke-dasharray: 2 4;"
 
         label_html = (
-            f'<span class="c4-edge-label">{edge.label}</span>'
+            f'<span class="c4-edge-label">{_esc(edge.label)}</span>'
             if edge.label else ""
         )
         edge_labels_html.append(f"""
-        <div class="c4-edge" data-from="{edge.source}" data-to="{edge.target}"
+        <div class="c4-edge" data-from="{_esc(edge.source)}" data-to="{_esc(edge.target)}"
              data-dash="{dash}">
-            <span class="c4-edge-from">{edge.source}</span>
+            <span class="c4-edge-from">{_esc(edge.source)}</span>
             <span class="c4-edge-arrow">&#x2192;</span>
             {label_html}
-            <span class="c4-edge-to">{edge.target}</span>
+            <span class="c4-edge-to">{_esc(edge.target)}</span>
         </div>
         """)
 
-    subtitle = spec.description or "C4 Architecture Diagram"
+    subtitle = _esc(spec.description) if spec.description else "C4 Architecture Diagram"
     edges_section = ""
     if edge_labels_html:
         edges_section = f"""
@@ -198,7 +198,7 @@ def generate_c4_diagram(
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .c4-layout {{
@@ -310,7 +310,7 @@ def generate_c4_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body">
         <div class="c4-layout">

--- a/mcp-nano-banana/src/diagrams/flowchart.py
+++ b/mcp-nano-banana/src/diagrams/flowchart.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _node_color
+from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
 
 
 def generate_flowchart_diagram(
@@ -21,25 +21,25 @@ def generate_flowchart_diagram(
     for i, node in enumerate(spec.nodes):
         bg, border, text = _node_color(node.type)
         shape_class = "flow-diamond" if node.type == "warning" else "flow-rect"
-        desc_html = f'<div class="flow-desc">{node.description}</div>' if node.description else ""
+        desc_html = f'<div class="flow-desc">{_esc(node.description)}</div>' if node.description else ""
         nodes_html.append(f"""
         <div class="flow-step">
             <div class="{shape_class}" style="background: {bg}; border-color: {border}; color: {text};">
-                <div class="flow-label">{node.label}</div>
+                <div class="flow-label">{_esc(node.label)}</div>
                 {desc_html}
             </div>
             {"<div class='flow-arrow'>&#x2193;</div>" if i < len(spec.nodes) - 1 else ""}
         </div>
         """)
 
-    subtitle = spec.description or "Process Flow"
+    subtitle = _esc(spec.description) if spec.description else "Process Flow"
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .flow-container {{
@@ -96,7 +96,7 @@ def generate_flowchart_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body">
         <div class="flow-container">

--- a/mcp-nano-banana/src/diagrams/mindmap.py
+++ b/mcp-nano-banana/src/diagrams/mindmap.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 
-from diagrams.base import DiagramSpec, _css_reset, _node_color
+from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
 
 
 def generate_mindmap_diagram(
@@ -35,7 +35,7 @@ def generate_mindmap_diagram(
         left: {cx - 80}px; top: {cy - 40}px;
         background: {bg}; border-color: {border}; color: {text};
     ">
-        <div class="mm-label">{center.label}</div>
+        <div class="mm-label">{_esc(center.label)}</div>
     </div>
     """
 
@@ -47,14 +47,14 @@ def generate_mindmap_diagram(
         nx = int(cx + radius * math.cos(angle))
         ny = int(cy + radius * math.sin(angle))
         bg, border, text = _node_color(node.type)
-        desc_html = f'<div class="mm-desc">{node.description}</div>' if node.description else ""
+        desc_html = f'<div class="mm-desc">{_esc(node.description)}</div>' if node.description else ""
 
         branch_html.append(f"""
         <div class="mm-branch" style="
             left: {nx - 70}px; top: {ny - 30}px;
             background: {bg}; border-color: {border}; color: {text};
         ">
-            <div class="mm-label">{node.label}</div>
+            <div class="mm-label">{_esc(node.label)}</div>
             {desc_html}
         </div>
         """)
@@ -64,14 +64,14 @@ def generate_mindmap_diagram(
             f'stroke="{border}" stroke-width="2" opacity="0.6"/>'
         )
 
-    subtitle = spec.description or "Concept Map"
+    subtitle = _esc(spec.description) if spec.description else "Concept Map"
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .mm-canvas {{
@@ -120,7 +120,7 @@ def generate_mindmap_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body">
         <div class="mm-canvas">
@@ -138,10 +138,10 @@ def generate_mindmap_diagram(
 
 def _empty_diagram(title: str, width: int, height: int, css: str) -> str:
     return f"""<!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><title>{title}</title>
+<html lang="en"><head><meta charset="UTF-8"><title>{_esc(title)}</title>
 <style>{css}</style></head>
 <body><div class="diagram-container">
-<div class="diagram-title">{title}</div>
+<div class="diagram-title">{_esc(title)}</div>
 <div class="diagram-subtitle">No nodes provided</div>
 <div class="diagram-body"><p style="color:#94a3b8;">Add nodes to generate a mind map.</p></div>
 </div></body></html>"""

--- a/mcp-nano-banana/src/diagrams/orgchart.py
+++ b/mcp-nano-banana/src/diagrams/orgchart.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _node_color
+from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
 
 
 def generate_orgchart_diagram(
@@ -36,7 +36,7 @@ def generate_orgchart_diagram(
         if not node:
             return ""
         bg, border, text = _node_color(node.type)
-        desc_html = f'<div class="org-desc">{node.description}</div>' if node.description else ""
+        desc_html = f'<div class="org-desc">{_esc(node.description)}</div>' if node.description else ""
 
         kids = children_map.get(node_id, [])
         kids_html = ""
@@ -47,7 +47,7 @@ def generate_orgchart_diagram(
         return f"""
         <div class="org-branch">
             <div class="org-card" style="background: {bg}; border-color: {border}; color: {text};">
-                <div class="org-name">{node.label}</div>
+                <div class="org-name">{_esc(node.label)}</div>
                 {desc_html}
             </div>
             {kids_html}
@@ -55,14 +55,14 @@ def generate_orgchart_diagram(
         """
 
     tree_html = "".join(render_node(r) for r in roots)
-    subtitle = spec.description or "Organization Chart"
+    subtitle = _esc(spec.description) if spec.description else "Organization Chart"
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .org-tree {{
@@ -116,7 +116,7 @@ def generate_orgchart_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body">
         <div class="org-tree">

--- a/mcp-nano-banana/src/diagrams/sequence.py
+++ b/mcp-nano-banana/src/diagrams/sequence.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _node_color
+from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
 
 
 def generate_sequence_diagram(
@@ -36,7 +36,7 @@ def generate_sequence_diagram(
             border-color: {border};
             color: {text};
         ">
-            <div class="seq-name">{p.label}</div>
+            <div class="seq-name">{_esc(p.label)}</div>
         </div>
         """)
 
@@ -74,18 +74,18 @@ def generate_sequence_diagram(
         # Label
         label_x = (x1 + x2) // 2
         label_y = msg_y - 8
-        messages_svg += f'<text x="{label_x}" y="{label_y}" text-anchor="middle" fill="#e2e8f0" font-size="13" font-family="Segoe UI, system-ui, sans-serif">{edge.label}</text>'
+        messages_svg += f'<text x="{label_x}" y="{label_y}" text-anchor="middle" fill="#e2e8f0" font-size="13" font-family="Segoe UI, system-ui, sans-serif">{_esc(edge.label)}</text>'
 
         msg_y += msg_step
 
-    subtitle = spec.description or "Sequence Diagram"
+    subtitle = _esc(spec.description) if spec.description else "Sequence Diagram"
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .seq-header {{
@@ -123,7 +123,7 @@ def generate_sequence_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body" style="flex-direction: column; align-items: stretch;">
         <div class="seq-header">

--- a/mcp-nano-banana/src/diagrams/timeline.py
+++ b/mcp-nano-banana/src/diagrams/timeline.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _node_color
+from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
 
 
 def generate_timeline_diagram(
@@ -20,26 +20,26 @@ def generate_timeline_diagram(
     items_html = []
     for i, node in enumerate(milestones):
         bg, border, text = _node_color(node.type)
-        desc_html = f'<div class="tl-desc">{node.description}</div>' if node.description else ""
+        desc_html = f'<div class="tl-desc">{_esc(node.description)}</div>' if node.description else ""
         side = "top" if i % 2 == 0 else "bottom"
         items_html.append(f"""
         <div class="tl-item tl-{side}">
             <div class="tl-dot" style="background: {bg}; border-color: {border};"></div>
             <div class="tl-card" style="background: {bg}; border-color: {border}; color: {text};">
-                <div class="tl-label">{node.label}</div>
+                <div class="tl-label">{_esc(node.label)}</div>
                 {desc_html}
             </div>
         </div>
         """)
 
-    subtitle = spec.description or "Project Timeline"
+    subtitle = _esc(spec.description) if spec.description else "Project Timeline"
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width={width}">
-<title>{spec.title}</title>
+<title>{_esc(spec.title)}</title>
 <style>
 {css}
 .tl-track {{
@@ -105,7 +105,7 @@ def generate_timeline_diagram(
 </head>
 <body>
 <div class="diagram-container">
-    <div class="diagram-title">{spec.title}</div>
+    <div class="diagram-title">{_esc(spec.title)}</div>
     <div class="diagram-subtitle">{subtitle}</div>
     <div class="diagram-body">
         <div class="tl-track">


### PR DESCRIPTION
## Summary

- Add `_esc()` HTML-escape helper to `diagrams/base.py` wrapping `html.escape()`
- Apply escaping across all 7 diagram generators: c4, architecture, flowchart, sequence, orgchart, timeline, mindmap
- Covers: node labels, descriptions, icons, edge labels, spec titles, subtitles, and data attributes
- Prevents stored XSS when malicious content in project files (README, code) is ingested by the LLM and rendered in diagram HTML

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (354 tests)
- [ ] Woodpecker CI pipeline passes
- [ ] Verify diagram HTML output with special characters (`<script>`, `&`, `"`) renders safely

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)