### PR TITLE
feat(c4): iterative L3/L4 diagram generation (Closes #258)

### DIFF
--- a/.claude/commands/documentation/c4.md
+++ b/.claude/commands/documentation/c4.md
@@ -1,5 +1,5 @@
 ---
-description: Generate C4 architecture diagrams for the current project (all 4 levels)
+description: Generate C4 architecture diagrams for the current project (all 4 levels, one per container/component)
 allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
 ---
 
@@ -8,6 +8,8 @@ allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_
 ## Arguments
 
 - `LEVEL` (optional): Generate only a specific level - `L1`, `L2`, `L3`, or `L4`. Default: all 4 levels.
+- When `L3` is specified alone, generates L3 for ALL containers found in an existing L2 diagram or by analyzing the project.
+- When `L4` is specified alone, generates L4 for top 3 components per container from existing L3 diagrams.
 
 ## Instructions
 
@@ -38,9 +40,9 @@ DOCS_DIR="docs/architecture"
 mkdir -p "$DOCS_DIR"
 ```
 
-### Step 3: Generate C4 Diagrams
+### Step 3: Generate L1 and L2 Diagrams
 
-Generate each level using the `generate_diagram` MCP tool with `diagram_type: "c4"`.
+Generate using the `generate_diagram` MCP tool with `diagram_type: "c4"`.
 
 **IMPORTANT:** Do NOT pass `save_path` to `generate_diagram`. The MCP tool runs in Docker and cannot write to host paths. Instead, capture the returned `html` string and save it using the `Write` tool.
 
@@ -97,55 +99,115 @@ result = generate_diagram(
 Write(file_path="{DOCS_DIR}/c4-l2-container.html", content=result.html)
 ```
 
-#### Level 3: Component
+### Step 3b: Plan L3/L4 Expansion
 
-Focus on: major components within the most important containers. Show how responsibilities are divided.
+After generating L2, plan the iterative L3 and L4 generation:
+
+1. **Build containers list** - Extract ALL nodes of type `container` from the L2 diagram you just generated:
+   ```
+   containers_for_l3 = [node for node in l2_nodes if node.type == "container"]
+   ```
+
+2. **Scope check** - If more than 5 containers are found, ask the user:
+   > "Found {N} containers. Generate L3 for all {N}, or select the most important ones?"
+
+   If the user selects a subset, use only those. Otherwise generate for all.
+
+3. **Plan L4 targets** - After generating each L3, you will pick the top 3 most architecturally significant components per container for L4 expansion. Significance criteria:
+   - Components with the most edges (highest connectivity)
+   - Components implementing core business logic
+   - Components with external integrations
+
+### Step 4: Generate L3 Diagrams (One Per Container)
+
+For EACH container identified in Step 3b, generate a separate L3 Component diagram.
+
+**Naming convention:** `c4-l3-{container-slug}.html` where `container-slug` is the container label lowercased with spaces/special chars replaced by hyphens.
 
 ```
-result = generate_diagram(
-    diagram_type="c4",
-    title="L3 Component - {Container Name}",
-    description="Components within {container}",
-    nodes=[
-        {"id": "auth", "label": "Auth Module", "type": "component", "description": "JWT / Sessions"},
-        {"id": "router", "label": "Router", "type": "component", "description": "FastAPI routes"},
-    ],
-    edges=[...],
-)
-Write(file_path="{DOCS_DIR}/c4-l3-{container-slug}.html", content=result.html)
+# Track all generated diagrams for the report
+generated_diagrams = []
+
+for container in containers_for_l3:
+    # Analyze the codebase to identify components within this container
+    # Read source files, configs, and modules belonging to this container
+
+    slug = slugify(container.label)  # e.g., "API Server" -> "api-server"
+
+    result = generate_diagram(
+        diagram_type="c4",
+        title="L3 Component - {container.label}",
+        description="Components within {container.label}",
+        nodes=[
+            # Components discovered by analyzing this container's code
+            {"id": "{container_slug}-comp1", "label": "Component Name", "type": "component", "description": "Purpose / tech"},
+            # ... more components
+        ],
+        edges=[
+            # Internal edges between components + edges to external containers
+        ],
+    )
+    Write(file_path="{DOCS_DIR}/c4-l3-{slug}.html", content=result.html)
+    generated_diagrams.append({"level": "L3", "file": "c4-l3-{slug}.html", "title": result.title, "container": container.label})
 ```
 
-#### Level 4: Code
+**Guidelines for L3 diagrams:**
+- Each L3 should have 5-15 nodes (components within one container)
+- Include edges to components in OTHER containers as external references (use `system` type for external container nodes)
+- Use descriptive IDs prefixed with the container slug to avoid collisions across diagrams
 
-Focus on: key classes, interfaces, and modules within the most critical components.
+### Step 5: Generate L4 Diagrams (Top 3 Components Per Container)
+
+For each L3 diagram, select the top 3 most architecturally significant components and generate an L4 Code diagram for each.
+
+**Naming convention:** `c4-l4-{container-slug}-{component-slug}.html`
 
 ```
-result = generate_diagram(
-    diagram_type="c4",
-    title="L4 Code - {Component Name}",
-    description="Classes and modules in {component}",
-    nodes=[
-        {"id": "cls1", "label": "UserService", "type": "code", "description": "class"},
-        {"id": "cls2", "label": "AuthMiddleware", "type": "code", "description": "class"},
-    ],
-    edges=[...],
-)
-Write(file_path="{DOCS_DIR}/c4-l4-{component-slug}.html", content=result.html)
+for container in containers_for_l3:
+    container_slug = slugify(container.label)
+
+    # From the L3 we just generated, pick top 3 components by significance
+    top_components = select_top_3_components(l3_nodes_for_container)
+
+    for component in top_components:
+        comp_slug = slugify(component.label)
+
+        # Analyze the source code for this component
+        # Identify classes, interfaces, functions, data models
+
+        result = generate_diagram(
+            diagram_type="c4",
+            title="L4 Code - {component.label} ({container.label})",
+            description="Classes and modules in {component.label}",
+            nodes=[
+                {"id": "{container_slug}-{comp_slug}-cls1", "label": "ClassName", "type": "code", "description": "class / interface / module"},
+                # ... more code elements
+            ],
+            edges=[...],
+        )
+        Write(file_path="{DOCS_DIR}/c4-l4-{container_slug}-{comp_slug}.html", content=result.html)
+        generated_diagrams.append({"level": "L4", "file": "c4-l4-{container_slug}-{comp_slug}.html", "title": result.title, "container": container.label, "component": component.label})
 ```
 
-### Step 4: Screenshot (if Playwright available)
+**Guidelines for L4 diagrams:**
+- Each L4 should have 5-12 nodes (classes/modules within one component)
+- Per Simon Brown: "Show the core, not the whole" - focus on the most important code elements
+- Skip L4 for simple components with fewer than 3 code elements
 
-For each HTML diagram:
+### Step 6: Screenshot (if Playwright available)
 
-1. Create a Playwright session (headless)
-2. Navigate to `file://{absolute_path}`
-3. Screenshot at 1920x1080
-4. Save PNG alongside HTML
-5. Close session
+Use ONE Playwright session for all screenshots:
+
+1. Create a single Playwright session (headless)
+2. For EACH generated HTML file (L1, L2, all L3s, all L4s):
+   a. Navigate to `file://{absolute_path}`
+   b. Screenshot at 1920x1080
+   c. Save PNG alongside HTML (same name with .png extension)
+3. Close session (once, at end)
 
 If Playwright is not available, skip screenshots and note the user can open HTML files in a browser.
 
-### Step 5: Review CLAUDE.md and README.md
+### Step 7: Review CLAUDE.md and README.md
 
 After generating diagrams, review these files for accuracy:
 
@@ -154,19 +216,28 @@ After generating diagrams, review these files for accuracy:
 
 Report any issues found but do NOT auto-edit these files. Ask the user for confirmation before making changes.
 
-### Step 6: Report
+### Step 8: Report
 
 ```
 C4 Architecture Diagrams Generated
 
   Output:  {DOCS_DIR}/
 
-  L1 Context:   c4-l1-context.html    ({node_count} nodes, {edge_count} edges)
-  L2 Container:  c4-l2-container.html  ({node_count} nodes, {edge_count} edges)
-  L3 Component:  c4-l3-{slug}.html     ({node_count} nodes, {edge_count} edges)
-  L4 Code:       c4-l4-{slug}.html     ({node_count} nodes, {edge_count} edges)
+  L1 Context:    c4-l1-context.html           ({node_count} nodes, {edge_count} edges)
+  L2 Container:  c4-l2-container.html         ({node_count} nodes, {edge_count} edges)
 
-  Screenshots:   {count} PNG files (or "Playwright not available")
+  L3 Component diagrams ({N} containers):
+    c4-l3-{slug-1}.html  ({node_count} nodes, {edge_count} edges)
+    c4-l3-{slug-2}.html  ({node_count} nodes, {edge_count} edges)
+    ...
+
+  L4 Code diagrams ({M} components):
+    c4-l4-{slug-1}-{comp-1}.html  ({node_count} nodes, {edge_count} edges)
+    c4-l4-{slug-1}-{comp-2}.html  ({node_count} nodes, {edge_count} edges)
+    ...
+
+  Total diagrams: {2 + N + M}
+  Screenshots:    {count} PNG files (or "Playwright not available")
 
   Doc Review:
     CLAUDE.md:  {OK | {N} issues found}
@@ -178,7 +249,9 @@ C4 Architecture Diagrams Generated
 ## Notes
 
 - The C4 model was created by Simon Brown - see https://c4model.com
-- L1 and L2 are most valuable; L3/L4 add detail for complex systems
+- L1 and L2 are always single diagrams; L3 generates one per container; L4 generates up to 3 per container
+- L3/L4 diagrams use slugified container/component names in filenames to avoid collisions
+- Node IDs are prefixed with container/component slugs to stay unique across diagrams
 - Regenerate after major architectural changes
 - Diagrams are gitignored by default (*.html in docs/architecture/ should be committed)
 - Use `/documentation:pptx` to embed C4 diagrams into a presentation


### PR DESCRIPTION
## Summary
- Updated `/documentation:c4` skill to generate **one L3 diagram per container** (from L2) instead of a single L3
- L4 now generates up to **3 diagrams per container** (top components by architectural significance)
- Added Step 3b planning phase to extract containers from L2 and scope-check (asks user if >5 containers)
- Slugified naming convention: `c4-l3-{container}.html`, `c4-l4-{container}-{component}.html`
- Node IDs prefixed with container/component slugs to avoid cross-diagram collisions
- Single Playwright session reused for all screenshots
- Updated report format to list all generated diagrams with totals

## Test plan
- [ ] Run `/documentation:c4` on a multi-container project (e.g., voice-bot with Bridge + MediaBot)
- [ ] Verify L3 generates one HTML file per container
- [ ] Verify L4 generates up to 3 HTML files per container
- [ ] Verify naming convention matches spec (`c4-l3-bridge.html`, `c4-l3-mediabot.html`, etc.)
- [ ] Verify scope check triggers when >5 containers are present
- [ ] Run `make lint && make test` - all 354 tests pass

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)