### PR TITLE
fix(nano-banana): WCAG AA color contrast failures in diagram palettes (Closes #257)

### DIFF
--- a/mcp-nano-banana/src/diagrams/base.py
+++ b/mcp-nano-banana/src/diagrams/base.py
@@ -15,6 +15,28 @@ def _esc(text: str) -> str:
     return _html_mod.escape(str(text), quote=True)
 
 
+def _relative_luminance(hex_color: str) -> float:
+    """Calculate relative luminance per WCAG 2.1 definition."""
+    h = hex_color.lstrip("#")
+    r, g, b = int(h[0:2], 16) / 255, int(h[2:4], 16) / 255, int(h[4:6], 16) / 255
+
+    def _linearize(c: float) -> float:
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * _linearize(r) + 0.7152 * _linearize(g) + 0.0722 * _linearize(b)
+
+
+def _contrast_ratio(fg: str, bg: str) -> float:
+    """Calculate WCAG 2.1 contrast ratio between two hex colors.
+
+    Returns a value >= 1.0 where 4.5:1 is the WCAG AA minimum for normal text
+    and 3.0:1 is the minimum for large text (>= 18px bold).
+    """
+    l1, l2 = _relative_luminance(fg), _relative_luminance(bg)
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
 DIAGRAM_TYPES = [
     "architecture",
     "c4",
@@ -96,13 +118,25 @@ def _css_reset(width: int, height: int) -> str:
 
 
 def _node_color(node_type: str) -> tuple[str, str, str]:
-    """Return (bg, border, text) colors for a node type."""
+    """Return (bg, border, text) colors for a node type.
+
+    All combinations meet WCAG AA contrast ratio >= 4.5:1 for normal text.
+
+    | Type      | BG      | Text    | Ratio |
+    |-----------|---------|---------|-------|
+    | primary   | #2563eb | #ffffff | 5.17  |
+    | secondary | #7c3aed | #ffffff | 5.70  |
+    | accent    | #f59e0b | #1e293b | 6.81  |
+    | warning   | #dc2626 | #ffffff | 4.83  |
+    | success   | #047857 | #ffffff | 5.48  |
+    | default   | #334155 | #e2e8f0 | 8.40  |
+    """
     colors = {
-        "primary": ("#3b82f6", "#60a5fa", "#ffffff"),
-        "secondary": ("#8b5cf6", "#a78bfa", "#ffffff"),
+        "primary": ("#2563eb", "#3b82f6", "#ffffff"),
+        "secondary": ("#7c3aed", "#a78bfa", "#ffffff"),
         "accent": ("#f59e0b", "#fbbf24", "#1e293b"),
-        "warning": ("#ef4444", "#f87171", "#ffffff"),
-        "success": ("#10b981", "#34d399", "#ffffff"),
+        "warning": ("#dc2626", "#f87171", "#ffffff"),
+        "success": ("#047857", "#34d399", "#ffffff"),
         "default": ("#334155", "#475569", "#e2e8f0"),
     }
     return colors.get(node_type, colors["default"])

--- a/mcp-nano-banana/src/diagrams/c4.py
+++ b/mcp-nano-banana/src/diagrams/c4.py
@@ -22,14 +22,23 @@ from __future__ import annotations
 from diagrams.base import DiagramSpec, _css_reset, _esc
 
 
-# C4-specific color palette
+# C4-specific color palette - all combos meet WCAG AA >= 4.5:1
+#
+# | Type         | BG      | Text    | Ratio |
+# |--------------|---------|---------|-------|
+# | person       | #1e40af | #ffffff | 8.72  |
+# | system       | #374151 | #f3f4f6 | 9.37  |
+# | system-focus | #1d4ed8 | #ffffff | 6.70  |
+# | container    | #15803d | #ffffff | 5.02  |
+# | component    | #7e22ce | #ffffff | 6.98  |
+# | code         | #92400e | #ffffff | 7.09  |
 _C4_COLORS = {
     "person":       ("#1e40af", "#3b82f6", "#ffffff"),  # dark blue
     "system":       ("#374151", "#6b7280", "#f3f4f6"),  # grey - external
     "system-focus": ("#1d4ed8", "#60a5fa", "#ffffff"),  # blue - focus
     "container":    ("#15803d", "#22c55e", "#ffffff"),  # green
     "component":    ("#7e22ce", "#a855f7", "#ffffff"),  # purple
-    "code":         ("#b45309", "#f59e0b", "#1e293b"),  # amber
+    "code":         ("#92400e", "#f59e0b", "#ffffff"),  # amber - darkened bg, white text
 }
 
 _DEFAULT_COLOR = ("#334155", "#475569", "#e2e8f0")


### PR DESCRIPTION
## Summary

- Darken node background colors in `base.py` (`_node_color()`) and `c4.py` (`_C4_COLORS`) to achieve WCAG AA minimum 4.5:1 contrast ratio for all text/background combinations
- Add `_contrast_ratio(fg, bg)` and `_relative_luminance(hex_color)` utility functions to `base.py` for programmatic WCAG validation
- Document final contrast ratios in palette docstrings

### Colors fixed

| Palette | Type | Old BG | New BG | Text | Old Ratio | New Ratio |
|---------|------|--------|--------|------|-----------|-----------|
| base | primary | #3b82f6 | #2563eb | #ffffff | 3.68 | 5.17 |
| base | secondary | #8b5cf6 | #7c3aed | #ffffff | 4.23 | 5.70 |
| base | warning | #ef4444 | #dc2626 | #ffffff | 3.76 | 4.83 |
| base | success | #10b981 | #047857 | #ffffff | 2.54 | 5.48 |
| c4 | code | #b45309 | #92400e | #ffffff | 2.91 | 7.09 |

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (354 tests)
- [x] All 12 color combinations verified >= 4.5:1 contrast ratio
- [x] `_contrast_ratio()` utility returns correct values (21:1 for white/black, 1:1 for same color)

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)