### PR TITLE
feat(nano-banana): node density scoring and overflow heuristics (Closes #262)

### DIFF
--- a/mcp-nano-banana/src/diagrams/__init__.py
+++ b/mcp-nano-banana/src/diagrams/__init__.py
@@ -8,7 +8,7 @@ from diagrams.orgchart import generate_orgchart_diagram
 from diagrams.timeline import generate_timeline_diagram
 from diagrams.mindmap import generate_mindmap_diagram
 from diagrams.base import DIAGRAM_TYPES, DiagramSpec, DiagramNode, DiagramEdge
-from diagrams.validate import validate_diagram
+from diagrams.validate import validate_diagram, score_diagram_density
 
 __all__ = [
     "generate_architecture_diagram",
@@ -19,6 +19,7 @@ __all__ = [
     "generate_timeline_diagram",
     "generate_mindmap_diagram",
     "validate_diagram",
+    "score_diagram_density",
     "DIAGRAM_TYPES",
     "DiagramSpec",
     "DiagramNode",

--- a/mcp-nano-banana/src/diagrams/validate.py
+++ b/mcp-nano-banana/src/diagrams/validate.py
@@ -67,6 +67,53 @@ def _get_palette_colors(
     return _node_color(node_type)
 
 
+def score_diagram_density(
+    node_count: int,
+    edge_count: int,
+    width: int = 1920,
+    height: int = 1080,
+    avg_node_width: int = 200,
+    avg_node_height: int = 100,
+) -> dict:
+    """Score diagram density and suggest actions.
+
+    Returns a dict with density ratio, capacity, status, and suggestion.
+
+    Thresholds:
+        <= 0.8: ok - no action needed
+        0.8-1.0: warning - near capacity, suggest tighter layout
+        1.0-1.5: overflow - recommend splitting into sub-diagrams
+        > 1.5: critical - must split, diagram will be unreadable
+    """
+    usable_area = width * height * 0.65  # 35% reserved for headers, padding, edges panel
+    node_area = avg_node_width * avg_node_height * 1.5  # 1.5x for margins between nodes
+    capacity = int(usable_area / node_area) if node_area > 0 else 1
+
+    density = node_count / max(capacity, 1)
+
+    if density <= 0.8:
+        status = "ok"
+        suggestion = None
+    elif density <= 1.0:
+        status = "warning"
+        suggestion = "Near capacity - consider tighter layout or reducing labels"
+    elif density <= 1.5:
+        status = "overflow"
+        suggestion = "Consider splitting into summary + detail sub-diagrams"
+    else:
+        status = "critical"
+        suggestion = "Must split - diagram will be unreadable at this density"
+
+    return {
+        "density": round(density, 2),
+        "capacity": capacity,
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "status": status,
+        "suggestion": suggestion,
+    }
+
+
 def validate_diagram(
     nodes: list[dict],
     edges: list[dict] | None = None,
@@ -83,13 +130,22 @@ def validate_diagram(
 
     Returns:
         dict with passed (bool), issue_count, high_severity,
-        issues (list of dicts), and suggestions (list of str).
+        issues (list of dicts), suggestions (list of str),
+        and density (dict with scoring metadata).
     """
     edges = edges or []
     issues: list[_ValidationIssue] = []
 
     node_ids = [n.get("id", f"n{i}") for i, n in enumerate(nodes)]
     node_id_set = set(node_ids)
+
+    # Compute density score up front for use in checks
+    density = score_diagram_density(
+        node_count=len(nodes),
+        edge_count=len(edges),
+        width=width,
+        height=height,
+    )
 
     # --- HIGH: duplicate_ids ---
     seen: set[str] = set()
@@ -122,35 +178,30 @@ def validate_diagram(
                 edge_index=i,
             ))
 
-    # --- HIGH: viewport_fit ---
-    avg_node_width = 200
-    avg_node_height = 100
+    # --- HIGH: viewport_fit (uses density scoring) ---
     node_count = len(nodes)
-    usable_area = width * height * 0.7
-    total_node_area = node_count * avg_node_width * avg_node_height
-    if total_node_area > usable_area:
+    if density["status"] in ("overflow", "critical"):
+        severity = "high"
         issues.append(_ValidationIssue(
             check="viewport_fit",
-            severity="high",
+            severity=severity,
             message=(
-                f"Estimated node area ({total_node_area:,}px^2) exceeds "
-                f"viewport capacity ({int(usable_area):,}px^2 at {width}x{height}). "
-                f"{node_count} nodes likely overflow the viewport."
+                f"Density {density['density']:.2f} ({density['status']}): "
+                f"{node_count} nodes exceed viewport capacity of ~{density['capacity']} "
+                f"at {width}x{height}. {density['suggestion']}"
             ),
         ))
 
-    # --- MEDIUM: readability ---
-    if node_count > 25:
+    # --- MEDIUM: readability (uses density scoring) ---
+    if density["status"] == "warning":
         issues.append(_ValidationIssue(
             check="readability",
             severity="medium",
-            message=f"Very high node count ({node_count}). Overflow risk - consider splitting.",
-        ))
-    elif node_count > 15:
-        issues.append(_ValidationIssue(
-            check="readability",
-            severity="medium",
-            message=f"Dense diagram ({node_count} nodes). May be hard to read.",
+            message=(
+                f"Density {density['density']:.2f} (warning): "
+                f"{node_count} nodes near capacity of ~{density['capacity']}. "
+                f"{density['suggestion']}"
+            ),
         ))
 
     # --- MEDIUM: orphan_nodes ---
@@ -263,4 +314,5 @@ def validate_diagram(
         "issues": issue_dicts,
         "suggestions": suggestions,
         "summary": summary,
+        "density": density,
     }

--- a/mcp-nano-banana/src/server.py
+++ b/mcp-nano-banana/src/server.py
@@ -191,6 +191,11 @@ async def generate_diagram(
         "node_count": len(parsed_nodes),
         "edge_count": len(parsed_edges),
     }
+
+    # Include density scoring metadata
+    if "density" in validation:
+        result["density"] = validation["density"]
+
     if warnings:
         result["warnings"] = warnings
         result["validation_summary"] = validation["summary"]

--- a/tests/test_validate_diagram.py
+++ b/tests/test_validate_diagram.py
@@ -150,19 +150,21 @@ class TestViewportFit:
 
 class TestReadability:
     def test_dense_warning(self):
-        nodes = _make_nodes(20)
-        edges = _make_chain_edges(20)
+        # Density ~0.86 (38/44 capacity) triggers warning
+        nodes = _make_nodes(38)
+        edges = _make_chain_edges(38)
         result = validate_diagram(nodes=nodes, edges=edges)
         read_issues = [iss for iss in result["issues"] if iss["check"] == "readability"]
         assert len(read_issues) >= 1
         assert read_issues[0]["severity"] == "medium"
 
     def test_overflow_warning(self):
-        nodes = _make_nodes(30)
-        edges = _make_chain_edges(30)
+        # Density ~1.14 (50/44 capacity) triggers viewport_fit overflow
+        nodes = _make_nodes(50)
+        edges = _make_chain_edges(50)
         result = validate_diagram(nodes=nodes, edges=edges)
-        read_issues = [iss for iss in result["issues"] if iss["check"] == "readability"]
-        assert len(read_issues) >= 1
+        fit_issues = [iss for iss in result["issues"] if iss["check"] == "viewport_fit"]
+        assert len(fit_issues) >= 1
 
     def test_small_diagram_no_warning(self):
         nodes = _make_nodes(10)


### PR DESCRIPTION
## Summary
- Added `score_diagram_density()` function with 4-tier threshold system: ok (<= 0.8), warning (0.8-1.0), overflow (1.0-1.5), critical (> 1.5)
- Replaced hardcoded node count thresholds in `viewport_fit` and `readability` checks with density-based scoring
- `validate_diagram` response now includes `density` metadata (density ratio, capacity, status, suggestion)
- `generate_diagram` response now includes `density` field for downstream consumers
- Exported `score_diagram_density` from `diagrams` package for direct use
- Updated existing tests to match new density-based thresholds (capacity ~44 nodes at 1920x1080)

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (385 tests, including updated readability/viewport tests)
- [ ] Verify density metadata appears in `generate_diagram` MCP tool response
- [ ] Verify `validate_diagram` includes density scoring in results

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)