### PR TITLE
feat(c4): generate c4-manifest.json tracking all diagram outputs (Closes #259)

### DIFF
--- a/.claude/commands/documentation/c4.md
+++ b/.claude/commands/documentation/c4.md
@@ -57,6 +57,15 @@ Generate using the `generate_diagram` MCP tool with `diagram_type: "c4"`.
 | `component` | Component | Modules, services, controllers within a container |
 | `code` | Code Element | Classes, interfaces, functions, data models |
 
+#### Initialize Diagram Tracking
+
+Before generating any diagrams, initialize a list to track all outputs for the manifest:
+
+```
+# Track ALL generated diagrams for the manifest (c4-manifest.json)
+generated_diagrams = []
+```
+
 #### Level 1: System Context
 
 Focus on: actors + external systems + the system of interest. Keep it high-level (5-10 nodes max).
@@ -78,6 +87,15 @@ result = generate_diagram(
 )
 # Save HTML using Write tool
 Write(file_path="{DOCS_DIR}/c4-l1-context.html", content=result.html)
+generated_diagrams.append({
+    "id": "l1-context",
+    "level": "L1",
+    "title": result.title,
+    "file": "c4-l1-context.html",
+    "node_count": len(nodes),
+    "edge_count": len(edges),
+    "parent": null
+})
 ```
 
 #### Level 2: Container
@@ -97,6 +115,15 @@ result = generate_diagram(
     edges=[...],
 )
 Write(file_path="{DOCS_DIR}/c4-l2-container.html", content=result.html)
+generated_diagrams.append({
+    "id": "l2-container",
+    "level": "L2",
+    "title": result.title,
+    "file": "c4-l2-container.html",
+    "node_count": len(nodes),
+    "edge_count": len(edges),
+    "parent": "l1-context"
+})
 ```
 
 ### Step 3b: Plan L3/L4 Expansion
@@ -125,9 +152,6 @@ For EACH container identified in Step 3b, generate a separate L3 Component diagr
 **Naming convention:** `c4-l3-{container-slug}.html` where `container-slug` is the container label lowercased with spaces/special chars replaced by hyphens.
 
 ```
-# Track all generated diagrams for the report
-generated_diagrams = []
-
 for container in containers_for_l3:
     # Analyze the codebase to identify components within this container
     # Read source files, configs, and modules belonging to this container
@@ -148,7 +172,16 @@ for container in containers_for_l3:
         ],
     )
     Write(file_path="{DOCS_DIR}/c4-l3-{slug}.html", content=result.html)
-    generated_diagrams.append({"level": "L3", "file": "c4-l3-{slug}.html", "title": result.title, "container": container.label})
+    generated_diagrams.append({
+        "id": "l3-{slug}",
+        "level": "L3",
+        "title": result.title,
+        "file": "c4-l3-{slug}.html",
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+        "parent": "l2-container",
+        "container_id": container.id
+    })
 ```
 
 **Guidelines for L3 diagrams:**
@@ -186,7 +219,17 @@ for container in containers_for_l3:
             edges=[...],
         )
         Write(file_path="{DOCS_DIR}/c4-l4-{container_slug}-{comp_slug}.html", content=result.html)
-        generated_diagrams.append({"level": "L4", "file": "c4-l4-{container_slug}-{comp_slug}.html", "title": result.title, "container": container.label, "component": component.label})
+        generated_diagrams.append({
+            "id": "l4-{container_slug}-{comp_slug}",
+            "level": "L4",
+            "title": result.title,
+            "file": "c4-l4-{container_slug}-{comp_slug}.html",
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+            "parent": "l3-{container_slug}",
+            "container_id": container.id,
+            "component_id": component.id
+        })
 ```
 
 **Guidelines for L4 diagrams:**
@@ -206,6 +249,45 @@ Use ONE Playwright session for all screenshots:
 3. Close session (once, at end)
 
 If Playwright is not available, skip screenshots and note the user can open HTML files in a browser.
+
+### Step 6b: Generate Manifest
+
+After all diagrams are generated (and optionally screenshotted), write the `c4-manifest.json` file to track what was produced:
+
+```json
+{
+  "project": "{project-name}",
+  "generated_at": "{ISO 8601 timestamp}",
+  "theme_id": "c4-default-dark-v1",
+  "diagrams": [
+    // ... all entries from generated_diagrams list
+  ]
+}
+```
+
+Use the Write tool to create the manifest:
+
+```
+import json
+from datetime import datetime, timezone
+
+manifest = {
+    "project": project_name,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "theme_id": "c4-default-dark-v1",
+    "diagrams": generated_diagrams
+}
+
+Write(file_path="{DOCS_DIR}/c4-manifest.json", content=json.dumps(manifest, indent=2))
+```
+
+**Manifest rules:**
+- Each diagram entry MUST have: `id`, `level`, `title`, `file`, `node_count`, `edge_count`, `parent`
+- L1 diagrams have `parent: null`
+- L2 diagrams have `parent: "l1-context"`
+- L3 diagrams have `parent: "l2-container"` and `container_id`
+- L4 diagrams have `parent: "l3-{container_slug}"`, `container_id`, and `component_id`
+- The `file` field is a relative path within the output directory (not absolute)
 
 ### Step 7: Review CLAUDE.md and README.md
 
@@ -236,6 +318,7 @@ C4 Architecture Diagrams Generated
     c4-l4-{slug-1}-{comp-2}.html  ({node_count} nodes, {edge_count} edges)
     ...
 
+  Manifest:       c4-manifest.json ({2 + N + M} diagrams tracked)
   Total diagrams: {2 + N + M}
   Screenshots:    {count} PNG files (or "Playwright not available")
 
@@ -253,5 +336,6 @@ C4 Architecture Diagrams Generated
 - L3/L4 diagrams use slugified container/component names in filenames to avoid collisions
 - Node IDs are prefixed with container/component slugs to stay unique across diagrams
 - Regenerate after major architectural changes
+- `c4-manifest.json` tracks all generated diagrams with parent-child relationships for downstream tools
 - Diagrams are gitignored by default (*.html in docs/architecture/ should be committed)
 - Use `/documentation:pptx` to embed C4 diagrams into a presentation


### PR DESCRIPTION
## Summary
- Add `c4-manifest.json` generation as Step 6b in the `/documentation:c4` skill
- Track all diagrams (L1-L4) with `id`, `level`, `title`, `file`, `node_count`, `edge_count`, `parent`
- Initialize `generated_diagrams` tracking at L1/L2 (previously only L3/L4 were tracked)
- Standardize L3/L4 tracking entries to include full manifest fields (`container_id`, `component_id`)
- Remove stale re-initialization of `generated_diagrams` in Step 4

## Files Changed
- `.claude/commands/documentation/c4.md` - Skill prompt (+89/-5 lines)

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (385 tests)
- [ ] Run `/documentation:c4` on a project and verify `c4-manifest.json` is generated

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)