### PR TITLE
feat(c4): generate index.html with hierarchical navigation for all C4 diagrams (Closes #260)

### DIFF
--- a/.claude/commands/documentation/c4.md
+++ b/.claude/commands/documentation/c4.md
@@ -289,6 +289,105 @@ Write(file_path="{DOCS_DIR}/c4-manifest.json", content=json.dumps(manifest, inde
 - L4 diagrams have `parent: "l3-{container_slug}"`, `container_id`, and `component_id`
 - The `file` field is a relative path within the output directory (not absolute)
 
+### Step 6c: Generate Index Page
+
+After writing the manifest, generate `index.html` for hierarchical diagram navigation. Build the page from the `generated_diagrams` list using this template:
+
+```
+# Build parent-child tree from generated_diagrams
+# L1 entries (parent == null) are roots
+# L2 entries have parent == "l1-context"
+# L3 entries have parent == "l2-container"
+# L4 entries have parent == "l3-{container_slug}"
+
+index_html = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>C4 Architecture - {project_name}</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+    color: #e2e8f0;
+    min-height: 100vh;
+    padding: 40px;
+}
+h1 { font-size: 32px; font-weight: 700; color: #f8fafc; margin-bottom: 8px; }
+.subtitle { font-size: 16px; color: #94a3b8; margin-bottom: 32px; }
+details { margin-left: 24px; margin-bottom: 8px; }
+details:first-child { margin-left: 0; }
+summary {
+    cursor: pointer; list-style: none; padding: 8px 0;
+    font-size: 15px; color: #cbd5e1; user-select: none;
+}
+summary::-webkit-details-marker { display: none; }
+summary::before { content: '+ '; color: #64748b; font-family: monospace; }
+details[open] > summary::before { content: '- '; }
+.card {
+    display: inline-flex; align-items: center; gap: 12px;
+    background: rgba(255,255,255,0.04); border: 1px solid #334155;
+    border-radius: 8px; padding: 12px 20px; margin: 4px 0;
+    text-decoration: none; color: inherit; transition: background 0.15s;
+}
+.card:hover { background: rgba(255,255,255,0.08); }
+.badge {
+    font-size: 11px; font-weight: 700; padding: 2px 8px;
+    border-radius: 4px; text-transform: uppercase; letter-spacing: 0.5px;
+}
+.badge-l1 { background: #1d4ed8; color: #fff; }
+.badge-l2 { background: #15803d; color: #fff; }
+.badge-l3 { background: #7e22ce; color: #fff; }
+.badge-l4 { background: #92400e; color: #fff; }
+.card-title { font-weight: 600; }
+.card-meta { font-size: 12px; color: #94a3b8; }
+a.card { display: inline-flex; }
+.generated { font-size: 12px; color: #475569; margin-top: 32px; }
+</style>
+</head>
+<body>
+<h1>C4 Architecture Diagrams</h1>
+<div class="subtitle">{project_name}</div>
+"""
+
+# For each L1 diagram, create root <details open>
+# Nest L2 inside L1, L3 inside L2, L4 inside matching L3
+# Each leaf is an <a class="card"> linking to the HTML file
+
+# Example for one L3 with L4 children:
+# <details open>
+#   <summary>
+#     <a class="card" href="c4-l3-api-server.html">
+#       <span class="badge badge-l3">L3</span>
+#       <span class="card-title">L3 Component - API Server</span>
+#       <span class="card-meta">8 nodes, 10 edges</span>
+#     </a>
+#   </summary>
+#   <a class="card" href="c4-l4-api-server-auth.html">
+#     <span class="badge badge-l4">L4</span>
+#     <span class="card-title">L4 Code - Auth Module</span>
+#     <span class="card-meta">5 nodes, 3 edges</span>
+#   </a>
+# </details>
+
+# After building the tree, close with:
+index_html += '<div class="generated">Generated {timestamp}</div>'
+index_html += "</body></html>"
+
+Write(file_path="{DOCS_DIR}/index.html", content=index_html)
+```
+
+**Index page rules:**
+- L1 and L2 sections are always `<details open>` (expanded by default)
+- L3 sections are `<details open>` only if they have L4 children
+- Each diagram entry is an `<a class="card">` linking to its HTML file
+- Level badges use the same colors as the C4 diagram palette
+- Show node_count and edge_count in the card metadata
+- Include generation timestamp at the bottom
+- The page must work when opened directly from the filesystem (`file://`)
+
 ### Step 7: Review CLAUDE.md and README.md
 
 After generating diagrams, review these files for accuracy:
@@ -319,6 +418,7 @@ C4 Architecture Diagrams Generated
     ...
 
   Manifest:       c4-manifest.json ({2 + N + M} diagrams tracked)
+  Index:          index.html (hierarchical navigation page)
   Total diagrams: {2 + N + M}
   Screenshots:    {count} PNG files (or "Playwright not available")
 
@@ -337,5 +437,6 @@ C4 Architecture Diagrams Generated
 - Node IDs are prefixed with container/component slugs to stay unique across diagrams
 - Regenerate after major architectural changes
 - `c4-manifest.json` tracks all generated diagrams with parent-child relationships for downstream tools
+- `index.html` provides hierarchical navigation across all generated diagrams
 - Diagrams are gitignored by default (*.html in docs/architecture/ should be committed)
 - Use `/documentation:pptx` to embed C4 diagrams into a presentation


### PR DESCRIPTION
## Summary

- Add Step 6c to the `/documentation:c4` skill that generates `docs/architecture/index.html` after the manifest
- Hierarchical tree navigation using native HTML `<details>/<summary>` - zero JS dependency
- Dark theme matching diagram styling (same gradient, fonts, colors)
- Diagram cards with level badges (L1-L4), titles, and node/edge counts
- Self-contained, responsive, works from `file://` paths
- Updated report template and notes to reference index.html

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (385 tests)
- [x] Skill prompt has valid HTML template with correct CSS
- [x] Level badge colors match C4 palette (L1=#1d4ed8, L2=#15803d, L3=#7e22ce, L4=#92400e)

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)