### PR TITLE
feat(nano-banana): shared theme token contract for cross-diagram consistency (Closes #261)

### DIFF
--- a/mcp-nano-banana/README.md
+++ b/mcp-nano-banana/README.md
@@ -4,7 +4,8 @@ Best-in-class diagram generation MCP server for Claude Code. Generates professio
 
 ## Features
 
-- **6 diagram types**: Architecture, Flowchart, Sequence, Org Chart, Timeline, Mind Map
+- **7 diagram types**: C4, Architecture, Flowchart, Sequence, Org Chart, Timeline, Mind Map
+- **Shared theme tokens**: Consistent color palette across all diagram types via `ThemeTokens`
 - **Presentation-quality**: All diagrams render at 1920x1080 (16:9 widescreen)
 - **PowerPoint builder**: Create PPTX files with embedded diagrams, dark theme
 - **Self-contained HTML**: No external dependencies, works offline
@@ -25,15 +26,18 @@ claude mcp add nano-banana --transport sse --url http://127.0.0.1:8084/sse
 
 | Tool | Purpose |
 |------|---------|
-| `list_diagram_types` | List available diagram types and their descriptions |
-| `generate_diagram` | Generate an HTML diagram (architecture, flowchart, sequence, etc.) |
+| `list_diagram_types` | List available diagram types, themes, and descriptions |
+| `generate_diagram` | Generate an HTML diagram with theme support |
+| `validate_diagram` | Validate diagram spec for quality issues (contrast, density, etc.) |
 | `create_pptx` | Create a PowerPoint file with slides and embedded images |
+| `validate_pptx_slides` | Validate slide definitions before creating a PPTX |
 | `diagram_to_pptx` | One-step: generate diagram + create PPTX |
 
 ## Diagram Types
 
 | Type | Use Case |
 |------|----------|
+| `c4` | C4 model - multi-level architecture (Context, Container, Component, Code) |
 | `architecture` | System components in a grid layout |
 | `flowchart` | Sequential process steps with arrows |
 | `sequence` | Message exchange between participants |
@@ -61,7 +65,25 @@ Or use `diagram_to_pptx` for a quick text-based PPTX.
 | `DIAGRAM_WIDTH` | `1920` | Default diagram width |
 | `DIAGRAM_HEIGHT` | `1080` | Default diagram height |
 
+## Theme System
+
+All diagrams use a shared `ThemeTokens` contract for consistent colors. Pass `theme_id` to
+`generate_diagram` and `validate_diagram` to select a named theme. Use `theme_tokens` to
+override individual tokens.
+
+**Available themes:** `c4-default-dark-v1` (default)
+
+**Key parameters:**
+
+| Parameter | Purpose |
+|-----------|---------|
+| `theme_id` | Named theme (e.g. `c4-default-dark-v1`) |
+| `theme_tokens` | Dict of token overrides (e.g. `{"background_primary": "#000"}`) |
+| `diagram_set_id` | Groups related diagrams for tracking |
+
 ## Node Types (Color Themes)
+
+### Generic (architecture, flowchart, sequence, orgchart, timeline, mindmap)
 
 | Type | Color | Use |
 |------|-------|-----|
@@ -71,6 +93,17 @@ Or use `diagram_to_pptx` for a quick text-based PPTX.
 | `warning` | Red | Alerts, critical items |
 | `success` | Green | Completed, healthy |
 | `default` | Slate | Standard elements |
+
+### C4-specific
+
+| Type | Color | Use |
+|------|-------|-----|
+| `person` | Dark blue | Actors / Users |
+| `system` | Grey | External systems |
+| `system-focus` | Blue | System of interest |
+| `container` | Green | Containers |
+| `component` | Purple | Components |
+| `code` | Amber | Code elements |
 
 ## Requirements
 

--- a/mcp-nano-banana/src/diagrams/__init__.py
+++ b/mcp-nano-banana/src/diagrams/__init__.py
@@ -7,7 +7,15 @@ from diagrams.sequence import generate_sequence_diagram
 from diagrams.orgchart import generate_orgchart_diagram
 from diagrams.timeline import generate_timeline_diagram
 from diagrams.mindmap import generate_mindmap_diagram
-from diagrams.base import DIAGRAM_TYPES, DiagramSpec, DiagramNode, DiagramEdge
+from diagrams.base import (
+    DIAGRAM_TYPES,
+    DiagramSpec,
+    DiagramNode,
+    DiagramEdge,
+    ThemeTokens,
+    THEMES,
+    get_theme,
+)
 from diagrams.validate import validate_diagram, score_diagram_density
 
 __all__ = [
@@ -24,4 +32,7 @@ __all__ = [
     "DiagramSpec",
     "DiagramNode",
     "DiagramEdge",
+    "ThemeTokens",
+    "THEMES",
+    "get_theme",
 ]

--- a/mcp-nano-banana/src/diagrams/architecture.py
+++ b/mcp-nano-banana/src/diagrams/architecture.py
@@ -2,25 +2,28 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _node_color
 
 
 def generate_architecture_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML architecture diagram with layered components.
 
     Renders nodes as boxes arranged in a responsive grid layout with
     connection lines between related components.
     """
-    css = _css_reset(width, height)
+    from diagrams.base import _DEFAULT_THEME
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
 
     # Build node HTML
     nodes_html = []
     for i, node in enumerate(spec.nodes):
-        bg, border, text = _node_color(node.type)
+        bg, border, text = _node_color(node.type, t)
         icon_html = f'<div class="node-icon">{_esc(node.icon)}</div>' if node.icon else ""
         desc_html = f'<div class="node-desc">{_esc(node.description)}</div>' if node.description else ""
         nodes_html.append(f"""
@@ -39,7 +42,7 @@ def generate_architecture_diagram(
     edges_svg = ""
     if spec.edges:
         edges_svg = '<svg class="edges-layer" width="100%" height="100%">'
-        edges_svg += '<defs><marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/></marker></defs>'
+        edges_svg += f'<defs><marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="{t.arrow_color}"/></marker></defs>'
         edges_svg += "</svg>"
 
     subtitle = _esc(spec.description) if spec.description else "System Architecture"

--- a/mcp-nano-banana/src/diagrams/base.py
+++ b/mcp-nano-banana/src/diagrams/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import html as _html_mod
 from dataclasses import dataclass, field
 
@@ -36,6 +37,102 @@ def _contrast_ratio(fg: str, bg: str) -> float:
     lighter, darker = max(l1, l2), min(l1, l2)
     return (lighter + 0.05) / (darker + 0.05)
 
+
+# ---------------------------------------------------------------------------
+# Theme token system
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThemeTokens:
+    """Shared color tokens for cross-diagram consistency.
+
+    All text/background combinations must meet WCAG AA >= 4.5:1 contrast.
+    """
+
+    # Background
+    background_primary: str = "#0f172a"
+    background_secondary: str = "#1e293b"
+
+    # Text
+    text_primary: str = "#f8fafc"
+    text_secondary: str = "#94a3b8"
+    text_body: str = "#e2e8f0"
+    text_tertiary: str = "#64748b"
+
+    # Utility colors
+    arrow_color: str = "#64748b"
+    lifeline_color: str = "#475569"
+    highlight_color: str = "#60a5fa"
+    connection_color: str = "#475569"
+    glow_color: str = "rgba(59, 130, 246, 0.4)"
+
+    # Timeline gradient
+    gradient_start: str = "#3b82f6"
+    gradient_mid: str = "#8b5cf6"
+    gradient_end: str = "#f59e0b"
+
+    # Section/panel backgrounds
+    boundary_bg: str = "rgba(255,255,255,0.03)"
+    panel_bg: str = "rgba(255,255,255,0.04)"
+    edge_from_to_color: str = "#cbd5e1"
+
+    # Generic node colors (bg, border, text)
+    node_primary: tuple[str, str, str] = ("#2563eb", "#3b82f6", "#ffffff")
+    node_secondary: tuple[str, str, str] = ("#7c3aed", "#a78bfa", "#ffffff")
+    node_accent: tuple[str, str, str] = ("#f59e0b", "#fbbf24", "#1e293b")
+    node_warning: tuple[str, str, str] = ("#dc2626", "#f87171", "#ffffff")
+    node_success: tuple[str, str, str] = ("#047857", "#34d399", "#ffffff")
+    node_default: tuple[str, str, str] = ("#334155", "#475569", "#e2e8f0")
+
+    # C4-specific node colors (bg, border, text)
+    c4_person: tuple[str, str, str] = ("#1e40af", "#3b82f6", "#ffffff")
+    c4_system: tuple[str, str, str] = ("#374151", "#6b7280", "#f3f4f6")
+    c4_system_focus: tuple[str, str, str] = ("#1d4ed8", "#60a5fa", "#ffffff")
+    c4_container: tuple[str, str, str] = ("#15803d", "#22c55e", "#ffffff")
+    c4_component: tuple[str, str, str] = ("#7e22ce", "#a855f7", "#ffffff")
+    c4_code: tuple[str, str, str] = ("#92400e", "#f59e0b", "#ffffff")
+    c4_default: tuple[str, str, str] = ("#334155", "#475569", "#e2e8f0")
+
+
+THEMES: dict[str, ThemeTokens] = {
+    "c4-default-dark-v1": ThemeTokens(),
+}
+
+_DEFAULT_THEME = THEMES["c4-default-dark-v1"]
+
+
+def get_theme(
+    theme_id: str = "c4-default-dark-v1",
+    overrides: dict | None = None,
+) -> ThemeTokens:
+    """Resolve a theme by ID with optional token overrides.
+
+    Args:
+        theme_id: Named theme from ``THEMES`` registry.
+        overrides: Dict of token names to override values. List values for
+            node color fields are converted to tuples automatically.
+
+    Returns:
+        A ``ThemeTokens`` instance (possibly a modified copy).
+    """
+    if theme_id not in THEMES:
+        raise ValueError(
+            f"Unknown theme '{theme_id}'. Available: {list(THEMES.keys())}"
+        )
+    theme = THEMES[theme_id]
+    if overrides:
+        valid = {k: v for k, v in overrides.items() if hasattr(theme, k)}
+        # Convert list overrides to tuples for node color fields
+        for k, v in list(valid.items()):
+            if isinstance(v, list) and k.startswith(("node_", "c4_")):
+                valid[k] = tuple(v)
+        theme = dataclasses.replace(theme, **valid)
+    return theme
+
+
+# ---------------------------------------------------------------------------
+# Diagram type registry and models
+# ---------------------------------------------------------------------------
 
 DIAGRAM_TYPES = [
     "architecture",
@@ -76,16 +173,21 @@ class DiagramSpec:
     description: str = ""
 
 
-def _css_reset(width: int, height: int) -> str:
+def _css_reset(
+    width: int,
+    height: int,
+    theme: ThemeTokens | None = None,
+) -> str:
     """Shared CSS reset and base styles for all diagrams."""
+    t = theme or _DEFAULT_THEME
     return f"""
     * {{ margin: 0; padding: 0; box-sizing: border-box; }}
     body {{
         width: {width}px;
         height: {height}px;
         font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
-        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
-        color: #e2e8f0;
+        background: linear-gradient(135deg, {t.background_primary} 0%, {t.background_secondary} 100%);
+        color: {t.text_body};
         overflow: hidden;
     }}
     .diagram-container {{
@@ -98,13 +200,13 @@ def _css_reset(width: int, height: int) -> str:
     .diagram-title {{
         font-size: 36px;
         font-weight: 700;
-        color: #f8fafc;
+        color: {t.text_primary};
         margin-bottom: 8px;
         letter-spacing: -0.5px;
     }}
     .diagram-subtitle {{
         font-size: 16px;
-        color: #94a3b8;
+        color: {t.text_secondary};
         margin-bottom: 30px;
     }}
     .diagram-body {{
@@ -117,26 +219,21 @@ def _css_reset(width: int, height: int) -> str:
     """
 
 
-def _node_color(node_type: str) -> tuple[str, str, str]:
+def _node_color(
+    node_type: str,
+    theme: ThemeTokens | None = None,
+) -> tuple[str, str, str]:
     """Return (bg, border, text) colors for a node type.
 
     All combinations meet WCAG AA contrast ratio >= 4.5:1 for normal text.
-
-    | Type      | BG      | Text    | Ratio |
-    |-----------|---------|---------|-------|
-    | primary   | #2563eb | #ffffff | 5.17  |
-    | secondary | #7c3aed | #ffffff | 5.70  |
-    | accent    | #f59e0b | #1e293b | 6.81  |
-    | warning   | #dc2626 | #ffffff | 4.83  |
-    | success   | #047857 | #ffffff | 5.48  |
-    | default   | #334155 | #e2e8f0 | 8.40  |
     """
+    t = theme or _DEFAULT_THEME
     colors = {
-        "primary": ("#2563eb", "#3b82f6", "#ffffff"),
-        "secondary": ("#7c3aed", "#a78bfa", "#ffffff"),
-        "accent": ("#f59e0b", "#fbbf24", "#1e293b"),
-        "warning": ("#dc2626", "#f87171", "#ffffff"),
-        "success": ("#047857", "#34d399", "#ffffff"),
-        "default": ("#334155", "#475569", "#e2e8f0"),
+        "primary": t.node_primary,
+        "secondary": t.node_secondary,
+        "accent": t.node_accent,
+        "warning": t.node_warning,
+        "success": t.node_success,
+        "default": t.node_default,
     }
-    return colors.get(node_type, colors["default"])
+    return colors.get(node_type, t.node_default)

--- a/mcp-nano-banana/src/diagrams/c4.py
+++ b/mcp-nano-banana/src/diagrams/c4.py
@@ -7,46 +7,36 @@ Supports all four C4 levels:
   L4 Code - classes, modules, interfaces within a component
 
 Node types map to C4 concepts:
-  person       → Actor / User (rounded pill with icon)
-  system       → External System (grey)
-  system-focus → System of Interest (blue)
-  container    → Container (green)
-  component    → Component (purple)
-  code         → Code element (amber)
+  person       -> Actor / User (rounded pill with icon)
+  system       -> External System (grey)
+  system-focus -> System of Interest (blue)
+  container    -> Container (green)
+  component    -> Component (purple)
+  code         -> Code element (amber)
 
 Use the ``description`` field for technology labels (e.g., "Python / FastAPI").
 """
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _esc
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _DEFAULT_THEME
 
 
-# C4-specific color palette - all combos meet WCAG AA >= 4.5:1
-#
-# | Type         | BG      | Text    | Ratio |
-# |--------------|---------|---------|-------|
-# | person       | #1e40af | #ffffff | 8.72  |
-# | system       | #374151 | #f3f4f6 | 9.37  |
-# | system-focus | #1d4ed8 | #ffffff | 6.70  |
-# | container    | #15803d | #ffffff | 5.02  |
-# | component    | #7e22ce | #ffffff | 6.98  |
-# | code         | #92400e | #ffffff | 7.09  |
-_C4_COLORS = {
-    "person":       ("#1e40af", "#3b82f6", "#ffffff"),  # dark blue
-    "system":       ("#374151", "#6b7280", "#f3f4f6"),  # grey - external
-    "system-focus": ("#1d4ed8", "#60a5fa", "#ffffff"),  # blue - focus
-    "container":    ("#15803d", "#22c55e", "#ffffff"),  # green
-    "component":    ("#7e22ce", "#a855f7", "#ffffff"),  # purple
-    "code":         ("#92400e", "#f59e0b", "#ffffff"),  # amber - darkened bg, white text
-}
-
-_DEFAULT_COLOR = ("#334155", "#475569", "#e2e8f0")
-
-
-def _c4_color(node_type: str) -> tuple[str, str, str]:
+def _c4_color(
+    node_type: str,
+    theme: ThemeTokens | None = None,
+) -> tuple[str, str, str]:
     """Return (bg, border, text) for a C4 node type."""
-    return _C4_COLORS.get(node_type, _DEFAULT_COLOR)
+    t = theme or _DEFAULT_THEME
+    colors = {
+        "person": t.c4_person,
+        "system": t.c4_system,
+        "system-focus": t.c4_system_focus,
+        "container": t.c4_container,
+        "component": t.c4_component,
+        "code": t.c4_code,
+    }
+    return colors.get(node_type, t.c4_default)
 
 
 def _person_svg(fill: str = "#ffffff") -> str:
@@ -66,6 +56,7 @@ def generate_c4_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML C4 model diagram.
 
@@ -74,21 +65,22 @@ def generate_c4_diagram(
     Boundary groupings are inferred from node types - nodes of the same
     ``type`` are visually grouped inside a dashed boundary box.
     """
-    css = _css_reset(width, height)
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
 
-    # ── group nodes by type for boundary rendering ──────────────────
+    # -- group nodes by type for boundary rendering --
     type_order = ["person", "system-focus", "container", "component", "code", "system"]
     groups: dict[str, list] = {}
     for node in spec.nodes:
         groups.setdefault(node.type, []).append(node)
 
-    # ── build node HTML ─────────────────────────────────────────────
+    # -- build node HTML --
     nodes_by_id: dict[str, int] = {}
     all_nodes_html = []
 
     for idx, node in enumerate(spec.nodes):
         nodes_by_id[node.id] = idx
-        bg, border, text = _c4_color(node.type)
+        bg, border, text = _c4_color(node.type, t)
         is_person = node.type == "person"
 
         icon_html = _person_svg(text) if is_person else ""
@@ -109,8 +101,7 @@ def generate_c4_diagram(
         </div>
         """)
 
-    # ── build boundary wrappers ─────────────────────────────────────
-    # Group nodes into boundary sections for visual clarity
+    # -- build boundary wrappers --
     boundary_labels = {
         "person": "Actors",
         "system": "External Systems",
@@ -123,10 +114,10 @@ def generate_c4_diagram(
     sections_html = []
     rendered_ids: set[str] = set()
 
-    for t in type_order:
-        if t not in groups:
+    for tp in type_order:
+        if tp not in groups:
             continue
-        g_nodes = groups[t]
+        g_nodes = groups[tp]
         if not g_nodes:
             continue
 
@@ -138,11 +129,10 @@ def generate_c4_diagram(
             if node.id in node_ids
         )
 
-        _, border, _ = _c4_color(t)
-        label = boundary_labels.get(t, t.title())
+        _, border, _ = _c4_color(tp, t)
+        label = boundary_labels.get(tp, tp.title())
 
-        if t in ("person", "system"):
-            # No boundary box for external actors/systems
+        if tp in ("person", "system"):
             sections_html.append(f"""
             <div class="c4-section c4-section-open">
                 <div class="c4-section-label" style="color:{border}">{label}</div>
@@ -169,7 +159,7 @@ def generate_c4_diagram(
         </div>
         """)
 
-    # ── build edge labels overlay ───────────────────────────────────
+    # -- build edge labels overlay --
     edge_labels_html = []
     for edge in spec.edges:
         dash = ""
@@ -238,7 +228,7 @@ def generate_c4_diagram(
 }}
 .c4-section-bounded {{
     border: 2px dashed;
-    background: rgba(255,255,255,0.03);
+    background: {t.boundary_bg};
 }}
 .c4-section-open {{
     border: none;
@@ -282,7 +272,7 @@ def generate_c4_diagram(
     font-style: italic;
 }}
 .c4-edges-panel {{
-    background: rgba(255,255,255,0.04);
+    background: {t.panel_bg};
     border-radius: 8px;
     padding: 12px 20px;
     margin-top: 8px;
@@ -292,12 +282,12 @@ def generate_c4_diagram(
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1.5px;
-    color: #64748b;
+    color: {t.text_tertiary};
     margin-bottom: 8px;
 }}
 .c4-edge {{
     font-size: 13px;
-    color: #94a3b8;
+    color: {t.text_secondary};
     padding: 3px 0;
     display: flex;
     align-items: center;
@@ -305,14 +295,14 @@ def generate_c4_diagram(
 }}
 .c4-edge-from, .c4-edge-to {{
     font-weight: 600;
-    color: #cbd5e1;
+    color: {t.edge_from_to_color};
 }}
 .c4-edge-arrow {{
-    color: #64748b;
+    color: {t.arrow_color};
     font-size: 16px;
 }}
 .c4-edge-label {{
-    color: #60a5fa;
+    color: {t.highlight_color};
     font-style: italic;
 }}
 </style>

--- a/mcp-nano-banana/src/diagrams/flowchart.py
+++ b/mcp-nano-banana/src/diagrams/flowchart.py
@@ -2,24 +2,27 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _node_color
 
 
 def generate_flowchart_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML flowchart with connected process steps.
 
     Renders nodes as rounded rectangles connected by arrows,
     arranged in a top-down or left-right flow.
     """
-    css = _css_reset(width, height)
+    from diagrams.base import _DEFAULT_THEME
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
 
     nodes_html = []
     for i, node in enumerate(spec.nodes):
-        bg, border, text = _node_color(node.type)
+        bg, border, text = _node_color(node.type, t)
         shape_class = "flow-diamond" if node.type == "warning" else "flow-rect"
         desc_html = f'<div class="flow-desc">{_esc(node.description)}</div>' if node.description else ""
         nodes_html.append(f"""
@@ -88,7 +91,7 @@ def generate_flowchart_diagram(
 }}
 .flow-arrow {{
     font-size: 28px;
-    color: #64748b;
+    color: {t.arrow_color};
     line-height: 1;
     padding: 4px 0;
 }}

--- a/mcp-nano-banana/src/diagrams/mindmap.py
+++ b/mcp-nano-banana/src/diagrams/mindmap.py
@@ -4,19 +4,22 @@ from __future__ import annotations
 
 import math
 
-from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _node_color
 
 
 def generate_mindmap_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML mind map with a central topic and radiating branches.
 
     First node is the central topic; remaining nodes radiate outward.
     """
-    css = _css_reset(width, height)
+    from diagrams.base import _DEFAULT_THEME
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
 
     if not spec.nodes:
         return _empty_diagram(spec.title, width, height, css)
@@ -29,7 +32,7 @@ def generate_mindmap_diagram(
     radius = min(cx, cy) - 100
 
     # Central node
-    bg, border, text = _node_color(center.type if center.type != "default" else "primary")
+    bg, border, text = _node_color(center.type if center.type != "default" else "primary", t)
     center_html = f"""
     <div class="mm-center" style="
         left: {cx - 80}px; top: {cy - 40}px;
@@ -46,7 +49,7 @@ def generate_mindmap_diagram(
         angle = (2 * math.pi * i / num_branches) - math.pi / 2
         nx = int(cx + radius * math.cos(angle))
         ny = int(cy + radius * math.sin(angle))
-        bg, border, text = _node_color(node.type)
+        bg, border, text = _node_color(node.type, t)
         desc_html = f'<div class="mm-desc">{_esc(node.description)}</div>' if node.description else ""
 
         branch_html.append(f"""
@@ -85,7 +88,7 @@ def generate_mindmap_diagram(
     border-radius: 50%;
     border: 3px solid;
     text-align: center;
-    box-shadow: 0 0 24px rgba(59, 130, 246, 0.4);
+    box-shadow: 0 0 24px {t.glow_color};
     z-index: 3;
     min-width: 160px;
 }}

--- a/mcp-nano-banana/src/diagrams/orgchart.py
+++ b/mcp-nano-banana/src/diagrams/orgchart.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _node_color
 
 
 def generate_orgchart_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML org chart / hierarchy diagram.
 
     Nodes are arranged in a tree layout using CSS flexbox nesting.
     Edges define parent-child relationships.
     """
-    css = _css_reset(width, height)
+    from diagrams.base import _DEFAULT_THEME
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
 
     # Build tree from edges
     children_map: dict[str, list[str]] = {}
@@ -35,7 +38,7 @@ def generate_orgchart_diagram(
         node = node_map.get(node_id)
         if not node:
             return ""
-        bg, border, text = _node_color(node.type)
+        bg, border, text = _node_color(node.type, t)
         desc_html = f'<div class="org-desc">{_esc(node.description)}</div>' if node.description else ""
 
         kids = children_map.get(node_id, [])
@@ -98,7 +101,7 @@ def generate_orgchart_diagram(
     gap: 24px;
     margin-top: 20px;
     padding-top: 20px;
-    border-top: 2px solid #475569;
+    border-top: 2px solid {t.connection_color};
     position: relative;
 }}
 .org-children::before {{
@@ -108,7 +111,7 @@ def generate_orgchart_diagram(
     left: 50%;
     width: 0;
     height: 20px;
-    border-left: 2px solid #475569;
+    border-left: 2px solid {t.connection_color};
     transform: translateX(-50%);
     top: -20px;
 }}

--- a/mcp-nano-banana/src/diagrams/sequence.py
+++ b/mcp-nano-banana/src/diagrams/sequence.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _node_color
 
 
 def generate_sequence_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML sequence diagram showing interactions between participants.
 
     Nodes are participants (columns), edges are messages (rows).
     """
-    css = _css_reset(width, height)
+    from diagrams.base import _DEFAULT_THEME
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
 
     participants = spec.nodes
     messages = spec.edges
@@ -28,7 +31,7 @@ def generate_sequence_diagram(
     # Build participant headers
     headers_html = []
     for i, p in enumerate(participants):
-        bg, border, text = _node_color(p.type)
+        bg, border, text = _node_color(p.type, t)
         headers_html.append(f"""
         <div class="seq-participant" style="
             width: {col_width}px;
@@ -48,7 +51,7 @@ def generate_sequence_diagram(
     lifelines_svg = ""
     for i in range(num_participants):
         x = 60 + i * lifeline_gap + lifeline_gap // 2
-        lifelines_svg += f'<line x1="{x}" y1="{lifeline_start_y}" x2="{x}" y2="{lifeline_end_y}" stroke="#475569" stroke-width="2" stroke-dasharray="6,4"/>'
+        lifelines_svg += f'<line x1="{x}" y1="{lifeline_start_y}" x2="{x}" y2="{lifeline_end_y}" stroke="{t.lifeline_color}" stroke-width="2" stroke-dasharray="6,4"/>'
 
     # Build messages
     messages_svg = ""
@@ -66,15 +69,15 @@ def generate_sequence_diagram(
 
         # Arrow
         if x1 != x2:
-            messages_svg += f'<line x1="{x1}" y1="{msg_y}" x2="{x2}" y2="{msg_y}" stroke="#60a5fa" stroke-width="2" marker-end="url(#seq-arrow)"/>'
+            messages_svg += f'<line x1="{x1}" y1="{msg_y}" x2="{x2}" y2="{msg_y}" stroke="{t.highlight_color}" stroke-width="2" marker-end="url(#seq-arrow)"/>'
         else:
             # Self-message (loop)
-            messages_svg += f'<path d="M {x1} {msg_y} C {x1 + 60} {msg_y - 15}, {x1 + 60} {msg_y + 15}, {x1} {msg_y + 20}" stroke="#60a5fa" stroke-width="2" fill="none" marker-end="url(#seq-arrow)"/>'
+            messages_svg += f'<path d="M {x1} {msg_y} C {x1 + 60} {msg_y - 15}, {x1 + 60} {msg_y + 15}, {x1} {msg_y + 20}" stroke="{t.highlight_color}" stroke-width="2" fill="none" marker-end="url(#seq-arrow)"/>'
 
         # Label
         label_x = (x1 + x2) // 2
         label_y = msg_y - 8
-        messages_svg += f'<text x="{label_x}" y="{label_y}" text-anchor="middle" fill="#e2e8f0" font-size="13" font-family="Segoe UI, system-ui, sans-serif">{_esc(edge.label)}</text>'
+        messages_svg += f'<text x="{label_x}" y="{label_y}" text-anchor="middle" fill="{t.text_body}" font-size="13" font-family="Segoe UI, system-ui, sans-serif">{_esc(edge.label)}</text>'
 
         msg_y += msg_step
 
@@ -133,7 +136,7 @@ def generate_sequence_diagram(
             <svg width="100%" height="100%" viewBox="0 0 {width - 80} {height - 200}">
                 <defs>
                     <marker id="seq-arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-                        <polygon points="0 0, 10 3.5, 0 7" fill="#60a5fa"/>
+                        <polygon points="0 0, 10 3.5, 0 7" fill="{t.highlight_color}"/>
                     </marker>
                 </defs>
                 {lifelines_svg}

--- a/mcp-nano-banana/src/diagrams/timeline.py
+++ b/mcp-nano-banana/src/diagrams/timeline.py
@@ -2,24 +2,27 @@
 
 from __future__ import annotations
 
-from diagrams.base import DiagramSpec, _css_reset, _esc, _node_color
+from diagrams.base import DiagramSpec, ThemeTokens, _css_reset, _esc, _node_color
 
 
 def generate_timeline_diagram(
     spec: DiagramSpec,
     width: int = 1920,
     height: int = 1080,
+    theme: ThemeTokens | None = None,
 ) -> str:
     """Generate an HTML timeline/roadmap visualization.
 
     Nodes are milestones arranged along a horizontal timeline.
     """
-    css = _css_reset(width, height)
+    from diagrams.base import _DEFAULT_THEME
+    t = theme or _DEFAULT_THEME
+    css = _css_reset(width, height, t)
     milestones = spec.nodes
 
     items_html = []
     for i, node in enumerate(milestones):
-        bg, border, text = _node_color(node.type)
+        bg, border, text = _node_color(node.type, t)
         desc_html = f'<div class="tl-desc">{_esc(node.description)}</div>' if node.description else ""
         side = "top" if i % 2 == 0 else "bottom"
         items_html.append(f"""
@@ -57,7 +60,7 @@ def generate_timeline_diagram(
     left: 40px;
     right: 40px;
     height: 4px;
-    background: linear-gradient(90deg, #3b82f6, #8b5cf6, #f59e0b);
+    background: linear-gradient(90deg, {t.gradient_start}, {t.gradient_mid}, {t.gradient_end});
     border-radius: 2px;
     transform: translateY(-50%);
 }}
@@ -81,7 +84,7 @@ def generate_timeline_diagram(
     height: 18px;
     border-radius: 50%;
     border: 3px solid;
-    box-shadow: 0 0 12px rgba(59, 130, 246, 0.4);
+    box-shadow: 0 0 12px {t.glow_color};
 }}
 .tl-card {{
     padding: 14px 18px;

--- a/mcp-nano-banana/src/diagrams/validate.py
+++ b/mcp-nano-banana/src/diagrams/validate.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from diagrams.base import _node_color
-from diagrams.c4 import _C4_COLORS, _DEFAULT_COLOR
+from diagrams.base import ThemeTokens, _DEFAULT_THEME, _node_color, get_theme
 
 
 @dataclass
@@ -60,11 +59,21 @@ def _contrast_ratio(fg_hex: str, bg_hex: str) -> float:
 def _get_palette_colors(
     diagram_type: str,
     node_type: str,
+    theme: ThemeTokens | None = None,
 ) -> tuple[str, str, str]:
     """Get (bg, border, text) colors for a given diagram/node type combo."""
+    t = theme or _DEFAULT_THEME
     if diagram_type == "c4":
-        return _C4_COLORS.get(node_type, _DEFAULT_COLOR)
-    return _node_color(node_type)
+        c4_colors = {
+            "person": t.c4_person,
+            "system": t.c4_system,
+            "system-focus": t.c4_system_focus,
+            "container": t.c4_container,
+            "component": t.c4_component,
+            "code": t.c4_code,
+        }
+        return c4_colors.get(node_type, t.c4_default)
+    return _node_color(node_type, t)
 
 
 def score_diagram_density(
@@ -120,6 +129,7 @@ def validate_diagram(
     width: int = 1920,
     height: int = 1080,
     diagram_type: str = "c4",
+    theme_id: str = "c4-default-dark-v1",
 ) -> dict:
     """Validate a diagram spec for quality issues.
 
@@ -128,6 +138,14 @@ def validate_diagram(
         MEDIUM: readability, orphan_nodes, contrast
         LOW: long_labels
 
+    Args:
+        nodes: List of node dicts with id, label, type, etc.
+        edges: List of edge dicts with source, target, label, style.
+        width: Viewport width in pixels.
+        height: Viewport height in pixels.
+        diagram_type: Diagram type for palette-specific checks.
+        theme_id: Named theme for palette-specific contrast checks.
+
     Returns:
         dict with passed (bool), issue_count, high_severity,
         issues (list of dicts), suggestions (list of str),
@@ -135,6 +153,7 @@ def validate_diagram(
     """
     edges = edges or []
     issues: list[_ValidationIssue] = []
+    theme = get_theme(theme_id)
 
     node_ids = [n.get("id", f"n{i}") for i, n in enumerate(nodes)]
     node_id_set = set(node_ids)
@@ -229,7 +248,7 @@ def validate_diagram(
         if ntype in checked_types:
             continue
         checked_types.add(ntype)
-        bg, _border, text = _get_palette_colors(diagram_type, ntype)
+        bg, _border, text = _get_palette_colors(diagram_type, ntype, theme)
         ratio = _contrast_ratio(text, bg)
         if ratio < 4.5:
             issues.append(_ValidationIssue(

--- a/mcp-nano-banana/src/server.py
+++ b/mcp-nano-banana/src/server.py
@@ -23,6 +23,8 @@ from diagrams import (
     DiagramSpec,
     DiagramNode,
     DiagramEdge,
+    THEMES,
+    get_theme,
     generate_architecture_diagram,
     generate_c4_diagram,
     generate_flowchart_diagram,
@@ -87,6 +89,7 @@ async def list_diagram_types() -> dict:
             "height": Config.DIAGRAM_HEIGHT,
         },
         "output_formats": ["html", "pptx"],
+        "available_themes": list(THEMES.keys()),
     }
 
 
@@ -100,6 +103,9 @@ async def generate_diagram(
     width: Optional[int] = None,
     height: Optional[int] = None,
     save_path: Optional[str] = None,
+    theme_id: str = "c4-default-dark-v1",
+    theme_tokens: Optional[dict] = None,
+    diagram_set_id: Optional[str] = None,
 ) -> dict:
     """Generate an HTML diagram at presentation quality (1920x1080).
 
@@ -124,6 +130,12 @@ async def generate_diagram(
         width: Diagram width in pixels (default: 1920).
         height: Diagram height in pixels (default: 1080).
         save_path: Optional file path to save the HTML. If not provided, returns HTML as string.
+        theme_id: Named theme for consistent colors across diagrams. Default: "c4-default-dark-v1".
+        theme_tokens: Optional dict of token overrides to customize the named theme.
+            Keys match ThemeTokens fields (e.g. background_primary, node_primary, c4_person).
+            Node color fields accept [bg, border, text] lists.
+        diagram_set_id: Optional identifier to group related diagrams (e.g. all L1-L4 C4 diagrams).
+            Returned in metadata for tracking; ensures grouped diagrams share the same theme.
 
     Returns:
         dict with html content, file path (if saved), and metadata.
@@ -132,6 +144,15 @@ async def generate_diagram(
         return {
             "success": False,
             "error": f"Unknown diagram type '{diagram_type}'. Use list_diagram_types to see options.",
+        }
+
+    # Resolve theme
+    try:
+        theme = get_theme(theme_id, overrides=theme_tokens)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
         }
 
     w = width or Config.DIAGRAM_WIDTH
@@ -170,7 +191,7 @@ async def generate_diagram(
 
     # Generate HTML
     generator = _GENERATORS[diagram_type]
-    html = generator(spec, width=w, height=h)
+    html = generator(spec, width=w, height=h, theme=theme)
 
     # Run validation and include warnings
     validation = _validate_diagram_impl(
@@ -179,6 +200,7 @@ async def generate_diagram(
         width=w,
         height=h,
         diagram_type=diagram_type,
+        theme_id=theme_id,
     )
     warnings = [
         iss for iss in validation.get("issues", [])
@@ -190,7 +212,11 @@ async def generate_diagram(
         "dimensions": {"width": w, "height": h},
         "node_count": len(parsed_nodes),
         "edge_count": len(parsed_edges),
+        "theme_id": theme_id,
     }
+
+    if diagram_set_id:
+        result["diagram_set_id"] = diagram_set_id
 
     # Include density scoring metadata
     if "density" in validation:
@@ -319,6 +345,7 @@ async def validate_diagram(
     width: int = 1920,
     height: int = 1080,
     diagram_type: str = "c4",
+    theme_id: str = "c4-default-dark-v1",
 ) -> dict:
     """Validate a diagram spec for quality issues before or after generation.
 
@@ -340,6 +367,7 @@ async def validate_diagram(
         width: Viewport width in pixels (default: 1920).
         height: Viewport height in pixels (default: 1080).
         diagram_type: Diagram type for palette-specific checks (default: c4).
+        theme_id: Named theme for palette-specific contrast checks (default: c4-default-dark-v1).
 
     Returns:
         dict with passed (bool), issue_count, high_severity, issues list,
@@ -351,6 +379,7 @@ async def validate_diagram(
         width=width,
         height=height,
         diagram_type=diagram_type,
+        theme_id=theme_id,
     )
 
 


### PR DESCRIPTION
## Summary

- Add `ThemeTokens` dataclass in `base.py` with 30+ color tokens covering backgrounds, text, node types (generic + C4), utility colors (arrows, lifelines, glows, gradients), and section/panel backgrounds
- Add `THEMES` registry with `c4-default-dark-v1` default theme and `get_theme()` resolver supporting token overrides
- Update all 7 diagram generators (architecture, c4, flowchart, sequence, orgchart, timeline, mindmap) to accept optional `theme` parameter, replacing all hardcoded color values with token lookups
- Add `theme_id`, `theme_tokens`, and `diagram_set_id` parameters to `generate_diagram` MCP tool
- Add `theme_id` parameter to `validate_diagram` MCP tool for theme-aware contrast checks
- Update `list_diagram_types` to include available themes
- Update README.md with theme system documentation, C4 diagram type, and full tool list

## Test plan

- [x] All 385 existing tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] All module imports verified
- [x] Theme resolution with overrides verified (list-to-tuple conversion for node colors)
- [x] All 7 generators produce correct HTML with theme tokens
- [x] Custom theme overrides propagate to generated HTML
- [x] Backward compatible - all parameters have defaults matching previous hardcoded values

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)