### PR TITLE
feat(nano-banana): summary + detail split strategy for large diagrams (Closes #263)

### DIFF
--- a/.claude/commands/documentation/c4.md
+++ b/.claude/commands/documentation/c4.md
@@ -1,6 +1,6 @@
 ---
 description: Generate C4 architecture diagrams for the current project (all 4 levels, one per container/component)
-allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
+allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__split_diagram, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
 ---
 
 # C4 Architecture Diagram Generation
@@ -188,6 +188,51 @@ for container in containers_for_l3:
 - Each L3 should have 5-15 nodes (components within one container)
 - Include edges to components in OTHER containers as external references (use `system` type for external container nodes)
 - Use descriptive IDs prefixed with the container slug to avoid collisions across diagrams
+
+#### Density-Aware Splitting for L3/L4
+
+After calling `generate_diagram`, check the `density` field in the response. If `density.status` is `"overflow"` or `"critical"` (node count exceeds ~15), use `split_diagram` instead to automatically produce summary + detail sub-diagrams:
+
+```
+# Check density from the generate_diagram response
+if result.density.status in ("overflow", "critical"):
+    # Re-generate using split_diagram for automatic splitting
+    split_result = split_diagram(
+        diagram_type="c4",
+        title="L3 Component - {container.label}",
+        description="Components within {container.label}",
+        nodes=[...],  # same nodes as above
+        edges=[...],
+        max_nodes_per_page=15,
+        strategy="c4_boundary",  # groups by C4 node type
+        save_path="{DOCS_DIR}/c4-l3-{slug}.html",
+    )
+
+    # split_diagram produces:
+    #   c4-l3-{slug}.html           (summary - one node per cluster)
+    #   c4-l3-{slug}-detail-1.html  (detail page 1)
+    #   c4-l3-{slug}-detail-2.html  (detail page 2)
+    #   ...
+
+    # Add ALL generated files to the manifest
+    for diagram in split_result.diagrams:
+        generated_diagrams.append({
+            "id": "l3-{slug}" if diagram.role == "summary" else "l3-{slug}-detail-{diagram.index}",
+            "level": "L3",
+            "title": diagram.title,
+            "file": os.path.basename(diagram.file_path),
+            "node_count": diagram.node_count,
+            "edge_count": diagram.edge_count,
+            "parent": "l2-container",
+            "container_id": container.id,
+            "split_role": diagram.role,  # "summary" or "detail"
+        })
+```
+
+Available clustering strategies:
+- `c4_boundary` - groups by C4 node type (best for C4 diagrams)
+- `connectivity` - groups by graph connectivity (connected components)
+- `type_group` - groups by generic node type
 
 ### Step 5: Generate L4 Diagrams (Top 3 Components Per Container)
 

--- a/mcp-nano-banana/src/diagrams/__init__.py
+++ b/mcp-nano-banana/src/diagrams/__init__.py
@@ -9,6 +9,7 @@ from diagrams.timeline import generate_timeline_diagram
 from diagrams.mindmap import generate_mindmap_diagram
 from diagrams.base import DIAGRAM_TYPES, DiagramSpec, DiagramNode, DiagramEdge
 from diagrams.validate import validate_diagram, score_diagram_density
+from diagrams.split import auto_split_diagram, split_save_paths, cluster_nodes
 
 __all__ = [
     "generate_architecture_diagram",
@@ -20,6 +21,9 @@ __all__ = [
     "generate_mindmap_diagram",
     "validate_diagram",
     "score_diagram_density",
+    "auto_split_diagram",
+    "split_save_paths",
+    "cluster_nodes",
     "DIAGRAM_TYPES",
     "DiagramSpec",
     "DiagramNode",

--- a/mcp-nano-banana/src/diagrams/split.py
+++ b/mcp-nano-banana/src/diagrams/split.py
@@ -1,0 +1,328 @@
+"""Auto-split large diagrams into summary + detail sub-diagrams.
+
+When a diagram has too many nodes to render legibly at 1920x1080, this module
+splits it into a summary diagram (showing clusters as single nodes) and detail
+diagrams (one per cluster with full node detail).
+
+Clustering strategies:
+  - c4_boundary: Group by C4 node type (person, system, container, etc.)
+  - connectivity: Group by connected components in the edge graph
+  - type_group: Group by generic node type (default, primary, secondary, ...)
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+from diagrams.base import DiagramEdge, DiagramNode, DiagramSpec
+
+
+@dataclass
+class Cluster:
+    """A group of related nodes within a diagram."""
+
+    name: str
+    node_ids: list[str] = field(default_factory=list)
+
+
+# -- Clustering strategies ---------------------------------------------------
+
+
+def _cluster_c4_boundary(spec: DiagramSpec) -> list[Cluster]:
+    """Group nodes by their C4 type (person, system, container, etc.)."""
+    groups: dict[str, list[str]] = defaultdict(list)
+    for node in spec.nodes:
+        groups[node.type].append(node.id)
+
+    label_map = {
+        "person": "Actors",
+        "system": "External Systems",
+        "system-focus": "System Boundary",
+        "container": "Containers",
+        "component": "Components",
+        "code": "Code",
+    }
+
+    clusters: list[Cluster] = []
+    for ntype, ids in groups.items():
+        name = label_map.get(ntype, ntype.replace("-", " ").title())
+        clusters.append(Cluster(name=name, node_ids=ids))
+    return clusters
+
+
+def _cluster_connectivity(spec: DiagramSpec) -> list[Cluster]:
+    """Group nodes by connected components (graph traversal)."""
+    adj: dict[str, set[str]] = defaultdict(set)
+    all_ids = {n.id for n in spec.nodes}
+
+    for edge in spec.edges:
+        if edge.source in all_ids and edge.target in all_ids:
+            adj[edge.source].add(edge.target)
+            adj[edge.target].add(edge.source)
+
+    visited: set[str] = set()
+    clusters: list[Cluster] = []
+    idx = 0
+
+    for node in spec.nodes:
+        if node.id in visited:
+            continue
+        # BFS to find connected component
+        component: list[str] = []
+        queue = [node.id]
+        while queue:
+            nid = queue.pop(0)
+            if nid in visited:
+                continue
+            visited.add(nid)
+            component.append(nid)
+            for neighbor in adj.get(nid, set()):
+                if neighbor not in visited:
+                    queue.append(neighbor)
+        idx += 1
+        clusters.append(Cluster(name=f"Group {idx}", node_ids=component))
+
+    return clusters
+
+
+def _cluster_type_group(spec: DiagramSpec) -> list[Cluster]:
+    """Group nodes by their generic type field."""
+    groups: dict[str, list[str]] = defaultdict(list)
+    for node in spec.nodes:
+        groups[node.type].append(node.id)
+
+    return [
+        Cluster(name=ntype.replace("-", " ").title(), node_ids=ids)
+        for ntype, ids in groups.items()
+    ]
+
+
+_STRATEGIES = {
+    "c4_boundary": _cluster_c4_boundary,
+    "connectivity": _cluster_connectivity,
+    "type_group": _cluster_type_group,
+}
+
+
+# -- Core split logic --------------------------------------------------------
+
+
+def cluster_nodes(
+    spec: DiagramSpec,
+    strategy: str = "c4_boundary",
+) -> list[Cluster]:
+    """Partition nodes into clusters using the given strategy.
+
+    Args:
+        spec: The diagram spec to cluster.
+        strategy: One of 'c4_boundary', 'connectivity', 'type_group'.
+
+    Returns:
+        List of Cluster objects, each containing a name and list of node IDs.
+
+    Raises:
+        ValueError: If the strategy name is not recognized.
+    """
+    fn = _STRATEGIES.get(strategy)
+    if fn is None:
+        valid = ", ".join(sorted(_STRATEGIES))
+        raise ValueError(f"Unknown clustering strategy '{strategy}'. Valid: {valid}")
+    return fn(spec)
+
+
+def build_summary(spec: DiagramSpec, clusters: list[Cluster]) -> DiagramSpec:
+    """Build a summary diagram where each cluster becomes a single node.
+
+    Inter-cluster edges are preserved (collapsed to cluster-level connections).
+    The summary inherits the original spec's title with a ' (Summary)' suffix.
+    """
+    # Map node IDs to their cluster index
+    node_to_cluster: dict[str, int] = {}
+    for idx, cluster in enumerate(clusters):
+        for nid in cluster.node_ids:
+            node_to_cluster[nid] = idx
+
+    # Build lookup for original nodes
+    nodes_by_id: dict[str, DiagramNode] = {n.id: n for n in spec.nodes}
+
+    # Create summary nodes (one per cluster)
+    summary_nodes: list[DiagramNode] = []
+    for idx, cluster in enumerate(clusters):
+        # Use the dominant type from the cluster's nodes
+        type_counts: dict[str, int] = defaultdict(int)
+        for nid in cluster.node_ids:
+            orig = nodes_by_id.get(nid)
+            if orig:
+                type_counts[orig.type] += 1
+        dominant_type = max(type_counts, key=type_counts.get) if type_counts else "default"
+
+        summary_nodes.append(DiagramNode(
+            id=f"cluster-{idx}",
+            label=cluster.name,
+            type=dominant_type,
+            description=f"{len(cluster.node_ids)} elements",
+        ))
+
+    # Collapse edges to cluster-level (deduplicate)
+    seen_edges: set[tuple[str, str]] = set()
+    summary_edges: list[DiagramEdge] = []
+    for edge in spec.edges:
+        src_cluster = node_to_cluster.get(edge.source)
+        tgt_cluster = node_to_cluster.get(edge.target)
+        if src_cluster is None or tgt_cluster is None:
+            continue
+        if src_cluster == tgt_cluster:
+            continue  # Internal edge, skip in summary
+        key = (f"cluster-{src_cluster}", f"cluster-{tgt_cluster}")
+        if key in seen_edges:
+            continue
+        seen_edges.add(key)
+        summary_edges.append(DiagramEdge(
+            source=key[0],
+            target=key[1],
+            label="",
+            style="solid",
+        ))
+
+    return DiagramSpec(
+        title=f"{spec.title} (Summary)",
+        nodes=summary_nodes,
+        edges=summary_edges,
+        description=spec.description,
+    )
+
+
+def build_detail(
+    spec: DiagramSpec,
+    cluster: Cluster,
+    cluster_index: int,
+) -> DiagramSpec:
+    """Build a detail diagram for a single cluster.
+
+    Includes all nodes in the cluster plus edges between them. External
+    connections (edges to nodes outside the cluster) are represented as
+    stub nodes with type 'system' so the viewer sees the boundary.
+    """
+    cluster_ids = set(cluster.node_ids)
+    nodes_by_id: dict[str, DiagramNode] = {n.id: n for n in spec.nodes}
+
+    # Collect nodes in this cluster
+    detail_nodes: list[DiagramNode] = [
+        nodes_by_id[nid] for nid in cluster.node_ids if nid in nodes_by_id
+    ]
+
+    # Collect edges and identify external stubs
+    detail_edges: list[DiagramEdge] = []
+    external_stubs: dict[str, DiagramNode] = {}
+
+    for edge in spec.edges:
+        src_in = edge.source in cluster_ids
+        tgt_in = edge.target in cluster_ids
+
+        if src_in and tgt_in:
+            detail_edges.append(edge)
+        elif src_in and not tgt_in:
+            # External target - create stub if not already present
+            if edge.target not in external_stubs:
+                orig = nodes_by_id.get(edge.target)
+                stub_label = orig.label if orig else edge.target
+                external_stubs[edge.target] = DiagramNode(
+                    id=edge.target,
+                    label=f"{stub_label} (external)",
+                    type="system",
+                    description="",
+                )
+            detail_edges.append(edge)
+        elif not src_in and tgt_in:
+            # External source - create stub if not already present
+            if edge.source not in external_stubs:
+                orig = nodes_by_id.get(edge.source)
+                stub_label = orig.label if orig else edge.source
+                external_stubs[edge.source] = DiagramNode(
+                    id=edge.source,
+                    label=f"{stub_label} (external)",
+                    type="system",
+                    description="",
+                )
+            detail_edges.append(edge)
+
+    all_nodes = detail_nodes + list(external_stubs.values())
+
+    return DiagramSpec(
+        title=f"{spec.title} - {cluster.name}",
+        nodes=all_nodes,
+        edges=detail_edges,
+        description=f"Detail view: {cluster.name}",
+    )
+
+
+def auto_split_diagram(
+    spec: DiagramSpec,
+    max_nodes_per_page: int = 15,
+    strategy: str = "c4_boundary",
+) -> list[DiagramSpec]:
+    """Split a large diagram into summary + detail specs.
+
+    If the diagram has fewer nodes than ``max_nodes_per_page``, returns it
+    unchanged as a single-element list.
+
+    Otherwise, clusters the nodes using the given strategy, then produces:
+      - A summary diagram with one node per cluster
+      - A detail diagram for each cluster
+
+    Args:
+        spec: The original DiagramSpec to split.
+        max_nodes_per_page: Maximum nodes before triggering a split.
+        strategy: Clustering strategy - 'c4_boundary', 'connectivity', or 'type_group'.
+
+    Returns:
+        List of DiagramSpec objects. First element is the summary (if split),
+        followed by detail specs. Returns ``[spec]`` if no split is needed.
+    """
+    if len(spec.nodes) <= max_nodes_per_page:
+        return [spec]
+
+    clusters = cluster_nodes(spec, strategy)
+
+    # If clustering produces only one cluster, no benefit in splitting
+    if len(clusters) <= 1:
+        return [spec]
+
+    summary = build_summary(spec, clusters)
+    details = [
+        build_detail(spec, cluster, idx)
+        for idx, cluster in enumerate(clusters)
+    ]
+    return [summary] + details
+
+
+def split_save_paths(base_path: str, count: int) -> list[str]:
+    """Generate file paths for split diagram output.
+
+    Given a base path like 'docs/architecture/c4-l3-api-server.html',
+    produces:
+      - 'docs/architecture/c4-l3-api-server.html'           (summary)
+      - 'docs/architecture/c4-l3-api-server-detail-1.html'  (detail 1)
+      - 'docs/architecture/c4-l3-api-server-detail-2.html'  (detail 2)
+      - ...
+
+    Args:
+        base_path: The original file path (before splitting).
+        count: Total number of specs (1 summary + N details).
+
+    Returns:
+        List of file path strings, one per spec.
+    """
+    if count <= 1:
+        return [base_path]
+
+    p = PurePosixPath(base_path)
+    stem = p.stem
+    suffix = p.suffix
+
+    paths = [base_path]  # summary keeps original name
+    for i in range(1, count):
+        paths.append(str(p.with_name(f"{stem}-detail-{i}{suffix}")))
+    return paths

--- a/mcp-nano-banana/src/server.py
+++ b/mcp-nano-banana/src/server.py
@@ -31,6 +31,8 @@ from diagrams import (
     generate_timeline_diagram,
     generate_mindmap_diagram,
     validate_diagram as _validate_diagram_impl,
+    auto_split_diagram as _auto_split_impl,
+    split_save_paths as _split_save_paths_impl,
 )
 from pptx_builder import create_presentation, validate_slides
 
@@ -352,6 +354,155 @@ async def validate_diagram(
         height=height,
         diagram_type=diagram_type,
     )
+
+
+@mcp.tool()
+async def split_diagram(
+    diagram_type: str,
+    title: str,
+    nodes: list[dict],
+    edges: Optional[list[dict]] = None,
+    description: str = "",
+    max_nodes_per_page: int = 15,
+    strategy: str = "c4_boundary",
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+    save_path: Optional[str] = None,
+) -> dict:
+    """Split a large diagram into summary + detail sub-diagrams.
+
+    When a diagram exceeds the node threshold, this tool clusters nodes and
+    produces a summary diagram (one node per cluster) plus detail diagrams
+    (one per cluster with full node detail).
+
+    If the diagram is small enough, it generates a single diagram as usual.
+
+    Use this instead of generate_diagram when you have (or may have) more than
+    ~15 nodes and want automatic splitting for readability.
+
+    Args:
+        diagram_type: Type of diagram (architecture, c4, flowchart, etc.).
+        title: Diagram title.
+        nodes: List of node dicts (same format as generate_diagram).
+        edges: List of edge dicts (same format as generate_diagram).
+        description: Subtitle text.
+        max_nodes_per_page: Maximum nodes before triggering a split (default: 15).
+        strategy: Clustering strategy - 'c4_boundary', 'connectivity', or 'type_group'.
+        width: Diagram width in pixels (default: 1920).
+        height: Diagram height in pixels (default: 1080).
+        save_path: Base file path. If splitting occurs, generates summary at this
+            path and details at '{stem}-detail-N{suffix}'.
+
+    Returns:
+        dict with split results: diagram count, file paths, density info.
+    """
+    if diagram_type not in _GENERATORS:
+        return {
+            "success": False,
+            "error": f"Unknown diagram type '{diagram_type}'. Use list_diagram_types to see options.",
+        }
+
+    w = width or Config.DIAGRAM_WIDTH
+    h = height or Config.DIAGRAM_HEIGHT
+
+    # Parse nodes and edges into a DiagramSpec
+    parsed_nodes = [
+        DiagramNode(
+            id=n.get("id", f"n{i}"),
+            label=n.get("label", f"Node {i}"),
+            type=n.get("type", "default"),
+            description=n.get("description", ""),
+            icon=n.get("icon", ""),
+        )
+        for i, n in enumerate(nodes)
+    ]
+
+    parsed_edges = []
+    if edges:
+        parsed_edges = [
+            DiagramEdge(
+                source=e.get("source", ""),
+                target=e.get("target", ""),
+                label=e.get("label", ""),
+                style=e.get("style", "solid"),
+            )
+            for e in edges
+        ]
+
+    spec = DiagramSpec(
+        title=title,
+        nodes=parsed_nodes,
+        edges=parsed_edges,
+        description=description,
+    )
+
+    # Run validation for density info
+    validation = _validate_diagram_impl(
+        nodes=nodes,
+        edges=edges,
+        width=w,
+        height=h,
+        diagram_type=diagram_type,
+    )
+
+    # Auto-split
+    try:
+        sub_specs = _auto_split_impl(spec, max_nodes_per_page, strategy)
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+    was_split = len(sub_specs) > 1
+
+    # Generate save paths
+    save_paths: list[str | None] = [None] * len(sub_specs)
+    if save_path:
+        save_paths = _split_save_paths_impl(save_path, len(sub_specs))
+
+    # Generate HTML for each sub-spec
+    generator = _GENERATORS[diagram_type]
+    diagrams: list[dict] = []
+    for idx, (sub_spec, sp) in enumerate(zip(sub_specs, save_paths)):
+        html = generator(sub_spec, width=w, height=h)
+        entry: dict = {
+            "index": idx,
+            "title": sub_spec.title,
+            "role": "summary" if (was_split and idx == 0) else ("detail" if was_split else "single"),
+            "node_count": len(sub_spec.nodes),
+            "edge_count": len(sub_spec.edges),
+        }
+
+        if sp:
+            path = Path(sp)
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(html, encoding="utf-8")
+                entry["file_path"] = str(path.resolve())
+            except PermissionError:
+                entry["html"] = html
+                entry["save_path_error"] = (
+                    f"Permission denied writing to '{sp}'. "
+                    f"Use the returned HTML content and save it with the Write tool."
+                )
+        else:
+            entry["html"] = html
+
+        diagrams.append(entry)
+
+    result = {
+        "success": True,
+        "was_split": was_split,
+        "strategy": strategy if was_split else None,
+        "diagram_count": len(sub_specs),
+        "diagrams": diagrams,
+        "original_node_count": len(parsed_nodes),
+        "original_edge_count": len(parsed_edges),
+        "max_nodes_per_page": max_nodes_per_page,
+    }
+
+    if "density" in validation:
+        result["density"] = validation["density"]
+
+    return result
 
 
 @mcp.tool()

--- a/tests/test_split_diagram.py
+++ b/tests/test_split_diagram.py
@@ -1,0 +1,371 @@
+"""Tests for the auto_split_diagram module in nano-banana."""
+
+import pytest
+from diagrams.base import DiagramEdge, DiagramNode, DiagramSpec
+from diagrams.split import (
+    auto_split_diagram,
+    build_detail,
+    build_summary,
+    cluster_nodes,
+    split_save_paths,
+)
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+def _make_spec(
+    node_count: int,
+    node_type: str = "default",
+    chain_edges: bool = True,
+    title: str = "Test Diagram",
+) -> DiagramSpec:
+    """Build a DiagramSpec with N nodes and optional chain edges."""
+    nodes = [
+        DiagramNode(id=f"n{i}", label=f"Node {i}", type=node_type)
+        for i in range(node_count)
+    ]
+    edges = []
+    if chain_edges and node_count > 1:
+        edges = [
+            DiagramEdge(source=f"n{i}", target=f"n{i+1}")
+            for i in range(node_count - 1)
+        ]
+    return DiagramSpec(title=title, nodes=nodes, edges=edges)
+
+
+def _make_c4_spec() -> DiagramSpec:
+    """Build a C4-style spec with multiple node types (>15 nodes)."""
+    nodes = [
+        DiagramNode(id="user1", label="Admin", type="person"),
+        DiagramNode(id="user2", label="End User", type="person"),
+        DiagramNode(id="ext1", label="Email Service", type="system"),
+        DiagramNode(id="ext2", label="Payment Gateway", type="system"),
+        DiagramNode(id="ext3", label="Auth Provider", type="system"),
+        DiagramNode(id="web", label="Web App", type="container", description="React"),
+        DiagramNode(id="api", label="API Server", type="container", description="FastAPI"),
+        DiagramNode(id="worker", label="Worker", type="container", description="Celery"),
+        DiagramNode(id="db", label="Database", type="container", description="PostgreSQL"),
+        DiagramNode(id="cache", label="Cache", type="container", description="Redis"),
+        DiagramNode(id="auth", label="Auth Module", type="component"),
+        DiagramNode(id="billing", label="Billing Module", type="component"),
+        DiagramNode(id="notif", label="Notification Module", type="component"),
+        DiagramNode(id="search", label="Search Module", type="component"),
+        DiagramNode(id="reports", label="Reports Module", type="component"),
+        DiagramNode(id="audit", label="Audit Module", type="component"),
+    ]
+    edges = [
+        DiagramEdge(source="user1", target="web", label="Manages"),
+        DiagramEdge(source="user2", target="web", label="Uses"),
+        DiagramEdge(source="web", target="api", label="REST API"),
+        DiagramEdge(source="api", target="db", label="SQL"),
+        DiagramEdge(source="api", target="cache", label="Read/Write"),
+        DiagramEdge(source="api", target="ext1", label="SMTP"),
+        DiagramEdge(source="api", target="ext2", label="Payment API"),
+        DiagramEdge(source="api", target="ext3", label="OAuth"),
+        DiagramEdge(source="worker", target="db", label="Background jobs"),
+        DiagramEdge(source="auth", target="ext3", label="Validates tokens"),
+        DiagramEdge(source="billing", target="ext2", label="Charges"),
+        DiagramEdge(source="notif", target="ext1", label="Sends emails"),
+    ]
+    return DiagramSpec(
+        title="L2 Container - MyApp",
+        nodes=nodes,
+        edges=edges,
+        description="System architecture",
+    )
+
+
+def _make_disconnected_spec() -> DiagramSpec:
+    """Build a spec with multiple disconnected components."""
+    nodes = [
+        # Group 1: connected
+        DiagramNode(id="a1", label="A1", type="default"),
+        DiagramNode(id="a2", label="A2", type="default"),
+        DiagramNode(id="a3", label="A3", type="default"),
+        # Group 2: connected
+        DiagramNode(id="b1", label="B1", type="primary"),
+        DiagramNode(id="b2", label="B2", type="primary"),
+        DiagramNode(id="b3", label="B3", type="primary"),
+        DiagramNode(id="b4", label="B4", type="primary"),
+        # Group 3: connected
+        DiagramNode(id="c1", label="C1", type="secondary"),
+        DiagramNode(id="c2", label="C2", type="secondary"),
+        DiagramNode(id="c3", label="C3", type="secondary"),
+        DiagramNode(id="c4", label="C4", type="secondary"),
+        DiagramNode(id="c5", label="C5", type="secondary"),
+        # Group 4: connected
+        DiagramNode(id="d1", label="D1", type="accent"),
+        DiagramNode(id="d2", label="D2", type="accent"),
+        DiagramNode(id="d3", label="D3", type="accent"),
+        DiagramNode(id="d4", label="D4", type="accent"),
+        DiagramNode(id="d5", label="D5", type="accent"),
+        DiagramNode(id="d6", label="D6", type="accent"),
+    ]
+    edges = [
+        # Group 1
+        DiagramEdge(source="a1", target="a2"),
+        DiagramEdge(source="a2", target="a3"),
+        # Group 2
+        DiagramEdge(source="b1", target="b2"),
+        DiagramEdge(source="b2", target="b3"),
+        DiagramEdge(source="b3", target="b4"),
+        # Group 3
+        DiagramEdge(source="c1", target="c2"),
+        DiagramEdge(source="c2", target="c3"),
+        DiagramEdge(source="c3", target="c4"),
+        DiagramEdge(source="c4", target="c5"),
+        # Group 4
+        DiagramEdge(source="d1", target="d2"),
+        DiagramEdge(source="d2", target="d3"),
+        DiagramEdge(source="d3", target="d4"),
+        DiagramEdge(source="d4", target="d5"),
+        DiagramEdge(source="d5", target="d6"),
+    ]
+    return DiagramSpec(
+        title="Disconnected Graph",
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+# -- cluster_nodes -----------------------------------------------------------
+
+
+class TestClusterNodes:
+    def test_c4_boundary_groups_by_type(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        # Should have clusters for person, system, container, component
+        names = {c.name for c in clusters}
+        assert "Actors" in names
+        assert "External Systems" in names
+        assert "Containers" in names
+        assert "Components" in names
+
+    def test_connectivity_finds_components(self):
+        spec = _make_disconnected_spec()
+        clusters = cluster_nodes(spec, strategy="connectivity")
+        assert len(clusters) == 4  # 4 disconnected groups
+
+    def test_connectivity_single_component(self):
+        spec = _make_spec(5, chain_edges=True)
+        clusters = cluster_nodes(spec, strategy="connectivity")
+        assert len(clusters) == 1
+        assert len(clusters[0].node_ids) == 5
+
+    def test_type_group_strategy(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="type_group")
+        types_found = {c.name for c in clusters}
+        assert "Person" in types_found
+        assert "System" in types_found
+        assert "Container" in types_found
+        assert "Component" in types_found
+
+    def test_invalid_strategy_raises(self):
+        spec = _make_spec(5)
+        with pytest.raises(ValueError, match="Unknown clustering strategy"):
+            cluster_nodes(spec, strategy="invalid_strategy")
+
+    def test_all_nodes_accounted_for(self):
+        spec = _make_c4_spec()
+        for strategy in ("c4_boundary", "connectivity", "type_group"):
+            clusters = cluster_nodes(spec, strategy=strategy)
+            all_ids = set()
+            for c in clusters:
+                all_ids.update(c.node_ids)
+            spec_ids = {n.id for n in spec.nodes}
+            assert all_ids == spec_ids, f"Strategy {strategy} lost nodes"
+
+
+# -- build_summary ----------------------------------------------------------
+
+
+class TestBuildSummary:
+    def test_summary_node_count(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        summary = build_summary(spec, clusters)
+        assert len(summary.nodes) == len(clusters)
+
+    def test_summary_title_suffix(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        summary = build_summary(spec, clusters)
+        assert summary.title.endswith("(Summary)")
+
+    def test_summary_nodes_have_cluster_ids(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        summary = build_summary(spec, clusters)
+        for node in summary.nodes:
+            assert node.id.startswith("cluster-")
+
+    def test_summary_edges_are_inter_cluster(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        summary = build_summary(spec, clusters)
+        # All edges should connect different cluster nodes
+        for edge in summary.edges:
+            assert edge.source != edge.target
+
+    def test_summary_no_duplicate_edges(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        summary = build_summary(spec, clusters)
+        edge_pairs = [(e.source, e.target) for e in summary.edges]
+        assert len(edge_pairs) == len(set(edge_pairs))
+
+    def test_summary_description_shows_count(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        summary = build_summary(spec, clusters)
+        for node in summary.nodes:
+            assert "elements" in node.description
+
+
+# -- build_detail ------------------------------------------------------------
+
+
+class TestBuildDetail:
+    def test_detail_contains_cluster_nodes(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        for idx, cluster in enumerate(clusters):
+            detail = build_detail(spec, cluster, idx)
+            detail_ids = {n.id for n in detail.nodes}
+            for nid in cluster.node_ids:
+                assert nid in detail_ids
+
+    def test_detail_title_includes_cluster_name(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        for idx, cluster in enumerate(clusters):
+            detail = build_detail(spec, cluster, idx)
+            assert cluster.name in detail.title
+
+    def test_detail_external_stubs_as_system(self):
+        spec = _make_c4_spec()
+        clusters = cluster_nodes(spec, strategy="c4_boundary")
+        # Find the "Containers" cluster - it has edges to external systems
+        container_cluster = next(c for c in clusters if c.name == "Containers")
+        idx = clusters.index(container_cluster)
+        detail = build_detail(spec, container_cluster, idx)
+
+        # Should have stub nodes for external connections
+        stub_nodes = [n for n in detail.nodes if "(external)" in n.label]
+        assert len(stub_nodes) > 0
+        for stub in stub_nodes:
+            assert stub.type == "system"
+
+    def test_detail_preserves_internal_edges(self):
+        spec = _make_disconnected_spec()
+        clusters = cluster_nodes(spec, strategy="connectivity")
+        for idx, cluster in enumerate(clusters):
+            detail = build_detail(spec, cluster, idx)
+            cluster_ids = set(cluster.node_ids)
+            for edge in detail.edges:
+                # At least one endpoint must be in the cluster
+                assert edge.source in cluster_ids or edge.target in cluster_ids
+
+
+# -- auto_split_diagram ------------------------------------------------------
+
+
+class TestAutoSplitDiagram:
+    def test_no_split_when_small(self):
+        spec = _make_spec(10)
+        result = auto_split_diagram(spec, max_nodes_per_page=15)
+        assert len(result) == 1
+        assert result[0] is spec
+
+    def test_split_when_large(self):
+        spec = _make_c4_spec()  # 16 nodes
+        result = auto_split_diagram(spec, max_nodes_per_page=15)
+        assert len(result) > 1
+        # First should be summary
+        assert "(Summary)" in result[0].title
+
+    def test_split_at_exact_threshold(self):
+        spec = _make_spec(15)
+        result = auto_split_diagram(spec, max_nodes_per_page=15)
+        assert len(result) == 1  # <= threshold, no split
+
+    def test_split_at_threshold_plus_one(self):
+        spec = _make_c4_spec()
+        result = auto_split_diagram(spec, max_nodes_per_page=15)
+        assert len(result) > 1
+
+    def test_custom_threshold(self):
+        spec = _make_spec(6, chain_edges=False)
+        # With chain_edges=False and all same type, only 1 cluster
+        # so no split even though above threshold
+        result = auto_split_diagram(spec, max_nodes_per_page=5, strategy="type_group")
+        # Only one type group - can't split into multiple clusters
+        assert len(result) == 1
+
+    def test_all_nodes_preserved_across_details(self):
+        spec = _make_c4_spec()
+        result = auto_split_diagram(spec, max_nodes_per_page=10)
+        if len(result) > 1:
+            # Collect all nodes from detail specs (skip summary)
+            detail_node_ids: set[str] = set()
+            for detail in result[1:]:
+                for node in detail.nodes:
+                    # Exclude external stubs
+                    if "(external)" not in node.label:
+                        detail_node_ids.add(node.id)
+            spec_ids = {n.id for n in spec.nodes}
+            assert detail_node_ids == spec_ids
+
+    def test_connectivity_strategy(self):
+        spec = _make_disconnected_spec()
+        result = auto_split_diagram(spec, max_nodes_per_page=5, strategy="connectivity")
+        assert len(result) > 1
+        # First is summary, rest are details (one per connected component)
+        assert "(Summary)" in result[0].title
+        # 4 disconnected groups -> summary + 4 details = 5
+        assert len(result) == 5
+
+    def test_single_cluster_no_split(self):
+        spec = _make_spec(20, chain_edges=True)
+        # All nodes same type and connected - connectivity produces 1 cluster
+        result = auto_split_diagram(spec, max_nodes_per_page=15, strategy="connectivity")
+        assert len(result) == 1
+
+    def test_invalid_strategy_raises(self):
+        spec = _make_spec(20)
+        with pytest.raises(ValueError, match="Unknown clustering strategy"):
+            auto_split_diagram(spec, max_nodes_per_page=10, strategy="bogus")
+
+
+# -- split_save_paths --------------------------------------------------------
+
+
+class TestSplitSavePaths:
+    def test_single_file_no_split(self):
+        paths = split_save_paths("docs/diagram.html", 1)
+        assert paths == ["docs/diagram.html"]
+
+    def test_split_naming_convention(self):
+        paths = split_save_paths("docs/architecture/c4-l3-api-server.html", 3)
+        assert len(paths) == 3
+        assert paths[0] == "docs/architecture/c4-l3-api-server.html"
+        assert paths[1] == "docs/architecture/c4-l3-api-server-detail-1.html"
+        assert paths[2] == "docs/architecture/c4-l3-api-server-detail-2.html"
+
+    def test_preserves_extension(self):
+        paths = split_save_paths("output/diagram.htm", 2)
+        assert paths[0].endswith(".htm")
+        assert paths[1].endswith(".htm")
+
+    def test_preserves_directory(self):
+        paths = split_save_paths("/absolute/path/to/diagram.html", 3)
+        for p in paths:
+            assert p.startswith("/absolute/path/to/")
+
+    def test_count_zero_or_one_returns_base(self):
+        paths = split_save_paths("x.html", 0)
+        assert paths == ["x.html"]
+        paths = split_save_paths("x.html", 1)
+        assert paths == ["x.html"]


### PR DESCRIPTION
## Summary
- Add `auto_split_diagram()` function with 3 clustering strategies (c4_boundary, connectivity, type_group) that splits large diagrams into summary + detail sub-diagrams
- Add `split_diagram` MCP tool exposing the split functionality via the server API
- Add `split_save_paths()` utility for generating naming convention: `name.html` (summary), `name-detail-N.html` (details)
- Update C4 skill (`c4.md`) with density-aware split guidance for L3/L4 diagrams

## Test plan
- [x] 30 new tests covering all clustering strategies, summary/detail builders, path generation, and edge cases
- [x] Full test suite passes (415 tests)
- [x] Lint passes (ruff check)

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)