### PR TITLE
feat(c4): integrate QA gating and retry logic into c4 and pptx skills (Closes #264)

### DIFF
--- a/.claude/commands/documentation/c4.md
+++ b/.claude/commands/documentation/c4.md
@@ -1,6 +1,6 @@
 ---
 description: Generate C4 architecture diagrams for the current project (all 4 levels, one per container/component)
-allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__split_diagram, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
+allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__validate_diagram, mcp__nano-banana__split_diagram, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
 ---
 
 # C4 Architecture Diagram Generation
@@ -189,38 +189,104 @@ for container in containers_for_l3:
 - Include edges to components in OTHER containers as external references (use `system` type for external container nodes)
 - Use descriptive IDs prefixed with the container slug to avoid collisions across diagrams
 
-#### Density-Aware Splitting for L3/L4
+#### QA Gating After Every `generate_diagram` Call
 
-After calling `generate_diagram`, check the `density` field in the response. If `density.status` is `"overflow"` or `"critical"` (node count exceeds ~15), use `split_diagram` instead to automatically produce summary + detail sub-diagrams:
+After EVERY `generate_diagram` call (L1, L2, L3, L4), inspect the response for QA signals and react. Track all QA events for the final report.
 
 ```
-# Check density from the generate_diagram response
-if result.density.status in ("overflow", "critical"):
-    # Re-generate using split_diagram for automatic splitting
+# Initialize QA tracking at the start (alongside generated_diagrams)
+qa_events = []  # {"level": "L3", "diagram": "c4-l3-api.html", "action": "split", "details": "..."}
+
+# After each generate_diagram call:
+def handle_qa_gating(result, level, slug, nodes, edges):
+    retries = 0
+    MAX_RETRIES = 2
+
+    while retries < MAX_RETRIES:
+        # 1. Check for warnings in the response
+        if not result.get("warnings"):
+            break  # No QA issues - proceed
+
+        for warning in result.warnings:
+            if warning.check == "edge_validity" and warning.severity == "high":
+                # EDGE_INVALID: fix the bad edge reference and retry
+                # Find the edge with invalid source/target and correct it
+                # (remove or remap to a valid node ID)
+                fix_invalid_edges(nodes, edges, warning)
+                qa_events.append({
+                    "level": level, "diagram": slug,
+                    "action": "edge_fix_retry",
+                    "details": warning.message
+                })
+                retries += 1
+                result = generate_diagram(...)  # retry with fixed edges
+                continue  # re-check warnings after retry
+
+            if warning.check == "orphan_nodes" and warning.severity == "medium":
+                # ORPHAN_NODES: warn the user but continue
+                qa_events.append({
+                    "level": level, "diagram": slug,
+                    "action": "orphan_warning",
+                    "details": warning.message
+                })
+                # Do NOT retry - just note it
+
+            if warning.check == "long_labels" and warning.severity == "low":
+                # LONG_LABELS: note but continue
+                qa_events.append({
+                    "level": level, "diagram": slug,
+                    "action": "long_label_warning",
+                    "details": warning.message
+                })
+
+        break  # Exit retry loop after processing non-retryable warnings
+
+    # 2. Check density for overflow
+    if result.density.status in ("overflow", "critical"):
+        qa_events.append({
+            "level": level, "diagram": slug,
+            "action": "split",
+            "details": f"density {result.density.density:.2f} ({result.density.status})"
+        })
+        return "SPLIT_NEEDED"
+
+    return result
+```
+
+#### Handling OVERFLOW: Split Strategy
+
+When QA gating returns `SPLIT_NEEDED`, use `split_diagram` to produce summary + detail sub-diagrams:
+
+```
+if qa_result == "SPLIT_NEEDED":
     split_result = split_diagram(
         diagram_type="c4",
         title="L3 Component - {container.label}",
         description="Components within {container.label}",
-        nodes=[...],  # same nodes as above
-        edges=[...],
+        nodes=[...],  # same nodes
+        edges=[...],  # same edges (after any edge fixes)
         max_nodes_per_page=15,
         strategy="c4_boundary",  # groups by C4 node type
-        save_path="{DOCS_DIR}/c4-l3-{slug}.html",
     )
 
-    # split_diagram produces:
-    #   c4-l3-{slug}.html           (summary - one node per cluster)
+    # split_diagram returns HTML in each diagram entry
+    # Save each using the Write tool with naming convention:
+    #   c4-l3-{slug}.html           (summary)
     #   c4-l3-{slug}-detail-1.html  (detail page 1)
     #   c4-l3-{slug}-detail-2.html  (detail page 2)
-    #   ...
 
-    # Add ALL generated files to the manifest
-    for diagram in split_result.diagrams:
+    for i, diagram in enumerate(split_result.diagrams):
+        if diagram.role == "summary":
+            file_name = f"c4-l3-{slug}.html"
+        else:
+            file_name = f"c4-l3-{slug}-detail-{diagram.index}.html"
+
+        Write(file_path=f"{DOCS_DIR}/{file_name}", content=diagram.html)
         generated_diagrams.append({
-            "id": "l3-{slug}" if diagram.role == "summary" else "l3-{slug}-detail-{diagram.index}",
+            "id": f"l3-{slug}" if diagram.role == "summary" else f"l3-{slug}-detail-{diagram.index}",
             "level": "L3",
             "title": diagram.title,
-            "file": os.path.basename(diagram.file_path),
+            "file": file_name,
             "node_count": diagram.node_count,
             "edge_count": diagram.edge_count,
             "parent": "l2-container",
@@ -233,6 +299,14 @@ Available clustering strategies:
 - `c4_boundary` - groups by C4 node type (best for C4 diagrams)
 - `connectivity` - groups by graph connectivity (connected components)
 - `type_group` - groups by generic node type
+
+#### Retry Rules
+
+- **EDGE_INVALID** (high severity): Fix the invalid edge references (remove or remap to a valid node ID), then retry `generate_diagram`. Maximum 2 retries per diagram.
+- **OVERFLOW** (viewport_fit, high severity): Do NOT retry `generate_diagram`. Instead, call `split_diagram` to produce summary + detail views.
+- **ORPHAN_NODES** (medium): Log warning, continue. Do not retry.
+- **LONG_LABELS** (low): Log warning, continue. Do not retry.
+- **CONTRAST** (medium): Log warning, continue. Theme tokens handle contrast.
 
 ### Step 5: Generate L4 Diagrams (Top 3 Components Per Container)
 
@@ -467,12 +541,21 @@ C4 Architecture Diagrams Generated
   Total diagrams: {2 + N + M}
   Screenshots:    {count} PNG files (or "Playwright not available")
 
+  QA Summary:
+    Diagrams validated: {total}
+    Splits performed:   {split_count} (overflow/critical density)
+    Edge fixes:         {edge_fix_count} retries
+    Warnings:           {orphan_count} orphan nodes, {label_count} long labels
+    All diagrams passed QA: {yes/no}
+
   Doc Review:
     CLAUDE.md:  {OK | {N} issues found}
     README.md:  {OK | {N} issues found}
 
   Open HTML files in a browser to view diagrams.
 ```
+
+Build the QA Summary from the `qa_events` list collected during generation. Count events by `action` type: `split`, `edge_fix_retry`, `orphan_warning`, `long_label_warning`.
 
 ## Notes
 

--- a/.claude/commands/documentation/pptx.md
+++ b/.claude/commands/documentation/pptx.md
@@ -1,6 +1,6 @@
 ---
 description: Create a PowerPoint presentation with optional diagrams
-allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__create_pptx, mcp__nano-banana__validate_pptx_slides, mcp__nano-banana__diagram_to_pptx, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
+allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__validate_diagram, mcp__nano-banana__split_diagram, mcp__nano-banana__create_pptx, mcp__nano-banana__validate_pptx_slides, mcp__nano-banana__diagram_to_pptx, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
 ---
 
 # PowerPoint Creation
@@ -97,16 +97,74 @@ Report the plan and ask for confirmation.
 For each diagram requested:
 
 1. Use `generate_diagram` to create the HTML diagram
-2. Save the HTML to a temp file
-3. If Playwright MCP is available:
-   - Create a browser session
-   - Navigate to the HTML file
-   - Take a screenshot at 1920x1080
-   - Close the session
-   - Use the screenshot as `image_base64` in the PPTX
-4. If Playwright is not available:
+2. **QA gate the result** before proceeding (see QA Gating below)
+3. Save the validated HTML to a temp file
+4. If Playwright MCP is available:
+   - Create ONE Playwright session for ALL diagrams (do not create/close per diagram)
+   - For EACH diagram: navigate to the HTML file, screenshot at 1920x1080
+   - Close session ONCE at the end, after all diagrams are captured
+   - Use each screenshot as `image_base64` in the PPTX
+5. If Playwright is not available:
    - Use `diagram_to_pptx` for text-based embedding
    - Note that the user can manually screenshot the HTML for better quality
+
+#### Diagram QA Gating
+
+After each `generate_diagram` call, check the response for warnings before embedding:
+
+```
+qa_events = []
+
+for each diagram:
+    result = generate_diagram(...)
+
+    # Check for warnings
+    if result.get("warnings"):
+        high_issues = [w for w in result.warnings if w.severity == "high"]
+        medium_issues = [w for w in result.warnings if w.severity == "medium"]
+
+        # HIGH severity: block embedding and fix
+        for warning in high_issues:
+            if warning.check == "edge_validity":
+                # Fix invalid edge references and retry (max 2 retries)
+                fix edges, retry generate_diagram
+                qa_events.append({"action": "edge_fix_retry", "details": warning.message})
+
+            if warning.check == "viewport_fit":
+                # Diagram overflows viewport - split or regenerate at higher dimensions
+                if result.density.status in ("overflow", "critical"):
+                    split_result = split_diagram(
+                        diagram_type=..., title=..., nodes=..., edges=...,
+                        max_nodes_per_page=15,
+                        strategy="c4_boundary",
+                    )
+                    # Use split summary diagram for PPTX (detail pages saved separately)
+                    result = split_result.diagrams[0]  # summary
+                    qa_events.append({"action": "split", "details": "overflow"})
+
+        # MEDIUM severity: warn but allow embedding
+        for warning in medium_issues:
+            qa_events.append({"action": "warning", "details": warning.message})
+
+    # Proceed with validated/fixed diagram HTML
+```
+
+#### Playwright Session Optimization
+
+Use ONE browser session for all diagram screenshots to reduce overhead:
+
+```
+# Create ONE session before the diagram loop
+session = create_session(headless=true, viewport={"width": 1920, "height": 1080})
+
+for each diagram_html in generated_diagrams:
+    browser_navigate(session_id=session.id, url="file://{absolute_path}")
+    screenshot = browser_screenshot(session_id=session.id, full_page=true)
+    # Store screenshot for PPTX embedding
+
+# Close session ONCE after all diagrams
+close_session(session_id=session.id)
+```
 
 ### Step 4: Create the PPTX
 
@@ -128,6 +186,12 @@ Presentation created!
   Diagrams generated:
   - {type}: {html_path}
   - ...
+
+  Diagram QA:
+    Validated:  {total} diagrams
+    Splits:     {split_count} (overflow diagrams split into summary + detail)
+    Retries:    {retry_count} (edge fixes)
+    Warnings:   {warning_count} (orphan nodes, long labels)
 
   Open the .pptx file to review.
 ```

--- a/tests/test_wcag_contrast.py
+++ b/tests/test_wcag_contrast.py
@@ -3,53 +3,57 @@
 from diagrams.base import _contrast_ratio as base_contrast_ratio
 from diagrams.base import _node_color
 from diagrams.base import _relative_luminance as base_luminance
-from diagrams.c4 import _C4_COLORS, _DEFAULT_COLOR
+from diagrams.c4 import _c4_color
 from diagrams.validate import _contrast_ratio, _relative_luminance, validate_diagram
 
 WCAG_AA_MINIMUM = 4.5
+
+# C4 node types to test
+_C4_NODE_TYPES = ["person", "system", "system-focus", "container", "component", "code"]
 
 
 class TestC4PaletteContrast:
     """Verify all C4 palette color combinations meet WCAG AA 4.5:1 minimum."""
 
     def test_person_contrast(self):
-        bg, _border, text = _C4_COLORS["person"]
+        bg, _border, text = _c4_color("person")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"person: {ratio:.2f}:1 (need >= {WCAG_AA_MINIMUM})"
 
     def test_system_contrast(self):
-        bg, _border, text = _C4_COLORS["system"]
+        bg, _border, text = _c4_color("system")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"system: {ratio:.2f}:1"
 
     def test_system_focus_contrast(self):
-        bg, _border, text = _C4_COLORS["system-focus"]
+        bg, _border, text = _c4_color("system-focus")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"system-focus: {ratio:.2f}:1"
 
     def test_container_contrast(self):
-        bg, _border, text = _C4_COLORS["container"]
+        bg, _border, text = _c4_color("container")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"container: {ratio:.2f}:1"
 
     def test_component_contrast(self):
-        bg, _border, text = _C4_COLORS["component"]
+        bg, _border, text = _c4_color("component")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"component: {ratio:.2f}:1"
 
     def test_code_contrast(self):
-        bg, _border, text = _C4_COLORS["code"]
+        bg, _border, text = _c4_color("code")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"code: {ratio:.2f}:1"
 
     def test_default_color_contrast(self):
-        bg, _border, text = _DEFAULT_COLOR
+        bg, _border, text = _c4_color("nonexistent_type")
         ratio = _contrast_ratio(text, bg)
         assert ratio >= WCAG_AA_MINIMUM, f"default: {ratio:.2f}:1"
 
     def test_all_c4_colors_at_once(self):
         """Parametric check of every C4 color type."""
-        for node_type, (bg, _border, text) in _C4_COLORS.items():
+        for node_type in _C4_NODE_TYPES:
+            bg, _border, text = _c4_color(node_type)
             ratio = _contrast_ratio(text, bg)
             assert ratio >= WCAG_AA_MINIMUM, (
                 f"C4 type '{node_type}': contrast {ratio:.2f}:1 < {WCAG_AA_MINIMUM}:1 "


### PR DESCRIPTION
## Summary
- Add comprehensive QA gating after every `generate_diagram` call in both `c4.md` and `pptx.md` skills
- Handle warnings by severity: EDGE_INVALID triggers retry (max 2), OVERFLOW triggers `split_diagram`, ORPHAN/LABELS logged as warnings
- Add `validate_diagram` and `split_diagram` to pptx skill allowed-tools
- Optimize Playwright to use ONE session for all diagram screenshots in pptx skill
- Include QA summary (splits, retries, warnings) in final reports for both skills
- Fix pre-existing `test_wcag_contrast.py` import to use `_c4_color()` after theme token refactor

## Test plan
- [x] All 496 tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] Verify c4 skill detects overflow and triggers split
- [ ] Verify pptx skill gates diagrams before embedding
- [ ] Verify edge_validity retry works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>