### PR TITLE
docs: update CLAUDE.md, README, and CHANGELOG for C4 QA enhancements (Closes #266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [5.2.0] - 2026-03-08
+
+### Added - C4 Diagram QA Framework
+
+- **`validate_diagram` MCP tool** - Diagram quality checks: duplicate IDs, edge validity, viewport fit, readability, orphan nodes, WCAG AA contrast, long labels (#255)
+- **Node density scoring** - Automatic overflow detection based on viewport capacity heuristics; status levels: ok, warning, overflow, critical (#262)
+- **`split_diagram` MCP tool** - Auto-splits large diagrams (>15 nodes) into summary + detail sub-diagrams with three clustering strategies: `c4_boundary`, `connectivity`, `type_group` (#263)
+- **Multi-diagram L3/L4 generation** - `/documentation:c4` generates L3 for all containers and L4 for top 3 components per container (#258)
+- **`c4-manifest.json`** - Tracks all generated diagrams with parent-child relationships, node/edge counts, and split roles (#259)
+- **`index.html` navigation page** - Hierarchical browser for all C4 diagrams with level badges and metadata (#260)
+- **Shared theme token system** - `ThemeTokens` dataclass provides consistent color palette across all diagram types via `theme_id` and `theme_tokens` parameters (#261)
+- **QA gating in c4 and pptx skills** - Post-generation warning inspection: EDGE_INVALID triggers retry (max 2), OVERFLOW triggers split, ORPHAN/LABELS logged as warnings; QA summary in final reports (#264)
+- **Playwright session optimization** - PPTX skill uses ONE browser session for all diagram screenshots (#264)
+- **Comprehensive test suite** - 285 new tests: validation, density scoring, split strategy, XSS sanitization, WCAG contrast, C4 integration (#265)
+
+### Fixed
+
+- **XSS vulnerability** - HTML-escape all node labels and descriptions in diagram HTML output (#256)
+- **WCAG AA color contrast** - All C4 and generic palettes updated to meet 4.5:1 minimum contrast ratio (#257)
+- **test_wcag_contrast.py import** - Updated to use `_c4_color()` after theme token refactor (#264)
+
+### Changed
+
+- Version bump: 5.1.0 -> 5.2.0
+- Nano-banana MCP tools: 4 -> 7 (added `validate_diagram`, `split_diagram`, `validate_pptx_slides`)
+- Test count: 211 -> 496
+
+---
+
 ## [5.0.0] - 2026-03-05
 
 ### Added - Wave 6: Polish, Quality & DX

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Core components and their locations:
 - `.specify/` - Spec-Driven Development (specs, plans, tasks, templates)
 - `mcp-second-opinion/` - Code review MCP server (port 8080)
 - `mcp-playwright-persistent/` - Browser automation MCP server (port 8081, 29 tools)
-- `mcp-nano-banana/` - Diagram generation + PowerPoint MCP server (port 8084)
+- `mcp-nano-banana/` - Diagram generation + PowerPoint MCP server (port 8084, 7 tools: `list_diagram_types`, `generate_diagram`, `validate_diagram`, `split_diagram`, `create_pptx`, `validate_pptx_slides`, `diagram_to_pptx`)
 - `extras/sequential-thinking/` - Optional: structured reasoning (stdio, npm)
 - `lib/creds/` - Secrets management (dotenv/AWS SM, FastAPI UI, audit logging)
 - `lib/security/` - Security scanning (native + external tools)
@@ -111,8 +111,8 @@ Docker containers read API keys from a root `.env` file (gitignored) via `env_fi
 - `/secrets:rotate KEY` - Rotate a secret
 
 ### Documentation
-- `/documentation:pptx [topic]` - Guided PowerPoint creation with diagrams
-- `/documentation:c4` - Generate C4 architecture diagrams (all 4 levels)
+- `/documentation:pptx [topic]` - Guided PowerPoint creation with diagrams (QA gating, Playwright session optimization)
+- `/documentation:c4` - Generate C4 architecture diagrams (all 4 levels, per-container L3, per-component L4, density-aware splitting, QA gating with retry, manifest + index)
 
 ### Evaluation
 - `/evaluate:issue` - 4-phase multi-model evaluation (divergence, reasoning, validation, spec output)
@@ -172,4 +172,4 @@ Tiered: dotenv-global (`~/.config/claude-power-pack/secrets/`) -> env-file -> AW
 
 ## Version
 
-Current version: 5.1.0
+Current version: 5.2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Power Pack
 
-**v5.1.0** - A productivity toolkit for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that adds workflow automation, MCP servers, security scanning, secrets management, and CI/CD integration.
+**v5.2.0** - A productivity toolkit for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that adds workflow automation, MCP servers, security scanning, secrets management, and CI/CD integration.
 
 ## What It Does
 
@@ -63,7 +63,7 @@ claude-power-pack/
   woodpecker/           Woodpecker CI server + agent deployment configs
   templates/            Makefile, workflow, and container templates
   scripts/              Shell utilities
-  tests/                211 unit tests
+  tests/                496 unit tests
   docker-compose.yml    MCP server orchestration
   .woodpecker.yml       CI pipeline (lint, test, typecheck, deploy)
   Makefile              Build interface for all operations
@@ -100,7 +100,7 @@ API keys are read from a root `.env` file (gitignored). For production, use AWS 
 
 Woodpecker CI runs on every push and PR via a self-hosted agent:
 
-- **Validate:** lint (ruff) + test (pytest, 211 tests) + typecheck (mypy) in a single consolidated step
+- **Validate:** lint (ruff) + test (pytest, 496 tests) + typecheck (mypy) in a single consolidated step
 - **Docker builds:** Conditional per-server dry-run builds when `mcp-*/` files change
 - **Auto-deploy:** On push to main, changed MCP servers are rebuilt and health-checked via `docker compose --wait`
 - **Disk cleanup:** Dangling images pruned after every deploy
@@ -109,6 +109,19 @@ Woodpecker CI runs on every push and PR via a self-hosted agent:
 Architecture: Woodpecker server on a dedicated VM, agent on the dev workstation, connected via gRPC over Tailscale. Web UI at `woodpecker.essent-ai.com` via Cloudflare tunnel.
 
 ## Changelog
+
+### v5.2.0 (2026-03-08)
+
+- **C4 diagram QA framework** - `validate_diagram` MCP tool with density scoring, XSS sanitization, WCAG AA contrast checks
+- **Multi-diagram C4 generation** - L3 for all containers, L4 for top 3 components per container
+- **Density-aware splitting** - `split_diagram` MCP tool auto-splits large diagrams into summary + detail views
+- **QA gating in skills** - c4 and pptx skills check warnings after every `generate_diagram`, retry on edge errors, split on overflow
+- **Shared theme tokens** - `ThemeTokens` contract for consistent colors across all diagram types
+- **c4-manifest.json** - Tracks all generated diagrams with parent-child relationships
+- **index.html** - Hierarchical navigation page for all C4 diagrams
+- **XSS fix** - HTML-escape all node labels in diagram output
+- **WCAG AA fix** - All color palettes meet 4.5:1 minimum contrast ratio
+- **496 tests** - Comprehensive test coverage for validation, density, splitting, contrast, and C4 integration
 
 ### v5.1.0 (2026-03-07)
 

--- a/mcp-nano-banana/README.md
+++ b/mcp-nano-banana/README.md
@@ -9,7 +9,9 @@ Best-in-class diagram generation MCP server for Claude Code. Generates professio
 - **Presentation-quality**: All diagrams render at 1920x1080 (16:9 widescreen)
 - **PowerPoint builder**: Create PPTX files with embedded diagrams, dark theme
 - **Self-contained HTML**: No external dependencies, works offline
-- **MCP integration**: 4 tools for diagram generation and PPTX creation
+- **QA validation**: `validate_diagram` checks density, edges, orphans, contrast, labels
+- **Auto-splitting**: `split_diagram` produces summary + detail views for large diagrams
+- **MCP integration**: 7 tools for diagram generation, validation, splitting, and PPTX creation
 
 ## Quick Start
 
@@ -27,8 +29,9 @@ claude mcp add nano-banana --transport sse --url http://127.0.0.1:8084/sse
 | Tool | Purpose |
 |------|---------|
 | `list_diagram_types` | List available diagram types, themes, and descriptions |
-| `generate_diagram` | Generate an HTML diagram with theme support |
-| `validate_diagram` | Validate diagram spec for quality issues (contrast, density, etc.) |
+| `generate_diagram` | Generate an HTML diagram with theme support (includes inline validation + density scoring) |
+| `validate_diagram` | Standalone QA checks: duplicate IDs, edge validity, viewport fit, orphan nodes, WCAG contrast, long labels |
+| `split_diagram` | Auto-split large diagrams into summary + detail sub-diagrams (3 strategies: `c4_boundary`, `connectivity`, `type_group`) |
 | `create_pptx` | Create a PowerPoint file with slides and embedded images |
 | `validate_pptx_slides` | Validate slide definitions before creating a PPTX |
 | `diagram_to_pptx` | One-step: generate diagram + create PPTX |
@@ -104,6 +107,29 @@ override individual tokens.
 | `container` | Green | Containers |
 | `component` | Purple | Components |
 | `code` | Amber | Code elements |
+
+## QA Checks Reference
+
+`validate_diagram` and `generate_diagram` (inline) run these checks:
+
+| Check | Severity | Condition |
+|-------|----------|-----------|
+| `duplicate_ids` | HIGH | Two or more nodes share the same ID |
+| `edge_validity` | HIGH | Edge references a node ID that does not exist |
+| `viewport_fit` | HIGH | Node density > 1.0 (overflow/critical) |
+| `readability` | MEDIUM | Node density 0.8-1.0 (near capacity) |
+| `orphan_nodes` | MEDIUM | Node has no edges (except person/system types) |
+| `contrast` | MEDIUM | Color contrast < 4.5:1 (WCAG AA failure) |
+| `long_labels` | LOW | Label > 40 chars or description > 80 chars |
+
+### Density Thresholds (at 1920x1080)
+
+| Density | Status | Action |
+|---------|--------|--------|
+| <= 0.8 | ok | No action needed |
+| 0.8-1.0 | warning | Consider tighter layout |
+| 1.0-1.5 | overflow | Use `split_diagram` for summary + detail views |
+| > 1.5 | critical | Must split - diagram will be unreadable |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Add comprehensive v5.2.0 changelog entry covering all C4 QA framework additions (#255-#265)
- Update CLAUDE.md: nano-banana now lists 7 tools, `/documentation:c4` description expanded, version bumped to 5.2.0
- Update README.md: v5.2.0 changelog section, test count updated to 496
- Update mcp-nano-banana/README.md: 7 tools with expanded descriptions, QA checks reference table, density thresholds

## Test plan
- [x] All 496 tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] Verify CLAUDE.md accurately reflects current project state
- [ ] Verify CHANGELOG entries match merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>