### PR TITLE
fix(dockers): replace bash 4+ associative arrays with POSIX-compatible pattern (Closes #280)

### DIFF
--- a/.claude/commands/dockers.md
+++ b/.claude/commands/dockers.md
@@ -48,14 +48,10 @@ For each container with an exposed port, hit the health endpoint:
 
 ```bash
 # Known MCP server ports and their health endpoints
-declare -A MCP_PORTS=(
-    ["mcp-second-opinion"]="8080"
-    ["mcp-nano-banana"]="8084"
-    ["mcp-playwright-persistent"]="8081"
-)
-
-for name in "${!MCP_PORTS[@]}"; do
-    port="${MCP_PORTS[$name]}"
+# Uses portable for-loop pattern (POSIX-compatible, no bash 4+ associative arrays)
+for pair in "mcp-second-opinion:8080" "mcp-nano-banana:8084" "mcp-playwright-persistent:8081"; do
+    name="${pair%%:*}"
+    port="${pair##*:}"
     response=$(curl -sf --max-time 3 "http://127.0.0.1:${port}/" 2>/dev/null)
     if [ $? -eq 0 ]; then
         # Check for no_api_keys status


### PR DESCRIPTION
## Summary
- Replaced `declare -A` associative array and `${!array[@]}` indirect expansion in `/dockers` skill health check with POSIX-compatible `for pair in "name:port"` pattern using `${pair%%:*}` / `${pair##*:}` parameter expansion
- Eliminates `bad substitution` error when Claude Code's Bash tool executes the health check

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (496 tests)
- [ ] Run `/dockers` and verify health checks execute without bash errors

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)