### PR TITLE
feat(codex): add optional Codex skill wrapper install target (Closes #300)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ mcp-second-opinion/src/tools/__pycache__/
 # Generated diagram outputs
 /diagrams/
 *.pptx
+
+# Generated Codex skill wrappers (created by scripts/codex-skill-gen.py)
+.agents/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test lint format typecheck verify update_docs clean \
        docker-build docker-check-env docker-up docker-down docker-logs docker-ps deploy \
-       drift-check setup-woodpecker-cli
+       drift-check setup-woodpecker-cli codex-init
 
 ## Quality gates (used by /flow:finish)
 
@@ -82,6 +82,14 @@ deploy: docker-build docker-up
 
 setup-woodpecker-cli:
 	@scripts/setup-woodpecker-cli.sh
+
+## Codex skill wrapper generation
+
+codex-init:
+	@python3 scripts/codex-skill-gen.py
+
+codex-init-force:
+	@python3 scripts/codex-skill-gen.py --force
 
 ## Utilities
 

--- a/scripts/codex-skill-gen.py
+++ b/scripts/codex-skill-gen.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Generate Codex-compatible skill wrappers from Claude Power Pack skills."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FALLBACK_METADATA: dict[str, dict[str, str]] = {
+    "browser-tiered.md": {
+        "name": "Browser Automation (Tiered)",
+        "description": (
+            "Tiered browser automation: lightweight bdg CLI for simple tasks,"
+            " Playwright MCP for complex workflows"
+        ),
+        "trigger": "browser, automation, playwright, bdg, DOM, screenshot, form fill",
+    },
+    "evaluate.md": {
+        "name": "Evaluation Prompts",
+        "description": (
+            "Domain-aware evaluation prompts for multi-model analysis across"
+            " architecture, concept, algorithm, ui-design, and workflow domains"
+        ),
+        "trigger": "evaluate, divergence scan, validation, multi-model, architecture review",
+    },
+    "project-deploy.md": {
+        "name": "Project Deployment",
+        "description": (
+            "Deployment patterns for projects with deploy scripts,"
+            " server management, and branch testing"
+        ),
+        "trigger": "deploy, start servers, run locally, test changes, restart dev",
+    },
+}
+
+MCP_INDICATORS = [
+    "mcp", "MCP", "slash command", "/flow", "/project", "/spec", "/cicd",
+    "/security", "/secrets", "/evaluate", "/documentation", "/qa",
+    "browser_screenshot", "browser_navigate", "browser_click", "browser_fill",
+    "second-opinion", "nano-banana", "playwright-persistent", "woodpecker-ci",
+]
+
+RELATIVE_PATH_PATTERN = re.compile(
+    r"(`(?:docs/|scripts/|templates/|lib/|\.claude/|\.specify/)[^`]+`)"
+)
+
+
+def slugify(name: str) -> str:
+    slug = name.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = slug.strip("-")
+    return slug[:50]
+
+
+def parse_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    if not content.startswith("---"):
+        return {}, content
+    end = content.find("---", 3)
+    if end == -1:
+        return {}, content
+    frontmatter_text = content[3:end].strip()
+    body = content[end + 3:].strip()
+    metadata: dict[str, str] = {}
+    for line in frontmatter_text.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and value:
+                metadata[key] = value
+    return metadata, body
+
+
+def build_description(metadata: dict[str, str]) -> str:
+    desc = metadata.get("description", "")
+    trigger = metadata.get("trigger", "")
+    if trigger and desc:
+        trigger_terms = [t.strip() for t in trigger.split(",")]
+        desc_lower = desc.lower()
+        extra = [t for t in trigger_terms if t.lower() not in desc_lower]
+        if extra:
+            desc = f"{desc}. Use for: {', '.join(extra)}"
+    return desc
+
+
+def has_mcp_content(body: str) -> bool:
+    for indicator in MCP_INDICATORS:
+        if indicator in body:
+            return True
+    return False
+
+
+def rewrite_paths(body: str, cpp_dir: str) -> str:
+    def replacer(match: re.Match[str]) -> str:
+        path = match.group(1)
+        inner = path.strip("`")
+        return f"`{cpp_dir}/{inner}`"
+
+    return RELATIVE_PATH_PATTERN.sub(replacer, body)
+
+
+def generate_codex_skill(
+    source_file: Path,
+    cpp_dir: str,
+) -> tuple[str, str, str]:
+    """Returns (slug, skill_content, source_filename)."""
+    content = source_file.read_text()
+    filename = source_file.name
+    metadata, body = parse_frontmatter(content)
+
+    if filename in FALLBACK_METADATA:
+        fallback = FALLBACK_METADATA[filename]
+        metadata.setdefault("name", fallback["name"])
+        metadata.setdefault("description", fallback["description"])
+        metadata.setdefault("trigger", fallback["trigger"])
+
+    if not metadata.get("name"):
+        stem = source_file.stem.replace("-", " ").replace("_", " ").title()
+        metadata["name"] = stem
+    if not metadata.get("description"):
+        metadata["description"] = f"Claude Power Pack skill: {metadata['name']}"
+
+    name = metadata["name"]
+    slug = f"claude-power-pack-{slugify(name)}"
+    description = build_description(metadata)
+
+    body = rewrite_paths(body, cpp_dir)
+
+    mcp_notice = ""
+    if has_mcp_content(body):
+        mcp_notice = (
+            "\n> **Note:** This skill references Claude Code slash commands and/or MCP tools.\n"
+            "> When running under Codex, use available local scripts, repo CLI entry points,\n"
+            "> or inspect the implementation directly. MCP tools are not available in Codex.\n\n"
+        )
+
+    skill_content = f"""---
+name: {slug}
+description: {description}
+metadata:
+  source: claude-power-pack/.claude/skills/{filename}
+---
+{mcp_notice}
+{body}
+"""
+    return slug, skill_content, filename
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate Codex skill wrappers from Claude Power Pack skills")
+    parser.add_argument("--source", default=".claude/skills", help="Source skills directory")
+    parser.add_argument("--output", default=".agents/skills", help="Output directory for Codex skills")
+    parser.add_argument("--cpp-dir", default=None, help="Claude Power Pack repo root (auto-detected if omitted)")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing generated skills")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be generated without writing")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    source_dir = repo_root / args.source
+    output_dir = repo_root / args.output
+
+    if args.cpp_dir:
+        cpp_dir = args.cpp_dir
+    else:
+        cpp_dir = str(repo_root)
+
+    if not source_dir.is_dir():
+        print(f"ERROR: Source directory not found: {source_dir}", file=sys.stderr)
+        return 1
+
+    skill_files = sorted(source_dir.glob("*.md"))
+    if not skill_files:
+        print(f"ERROR: No .md files found in {source_dir}", file=sys.stderr)
+        return 1
+
+    generated = 0
+    skipped = 0
+    errors = 0
+
+    for skill_file in skill_files:
+        try:
+            slug, content, filename = generate_codex_skill(skill_file, cpp_dir)
+        except Exception as e:
+            print(f"  WARN: Failed to process {skill_file.name}: {e}", file=sys.stderr)
+            errors += 1
+            continue
+
+        target_dir = output_dir / slug
+        target_file = target_dir / "SKILL.md"
+
+        if target_file.exists() and not args.force:
+            print(f"  SKIP: {target_file} (exists, use --force to overwrite)")
+            skipped += 1
+            continue
+
+        if args.dry_run:
+            print(f"  WOULD CREATE: {target_file}")
+            print(f"    slug: {slug}")
+            print(f"    source: {filename}")
+            generated += 1
+            continue
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_file.write_text(content)
+        print(f"  CREATED: {target_file}")
+        generated += 1
+
+    print(f"\nDone: {generated} generated, {skipped} skipped, {errors} errors")
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_codex_skill_gen.py
+++ b/tests/test_codex_skill_gen.py
@@ -1,0 +1,268 @@
+"""Tests for Codex skill wrapper generation."""
+
+from __future__ import annotations
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from textwrap import dedent
+
+_script_path = Path(__file__).resolve().parent.parent / "scripts" / "codex-skill-gen.py"
+_spec = spec_from_file_location("codex_skill_gen", _script_path)
+codex_skill_gen = module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(codex_skill_gen)  # type: ignore[union-attr]
+sys.modules["codex_skill_gen"] = codex_skill_gen
+
+parse_frontmatter = codex_skill_gen.parse_frontmatter
+build_description = codex_skill_gen.build_description
+slugify = codex_skill_gen.slugify
+generate_codex_skill = codex_skill_gen.generate_codex_skill
+has_mcp_content = codex_skill_gen.has_mcp_content
+rewrite_paths = codex_skill_gen.rewrite_paths
+FALLBACK_METADATA = codex_skill_gen.FALLBACK_METADATA
+
+
+class TestParseFrontmatter:
+    def test_valid_frontmatter(self) -> None:
+        content = dedent("""\
+            ---
+            name: Test Skill
+            description: A test skill
+            trigger: test, demo
+            ---
+
+            # Body here
+        """)
+        metadata, body = parse_frontmatter(content)
+        assert metadata["name"] == "Test Skill"
+        assert metadata["description"] == "A test skill"
+        assert metadata["trigger"] == "test, demo"
+        assert "# Body here" in body
+
+    def test_no_frontmatter(self) -> None:
+        content = "# Just a heading\n\nSome content."
+        metadata, body = parse_frontmatter(content)
+        assert metadata == {}
+        assert body == content
+
+    def test_quoted_values(self) -> None:
+        content = '---\nname: "Quoted Name"\ndescription: \'Single quoted\'\n---\nBody'
+        metadata, body = parse_frontmatter(content)
+        assert metadata["name"] == "Quoted Name"
+        assert metadata["description"] == "Single quoted"
+
+
+class TestSlugify:
+    def test_basic(self) -> None:
+        assert slugify("Code Quality") == "code-quality"
+
+    def test_special_chars(self) -> None:
+        assert slugify("Hooks & Automation") == "hooks-automation"
+
+    def test_truncation(self) -> None:
+        long_name = "A" * 100
+        assert len(slugify(long_name)) <= 50
+
+    def test_parentheses(self) -> None:
+        assert slugify("Python Packaging (PEP 621 & PEP 723)") == "python-packaging-pep-621-pep-723"
+
+
+class TestBuildDescription:
+    def test_description_with_trigger(self) -> None:
+        metadata = {"description": "Code review patterns", "trigger": "code review, testing, production"}
+        desc = build_description(metadata)
+        assert "Code review patterns" in desc
+        assert "testing" in desc
+        assert "production" in desc
+
+    def test_no_duplicate_terms(self) -> None:
+        metadata = {"description": "Code review patterns and testing", "trigger": "code review, testing"}
+        desc = build_description(metadata)
+        assert desc.count("testing") == 1
+
+    def test_no_trigger(self) -> None:
+        metadata = {"description": "Just a description"}
+        desc = build_description(metadata)
+        assert desc == "Just a description"
+
+
+class TestHasMcpContent:
+    def test_detects_mcp(self) -> None:
+        assert has_mcp_content("Use the MCP server for this")
+        assert has_mcp_content("Run /flow:start to begin")
+        assert has_mcp_content("Call browser_screenshot")
+
+    def test_no_mcp(self) -> None:
+        assert not has_mcp_content("Just regular Python code here")
+
+
+class TestRewritePaths:
+    def test_rewrites_docs_path(self) -> None:
+        body = "Read `docs/skills/code-quality.md` for details"
+        result = rewrite_paths(body, "/home/user/claude-power-pack")
+        assert "`/home/user/claude-power-pack/docs/skills/code-quality.md`" in result
+
+    def test_rewrites_lib_path(self) -> None:
+        body = "See `lib/creds/provider.py`"
+        result = rewrite_paths(body, "/opt/cpp")
+        assert "`/opt/cpp/lib/creds/provider.py`" in result
+
+    def test_ignores_non_relative(self) -> None:
+        body = "Use `pip install something`"
+        result = rewrite_paths(body, "/opt/cpp")
+        assert result == body
+
+    def test_rewrites_scripts_path(self) -> None:
+        body = "Run `scripts/drift-detect.sh`"
+        result = rewrite_paths(body, "/repo")
+        assert "`/repo/scripts/drift-detect.sh`" in result
+
+
+class TestGenerateCodexSkill:
+    def test_generates_from_full_frontmatter(self, tmp_path: Path) -> None:
+        skill = tmp_path / "code-quality.md"
+        skill.write_text(dedent("""\
+            ---
+            name: Code Quality
+            description: Code review patterns, testing, and quality best practices
+            trigger: code review, quality, testing, production ready, best practices
+            ---
+
+            # Code Quality Skill
+
+            When the user asks about code quality:
+            1. Read `docs/skills/code-quality.md`
+        """))
+        slug, content, filename = generate_codex_skill(skill, "/opt/cpp")
+        assert slug == "claude-power-pack-code-quality"
+        assert "name: claude-power-pack-code-quality" in content
+        assert "Code review patterns" in content
+        assert "source: claude-power-pack/.claude/skills/code-quality.md" in content
+        assert "`/opt/cpp/docs/skills/code-quality.md`" in content
+
+    def test_generates_with_fallback_metadata(self, tmp_path: Path) -> None:
+        skill = tmp_path / "browser-tiered.md"
+        skill.write_text("# Tiered Browser Automation\n\nUse bdg for simple tasks.")
+        slug, content, filename = generate_codex_skill(skill, "/opt/cpp")
+        assert slug == "claude-power-pack-browser-automation-tiered"
+        assert "Tiered browser automation" in content
+        assert "source: claude-power-pack/.claude/skills/browser-tiered.md" in content
+
+    def test_generates_with_partial_frontmatter(self, tmp_path: Path) -> None:
+        skill = tmp_path / "evaluate.md"
+        skill.write_text(dedent("""\
+            ---
+            description: Domain-aware evaluation prompts
+            globs: .claude/commands/evaluate/**
+            ---
+
+            # Evaluation Domain Prompts
+        """))
+        slug, content, filename = generate_codex_skill(skill, "/opt/cpp")
+        assert "claude-power-pack-evaluation-prompts" in slug
+        assert "Domain-aware evaluation prompts" in content
+
+    def test_mcp_notice_added(self, tmp_path: Path) -> None:
+        skill = tmp_path / "test-mcp.md"
+        skill.write_text(dedent("""\
+            ---
+            name: MCP Test
+            description: Tests MCP integration
+            ---
+
+            Use browser_screenshot to capture the page.
+            Run /flow:start to begin work.
+        """))
+        _, content, _ = generate_codex_skill(skill, "/opt/cpp")
+        assert "MCP tools are not available in Codex" in content
+
+    def test_no_mcp_notice_for_plain_skill(self, tmp_path: Path) -> None:
+        skill = tmp_path / "plain.md"
+        skill.write_text(dedent("""\
+            ---
+            name: Plain Skill
+            description: A plain skill with no MCP
+            ---
+
+            Just regular guidance content here.
+        """))
+        _, content, _ = generate_codex_skill(skill, "/opt/cpp")
+        assert "MCP tools are not available in Codex" not in content
+
+    def test_codex_frontmatter_format(self, tmp_path: Path) -> None:
+        skill = tmp_path / "test.md"
+        skill.write_text(dedent("""\
+            ---
+            name: Test Skill
+            description: Testing frontmatter output
+            trigger: test, verify
+            ---
+
+            Body content.
+        """))
+        slug, content, _ = generate_codex_skill(skill, "/opt/cpp")
+        assert content.startswith("---\n")
+        assert "name: claude-power-pack-test-skill" in content
+        assert "description: Testing frontmatter output. Use for: verify" in content
+        assert "metadata:" in content
+        assert "  source: claude-power-pack/.claude/skills/test.md" in content
+
+
+class TestEndToEnd:
+    def test_full_generation_no_overwrite(self, tmp_path: Path) -> None:
+        source = tmp_path / "source"
+        source.mkdir()
+        output = tmp_path / "output"
+
+        (source / "skill-a.md").write_text(dedent("""\
+            ---
+            name: Skill A
+            description: First skill
+            ---
+
+            Content A.
+        """))
+        (source / "skill-b.md").write_text(dedent("""\
+            ---
+            name: Skill B
+            description: Second skill
+            ---
+
+            Content B.
+        """))
+
+        # Generate first time
+        for sf in sorted(source.glob("*.md")):
+            slug, content, _ = generate_codex_skill(sf, str(tmp_path))
+            target_dir = output / slug
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "SKILL.md").write_text(content)
+
+        assert (output / "claude-power-pack-skill-a" / "SKILL.md").exists()
+        assert (output / "claude-power-pack-skill-b" / "SKILL.md").exists()
+
+        # Modify source and verify no overwrite without --force
+        original_content = (output / "claude-power-pack-skill-a" / "SKILL.md").read_text()
+        (source / "skill-a.md").write_text(dedent("""\
+            ---
+            name: Skill A
+            description: Modified description
+            ---
+
+            Modified content.
+        """))
+
+        # Simulate no-force: file exists, so skip
+        target_file = output / "claude-power-pack-skill-a" / "SKILL.md"
+        assert target_file.exists()
+        current = target_file.read_text()
+        assert current == original_content
+
+    def test_fallback_skills_have_entries(self) -> None:
+        assert "browser-tiered.md" in FALLBACK_METADATA
+        assert "evaluate.md" in FALLBACK_METADATA
+        assert "project-deploy.md" in FALLBACK_METADATA
+        for key, meta in FALLBACK_METADATA.items():
+            assert "name" in meta
+            assert "description" in meta
+            assert "trigger" in meta


### PR DESCRIPTION
## Summary
- Adds `scripts/codex-skill-gen.py` generator that scans `.claude/skills/*.md` and creates `.agents/skills/claude-power-pack-<slug>/SKILL.md` Codex-compatible wrappers
- Parses YAML frontmatter (name, description, trigger), applies fallback metadata for 3 incomplete-frontmatter skills (browser-tiered, evaluate, project-deploy)
- Rewrites relative doc paths to absolute CPP repo paths, marks MCP-dependent skills as conditional for Codex
- Supports `--force` (overwrite), `--dry-run`, `--cpp-dir` (custom root) flags
- Adds `make codex-init` / `make codex-init-force` Makefile targets
- 24 unit tests covering all acceptance criteria

## Lint result
All checks passed (ruff, mypy, 541 tests)

## Second-opinion review
Gemini reviewed the implementation; no actionable issues (reviewer missed main() due to truncated snippet)

## Test plan
- [x] `make verify` passes (lint + 541 tests + typecheck)
- [x] `python3 scripts/codex-skill-gen.py --dry-run` shows 17 skills
- [x] `python3 scripts/codex-skill-gen.py` generates all wrappers
- [x] Re-run without --force skips existing files
- [x] Generated SKILL.md has correct frontmatter (name, description, metadata.source)
- [x] Fallback metadata applied for browser-tiered, evaluate, project-deploy
- [x] MCP notice present for MCP-dependent skills
- [x] Relative paths rewritten to absolute
- [x] Existing Claude install (.claude/skills, .claude/commands) unchanged

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)