### PR TITLE
fix(nano-banana): resolve node labels in C4 relationships panel (Closes #291)

### DIFF
--- a/mcp-nano-banana/src/diagrams/c4.py
+++ b/mcp-nano-banana/src/diagrams/c4.py
@@ -160,6 +160,7 @@ def generate_c4_diagram(
         """)
 
     # -- build edge labels overlay --
+    id_to_label = {node.id: node.label for node in spec.nodes}
     edge_labels_html = []
     for edge in spec.edges:
         dash = ""
@@ -172,13 +173,15 @@ def generate_c4_diagram(
             f'<span class="c4-edge-label">{_esc(edge.label)}</span>'
             if edge.label else ""
         )
+        from_label = id_to_label.get(edge.source, edge.source)
+        to_label = id_to_label.get(edge.target, edge.target)
         edge_labels_html.append(f"""
         <div class="c4-edge" data-from="{_esc(edge.source)}" data-to="{_esc(edge.target)}"
              data-dash="{dash}">
-            <span class="c4-edge-from">{_esc(edge.source)}</span>
+            <span class="c4-edge-from">{_esc(from_label)}</span>
             <span class="c4-edge-arrow">&#x2192;</span>
             {label_html}
-            <span class="c4-edge-to">{_esc(edge.target)}</span>
+            <span class="c4-edge-to">{_esc(to_label)}</span>
         </div>
         """)
 
@@ -276,6 +279,9 @@ def generate_c4_diagram(
     border-radius: 8px;
     padding: 12px 20px;
     margin-top: 8px;
+    max-height: 200px;
+    overflow-y: auto;
+    flex-shrink: 0;
 }}
 .c4-edges-title {{
     font-size: 13px;

--- a/mcp-nano-banana/src/diagrams/validate.py
+++ b/mcp-nano-banana/src/diagrams/validate.py
@@ -260,6 +260,44 @@ def validate_diagram(
                 ),
             ))
 
+    # --- MEDIUM: label_resolution ---
+    node_labels = {n.get("id", f"n{i}"): n.get("label", "") for i, n in enumerate(nodes)}
+    for i, edge in enumerate(edges):
+        src = edge.get("source", "")
+        tgt = edge.get("target", "")
+        if src in node_id_set and not node_labels.get(src, "").strip():
+            issues.append(_ValidationIssue(
+                check="label_resolution",
+                severity="medium",
+                message=f"Edge {i} source node '{src}' has an empty label - relationship will show raw ID",
+                edge_index=i,
+            ))
+        if tgt in node_id_set and not node_labels.get(tgt, "").strip():
+            issues.append(_ValidationIssue(
+                check="label_resolution",
+                severity="medium",
+                message=f"Edge {i} target node '{tgt}' has an empty label - relationship will show raw ID",
+                edge_index=i,
+            ))
+
+    # --- MEDIUM: relationships_overflow ---
+    if edges:
+        edge_row_height = 20
+        panel_header_height = 30
+        panel_padding = 24
+        panel_max_height = 200
+        estimated_panel_height = len(edges) * edge_row_height + panel_header_height + panel_padding
+        if estimated_panel_height > panel_max_height:
+            issues.append(_ValidationIssue(
+                check="relationships_overflow",
+                severity="medium",
+                message=(
+                    f"Relationships panel has {len(edges)} edges "
+                    f"(estimated {estimated_panel_height}px) exceeding "
+                    f"{panel_max_height}px max-height - panel will scroll"
+                ),
+            ))
+
     # --- LOW: long_labels ---
     for i, n in enumerate(nodes):
         nid = n.get("id", f"n{i}")
@@ -300,6 +338,16 @@ def validate_diagram(
     if any(iss.check == "contrast" for iss in issues):
         suggestions.append(
             "Adjust text or background colors to meet WCAG AA 4.5:1 contrast ratio."
+        )
+    if any(iss.check == "label_resolution" for iss in issues):
+        suggestions.append(
+            "Add a non-empty label to every node so relationship endpoints "
+            "display human-readable names instead of raw IDs."
+        )
+    if any(iss.check == "relationships_overflow" for iss in issues):
+        suggestions.append(
+            "The relationships panel will scroll. Consider splitting the diagram "
+            "to reduce edge count, or accept the scrollable panel."
         )
 
     issue_dicts = [

--- a/tests/test_c4_integration.py
+++ b/tests/test_c4_integration.py
@@ -245,6 +245,39 @@ class TestC4EdgeRendering:
         html = generate_c4_diagram(spec)
         assert "stroke-dasharray" in html
 
+    def test_edges_show_node_labels_not_ids(self):
+        spec = DiagramSpec(
+            title="Test",
+            nodes=[
+                DiagramNode(id="web-app", label="Web Application", type="container"),
+                DiagramNode(id="db-001", label="PostgreSQL Database", type="container"),
+            ],
+            edges=[DiagramEdge(source="web-app", target="db-001", label="SQL queries")],
+        )
+        html = generate_c4_diagram(spec)
+        assert "Web Application" in html
+        assert "PostgreSQL Database" in html
+        assert 'class="c4-edge-from">Web Application</span>' in html
+        assert 'class="c4-edge-to">PostgreSQL Database</span>' in html
+
+    def test_edges_fallback_to_id_for_unknown_source(self):
+        spec = DiagramSpec(
+            title="Test",
+            nodes=[
+                DiagramNode(id="a", label="Node A", type="container"),
+            ],
+            edges=[DiagramEdge(source="unknown", target="a", label="test")],
+        )
+        html = generate_c4_diagram(spec)
+        assert 'class="c4-edge-from">unknown</span>' in html
+        assert 'class="c4-edge-to">Node A</span>' in html
+
+    def test_edges_panel_has_overflow_css(self):
+        spec = _sample_l1_spec()
+        html = generate_c4_diagram(spec)
+        assert "max-height: 200px" in html
+        assert "overflow-y: auto" in html
+
 
 class TestC4CustomViewport:
     """Test custom width/height parameters."""

--- a/tests/test_validate_diagram.py
+++ b/tests/test_validate_diagram.py
@@ -274,6 +274,75 @@ class TestLongLabels:
         assert len(label_issues) == 0
 
 
+# ── label_resolution (MEDIUM) ───────────────────────────────────────────
+
+
+class TestLabelResolution:
+    def test_empty_label_flagged(self):
+        nodes = [
+            {"id": "a", "label": "Node A"},
+            {"id": "b", "label": ""},
+        ]
+        edges = [{"source": "a", "target": "b"}]
+        result = validate_diagram(nodes=nodes, edges=edges)
+        lr_issues = [iss for iss in result["issues"] if iss["check"] == "label_resolution"]
+        assert len(lr_issues) == 1
+        assert "empty label" in lr_issues[0]["message"]
+
+    def test_whitespace_only_label_flagged(self):
+        nodes = [
+            {"id": "a", "label": "Node A"},
+            {"id": "b", "label": "   "},
+        ]
+        edges = [{"source": "a", "target": "b"}]
+        result = validate_diagram(nodes=nodes, edges=edges)
+        lr_issues = [iss for iss in result["issues"] if iss["check"] == "label_resolution"]
+        assert len(lr_issues) == 1
+
+    def test_valid_labels_pass(self):
+        nodes = [
+            {"id": "a", "label": "Node A"},
+            {"id": "b", "label": "Node B"},
+        ]
+        edges = [{"source": "a", "target": "b"}]
+        result = validate_diagram(nodes=nodes, edges=edges)
+        lr_issues = [iss for iss in result["issues"] if iss["check"] == "label_resolution"]
+        assert len(lr_issues) == 0
+
+    def test_dangling_edge_not_double_flagged(self):
+        nodes = [{"id": "a", "label": "Node A"}]
+        edges = [{"source": "a", "target": "missing"}]
+        result = validate_diagram(nodes=nodes, edges=edges)
+        lr_issues = [iss for iss in result["issues"] if iss["check"] == "label_resolution"]
+        assert len(lr_issues) == 0
+
+
+# ── relationships_overflow (MEDIUM) ────────────────────────────────────
+
+
+class TestRelationshipsOverflow:
+    def test_many_edges_flagged(self):
+        nodes = [{"id": f"n{i}", "label": f"Node {i}"} for i in range(15)]
+        edges = [{"source": f"n{i}", "target": f"n{i+1}"} for i in range(14)]
+        result = validate_diagram(nodes=nodes, edges=edges)
+        ro_issues = [iss for iss in result["issues"] if iss["check"] == "relationships_overflow"]
+        assert len(ro_issues) == 1
+        assert "scroll" in ro_issues[0]["message"]
+
+    def test_few_edges_pass(self):
+        nodes = [{"id": f"n{i}", "label": f"Node {i}"} for i in range(4)]
+        edges = [{"source": f"n{i}", "target": f"n{i+1}"} for i in range(3)]
+        result = validate_diagram(nodes=nodes, edges=edges)
+        ro_issues = [iss for iss in result["issues"] if iss["check"] == "relationships_overflow"]
+        assert len(ro_issues) == 0
+
+    def test_no_edges_no_overflow(self):
+        nodes = [{"id": "a", "label": "A"}]
+        result = validate_diagram(nodes=nodes, edges=[])
+        ro_issues = [iss for iss in result["issues"] if iss["check"] == "relationships_overflow"]
+        assert len(ro_issues) == 0
+
+
 # ── Result structure ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Edge endpoints in the C4 relationships panel now display human-readable node labels instead of raw IDs (e.g., "Web Application" instead of "web-app")
- Added `max-height: 200px` with `overflow-y: auto` to the relationships panel to prevent clipping on diagrams with 10+ edges
- Added two new validation checks: `label_resolution` (warns on empty node labels) and `relationships_overflow` (warns when panel will scroll)

## Lint result
All checks passed (lint, test, typecheck via `make verify`)

## Test plan
- [x] `test_edges_show_node_labels_not_ids` - verifies labels appear in edge spans
- [x] `test_edges_fallback_to_id_for_unknown_source` - verifies graceful fallback for unresolved IDs
- [x] `test_edges_panel_has_overflow_css` - verifies overflow CSS is applied
- [x] `test_empty_label_flagged` / `test_whitespace_only_label_flagged` - validation catches empty labels
- [x] `test_many_edges_flagged` - validation catches panel overflow
- [x] All 551 tests pass

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)