### PR TITLE
feat(cicd): add mandatory gitleaks secret scan to Woodpecker pipeline (Closes #292)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,36 @@
+# Gitleaks configuration for claude-power-pack
+# https://github.com/gitleaks/gitleaks
+#
+# Local usage:  make secret-scan
+# CI usage:     runs automatically in Woodpecker pipeline before validate step
+
+[extend]
+useDefault = true
+
+# Global allowlist - paths and patterns that are known false positives
+[allowlist]
+  paths = [
+    # Virtual environments and caches
+    '''\.venv/''',
+    '''__pycache__/''',
+    '''\.mypy_cache/''',
+    '''node_modules/''',
+    # Lock files
+    '''uv\.lock$''',
+    # Documentation with example/placeholder credentials
+    '''docs/AWS_SECRETS_SIDECAR\.md$''',
+    '''\.claude/commands/secrets/validate\.md$''',
+    '''\.claude/commands/security/explain\.md$''',
+    '''\.claude/commands/cpp/init\.md$''',
+    '''\.claude/commands/second-opinion/help\.md$''',
+    '''INSTALLATION_ISSUES\.md$''',
+    # Security scanner/masking code references key patterns for detection
+    '''lib/security/explain\.py$''',
+    '''lib/creds/masking\.py$''',
+    # Secret masking scripts contain test patterns
+    '''scripts/secrets-mask\.sh$''',
+    # Test fixtures with dummy/example credentials
+    '''tests/test_security_scanners\.py$''',
+    '''tests/test_security_models\.py$''',
+    '''tests/test_creds_masking\.py$''',
+  ]

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,15 +2,21 @@
 # Runs quality gates, builds Docker containers, and deploys MCP servers
 #
 # Pipeline:
-#   PR/push   -> validate (lint+test+typecheck), dry-run builds
+#   PR/push   -> secret-scan -> validate (lint+test+typecheck) -> dry-run builds
 #   main push -> above + deploy-mcp (rebuild + restart containers)
 
 when:
   - event: [push, pull_request]
 
 steps:
+  secret-scan:
+    image: zricethezav/gitleaks:latest
+    commands:
+      - gitleaks detect --source . --config .gitleaks.toml --verbose
+
   validate:
     image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+    depends_on: [secret-scan]
     commands:
       - uv sync --extra dev --frozen
       - uv run ruff check .
@@ -19,6 +25,7 @@ steps:
 
   build-second-opinion:
     image: woodpeckerci/plugin-docker-buildx
+    depends_on: [validate]
     settings:
       repo: mcp-second-opinion
       dockerfile: mcp-second-opinion/deploy/Dockerfile
@@ -31,6 +38,7 @@ steps:
 
   build-playwright:
     image: woodpeckerci/plugin-docker-buildx
+    depends_on: [validate]
     settings:
       repo: mcp-playwright-persistent
       dockerfile: mcp-playwright-persistent/deploy/Dockerfile
@@ -43,6 +51,7 @@ steps:
 
   build-nano-banana:
     image: woodpeckerci/plugin-docker-buildx
+    depends_on: [validate]
     settings:
       repo: mcp-nano-banana
       dockerfile: mcp-nano-banana/deploy/Dockerfile
@@ -55,6 +64,7 @@ steps:
 
   build-woodpecker-ci:
     image: woodpeckerci/plugin-docker-buildx
+    depends_on: [validate]
     settings:
       repo: mcp-woodpecker-ci
       dockerfile: mcp-woodpecker-ci/deploy/Dockerfile
@@ -65,10 +75,9 @@ steps:
       - event: [push, pull_request]
         path: "mcp-woodpecker-ci/**"
 
-  # mcp-evaluate removed - deprecated, absorbed into /evaluate:issue skill
-
   drift-check:
     image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+    depends_on: [validate]
     commands:
       - scripts/drift-detect.sh || echo "WARN - drift detected (non-blocking on CI agent)"
     when:
@@ -82,6 +91,7 @@ steps:
 
   deploy-mcp:
     image: docker:cli
+    depends_on: [validate]
     commands:
       - apk add --no-cache docker-compose
       - echo "Deploying MCP containers..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **All profiles:** `make docker-up PROFILE="core browser cicd"`
 - **Status/logs/stop:** `make docker-ps`, `make docker-logs`, `make docker-down`
 - **MCP connections:** Defined in project `.mcp.json` pointing to `127.0.0.1:{port}/sse` (SSE transport)
-- **Woodpecker CI** runs on push/PR: lint, test, typecheck, conditional Docker builds
+- **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, conditional Docker builds
+- **Secret scanning:** `make secret-scan` runs gitleaks locally (native binary or Docker fallback). Config in `.gitleaks.toml` with allowlists for doc/test false positives
 - **Auto-deploy:** On push to main, if `mcp-*/` or `docker-compose.yml` changed, Woodpecker rebuilds and restarts MCP containers via the local agent
 - **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries) against repo templates. Runs as a pre-deploy gate in the CI pipeline. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint format typecheck verify update_docs clean \
+.PHONY: test lint format typecheck verify secret-scan update_docs clean \
        docker-build docker-check-env docker-secrets-check docker-up docker-down docker-logs docker-ps deploy \
        drift-check setup-woodpecker-cli codex-init
 
@@ -15,6 +15,17 @@ test:
 
 typecheck:
 	uv run --extra dev mypy .
+
+secret-scan:
+	@if command -v gitleaks > /dev/null 2>&1; then \
+		gitleaks detect --source . --config .gitleaks.toml --no-git --verbose; \
+	elif command -v docker > /dev/null 2>&1; then \
+		docker run --rm -v "$$(pwd):/repo" zricethezav/gitleaks:latest detect --source /repo --config /repo/.gitleaks.toml --no-git --verbose; \
+	else \
+		echo "ERROR: gitleaks not found. Install via: brew install gitleaks / go install github.com/gitleaks/gitleaks/v8@latest"; \
+		echo "       Or use Docker: docker run --rm -v \$$(pwd):/repo zricethezav/gitleaks:latest detect --source /repo"; \
+		exit 1; \
+	fi
 
 ## Pre-deploy gate (runs all quality checks)
 


### PR DESCRIPTION
## Summary
- Added `secret-scan` step to `.woodpecker.yml` using `zricethezav/gitleaks:latest` image, runs before all other steps on every push/PR
- Added `make secret-scan` target with native gitleaks or Docker fallback, using `--no-git` for fast filesystem scanning
- Created `.gitleaks.toml` with path-based allowlists for docs, test fixtures, and masking scripts that contain example/dummy credentials
- All pipeline steps now use explicit `depends_on` for DAG ordering: secret-scan -> validate -> builds/drift/deploy
- Updated CLAUDE.md to document the new secret scanning capability

## Test plan
- [x] `make secret-scan` passes locally with 0 leaks found (1.81 MB scanned)
- [x] `make verify` passes (551 tests, lint, typecheck)
- [x] Gitleaks correctly allowlists known false positives in docs/tests/masking code
- [ ] Woodpecker pipeline runs secret-scan step before validate on next push

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)