### PR TITLE
feat(codex): support workspace-root skill symlinks (Closes #304)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test lint format typecheck verify update_docs clean \
        docker-build docker-check-env docker-secrets-check docker-up docker-down docker-logs docker-ps deploy \
-       drift-check setup-woodpecker-cli codex-init
+       drift-check setup-woodpecker-cli codex-init codex-init-workspace
 
 ## Quality gates (used by /flow:finish)
 
@@ -119,6 +119,9 @@ codex-init:
 
 codex-init-force:
 	@python3 scripts/codex-skill-gen.py --force
+
+codex-init-workspace:
+	@python3 scripts/codex-skill-gen.py --force --workspace-root ..
 
 ## Utilities
 

--- a/scripts/codex-skill-gen.py
+++ b/scripts/codex-skill-gen.py
@@ -46,6 +46,12 @@ RELATIVE_PATH_PATTERN = re.compile(
     r"(`(?:docs/|scripts/|templates/|lib/|\.claude/|\.specify/)[^`]+`)"
 )
 
+BARE_PATH_PATTERN = re.compile(
+    r"(?<!`)(?<!/)((?:docs/|scripts/|templates/|lib/|\.claude/|\.specify/)"
+    r"\S+\.(?:md|py|sh|yml|yaml|json|toml))"
+    r"(?!`)"
+)
+
 
 def slugify(name: str) -> str:
     slug = name.lower()
@@ -93,12 +99,18 @@ def has_mcp_content(body: str) -> bool:
 
 
 def rewrite_paths(body: str, cpp_dir: str) -> str:
-    def replacer(match: re.Match[str]) -> str:
+    def backtick_replacer(match: re.Match[str]) -> str:
         path = match.group(1)
         inner = path.strip("`")
         return f"`{cpp_dir}/{inner}`"
 
-    return RELATIVE_PATH_PATTERN.sub(replacer, body)
+    def bare_replacer(match: re.Match[str]) -> str:
+        path = match.group(1)
+        return f"{cpp_dir}/{path}"
+
+    result = RELATIVE_PATH_PATTERN.sub(backtick_replacer, body)
+    result = BARE_PATH_PATTERN.sub(bare_replacer, result)
+    return result
 
 
 def generate_codex_skill(
@@ -148,6 +160,71 @@ metadata:
     return slug, skill_content, filename
 
 
+def link_workspace_skills(
+    cpp_skills_dir: Path,
+    workspace_root: Path,
+    *,
+    refresh: bool = False,
+    dry_run: bool = False,
+) -> tuple[int, int, int, int]:
+    """Create symlinks from workspace root .agents/skills to generated Codex skills.
+
+    Returns (linked, already_ok, skipped, stale) counts.
+    """
+    ws_skills_dir = workspace_root / ".agents" / "skills"
+    skill_dirs = sorted(
+        d for d in cpp_skills_dir.iterdir()
+        if d.is_dir() and d.name.startswith("claude-power-pack-")
+    )
+
+    if not skill_dirs:
+        print("  No generated skills found. Run codex-init first.", file=sys.stderr)
+        return 0, 0, 0, 0
+
+    if not dry_run:
+        ws_skills_dir.mkdir(parents=True, exist_ok=True)
+
+    linked = 0
+    already_ok = 0
+    skipped = 0
+    stale = 0
+
+    for skill_dir in skill_dirs:
+        link_path = ws_skills_dir / skill_dir.name
+        target = skill_dir.resolve()
+
+        if link_path.is_symlink():
+            existing_target = link_path.resolve()
+            if existing_target == target:
+                print(f"  OK: {link_path.name} (already linked)")
+                already_ok += 1
+                continue
+            if refresh:
+                if not dry_run:
+                    link_path.unlink()
+                    link_path.symlink_to(target)
+                print(f"  REFRESHED: {link_path.name} (was -> {existing_target})")
+                linked += 1
+            else:
+                print(f"  STALE: {link_path.name} -> {existing_target} (use --refresh to update)")
+                stale += 1
+            continue
+
+        if link_path.exists():
+            print(f"  SKIP: {link_path.name} (exists as non-symlink, will not overwrite)")
+            skipped += 1
+            continue
+
+        if dry_run:
+            print(f"  WOULD LINK: {link_path.name} -> {target}")
+        else:
+            link_path.symlink_to(target)
+            print(f"  LINKED: {link_path.name} -> {target}")
+        linked += 1
+
+    return linked, already_ok, skipped, stale
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate Codex skill wrappers from Claude Power Pack skills")
     parser.add_argument("--source", default=".claude/skills", help="Source skills directory")
@@ -155,6 +232,12 @@ def main() -> int:
     parser.add_argument("--cpp-dir", default=None, help="Claude Power Pack repo root (auto-detected if omitted)")
     parser.add_argument("--force", action="store_true", help="Overwrite existing generated skills")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be generated without writing")
+    parser.add_argument(
+        "--workspace-root",
+        default=None,
+        help="Link generated skills into workspace root .agents/skills (default: parent of repo root)",
+    )
+    parser.add_argument("--refresh", action="store_true", help="Replace stale symlinks in workspace root")
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parent.parent
@@ -208,6 +291,23 @@ def main() -> int:
         generated += 1
 
     print(f"\nDone: {generated} generated, {skipped} skipped, {errors} errors")
+
+    if args.workspace_root is not None:
+        ws_root = Path(args.workspace_root).resolve()
+        print(f"\nLinking skills into workspace root: {ws_root}")
+        linked, already_ok, ws_skipped, ws_stale = link_workspace_skills(
+            output_dir.resolve(),
+            ws_root,
+            refresh=args.refresh,
+            dry_run=args.dry_run,
+        )
+        print(
+            f"\nWorkspace links: {linked} linked, {already_ok} already OK,"
+            f" {ws_skipped} skipped, {ws_stale} stale"
+        )
+        if ws_stale > 0:
+            errors += 1
+
     return 0 if errors == 0 else 1
 
 

--- a/tests/test_codex_skill_gen.py
+++ b/tests/test_codex_skill_gen.py
@@ -19,6 +19,7 @@ slugify = codex_skill_gen.slugify
 generate_codex_skill = codex_skill_gen.generate_codex_skill
 has_mcp_content = codex_skill_gen.has_mcp_content
 rewrite_paths = codex_skill_gen.rewrite_paths
+link_workspace_skills = codex_skill_gen.link_workspace_skills
 FALLBACK_METADATA = codex_skill_gen.FALLBACK_METADATA
 
 
@@ -116,6 +117,23 @@ class TestRewritePaths:
         body = "Run `scripts/drift-detect.sh`"
         result = rewrite_paths(body, "/repo")
         assert "`/repo/scripts/drift-detect.sh`" in result
+
+    def test_rewrites_bare_path(self) -> None:
+        body = "Read docs/skills/cicd-verification.md"
+        result = rewrite_paths(body, "/opt/cpp")
+        assert "/opt/cpp/docs/skills/cicd-verification.md" in result
+
+    def test_rewrites_bare_scripts_path(self) -> None:
+        body = "Run scripts/setup.sh to start"
+        result = rewrite_paths(body, "/opt/cpp")
+        assert "/opt/cpp/scripts/setup.sh" in result
+
+    def test_bare_path_not_double_rewritten(self) -> None:
+        body = "See `docs/skills/foo.md` and docs/skills/bar.md"
+        result = rewrite_paths(body, "/opt/cpp")
+        assert "`/opt/cpp/docs/skills/foo.md`" in result
+        assert "/opt/cpp/docs/skills/bar.md" in result
+        assert result.count("/opt/cpp/docs/skills/foo.md") == 1
 
 
 class TestGenerateCodexSkill:
@@ -266,3 +284,119 @@ class TestEndToEnd:
             assert "name" in meta
             assert "description" in meta
             assert "trigger" in meta
+
+
+def _make_skill_dirs(base: Path, names: list[str]) -> None:
+    for name in names:
+        d = base / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(f"# {name}\n")
+
+
+class TestLinkWorkspaceSkills:
+    def test_creates_symlinks(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        ws_root.mkdir()
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo", "claude-power-pack-bar"])
+
+        linked, ok, skipped, stale = link_workspace_skills(cpp_skills, ws_root)
+        assert linked == 2
+        assert ok == 0
+        assert skipped == 0
+        assert stale == 0
+
+        link_bar = ws_root / ".agents" / "skills" / "claude-power-pack-bar"
+        assert link_bar.is_symlink()
+        assert (link_bar / "SKILL.md").read_text() == "# claude-power-pack-bar\n"
+
+    def test_idempotent_rerun(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        ws_root.mkdir()
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo"])
+
+        link_workspace_skills(cpp_skills, ws_root)
+        linked, ok, skipped, stale = link_workspace_skills(cpp_skills, ws_root)
+        assert linked == 0
+        assert ok == 1
+
+    def test_refuses_to_overwrite_non_symlink(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo"])
+        existing = ws_root / ".agents" / "skills" / "claude-power-pack-foo"
+        existing.mkdir(parents=True)
+        (existing / "SKILL.md").write_text("user content")
+
+        linked, ok, skipped, stale = link_workspace_skills(cpp_skills, ws_root)
+        assert linked == 0
+        assert skipped == 1
+        assert (existing / "SKILL.md").read_text() == "user content"
+
+    def test_detects_stale_symlinks(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo"])
+
+        link_path = ws_root / ".agents" / "skills" / "claude-power-pack-foo"
+        link_path.parent.mkdir(parents=True)
+        stale_target = tmp_path / "old-cpp" / "skills" / "claude-power-pack-foo"
+        stale_target.mkdir(parents=True)
+        link_path.symlink_to(stale_target)
+
+        linked, ok, skipped, stale = link_workspace_skills(cpp_skills, ws_root)
+        assert stale == 1
+        assert linked == 0
+
+    def test_refresh_replaces_stale(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo"])
+
+        link_path = ws_root / ".agents" / "skills" / "claude-power-pack-foo"
+        link_path.parent.mkdir(parents=True)
+        stale_target = tmp_path / "old-cpp" / "skills" / "claude-power-pack-foo"
+        stale_target.mkdir(parents=True)
+        link_path.symlink_to(stale_target)
+
+        linked, ok, skipped, stale = link_workspace_skills(
+            cpp_skills, ws_root, refresh=True,
+        )
+        assert linked == 1
+        assert stale == 0
+        assert link_path.resolve() == (cpp_skills / "claude-power-pack-foo").resolve()
+
+    def test_ignores_non_cpp_dirs(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        ws_root.mkdir()
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo", "other-skill"])
+
+        linked, ok, skipped, stale = link_workspace_skills(cpp_skills, ws_root)
+        assert linked == 1
+        ws_skills = ws_root / ".agents" / "skills"
+        assert (ws_skills / "claude-power-pack-foo").is_symlink()
+        assert not (ws_skills / "other-skill").exists()
+
+    def test_no_generated_skills_warns(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "empty"
+        cpp_skills.mkdir()
+        ws_root = tmp_path / "workspace"
+        ws_root.mkdir()
+
+        linked, ok, skipped, stale = link_workspace_skills(cpp_skills, ws_root)
+        assert linked == 0
+        assert ok == 0
+
+    def test_dry_run_no_side_effects(self, tmp_path: Path) -> None:
+        cpp_skills = tmp_path / "cpp" / ".agents" / "skills"
+        ws_root = tmp_path / "workspace"
+        ws_root.mkdir()
+        _make_skill_dirs(cpp_skills, ["claude-power-pack-foo"])
+
+        linked, ok, skipped, stale = link_workspace_skills(
+            cpp_skills, ws_root, dry_run=True,
+        )
+        assert linked == 1
+        assert not (ws_root / ".agents" / "skills" / "claude-power-pack-foo").exists()


### PR DESCRIPTION
## Summary
- Add `--workspace-root` and `--refresh` flags to `codex-skill-gen.py` for symlinking generated Codex skills into a parent workspace root `.agents/skills/`
- Extend `rewrite_paths` to handle bare relative paths (not just backtick-wrapped), fixing the cicd-verification wrapper's broken `docs/skills/...` reference
- Add `codex-init-workspace` Makefile target (`make codex-init-workspace` generates + links in one step)
- Add 11 new tests covering symlink creation, idempotency, stale detection, refresh, non-overwrite safety, dry-run, and bare path rewriting

## Test plan
- [x] All 562 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] Typecheck clean (`make typecheck`)
- [x] Manual validation: `codex-skill-gen.py --force` rewrites `docs/skills/cicd-verification.md` to absolute path
- [ ] After merge, run `make codex-init-workspace` from claude-power-pack and verify Codex discovers skills from ~/Projects

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)