### PR TITLE
feat(cicd): add bootstrap dependency checker for admin-only prerequisites (Closes #298)

### DIFF
--- a/.claude/cicd_tasks.yml
+++ b/.claude/cicd_tasks.yml
@@ -51,6 +51,14 @@ steps:
     timeout: 120
     skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
 
+  bootstrap_check:
+    command: >-
+      PYTHONPATH="${HOME}/Projects/claude-power-pack/lib"
+      python3 -m lib.cicd.bootstrap check
+    description: Check admin-only bootstrap dependencies are satisfied
+    timeout: 30
+    skip_if: '! [ -f .claude/bootstrap.yaml ]'
+
   drift_check:
     command: make drift-check
     description: Detect drift between repo templates and host-installed artifacts
@@ -80,6 +88,7 @@ plans:
   deploy:
     description: Deployment pipeline for /flow:deploy
     steps:
+      - bootstrap_check
       - deploy_security_scan
       - drift_check
       - deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, conditional Docker builds
 - **Secret scanning:** `make secret-scan` runs gitleaks locally (native binary or Docker fallback). Config in `.gitleaks.toml` with allowlists for doc/test false positives
 - **Auto-deploy:** On push to main, if `mcp-*/` or `docker-compose.yml` changed, Woodpecker rebuilds and restarts MCP containers via the local agent
+- **Bootstrap checks:** `make bootstrap-check` verifies admin-only prerequisites (IAM roles, secrets provisioning) before deploy. Configure in `.claude/bootstrap.yaml`. Runs as the first step in the deploy pipeline - blocks with remediation if unsatisfied.
 - **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries) against repo templates. Runs as a pre-deploy gate in the CI pipeline. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
 
 ## Commands Reference
@@ -105,6 +106,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `python -m lib.cicd validate` - Validate .claude/cicd.yml with fix suggestions (Pydantic v2)
 - `python -m lib.cicd validate --schema` - Generate JSON Schema for IDE autocompletion
 - `python -m lib.cicd run --plan <name>` - Execute CI/CD plan deterministically (finish, check, deploy)
+- `python -m lib.cicd.bootstrap check` - Check admin-only bootstrap dependencies (config: `.claude/bootstrap.yaml`)
 
 ### Security
 - `/security:scan` - Full scan: native + external tools

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test lint format typecheck verify secret-scan update_docs clean \
        docker-build docker-check-env docker-secrets-check docker-up docker-down docker-logs docker-ps deploy \
-       drift-check setup-woodpecker-cli codex-init codex-init-workspace
+       bootstrap-check drift-check setup-woodpecker-cli codex-init codex-init-workspace
 
 ## Quality gates (used by /flow:finish)
 
@@ -106,6 +106,11 @@ docker-logs:
 
 docker-ps:
 	docker compose --profile core --profile browser --profile cicd --profile coord ps
+
+## Bootstrap dependency check (admin-only prerequisites)
+
+bootstrap-check:
+	@scripts/bootstrap-check.sh
 
 ## Drift detection (compare host-installed artifacts against repo templates)
 

--- a/lib/cicd/bootstrap.py
+++ b/lib/cicd/bootstrap.py
@@ -1,0 +1,228 @@
+"""Bootstrap dependency checker for the CI/CD runner.
+
+Detects admin-only bootstrap prerequisites (IAM roles, secrets provisioning,
+manual infrastructure steps) and blocks deploy/merge if they are not satisfied.
+
+Projects declare bootstrap dependencies in .claude/bootstrap.yaml. Each
+dependency has a check_command that exits 0 when satisfied. If any check
+fails, the gate blocks with a remediation message.
+
+Usage:
+    python -m lib.cicd.bootstrap check [--project-root PATH]
+    python -m lib.cicd.bootstrap list  [--project-root PATH]
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+CONFIG_FILENAME = ".claude/bootstrap.yaml"
+
+
+@dataclass
+class BootstrapDependency:
+    """A single bootstrap prerequisite."""
+
+    name: str
+    description: str
+    check_command: str
+    remediation: str
+    timeout_seconds: int = 30
+
+    @classmethod
+    def from_dict(cls, name: str, data: dict[str, Any]) -> BootstrapDependency:
+        return cls(
+            name=name,
+            description=data.get("description", ""),
+            check_command=data["check_command"],
+            remediation=data.get("remediation", f"Run the bootstrap step for '{name}'"),
+            timeout_seconds=data.get("timeout_seconds", 30),
+        )
+
+
+@dataclass
+class BootstrapConfig:
+    """Configuration for bootstrap dependency checking."""
+
+    version: str = "1"
+    dependencies: list[BootstrapDependency] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, project_root: Path) -> Optional[BootstrapConfig]:
+        config_path = project_root / CONFIG_FILENAME
+        if not config_path.exists():
+            return None
+
+        with open(config_path) as f:
+            raw = yaml.safe_load(f)
+
+        if not raw or not isinstance(raw, dict):
+            return None
+
+        deps = []
+        for name, dep_data in raw.get("dependencies", {}).items():
+            if isinstance(dep_data, dict) and "check_command" in dep_data:
+                deps.append(BootstrapDependency.from_dict(name, dep_data))
+
+        return cls(
+            version=raw.get("version", "1"),
+            dependencies=deps,
+        )
+
+
+@dataclass
+class CheckResult:
+    """Result of checking a single bootstrap dependency."""
+
+    name: str
+    satisfied: bool
+    description: str = ""
+    remediation: str = ""
+    error: str = ""
+
+
+def check_dependency(dep: BootstrapDependency, project_root: Path) -> CheckResult:
+    """Run a dependency's check_command and return the result."""
+    try:
+        proc = subprocess.run(
+            dep.check_command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=dep.timeout_seconds,
+            cwd=str(project_root),
+        )
+        return CheckResult(
+            name=dep.name,
+            satisfied=proc.returncode == 0,
+            description=dep.description,
+            remediation=dep.remediation,
+            error=proc.stderr.strip() if proc.returncode != 0 else "",
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            name=dep.name,
+            satisfied=False,
+            description=dep.description,
+            remediation=dep.remediation,
+            error=f"Check timed out after {dep.timeout_seconds}s",
+        )
+    except OSError as e:
+        return CheckResult(
+            name=dep.name,
+            satisfied=False,
+            description=dep.description,
+            remediation=dep.remediation,
+            error=str(e),
+        )
+
+
+def check_all(project_root: Path) -> tuple[bool, list[CheckResult]]:
+    """Check all bootstrap dependencies.
+
+    Returns:
+        Tuple of (all_satisfied, results).
+    """
+    config = BootstrapConfig.load(project_root)
+    if config is None:
+        return True, []
+
+    if not config.dependencies:
+        return True, []
+
+    results = [check_dependency(dep, project_root) for dep in config.dependencies]
+    all_satisfied = all(r.satisfied for r in results)
+    return all_satisfied, results
+
+
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+BLUE = "\033[0;34m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+
+def _print_report(passed: bool, results: list[CheckResult], project_root: Path) -> None:
+    """Print a human-readable report."""
+    print(f"\n{BOLD}Bootstrap Dependency Check{NC}")
+    print("================================================")
+    print(f"Config: {BLUE}{project_root / CONFIG_FILENAME}{NC}")
+    print()
+
+    if not results:
+        print(f"{GREEN}No bootstrap dependencies configured.{NC}")
+        return
+
+    satisfied_count = sum(1 for r in results if r.satisfied)
+    blocked_count = len(results) - satisfied_count
+
+    for r in results:
+        if r.satisfied:
+            print(f"{GREEN}ok{NC}    {r.name} - {r.description}")
+        else:
+            print(f"{RED}BLOCK{NC} {r.name} - {r.description}")
+            if r.error:
+                print(f"       {YELLOW}error:{NC} {r.error}")
+            print(f"       {YELLOW}fix:{NC}   {r.remediation}")
+
+    print()
+    print("================================================")
+    if blocked_count > 0:
+        print(
+            f"{RED}BLOCKED{NC}: {blocked_count} bootstrap prerequisite(s) not satisfied "
+            f"({satisfied_count}/{len(results)} passed)"
+        )
+        print()
+        print(f"{BOLD}These require a manual bootstrap apply outside CI before deploying.{NC}")
+    else:
+        print(f"{GREEN}ALL SATISFIED{NC}: {satisfied_count}/{len(results)} bootstrap prerequisites passed")
+
+
+def main(args: list[str] | None = None) -> int:
+    """CLI entry point."""
+    if args is None:
+        args = sys.argv[1:]
+
+    project_root = Path(".")
+    command = "check"
+
+    i = 0
+    while i < len(args):
+        if args[i] == "--project-root" and i + 1 < len(args):
+            project_root = Path(args[i + 1])
+            i += 2
+        elif args[i] in ("check", "list"):
+            command = args[i]
+            i += 1
+        else:
+            i += 1
+
+    config = BootstrapConfig.load(project_root)
+
+    if command == "list":
+        if config is None or not config.dependencies:
+            print("No bootstrap dependencies configured.")
+            return 0
+        for dep in config.dependencies:
+            print(f"  {dep.name}: {dep.description}")
+            print(f"    check: {dep.check_command}")
+            print(f"    fix:   {dep.remediation}")
+        return 0
+
+    if config is None:
+        return 0
+
+    passed, results = check_all(project_root)
+    _print_report(passed, results, project_root)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -222,6 +222,17 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
     ],
     "deploy": [
         StepDef(
+            id="bootstrap_check",
+            command=(
+                'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '
+                "python3 -m lib.cicd.bootstrap check"
+            ),
+            description="Check admin-only bootstrap dependencies",
+            timeout_seconds=30,
+            max_attempts=1,
+            skip_if="! [ -f .claude/bootstrap.yaml ]",
+        ),
+        StepDef(
             id="security_scan",
             command=(
                 'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '

--- a/scripts/bootstrap-check.sh
+++ b/scripts/bootstrap-check.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# bootstrap-check.sh - Check admin-only bootstrap dependencies before deploy
+# Part of Claude Power Pack (CPP)
+#
+# Thin wrapper that invokes the Python bootstrap checker. Projects declare
+# dependencies in .claude/bootstrap.yaml; each dependency has a check_command
+# that must exit 0 for the deploy to proceed.
+#
+# Usage:
+#   bootstrap-check.sh              # Check all dependencies
+#   bootstrap-check.sh --list       # List configured dependencies
+#   bootstrap-check.sh --help       # Show help
+#
+# Exit codes:
+#   0 - All satisfied (or no config present)
+#   1 - One or more prerequisites not satisfied
+#   2 - Usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+    cat <<'EOF'
+bootstrap-check.sh - Check admin-only bootstrap dependencies
+
+Usage:
+  bootstrap-check.sh              Check all bootstrap prerequisites
+  bootstrap-check.sh --list       List configured dependencies
+  bootstrap-check.sh --help       Show this help
+
+Config file: .claude/bootstrap.yaml
+
+Dependencies define a check_command (exits 0 when satisfied) and a
+remediation message shown when the check fails.
+
+Exit codes:
+  0 - All satisfied (or no bootstrap.yaml present)
+  1 - One or more prerequisites not satisfied
+  2 - Usage error
+EOF
+}
+
+case "${1:-}" in
+    --help|-h)
+        usage
+        exit 0
+        ;;
+    --list)
+        PYTHONPATH="${REPO_ROOT}/lib:${PYTHONPATH:-}" \
+            python3 -m lib.cicd.bootstrap list --project-root "$REPO_ROOT"
+        exit $?
+        ;;
+    ""|--check)
+        PYTHONPATH="${REPO_ROOT}/lib:${PYTHONPATH:-}" \
+            python3 -m lib.cicd.bootstrap check --project-root "$REPO_ROOT"
+        exit $?
+        ;;
+    *)
+        echo "Unknown option: $1"
+        usage
+        exit 2
+        ;;
+esac

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,266 @@
+"""Tests for the bootstrap dependency checker."""
+
+from pathlib import Path
+
+import pytest
+
+from lib.cicd.bootstrap import (
+    BootstrapConfig,
+    BootstrapDependency,
+    check_all,
+    check_dependency,
+    main,
+)
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    (tmp_path / ".claude").mkdir()
+    return tmp_path
+
+
+def _write_config(project_root: Path, yaml_content: str) -> None:
+    config_path = project_root / ".claude" / "bootstrap.yaml"
+    config_path.write_text(yaml_content)
+
+
+class TestBootstrapConfig:
+    def test_load_missing_file(self, tmp_project: Path):
+        config = BootstrapConfig.load(tmp_project)
+        assert config is None
+
+    def test_load_empty_file(self, tmp_project: Path):
+        _write_config(tmp_project, "")
+        config = BootstrapConfig.load(tmp_project)
+        assert config is None
+
+    def test_load_valid_config(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  iam-role:
+    description: IAM role for project isolation
+    check_command: "test -f .bootstrap/iam-applied"
+    remediation: "Run: make iam-apply"
+  secrets:
+    description: AWS secrets provisioned
+    check_command: "aws secretsmanager describe-secret --secret-id test 2>/dev/null"
+    remediation: "Run: python woodpecker/bootstrap-secrets.py"
+    timeout_seconds: 15
+""",
+        )
+        config = BootstrapConfig.load(tmp_project)
+        assert config is not None
+        assert len(config.dependencies) == 2
+        assert config.dependencies[0].name == "iam-role"
+        assert config.dependencies[0].timeout_seconds == 30
+        assert config.dependencies[1].name == "secrets"
+        assert config.dependencies[1].timeout_seconds == 15
+
+    def test_load_config_without_check_command_skips(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  bad-dep:
+    description: Missing check_command
+    remediation: "Do something"
+  good-dep:
+    description: Has check_command
+    check_command: "true"
+    remediation: "Run something"
+""",
+        )
+        config = BootstrapConfig.load(tmp_project)
+        assert config is not None
+        assert len(config.dependencies) == 1
+        assert config.dependencies[0].name == "good-dep"
+
+
+class TestCheckDependency:
+    def test_satisfied(self, tmp_project: Path):
+        dep = BootstrapDependency(
+            name="test",
+            description="Always passes",
+            check_command="true",
+            remediation="N/A",
+        )
+        result = check_dependency(dep, tmp_project)
+        assert result.satisfied
+        assert result.error == ""
+
+    def test_not_satisfied(self, tmp_project: Path):
+        dep = BootstrapDependency(
+            name="test",
+            description="Always fails",
+            check_command="false",
+            remediation="Fix it",
+        )
+        result = check_dependency(dep, tmp_project)
+        assert not result.satisfied
+        assert result.remediation == "Fix it"
+
+    def test_timeout(self, tmp_project: Path):
+        dep = BootstrapDependency(
+            name="slow",
+            description="Times out",
+            check_command="sleep 10",
+            remediation="Speed up",
+            timeout_seconds=1,
+        )
+        result = check_dependency(dep, tmp_project)
+        assert not result.satisfied
+        assert "timed out" in result.error.lower()
+
+    def test_check_command_with_file(self, tmp_project: Path):
+        marker = tmp_project / ".bootstrap-done"
+        dep = BootstrapDependency(
+            name="marker",
+            description="Checks marker file",
+            check_command=f"test -f {marker}",
+            remediation="Run bootstrap",
+        )
+        result = check_dependency(dep, tmp_project)
+        assert not result.satisfied
+
+        marker.write_text("done")
+        result = check_dependency(dep, tmp_project)
+        assert result.satisfied
+
+
+class TestCheckAll:
+    def test_no_config(self, tmp_project: Path):
+        passed, results = check_all(tmp_project)
+        assert passed
+        assert results == []
+
+    def test_all_satisfied(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  dep1:
+    description: First dep
+    check_command: "true"
+    remediation: N/A
+  dep2:
+    description: Second dep
+    check_command: "true"
+    remediation: N/A
+""",
+        )
+        passed, results = check_all(tmp_project)
+        assert passed
+        assert len(results) == 2
+        assert all(r.satisfied for r in results)
+
+    def test_one_blocked(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  ok-dep:
+    description: Passes
+    check_command: "true"
+    remediation: N/A
+  bad-dep:
+    description: Fails
+    check_command: "false"
+    remediation: "Fix this"
+""",
+        )
+        passed, results = check_all(tmp_project)
+        assert not passed
+        assert len(results) == 2
+        blocked = [r for r in results if not r.satisfied]
+        assert len(blocked) == 1
+        assert blocked[0].name == "bad-dep"
+
+    def test_empty_dependencies(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies: {}
+""",
+        )
+        passed, results = check_all(tmp_project)
+        assert passed
+        assert results == []
+
+
+class TestCLI:
+    def test_check_no_config(self, tmp_project: Path, monkeypatch):
+        monkeypatch.chdir(tmp_project)
+        exit_code = main(["check"])
+        assert exit_code == 0
+
+    def test_check_all_pass(self, tmp_project: Path, monkeypatch):
+        monkeypatch.chdir(tmp_project)
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  dep1:
+    description: Passes
+    check_command: "true"
+    remediation: N/A
+""",
+        )
+        exit_code = main(["check"])
+        assert exit_code == 0
+
+    def test_check_blocked(self, tmp_project: Path, monkeypatch):
+        monkeypatch.chdir(tmp_project)
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  blocker:
+    description: Fails
+    check_command: "false"
+    remediation: "Run bootstrap"
+""",
+        )
+        exit_code = main(["check"])
+        assert exit_code == 1
+
+    def test_list_command(self, tmp_project: Path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_project)
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  my-dep:
+    description: A dependency
+    check_command: "test -f marker"
+    remediation: "Run setup"
+""",
+        )
+        exit_code = main(["list"])
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "my-dep" in output
+
+    def test_project_root_flag(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  dep:
+    description: Test
+    check_command: "true"
+    remediation: N/A
+""",
+        )
+        exit_code = main(["check", "--project-root", str(tmp_project)])
+        assert exit_code == 0


### PR DESCRIPTION
## Summary
- Adds `lib/cicd/bootstrap.py` - config-driven bootstrap dependency checker that gates deploys on admin-only prerequisites (IAM roles, secrets provisioning)
- Projects declare dependencies in `.claude/bootstrap.yaml` with check commands and remediation messages
- Inserts `bootstrap_check` as the first step in the deploy pipeline (before security scan and drift check)
- Includes shell wrapper (`scripts/bootstrap-check.sh`), Makefile target, and 17 tests

## Lint result
```
All checks passed! (568 tests, ruff clean, mypy clean)
```

## Grill-yourself transcript
Fired (inline self-interrogation). Verdict: yes. Key adjustment: made the check state-based (run check_commands against current system state) rather than diff-based, since at deploy time we're on main after merge.

## Second-opinion review
Skipped (MCP unreachable)

## Test plan
- [x] 17 unit tests covering config loading, dependency checking, timeouts, CLI entry points
- [x] No regressions in existing 551 tests (568 total)
- [x] `make verify` passes (lint + test + typecheck)
- [ ] Manual: create `.claude/bootstrap.yaml` in a test repo, verify `make bootstrap-check` blocks when check_command fails and passes when satisfied

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)