### PR TITLE
feat(mcp): add dual transport and Codex MCP registration (Closes #305)

### DIFF
--- a/.agents/CODEX_SETUP.md
+++ b/.agents/CODEX_SETUP.md
@@ -1,0 +1,67 @@
+# Claude Power Pack - Codex MCP Setup
+
+Claude Power Pack MCP servers expose both SSE (`/sse`) and streamable HTTP (`/mcp`) transports.
+Codex uses the streamable HTTP endpoint at `/mcp`.
+
+## Prerequisites
+
+1. Docker MCP containers are running and healthy:
+
+   ```bash
+   make docker-ps
+   # or: curl -sf http://127.0.0.1:8080/ && echo OK
+   ```
+
+2. Codex CLI is installed:
+
+   ```bash
+   command -v codex && codex mcp list
+   ```
+
+## Register MCP Servers with Codex
+
+Run each command to register the corresponding MCP server:
+
+```bash
+codex mcp add second-opinion --url http://127.0.0.1:8080/mcp
+codex mcp add playwright-persistent --url http://127.0.0.1:8081/mcp
+codex mcp add nano-banana --url http://127.0.0.1:8084/mcp
+```
+
+## Verify Registration
+
+```bash
+codex mcp list
+codex mcp get second-opinion
+codex mcp get playwright-persistent
+codex mcp get nano-banana
+```
+
+Restart Codex after registration for tools to become available.
+
+## Remove Registration
+
+```bash
+codex mcp remove second-opinion
+codex mcp remove playwright-persistent
+codex mcp remove nano-banana
+```
+
+## Transport Reference
+
+| Server               | Port | Claude Code (SSE)                          | Codex (streamable HTTP)                |
+|----------------------|------|--------------------------------------------|----------------------------------------|
+| second-opinion       | 8080 | `http://127.0.0.1:8080/sse`               | `http://127.0.0.1:8080/mcp`          |
+| playwright-persistent| 8081 | `http://127.0.0.1:8081/sse`               | `http://127.0.0.1:8081/mcp`          |
+| nano-banana          | 8084 | `http://127.0.0.1:8084/sse`               | `http://127.0.0.1:8084/mcp`          |
+
+## Notes
+
+- Claude Code and Codex registrations are independent. Registering with one does not affect the other.
+- Docker server health (`/`) is separate from MCP registration. A healthy server still needs explicit registration.
+- If Codex reports connection errors, verify the container is running and the `/mcp` endpoint responds:
+
+  ```bash
+  curl -sf http://127.0.0.1:8080/mcp -X POST -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}},"id":1}'
+  ```

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -1058,7 +1058,67 @@ echo "→ Sequential Thinking skipped"
 echo "  Install later: claude mcp add --transport stdio --scope user sequential-thinking -- npx -y @modelcontextprotocol/server-sequential-thinking"
 ```
 
-### 8b. Workstation Tuning (bash-prep)
+### 8b. Codex MCP Registration (optional)
+
+```
+=== Optional: Codex MCP Registration ===
+
+Register Claude Power Pack MCP servers with Codex?
+This will run `codex mcp add ...` and update Codex configuration.
+
+MCP servers expose streamable HTTP at /mcp for Codex compatibility.
+Claude Code continues to use /sse (unchanged).
+
+Register with Codex? [y/N]
+```
+
+If yes:
+
+```bash
+# Check if Codex CLI is available
+if ! command -v codex &>/dev/null; then
+  echo "⚠ Codex CLI not found. Skipping registration."
+  echo "  Install Codex first, then run the commands in .agents/CODEX_SETUP.md"
+else
+  CODEX_LIST=$(codex mcp list 2>/dev/null || echo "")
+
+  for entry in "second-opinion:8080" "playwright-persistent:8081" "nano-banana:8084"; do
+    NAME="${entry%%:*}"
+    PORT="${entry#*:}"
+    if echo "$CODEX_LIST" | grep -q "$NAME"; then
+      echo "-> $NAME already registered with Codex (skipped)"
+    else
+      # Verify container is reachable before registering
+      if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1; then
+        codex mcp add "$NAME" --url "http://127.0.0.1:${PORT}/mcp"
+        echo "✓ $NAME registered with Codex (http://127.0.0.1:${PORT}/mcp)"
+      else
+        echo "⚠ $NAME not reachable on port $PORT - skipping Codex registration"
+        echo "  Start containers first: make docker-up PROFILE=core"
+      fi
+    fi
+  done
+
+  echo ""
+  echo "Restart Codex for tools to become available."
+fi
+```
+
+If no:
+
+```bash
+echo "-> Codex registration skipped"
+# Write setup artifact for manual registration later
+mkdir -p .agents
+if [ -f "$CPP_DIR/.agents/CODEX_SETUP.md" ]; then
+  cp "$CPP_DIR/.agents/CODEX_SETUP.md" .agents/CODEX_SETUP.md
+  echo "  Setup commands saved to .agents/CODEX_SETUP.md"
+else
+  echo "  Register later with: codex mcp add <name> --url http://127.0.0.1:<port>/mcp"
+fi
+```
+
+### 8c. Workstation Tuning (bash-prep)
 
 ```
 === Optional: Workstation Tuning ===

--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -226,6 +226,39 @@ for server in second-opinion playwright-persistent woodpecker-ci; do
   fi
 done
 
+# Check Codex MCP registrations
+echo ""
+echo "MCP Servers (Codex):"
+if command -v codex &>/dev/null; then
+  CODEX_LIST=$(codex mcp list 2>/dev/null || echo "")
+  for server in second-opinion playwright-persistent nano-banana; do
+    if echo "$CODEX_LIST" | grep -q "$server"; then
+      echo "  [x] $server: registered"
+    else
+      echo "  [ ] $server: not registered"
+    fi
+  done
+else
+  echo "  [ ] Codex CLI: not installed"
+fi
+
+# Check MCP transport endpoints
+echo ""
+echo "MCP Transport Endpoints:"
+for entry in "8080:second-opinion" "8081:playwright-persistent" "8084:nano-banana"; do
+  PORT="${entry%%:*}"
+  NAME="${entry#*:}"
+  SSE_OK=$(curl -sf --max-time 2 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/sse" 2>/dev/null || echo "000")
+  MCP_OK=$(curl -sf --max-time 2 -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' "http://127.0.0.1:${PORT}/mcp" 2>/dev/null || echo "000")
+  if [ "$SSE_OK" != "000" ] && [ "$MCP_OK" != "000" ]; then
+    echo "  [x] $NAME: /sse ($SSE_OK) + /mcp ($MCP_OK)"
+  elif [ "$SSE_OK" != "000" ]; then
+    echo "  [~] $NAME: /sse ($SSE_OK) only - /mcp not available (upgrade containers)"
+  else
+    echo "  [ ] $NAME: not reachable on port $PORT"
+  fi
+done
+
 # Check MCP server connectivity and API key status
 echo ""
 echo "MCP Server Connectivity:"

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ mcp-second-opinion/src/tools/__pycache__/
 
 # Generated Codex skill wrappers (created by scripts/codex-skill-gen.py)
 .agents/
+!.agents/CODEX_SETUP.md

--- a/mcp-nano-banana/pyproject.toml
+++ b/mcp-nano-banana/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "pydantic>=2.6.0",
     "python-pptx>=1.0.0",
     "Pillow>=10.0.0",
+    "starlette>=0.38.0",
+    "uvicorn>=0.30.0",
 ]
 
 [build-system]

--- a/mcp-nano-banana/src/server.py
+++ b/mcp-nano-banana/src/server.py
@@ -653,6 +653,26 @@ def _html_to_text_summary(html: str, nodes: list[dict], edges: list | None) -> s
     return "\n".join(lines)
 
 
+def _build_dual_transport_app():
+    """Build a Starlette app serving both SSE and streamable-http transports.
+
+    SSE at /sse (Claude Code) and streamable-http at /mcp (Codex).
+    """
+    sse_app = mcp.http_app(transport="sse")
+    streamable_app = mcp.http_app(transport="streamable-http")
+
+    from starlette.applications import Starlette
+
+    routes = list(sse_app.routes)
+    for r in streamable_app.routes:
+        if getattr(r, "path", "") == "/mcp":
+            routes.append(r)
+            break
+
+    app = Starlette(routes=routes)
+    return app
+
+
 def main():
     """Main entry point for the MCP server."""
     parser = argparse.ArgumentParser(description="MCP Nano-Banana Diagram Server")
@@ -665,12 +685,14 @@ def main():
         logger.info("Transport: stdio")
         mcp.run(transport="stdio")
     else:
-        logger.info(f"Transport: SSE on {Config.SERVER_HOST}:{Config.SERVER_PORT}")
-        mcp.run(
-            transport="sse",
-            host=Config.SERVER_HOST,
-            port=Config.SERVER_PORT,
-        )
+        logger.info(f"Transport: sse+streamable-http on {Config.SERVER_HOST}:{Config.SERVER_PORT}")
+        logger.info("  /sse -> SSE transport (Claude Code)")
+        logger.info("  /mcp -> Streamable HTTP transport (Codex)")
+
+        import uvicorn
+
+        app = _build_dual_transport_app()
+        uvicorn.run(app, host=Config.SERVER_HOST, port=Config.SERVER_PORT)
 
 
 if __name__ == "__main__":

--- a/mcp-playwright-persistent/src/server.py
+++ b/mcp-playwright-persistent/src/server.py
@@ -750,6 +750,26 @@ async def health_check() -> dict:
 # Server Entry Point
 # ============================================================================
 
+def _build_dual_transport_app():
+    """Build a Starlette app serving both SSE and streamable-http transports.
+
+    SSE at /sse (Claude Code) and streamable-http at /mcp (Codex).
+    """
+    sse_app = mcp.http_app(transport="sse")
+    streamable_app = mcp.http_app(transport="streamable-http")
+
+    from starlette.applications import Starlette
+
+    routes = list(sse_app.routes)
+    for r in streamable_app.routes:
+        if getattr(r, "path", "") == "/mcp":
+            routes.append(r)
+            break
+
+    app = Starlette(routes=routes)
+    return app
+
+
 def main():
     """Main entry point for the MCP server."""
     parser = argparse.ArgumentParser(description="MCP Playwright Persistent")
@@ -766,11 +786,13 @@ def main():
     else:
         logger.info(f"Starting MCP Playwright Persistent on {SERVER_HOST}:{SERVER_PORT}")
         logger.info("SSE keepalive ping enabled (15s interval)")
-        mcp.run(
-            transport="sse",
-            host=SERVER_HOST,
-            port=SERVER_PORT,
-        )
+        logger.info("  /sse -> SSE transport (Claude Code)")
+        logger.info("  /mcp -> Streamable HTTP transport (Codex)")
+
+        import uvicorn
+
+        app = _build_dual_transport_app()
+        uvicorn.run(app, host=SERVER_HOST, port=SERVER_PORT)
 
 
 if __name__ == "__main__":

--- a/mcp-second-opinion/pyproject.toml
+++ b/mcp-second-opinion/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "tenacity>=8.0.0",
     "pydantic>=2.6.0",
     "httpx>=0.27.0",
+    "starlette>=0.38.0",
+    "uvicorn>=0.30.0",
 ]
 
 [build-system]

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -1757,6 +1757,26 @@ def _run_diagnose() -> int:
         return 1
 
 
+def _build_dual_transport_app():
+    """Build a Starlette app serving both SSE and streamable-http transports.
+
+    SSE at /sse (Claude Code) and streamable-http at /mcp (Codex).
+    """
+    sse_app = mcp.http_app(transport="sse")
+    streamable_app = mcp.http_app(transport="streamable-http")
+
+    from starlette.applications import Starlette
+
+    routes = list(sse_app.routes)
+    for r in streamable_app.routes:
+        if getattr(r, "path", "") == "/mcp":
+            routes.append(r)
+            break
+
+    app = Starlette(routes=routes)
+    return app
+
+
 def main():
     """Main entry point for the MCP server."""
     parser = argparse.ArgumentParser(description=Config.SERVER_NAME)
@@ -1782,7 +1802,9 @@ def main():
         logger.info("Transport: stdio")
     else:
         logger.info(f"Starting {Config.SERVER_NAME} v{Config.SERVER_VERSION}")
-        logger.info(f"Transport: sse on {Config.SERVER_HOST}:{Config.SERVER_PORT}")
+        logger.info(f"Transport: sse+streamable-http on {Config.SERVER_HOST}:{Config.SERVER_PORT}")
+        logger.info("  /sse -> SSE transport (Claude Code)")
+        logger.info("  /mcp -> Streamable HTTP transport (Codex)")
 
     logger.info(f"Context caching: {'enabled' if Config.ENABLE_CONTEXT_CACHING else 'disabled'}")
 
@@ -1796,11 +1818,10 @@ def main():
     if args.stdio:
         mcp.run(transport="stdio")
     else:
-        mcp.run(
-            transport="sse",
-            host=Config.SERVER_HOST,
-            port=Config.SERVER_PORT,
-        )
+        import uvicorn
+
+        app = _build_dual_transport_app()
+        uvicorn.run(app, host=Config.SERVER_HOST, port=Config.SERVER_PORT)
 
 
 if __name__ == "__main__":

--- a/tests/test_dual_transport.py
+++ b/tests/test_dual_transport.py
@@ -1,0 +1,112 @@
+"""Tests for dual-transport (SSE + streamable-http) MCP server configuration.
+
+Tests nano-banana directly (lightweight deps, in pythonpath).
+Tests second-opinion and playwright only if their deps are available.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    from starlette.testclient import TestClient
+except ImportError:
+    pytest.skip("starlette not installed", allow_module_level=True)
+
+
+def _load_module(server_dir: str, module_name: str):
+    """Load a server module, adding its src/ to sys.path temporarily."""
+    src_path = str(Path(__file__).resolve().parent.parent / server_dir / "src")
+    inserted = False
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+        inserted = True
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    try:
+        mod = importlib.import_module(module_name)
+    finally:
+        if inserted:
+            sys.path.remove(src_path)
+    return mod
+
+
+class TestNanoBananaDualTransport:
+    """Nano-banana has lightweight deps available in the root project."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.server = _load_module("mcp-nano-banana", "server")
+
+    def test_build_dual_transport_app_exists(self):
+        assert hasattr(self.server, "_build_dual_transport_app")
+        assert callable(self.server._build_dual_transport_app)
+
+    def test_dual_transport_app_has_all_routes(self):
+        app = self.server._build_dual_transport_app()
+        paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/" in paths, "Health check route missing"
+        assert "/sse" in paths, "SSE transport route missing"
+        assert "/mcp" in paths, "Streamable HTTP transport route missing"
+
+    def test_health_endpoint_responds_200(self):
+        app = self.server._build_dual_transport_app()
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+
+    def test_sse_route_registered(self):
+        """SSE transport route is registered (don't actually stream - it blocks)."""
+        app = self.server._build_dual_transport_app()
+        paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/sse" in paths
+
+    def test_mcp_route_registered(self):
+        """Streamable HTTP transport route is registered."""
+        app = self.server._build_dual_transport_app()
+        paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/mcp" in paths
+
+    def test_messages_mount_exists(self):
+        """SSE transport needs /messages for JSON-RPC message posting."""
+        app = self.server._build_dual_transport_app()
+        path_types = {getattr(r, "path", None): type(r).__name__ for r in app.routes}
+        assert "/messages" in path_types, "SSE /messages mount missing"
+
+
+class TestSecondOpinionDualTransport:
+    """Second-opinion has heavy deps - skip if not available."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        try:
+            from unittest.mock import patch
+
+            with patch.dict("os.environ", {
+                "GEMINI_API_KEY": "",
+                "OPENAI_API_KEY": "",
+                "ANTHROPIC_API_KEY": "",
+            }):
+                self.server = _load_module("mcp-second-opinion", "server")
+        except ImportError as e:
+            pytest.skip(f"second-opinion deps not available: {e}")
+
+    def test_dual_transport_app_has_all_routes(self):
+        app = self.server._build_dual_transport_app()
+        paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/" in paths
+        assert "/sse" in paths
+        assert "/mcp" in paths
+
+    def test_health_endpoint_responds_200(self):
+        app = self.server._build_dual_transport_app()
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"


### PR DESCRIPTION
## Summary
- All three Docker-hosted MCP servers (second-opinion :8080, playwright-persistent :8081, nano-banana :8084) now expose **both** `/sse` (legacy SSE for Claude Code) and `/mcp` (streamable HTTP for Codex) on the same port
- `/cpp:init` gains an optional Codex MCP registration step (user-mediated, not silent)
- `/cpp:status` reports Codex MCP registrations and dual-transport endpoint health
- `.agents/CODEX_SETUP.md` provides manual setup commands when automatic registration is skipped

## Changes
| File | Change |
|------|--------|
| `mcp-second-opinion/src/server.py` | Replace `mcp.run(transport="sse")` with combined Starlette app serving both `/sse` and `/mcp` |
| `mcp-playwright-persistent/src/server.py` | Same dual-transport pattern |
| `mcp-nano-banana/src/server.py` | Same dual-transport pattern |
| `mcp-second-opinion/pyproject.toml` | Add explicit `starlette`, `uvicorn` deps |
| `mcp-nano-banana/pyproject.toml` | Add explicit `starlette`, `uvicorn` deps |
| `.claude/commands/cpp/init.md` | Add Step 8b: Codex MCP registration (user-mediated) |
| `.claude/commands/cpp/status.md` | Add Codex MCP registration + transport endpoint sections |
| `.agents/CODEX_SETUP.md` | Manual Codex setup artifact with registration commands |
| `tests/test_dual_transport.py` | 8 tests: route structure, health endpoint, transport availability |
| `.gitignore` | Allow `.agents/CODEX_SETUP.md` through gitignore |

## Grill-yourself transcript
Verdict: **yes-with-caveats**
- Combined Starlette app approach (extracting routes from two `http_app()` calls) relies on FastMCP internal route structure
- `starlette` and `uvicorn` added as explicit deps to avoid breakage if FastMCP drops them as transitive deps

## Test plan
- [x] `ruff check .` passes (0 errors)
- [x] 547 tests pass, 2 skipped, 0 failures
- [x] Nano-banana dual transport: 6/6 tests pass (health, routes, mount verification)
- [x] Second-opinion dual transport: skipped in CI (heavy deps); verified manually via FastMCP API inspection
- [ ] Rebuild Docker containers and verify `/sse` still works for Claude Code
- [ ] Verify `/mcp` responds to streamable HTTP MCP initialize handshake
- [ ] Test `codex mcp add <name> --url http://127.0.0.1:<port>/mcp` after container rebuild

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)