### PR TITLE
feat(bootstrap): add jq as declared dependency (Closes #295)

### DIFF
--- a/.claude/bootstrap.yaml
+++ b/.claude/bootstrap.yaml
@@ -1,0 +1,12 @@
+version: "1"
+
+dependencies:
+  jq:
+    description: "JSON processor - required by flow commands (merge, finish, auto, status) and project commands"
+    check_command: "command -v jq > /dev/null 2>&1"
+    remediation: |
+      Install jq:
+        Ubuntu/Debian: sudo apt-get install -y jq
+        macOS:         brew install jq
+        Alpine:        apk add --no-cache jq
+        Arch:          sudo pacman -S jq


### PR DESCRIPTION
## Summary
- Created `.claude/bootstrap.yaml` declaring `jq` as a required bootstrap dependency
- `jq` is used in 25+ flow/project commands (merge, finish, auto, status, project-next, project-lite) but was never explicitly declared
- `make bootstrap-check` now validates `jq` is installed before deploy workflows can fail silently
- Includes install instructions for Ubuntu/Debian, macOS, Alpine, and Arch

## Test plan
- [x] `make bootstrap-check` passes with jq installed
- [x] `make verify` (lint + test + typecheck) passes
- [x] 579 tests pass, 0 failures

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)