### PR TITLE
fix(mcp): compose ASGI lifespans in dual-transport app to fix /mcp 500 (Closes #314)

### DIFF
--- a/mcp-nano-banana/src/server.py
+++ b/mcp-nano-banana/src/server.py
@@ -658,10 +658,12 @@ def _build_dual_transport_app():
 
     SSE at /sse (Claude Code) and streamable-http at /mcp (Codex).
     """
-    sse_app = mcp.http_app(transport="sse")
-    streamable_app = mcp.http_app(transport="streamable-http")
+    from contextlib import asynccontextmanager
 
     from starlette.applications import Starlette
+
+    sse_app = mcp.http_app(transport="sse")
+    streamable_app = mcp.http_app(transport="streamable-http")
 
     routes = list(sse_app.routes)
     for r in streamable_app.routes:
@@ -669,7 +671,12 @@ def _build_dual_transport_app():
             routes.append(r)
             break
 
-    app = Starlette(routes=routes)
+    @asynccontextmanager
+    async def _combined_lifespan(app):
+        async with sse_app.router.lifespan_context(app), streamable_app.router.lifespan_context(app):
+            yield
+
+    app = Starlette(routes=routes, lifespan=_combined_lifespan)
     return app
 
 

--- a/mcp-playwright-persistent/src/server.py
+++ b/mcp-playwright-persistent/src/server.py
@@ -755,10 +755,12 @@ def _build_dual_transport_app():
 
     SSE at /sse (Claude Code) and streamable-http at /mcp (Codex).
     """
-    sse_app = mcp.http_app(transport="sse")
-    streamable_app = mcp.http_app(transport="streamable-http")
+    from contextlib import asynccontextmanager
 
     from starlette.applications import Starlette
+
+    sse_app = mcp.http_app(transport="sse")
+    streamable_app = mcp.http_app(transport="streamable-http")
 
     routes = list(sse_app.routes)
     for r in streamable_app.routes:
@@ -766,7 +768,12 @@ def _build_dual_transport_app():
             routes.append(r)
             break
 
-    app = Starlette(routes=routes)
+    @asynccontextmanager
+    async def _combined_lifespan(app):
+        async with sse_app.router.lifespan_context(app), streamable_app.router.lifespan_context(app):
+            yield
+
+    app = Starlette(routes=routes, lifespan=_combined_lifespan)
     return app
 
 

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -1762,10 +1762,12 @@ def _build_dual_transport_app():
 
     SSE at /sse (Claude Code) and streamable-http at /mcp (Codex).
     """
-    sse_app = mcp.http_app(transport="sse")
-    streamable_app = mcp.http_app(transport="streamable-http")
+    from contextlib import asynccontextmanager
 
     from starlette.applications import Starlette
+
+    sse_app = mcp.http_app(transport="sse")
+    streamable_app = mcp.http_app(transport="streamable-http")
 
     routes = list(sse_app.routes)
     for r in streamable_app.routes:
@@ -1773,7 +1775,12 @@ def _build_dual_transport_app():
             routes.append(r)
             break
 
-    app = Starlette(routes=routes)
+    @asynccontextmanager
+    async def _combined_lifespan(app):
+        async with sse_app.router.lifespan_context(app), streamable_app.router.lifespan_context(app):
+            yield
+
+    app = Starlette(routes=routes, lifespan=_combined_lifespan)
     return app
 
 


### PR DESCRIPTION
## Summary
- Fix 500 Internal Server Error on `/mcp` streamable HTTP endpoints for all three core MCP servers (second-opinion, playwright-persistent, nano-banana)
- Root cause: `_build_dual_transport_app()` extracted routes from SSE and streamable-http FastMCP apps into a bare `Starlette()` without passing either app's lifespan, leaving `StreamableHTTPSessionManager`'s task group uninitialized
- Fix composes both apps' lifespan contexts into the parent Starlette app via `asynccontextmanager`

## Lint result
```
All checks passed! (ruff, pytest 591/591, mypy clean)
```

## Grill-yourself transcript
Skipped (trivial: 3 files, ~30 lines)

## Second-opinion review
Gemini confirms fix is correct - composing lifespans addresses the root cause. No issues found.

## Test plan
- [ ] `curl -i http://127.0.0.1:8080/` - health check still green
- [ ] `curl -i http://127.0.0.1:8081/` - health check still green
- [ ] `curl -i http://127.0.0.1:8084/` - health check still green
- [ ] `curl -i --max-time 2 http://127.0.0.1:8080/sse` - SSE still works
- [ ] `curl -i --max-time 2 http://127.0.0.1:8081/sse` - SSE still works
- [ ] `curl -i --max-time 2 http://127.0.0.1:8084/sse` - SSE still works
- [ ] `curl -i -X POST http://127.0.0.1:8080/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0.1"}}}'` - no longer 500
- [ ] Same for ports 8081 and 8084
- [ ] `tools/list` over `/mcp` returns tool lists for all three servers

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)