### PR TITLE
feat(cicd): add Woodpecker deployment guardrails (Closes #296)

### DIFF
--- a/.claude/bootstrap.yaml
+++ b/.claude/bootstrap.yaml
@@ -10,3 +10,29 @@ dependencies:
         macOS:         brew install jq
         Alpine:        apk add --no-cache jq
         Arch:          sudo pacman -S jq
+
+  aws-credentials:
+    description: "AWS credentials for secrets-agent sidecar (deploy-time secret fetching)"
+    check_command: "test -f .env && grep -q '^AWS_ACCESS_KEY_ID=.' .env"
+    remediation: |
+      Create .env with AWS credentials:
+        AWS_ACCESS_KEY_ID=<your-key>
+        AWS_SECRET_ACCESS_KEY=<your-secret>
+        AWS_TOKEN=<ssrf-protection-token>
+      Or run: make docker-secrets-check
+
+  docker-socket:
+    description: "Docker socket access for container deployment"
+    check_command: "test -S /var/run/docker.sock && test -w /var/run/docker.sock"
+    remediation: |
+      Ensure the current user has Docker socket access:
+        sudo usermod -aG docker $USER
+      Then log out and back in, or run: newgrp docker
+
+  docker-compose:
+    description: "Docker Compose v2 for MCP container orchestration"
+    check_command: "docker compose version > /dev/null 2>&1"
+    remediation: |
+      Install Docker Compose v2:
+        Ubuntu/Debian: sudo apt-get install -y docker-compose-plugin
+        Or: https://docs.docker.com/compose/install/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -89,16 +89,79 @@ steps:
           - "scripts/bash-prep.sh"
           - "scripts/drift-detect.sh"
 
-  deploy-mcp:
+  pre-deploy-guardrails:
     image: docker:cli
     depends_on: [validate]
     commands:
-      - apk add --no-cache docker-compose
+      - apk add --no-cache git curl
+      # Stale commit guard - verify we are deploying the latest
+      - |
+        LOCAL=$(git rev-parse HEAD)
+        git fetch origin main --quiet 2>/dev/null || true
+        REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "$LOCAL")
+        if [ "$LOCAL" != "$REMOTE" ]; then
+          echo "BLOCKED: Stale commit detected"
+          echo "  local=$LOCAL"
+          echo "  remote=$REMOTE"
+          echo "  Run 'git pull origin main' before deploying."
+          exit 1
+        fi
+        echo "OK: HEAD matches origin/main at ${LOCAL:0:12}"
+      # Docker socket access check
+      - |
+        if [ ! -S /var/run/docker.sock ]; then
+          echo "BLOCKED: docker.sock not mounted"
+          exit 1
+        fi
+        echo "OK: docker.sock accessible"
+        echo "AUDIT: docker.sock access by $(whoami) at $(date -Iseconds)"
+      # Deploy lock - prevent concurrent deploys
+      - |
+        LOCKFILE="/tmp/cpp-deploy.lock"
+        exec 9>"$LOCKFILE"
+        if ! flock -n -w 60 9; then
+          echo "BLOCKED: Another deploy is in progress (lock held)"
+          exit 1
+        fi
+        echo "OK: Deploy lock acquired"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      - event: push
+        branch: main
+        path:
+          - "mcp-second-opinion/**"
+          - "mcp-playwright-persistent/**"
+          - "mcp-nano-banana/**"
+          - "mcp-woodpecker-ci/**"
+          - "docker-compose.yml"
+
+  deploy-mcp:
+    image: docker:cli
+    depends_on: [validate, pre-deploy-guardrails]
+    commands:
+      - apk add --no-cache docker-compose curl
       - echo "Deploying MCP containers..."
       - docker compose --profile core --profile browser --profile cicd up -d --build --wait
       - docker compose --profile core --profile browser --profile cicd ps
-      - docker image prune -f
+      # Safe prune with time filter to avoid cache races with concurrent builds
+      - docker image prune -f --filter "until=1h"
       - echo "Deploy complete."
+      # Capability check - verify services can actually serve, not just respond
+      - |
+        FAILED=0
+        for port in 8080 8081 8084; do
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:${port}/" 2>/dev/null || echo "000")
+          if [ "$STATUS" = "200" ]; then
+            echo "OK: port $port health check passed (HTTP $STATUS)"
+          else
+            echo "WARN: port $port returned HTTP $STATUS"
+            FAILED=$((FAILED + 1))
+          fi
+        done
+        if [ "$FAILED" -gt 0 ]; then
+          echo "WARNING: $FAILED service(s) not healthy after deploy"
+        fi
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     when:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,14 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Secret scanning:** `make secret-scan` runs gitleaks locally (native binary or Docker fallback). Config in `.gitleaks.toml` with allowlists for doc/test false positives
 - **Auto-deploy:** On push to main, if `mcp-*/` or `docker-compose.yml` changed, Woodpecker rebuilds and restarts MCP containers via the local agent
 - **Bootstrap checks:** `make bootstrap-check` verifies admin-only prerequisites (IAM roles, secrets provisioning) before deploy. Configure in `.claude/bootstrap.yaml`. Runs as the first step in the deploy pipeline - blocks with remediation if unsatisfied.
-- **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries) against repo templates. Runs as a pre-deploy gate in the CI pipeline. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
+- **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries, shared scripts) against repo templates. Runs as a pre-deploy gate in the CI pipeline. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
+- **Deploy guardrails:** Pre-deploy validation gates in the Woodpecker pipeline and `lib/cicd/deploy/guardrails.py`:
+  - Stale commit protection (HEAD must match origin/main before deploy)
+  - Deploy lock (flock-based, prevents concurrent deploys on shared Docker hosts)
+  - Capability-based readiness checks (validate services can serve, not just respond to health pings)
+  - Safe Docker prune (time-filtered cleanup under lock to avoid cache races)
+  - docker.sock access audit logging
+  - Shared script contract drift detection (fetch-secrets.sh, bash-prep.sh consistency across containers)
 
 ## Commands Reference
 

--- a/lib/cicd/deploy/__init__.py
+++ b/lib/cicd/deploy/__init__.py
@@ -1,13 +1,23 @@
-"""Deployment strategies with readiness gates and rollback.
+"""Deployment strategies with readiness gates, rollback, and guardrails.
 
 Provides a pluggable strategy system for CI/CD deployments:
 - DeploymentStrategy Protocol for custom strategies
 - DockerComposeStrategy for docker compose deployments
 - ReadinessPolicy for polling health endpoints after deploy
 - Automatic rollback on readiness failure
+- Deploy guardrails: stale commit checks, deploy locks, capability checks
 """
 
 from .docker_compose import DockerComposeStrategy
+from .guardrails import (
+    CapabilityCheck,
+    CapabilityResult,
+    check_docker_socket,
+    check_stale_commit,
+    deploy_lock,
+    run_capability_checks,
+    safe_docker_prune,
+)
 from .strategy import (
     DeployConfig,
     DeploymentStrategy,
@@ -19,12 +29,19 @@ from .strategy import (
 )
 
 __all__ = [
+    "CapabilityCheck",
+    "CapabilityResult",
     "DeployConfig",
     "DeploymentStrategy",
     "DockerComposeStrategy",
     "ReadinessPolicy",
     "ReadinessResult",
+    "check_docker_socket",
+    "check_stale_commit",
+    "deploy_lock",
     "get_strategy",
     "poll_readiness",
     "register_strategy",
+    "run_capability_checks",
+    "safe_docker_prune",
 ]

--- a/lib/cicd/deploy/docker_compose.py
+++ b/lib/cicd/deploy/docker_compose.py
@@ -3,16 +3,23 @@
 Handles deploy, rollback, and readiness checking for services
 managed by docker compose. This is the primary deployment strategy
 for Claude Power Pack MCP servers.
+
+Guardrails integration:
+- Optional deploy lock prevents concurrent deploys on shared Docker hosts
+- Safe prune uses time-filtered cleanup under lock to avoid cache races
 """
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import Any
 
 from ..state import StepStatus
 from ..steps import StepResult
 from .strategy import DeployConfig, register_strategy
+
+logger = logging.getLogger(__name__)
 
 
 class DockerComposeStrategy:
@@ -32,7 +39,50 @@ class DockerComposeStrategy:
 
         Uses `docker compose up -d` with optional profiles and services.
         If a custom deploy_command is set in config, uses that instead.
+
+        When use_deploy_lock is True, the entire deploy operation is wrapped
+        in a flock to prevent concurrent deploys on shared Docker hosts.
+        When safe_prune is True, image cleanup uses a time filter under lock
+        to avoid cache races with other builds.
         """
+        if config.use_deploy_lock:
+            from .guardrails import deploy_lock
+
+            try:
+                with deploy_lock():
+                    result = self._deploy_inner(context, config)
+                    if result.success and config.safe_prune:
+                        from .guardrails import safe_docker_prune
+
+                        prune_result = safe_docker_prune(
+                            project_root=context.get("project_root"),
+                        )
+                        if not prune_result.success:
+                            logger.warning(
+                                "Post-deploy prune failed: %s",
+                                prune_result.error,
+                            )
+                    return result
+            except TimeoutError as e:
+                return StepResult(
+                    status=StepStatus.FAILED,
+                    exit_code=1,
+                    error=str(e),
+                )
+
+        result = self._deploy_inner(context, config)
+        if result.success and config.safe_prune:
+            from .guardrails import safe_docker_prune
+
+            prune_result = safe_docker_prune(
+                project_root=context.get("project_root"),
+            )
+            if not prune_result.success:
+                logger.warning("Post-deploy prune failed: %s", prune_result.error)
+        return result
+
+    def _deploy_inner(self, context: dict[str, Any], config: DeployConfig) -> StepResult:
+        """Core deploy logic: pull + up."""
         cwd = context.get("project_root")
         env = context.get("env")
 
@@ -41,7 +91,6 @@ class DockerComposeStrategy:
                                    timeout=config.timeout_seconds)
 
         base = self._compose_base_cmd(config)
-        # Pull first, then up
         pull_cmd = base + ["pull"]
         if config.services:
             pull_cmd.extend(config.services)

--- a/lib/cicd/deploy/guardrails.py
+++ b/lib/cicd/deploy/guardrails.py
@@ -1,0 +1,305 @@
+"""Woodpecker deployment guardrails.
+
+Pre-deploy validation gates that prevent common deployment failures:
+- Stale commit protection (HEAD must match remote)
+- Deploy lock (flock-based, prevents concurrent deploys on shared Docker hosts)
+- Capability-based readiness checks (validate service can actually serve, not just respond)
+- docker.sock access audit logging
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import shutil
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generator, Optional
+
+from ..state import StepStatus
+from ..steps import StepResult
+
+logger = logging.getLogger(__name__)
+
+DEPLOY_LOCK_PATH = Path("/tmp/claude-power-pack-deploy.lock")
+
+
+@dataclass
+class CapabilityCheck:
+    """A post-readiness capability validation.
+
+    Unlike health checks (HTTP 200), capability checks verify that a
+    service can actually perform its function - e.g., has loaded secrets,
+    can reach required dependencies, responds to domain-specific probes.
+    """
+
+    name: str
+    command: str
+    timeout_seconds: int = 10
+
+    def run(self, cwd: Optional[str] = None) -> CapabilityResult:
+        try:
+            proc = subprocess.run(
+                self.command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                cwd=cwd,
+            )
+            return CapabilityResult(
+                name=self.name,
+                passed=proc.returncode == 0,
+                output=proc.stdout.strip(),
+                error=proc.stderr.strip() if proc.returncode != 0 else "",
+            )
+        except subprocess.TimeoutExpired:
+            return CapabilityResult(
+                name=self.name,
+                passed=False,
+                error=f"Timed out after {self.timeout_seconds}s",
+            )
+        except OSError as e:
+            return CapabilityResult(
+                name=self.name,
+                passed=False,
+                error=str(e),
+            )
+
+
+@dataclass
+class CapabilityResult:
+    name: str
+    passed: bool
+    output: str = ""
+    error: str = ""
+
+
+def run_capability_checks(
+    checks: list[CapabilityCheck],
+    cwd: Optional[str] = None,
+) -> tuple[bool, list[CapabilityResult]]:
+    """Run all capability checks and return aggregate result."""
+    if not checks:
+        return True, []
+
+    results = [check.run(cwd=cwd) for check in checks]
+    all_passed = all(r.passed for r in results)
+    return all_passed, results
+
+
+def check_stale_commit(
+    project_root: Optional[str] = None,
+    branch: str = "main",
+    remote: str = "origin",
+) -> StepResult:
+    """Verify local HEAD matches the remote branch tip.
+
+    Prevents deploying stale code when the local checkout has drifted
+    behind the canonical remote.
+    """
+    cwd = project_root or os.getcwd()
+    git = shutil.which("git")
+    if not git:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error="git not found in PATH",
+        )
+
+    try:
+        subprocess.run(
+            [git, "fetch", remote, branch],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=cwd,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error=f"Failed to fetch {remote}/{branch}: {e}",
+        )
+
+    try:
+        local = subprocess.run(
+            [git, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+        remote_ref = subprocess.run(
+            [git, "rev-parse", f"{remote}/{branch}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error=f"Failed to resolve refs: {e}",
+        )
+
+    local_sha = local.stdout.strip()
+    remote_sha = remote_ref.stdout.strip()
+
+    if local_sha != remote_sha:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            output=f"local={local_sha[:12]} remote={remote_sha[:12]}",
+            error=(
+                f"Stale commit: HEAD ({local_sha[:12]}) does not match "
+                f"{remote}/{branch} ({remote_sha[:12]}). "
+                f"Run 'git pull {remote} {branch}' before deploying."
+            ),
+        )
+
+    return StepResult(
+        status=StepStatus.SUCCESS,
+        exit_code=0,
+        output=f"HEAD matches {remote}/{branch} at {local_sha[:12]}",
+    )
+
+
+@contextmanager
+def deploy_lock(
+    lock_path: Optional[Path] = None,
+    timeout_seconds: float = 300,
+) -> Generator[None, None, None]:
+    """Acquire an exclusive deploy lock to prevent concurrent deploys.
+
+    Uses flock to coordinate on shared Docker hosts where multiple
+    pipelines may attempt simultaneous deploys.
+    """
+    path = lock_path or DEPLOY_LOCK_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    start = time.monotonic()
+    lock_file = open(path, "w")
+    acquired = False
+
+    try:
+        while True:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                lock_file.write(f"pid={os.getpid()} time={time.time():.0f}\n")
+                lock_file.flush()
+                logger.info("Deploy lock acquired: %s", path)
+                break
+            except BlockingIOError:
+                elapsed = time.monotonic() - start
+                if elapsed >= timeout_seconds:
+                    raise TimeoutError(
+                        f"Could not acquire deploy lock at {path} "
+                        f"after {timeout_seconds:.0f}s. Another deploy may "
+                        f"be in progress."
+                    )
+                time.sleep(2)
+
+        yield
+
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+        lock_file.close()
+        logger.info("Deploy lock released: %s", path)
+
+
+def check_docker_socket(socket_path: str = "/var/run/docker.sock") -> StepResult:
+    """Validate docker.sock is accessible and log the access for auditability."""
+    if not os.path.exists(socket_path):
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error=f"Docker socket not found: {socket_path}",
+        )
+
+    if not os.access(socket_path, os.R_OK | os.W_OK):
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error=(
+                f"Docker socket not accessible: {socket_path}. "
+                f"Current user: {os.getenv('USER', 'unknown')} "
+                f"(uid={os.getuid()})"
+            ),
+        )
+
+    logger.info(
+        "docker.sock access validated: path=%s user=%s uid=%d pid=%d",
+        socket_path,
+        os.getenv("USER", "unknown"),
+        os.getuid(),
+        os.getpid(),
+    )
+
+    return StepResult(
+        status=StepStatus.SUCCESS,
+        exit_code=0,
+        output=f"Docker socket accessible: {socket_path}",
+    )
+
+
+def safe_docker_prune(
+    project_root: Optional[str] = None,
+    lock_path: Optional[Path] = None,
+) -> StepResult:
+    """Run docker image prune under deploy lock to prevent cache races.
+
+    Concurrent prune operations can remove images that another build
+    is actively using. This wraps the prune in the same deploy lock.
+    """
+    docker = shutil.which("docker")
+    if not docker:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error="docker not found in PATH",
+        )
+
+    try:
+        with deploy_lock(lock_path=lock_path, timeout_seconds=60):
+            proc = subprocess.run(
+                [docker, "image", "prune", "-f", "--filter", "until=1h"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                cwd=project_root,
+            )
+            if proc.returncode == 0:
+                return StepResult(
+                    status=StepStatus.SUCCESS,
+                    exit_code=0,
+                    output=proc.stdout.strip(),
+                )
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=proc.returncode,
+                output=proc.stdout,
+                error=proc.stderr,
+            )
+    except TimeoutError as e:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error=str(e),
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=1,
+            error=f"Docker prune failed: {e}",
+        )

--- a/lib/cicd/deploy/strategy.py
+++ b/lib/cicd/deploy/strategy.py
@@ -68,6 +68,10 @@ class ReadinessPolicy:
 
     Polls a URL until N consecutive successful responses or timeout.
     Uses exponential backoff between attempts.
+
+    Optional capability_checks run after HTTP readiness passes, validating
+    that the service can actually perform its function (has secrets loaded,
+    can reach dependencies, responds to domain-specific probes).
     """
 
     url: str
@@ -76,6 +80,7 @@ class ReadinessPolicy:
     consecutive_successes: int = 3
     backoff_multiplier: float = 1.5
     expected_status: int = 200
+    capability_checks: list[dict[str, Any]] = field(default_factory=list)
 
     def validate(self) -> list[str]:
         """Return validation errors, if any."""
@@ -108,6 +113,9 @@ class DeployConfig:
     rollback_command: Optional[str] = None
     deploy_command: Optional[str] = None
     timeout_seconds: int = 900
+    use_deploy_lock: bool = False
+    stale_commit_check: bool = False
+    safe_prune: bool = False
     extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -121,6 +129,7 @@ class DeployConfig:
         known_keys = {
             "strategy", "compose_file", "readiness", "rollback_command",
             "deploy_command", "timeout_seconds", "profiles", "services",
+            "use_deploy_lock", "stale_commit_check", "safe_prune",
         }
         for k, v in list(data.items()):
             if k not in known_keys:
@@ -136,6 +145,9 @@ class DeployConfig:
             rollback_command=data.get("rollback_command"),
             deploy_command=data.get("deploy_command"),
             timeout_seconds=data.get("timeout_seconds", 900),
+            use_deploy_lock=data.get("use_deploy_lock", False),
+            stale_commit_check=data.get("stale_commit_check", False),
+            safe_prune=data.get("safe_prune", False),
             extra=extra,
         )
 
@@ -248,6 +260,31 @@ def poll_readiness(
             if status_code == policy.expected_status:
                 consecutive_ok += 1
                 if consecutive_ok >= policy.consecutive_successes:
+                    # HTTP is ready - run capability checks if configured
+                    if policy.capability_checks:
+                        from .guardrails import CapabilityCheck, run_capability_checks
+
+                        checks = [
+                            CapabilityCheck(
+                                name=c.get("name", f"check-{i}"),
+                                command=c["command"],
+                                timeout_seconds=c.get("timeout_seconds", 10),
+                            )
+                            for i, c in enumerate(policy.capability_checks)
+                        ]
+                        cap_ok, cap_results = run_capability_checks(checks)
+                        if not cap_ok:
+                            failed = [r for r in cap_results if not r.passed]
+                            names = ", ".join(r.name for r in failed)
+                            errors_str = "; ".join(
+                                f"{r.name}: {r.error}" for r in failed
+                            )
+                            consecutive_ok = 0
+                            last_error = (
+                                f"Capability checks failed ({names}): {errors_str}"
+                            )
+                            continue
+
                     return ReadinessResult(
                         ready=True,
                         attempts=attempts,

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -233,6 +233,20 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
             skip_if="! [ -f .claude/bootstrap.yaml ]",
         ),
         StepDef(
+            id="stale_commit_check",
+            command=(
+                'LOCAL=$(git rev-parse HEAD) && '
+                'git fetch origin main --quiet && '
+                'REMOTE=$(git rev-parse origin/main) && '
+                '[ "$LOCAL" = "$REMOTE" ] || '
+                '{ echo "STALE: local=$LOCAL remote=$REMOTE"; exit 1; }'
+            ),
+            description="Verify HEAD matches origin/main (stale commit guard)",
+            timeout_seconds=30,
+            max_attempts=1,
+            skip_if='[ "$(git branch --show-current)" != "main" ]',
+        ),
+        StepDef(
             id="security_scan",
             command=(
                 'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '

--- a/scripts/drift-detect.sh
+++ b/scripts/drift-detect.sh
@@ -55,6 +55,8 @@ Categories checked:
   1. Systemd units    - installed .service files vs repo templates
   2. Sysctl config    - /etc/sysctl.d/99-claude-code.conf vs bash-prep.sh targets
   3. Go binary        - ~/go/bin/woodpecker-mcp version currency
+  4. Docker containers - running container health status
+  5. Shared scripts   - cross-container script consistency (fetch-secrets.sh, bash-prep.sh)
 
 Exit codes:
   0 - No drift (or no artifacts installed to check)
@@ -248,6 +250,75 @@ check_docker_compose() {
     fi
 }
 
+# --- Shared script contract drift ---
+# Detects when scripts used by multiple containers have diverged.
+# Each MCP container that copies a shared script should use the same version.
+check_shared_scripts() {
+    # fetch-secrets.sh is the primary shared script across MCP containers
+    local canonical="$REPO_ROOT/scripts/fetch-secrets.sh"
+    if [[ ! -f "$canonical" ]]; then
+        # Look for a canonical copy in any MCP container's deploy dir
+        for dir in "$REPO_ROOT"/mcp-*/deploy; do
+            if [[ -f "$dir/fetch-secrets.sh" ]]; then
+                canonical="$dir/fetch-secrets.sh"
+                break
+            fi
+        done
+    fi
+
+    if [[ ! -f "$canonical" ]]; then
+        skip "shared scripts - no fetch-secrets.sh found in any deploy dir"
+        return
+    fi
+
+    local canonical_hash
+    canonical_hash=$(sha256sum "$canonical" | cut -d' ' -f1)
+    local canonical_rel="${canonical#$REPO_ROOT/}"
+    local has_drift=false
+
+    for dir in "$REPO_ROOT"/mcp-*/deploy; do
+        local script="$dir/fetch-secrets.sh"
+        [[ -f "$script" ]] || continue
+        [[ "$script" = "$canonical" ]] && continue
+
+        local script_hash
+        script_hash=$(sha256sum "$script" | cut -d' ' -f1)
+        local script_rel="${script#$REPO_ROOT/}"
+
+        if [[ "$canonical_hash" != "$script_hash" ]]; then
+            drift "shared script divergence: $script_rel differs from $canonical_rel"
+            has_drift=true
+        fi
+    done
+
+    # Also check bash-prep.sh if it exists in multiple locations
+    local bash_preps=()
+    while IFS= read -r -d '' f; do
+        bash_preps+=("$f")
+    done < <(find "$REPO_ROOT" -maxdepth 3 -name "bash-prep.sh" -print0 2>/dev/null)
+
+    if (( ${#bash_preps[@]} > 1 )); then
+        local ref_hash
+        ref_hash=$(sha256sum "${bash_preps[0]}" | cut -d' ' -f1)
+        for ((i=1; i<${#bash_preps[@]}; i++)); do
+            local other_hash
+            other_hash=$(sha256sum "${bash_preps[$i]}" | cut -d' ' -f1)
+            if [[ "$ref_hash" != "$other_hash" ]]; then
+                local ref_rel="${bash_preps[0]#$REPO_ROOT/}"
+                local other_rel="${bash_preps[$i]#$REPO_ROOT/}"
+                drift "shared script divergence: $other_rel differs from $ref_rel"
+                has_drift=true
+            fi
+        done
+    fi
+
+    if ! $has_drift; then
+        ok "shared scripts - all copies consistent"
+    else
+        fix "Sync shared scripts from canonical source, then rebuild containers"
+    fi
+}
+
 # --- Main ---
 main() {
     local mode="check"
@@ -291,6 +362,12 @@ main() {
     echo -e "${BOLD}Docker Containers${NC}"
     echo "------------------------------------------------"
     check_docker_compose
+    echo ""
+
+    # Category 5: Shared script contracts
+    echo -e "${BOLD}Shared Script Contracts${NC}"
+    echo "------------------------------------------------"
+    check_shared_scripts
     echo ""
 
     # Summary

--- a/tests/test_deploy_guardrails.py
+++ b/tests/test_deploy_guardrails.py
@@ -1,0 +1,237 @@
+"""Unit tests for deployment guardrails."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.cicd.deploy.guardrails import (
+    CapabilityCheck,
+    CapabilityResult,
+    check_docker_socket,
+    check_stale_commit,
+    deploy_lock,
+    run_capability_checks,
+    safe_docker_prune,
+)
+from lib.cicd.deploy.strategy import DeployConfig, ReadinessPolicy, poll_readiness
+
+
+class TestCapabilityCheck:
+    def test_passing_check(self):
+        check = CapabilityCheck(name="echo-test", command="echo ok")
+        result = check.run()
+        assert result.passed
+        assert result.output == "ok"
+
+    def test_failing_check(self):
+        check = CapabilityCheck(name="fail-test", command="exit 1")
+        result = check.run()
+        assert not result.passed
+
+    def test_timeout(self):
+        check = CapabilityCheck(
+            name="slow-test", command="sleep 10", timeout_seconds=1
+        )
+        result = check.run()
+        assert not result.passed
+        assert "Timed out" in result.error
+
+    def test_cwd(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            check = CapabilityCheck(name="pwd-test", command="pwd")
+            result = check.run(cwd=tmpdir)
+            assert result.passed
+            assert tmpdir in result.output
+
+
+class TestRunCapabilityChecks:
+    def test_empty_checks(self):
+        ok, results = run_capability_checks([])
+        assert ok
+        assert results == []
+
+    def test_all_pass(self):
+        checks = [
+            CapabilityCheck(name="a", command="true"),
+            CapabilityCheck(name="b", command="echo hello"),
+        ]
+        ok, results = run_capability_checks(checks)
+        assert ok
+        assert len(results) == 2
+        assert all(r.passed for r in results)
+
+    def test_one_fails(self):
+        checks = [
+            CapabilityCheck(name="a", command="true"),
+            CapabilityCheck(name="b", command="false"),
+        ]
+        ok, results = run_capability_checks(checks)
+        assert not ok
+        assert results[0].passed
+        assert not results[1].passed
+
+
+class TestCheckStaleCommit:
+    @patch("lib.cicd.deploy.guardrails.shutil.which", return_value=None)
+    def test_no_git(self, mock_which: MagicMock):
+        result = check_stale_commit()
+        assert not result.success
+        assert "git not found" in result.error
+
+    @patch("lib.cicd.deploy.guardrails.shutil.which", return_value="/usr/bin/git")
+    @patch("lib.cicd.deploy.guardrails.subprocess.run")
+    def test_matching_commits(self, mock_run: MagicMock, mock_which: MagicMock):
+        sha = "abc123def456"
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # fetch
+            MagicMock(stdout=f"{sha}\n", returncode=0),  # local rev-parse
+            MagicMock(stdout=f"{sha}\n", returncode=0),  # remote rev-parse
+        ]
+        result = check_stale_commit()
+        assert result.success
+        assert sha[:12] in result.output
+
+    @patch("lib.cicd.deploy.guardrails.shutil.which", return_value="/usr/bin/git")
+    @patch("lib.cicd.deploy.guardrails.subprocess.run")
+    def test_stale_commit(self, mock_run: MagicMock, mock_which: MagicMock):
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # fetch
+            MagicMock(stdout="aaa111\n", returncode=0),  # local
+            MagicMock(stdout="bbb222\n", returncode=0),  # remote
+        ]
+        result = check_stale_commit()
+        assert not result.success
+        assert "Stale commit" in result.error
+
+    @patch("lib.cicd.deploy.guardrails.shutil.which", return_value="/usr/bin/git")
+    @patch("lib.cicd.deploy.guardrails.subprocess.run")
+    def test_fetch_timeout(self, mock_run: MagicMock, mock_which: MagicMock):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git fetch", timeout=30)
+        result = check_stale_commit()
+        assert not result.success
+        assert "fetch" in result.error.lower()
+
+
+class TestDeployLock:
+    def test_acquire_and_release(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "test.lock"
+            with deploy_lock(lock_path=lock_path, timeout_seconds=5):
+                assert lock_path.exists()
+
+    def test_reentrant_fails(self):
+        """A second lock attempt should time out if the first is held."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "test.lock"
+            with deploy_lock(lock_path=lock_path, timeout_seconds=5):
+                with pytest.raises(TimeoutError, match="Could not acquire"):
+                    with deploy_lock(lock_path=lock_path, timeout_seconds=1):
+                        pass  # pragma: no cover
+
+
+class TestCheckDockerSocket:
+    @patch("lib.cicd.deploy.guardrails.os.path.exists", return_value=False)
+    def test_missing_socket(self, mock_exists: MagicMock):
+        result = check_docker_socket()
+        assert not result.success
+        assert "not found" in result.error
+
+    @patch("lib.cicd.deploy.guardrails.os.access", return_value=False)
+    @patch("lib.cicd.deploy.guardrails.os.path.exists", return_value=True)
+    def test_no_access(self, mock_exists: MagicMock, mock_access: MagicMock):
+        result = check_docker_socket()
+        assert not result.success
+        assert "not accessible" in result.error
+
+    @patch("lib.cicd.deploy.guardrails.os.access", return_value=True)
+    @patch("lib.cicd.deploy.guardrails.os.path.exists", return_value=True)
+    def test_accessible(self, mock_exists: MagicMock, mock_access: MagicMock):
+        result = check_docker_socket()
+        assert result.success
+
+
+class TestSafeDockerPrune:
+    @patch("lib.cicd.deploy.guardrails.shutil.which", return_value=None)
+    def test_no_docker(self, mock_which: MagicMock):
+        result = safe_docker_prune()
+        assert not result.success
+        assert "docker not found" in result.error
+
+    @patch("lib.cicd.deploy.guardrails.shutil.which", return_value="/usr/bin/docker")
+    @patch("lib.cicd.deploy.guardrails.subprocess.run")
+    def test_successful_prune(self, mock_run: MagicMock, mock_which: MagicMock):
+        mock_run.return_value = MagicMock(
+            stdout="Deleted: sha256:abc", returncode=0
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "test.lock"
+            result = safe_docker_prune(lock_path=lock_path)
+            assert result.success
+
+
+class TestDeployConfigGuardrails:
+    def test_default_guardrails_off(self):
+        config = DeployConfig()
+        assert config.use_deploy_lock is False
+        assert config.stale_commit_check is False
+        assert config.safe_prune is False
+
+    def test_from_dict_with_guardrails(self):
+        data = {
+            "strategy": "docker_compose",
+            "use_deploy_lock": True,
+            "stale_commit_check": True,
+            "safe_prune": True,
+        }
+        config = DeployConfig.from_dict(data)
+        assert config.use_deploy_lock is True
+        assert config.stale_commit_check is True
+        assert config.safe_prune is True
+
+
+class TestReadinessPolicyCapabilityChecks:
+    def test_default_no_capability_checks(self):
+        policy = ReadinessPolicy(url="http://localhost/health")
+        assert policy.capability_checks == []
+
+    def test_capability_checks_in_policy(self):
+        policy = ReadinessPolicy(
+            url="http://localhost/health",
+            capability_checks=[
+                {"name": "secrets-loaded", "command": "curl -sf http://localhost/ready"},
+            ],
+        )
+        assert len(policy.capability_checks) == 1
+
+    @patch("lib.cicd.deploy.strategy.shutil.which", return_value="/usr/bin/curl")
+    @patch("lib.cicd.deploy.strategy.subprocess.run")
+    def test_capability_check_blocks_readiness(
+        self, mock_run: MagicMock, mock_which: MagicMock
+    ):
+        """HTTP readiness passes but capability check fails -> not ready."""
+        mock_run.return_value = MagicMock(stdout="200", stderr="", returncode=0)
+
+        mock_cap_result = CapabilityResult(name="always-fail", passed=False, error="failed")
+        with patch(
+            "lib.cicd.deploy.guardrails.run_capability_checks",
+            return_value=(False, [mock_cap_result]),
+        ):
+            policy = ReadinessPolicy(
+                url="http://localhost/health",
+                consecutive_successes=1,
+                interval_seconds=0.01,
+                timeout_seconds=2,
+                backoff_multiplier=1.0,
+                capability_checks=[
+                    {"name": "always-fail", "command": "false"},
+                ],
+            )
+            result = poll_readiness(policy, sleep_fn=lambda s: None)
+        assert not result.ready
+        assert result.last_error is not None
+        assert "Capability" in result.last_error


### PR DESCRIPTION
## Summary

- Add pre-deploy validation gates to prevent common Woodpecker deployment failures
- New `lib/cicd/deploy/guardrails.py` module with: stale commit protection, flock-based deploy locks, capability-based readiness checks, safe Docker prune, docker.sock audit logging
- Harden `.woodpecker.yml` pipeline with pre-deploy-guardrails step (stale commit check, docker.sock validation, deploy lock, post-deploy capability verification)
- Extend `scripts/drift-detect.sh` with shared script contract drift detection (fetch-secrets.sh, bash-prep.sh consistency across containers)
- Add auth bootstrap dependencies to `.claude/bootstrap.yaml` (AWS creds, docker.sock, docker-compose)
- Add stale commit guard step to the deterministic runner's deploy plan
- 23 new tests covering all guardrail components

Closes #296

## Test plan

- [x] All 614 tests pass (including 23 new guardrail tests)
- [x] Lint clean (ruff)
- [x] Type check clean (mypy)
- [ ] Verify pre-deploy-guardrails step runs in Woodpecker on next main push
- [ ] Verify `make drift-check` reports shared script consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)