### PR TITLE
fix(cicd): return empty FailureInstance list on deploy log read error (Closes #319)

### DIFF
--- a/lib/cicd/failure_patterns.py
+++ b/lib/cicd/failure_patterns.py
@@ -235,7 +235,7 @@ def _scan_deploy_log(project_root: Path) -> list[FailureInstance]:
     try:
         lines = deploy_log.read_text().splitlines()
     except OSError:
-        return lines
+        return instances
 
     for line in lines:
         parts = line.split("|")


### PR DESCRIPTION
## Summary
- Fix mypy type error in `lib/cicd/failure_patterns.py:238` that broke Woodpecker pipeline #175
- The `except OSError` handler in `_scan_deploy_log` was returning `lines` (a `list[str]`) instead of `instances` (a `list[FailureInstance]`)

## Test plan
- [x] `uv run mypy .` - 99 source files, no errors
- [x] `uv run ruff check .` - all checks passed
- [x] `uv run pytest` - 633 passed, 1 skipped

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)