### PR TITLE
feat(second-opinion): add free-tier providers for diverse multi-model reviews (Closes #321)

### DIFF
--- a/mcp-second-opinion/.env.example
+++ b/mcp-second-opinion/.env.example
@@ -41,6 +41,51 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 #   - claude-opus-4-6: Most capable, complex reasoning ($5/$25 per 1M tokens)
 
 # =============================================================================
+# Mistral API (free tier - 1B tokens/month, no credit card needed)
+# =============================================================================
+# Get your Mistral API key from: https://console.mistral.ai/api-keys
+# Free "Experiment" plan includes all models (phone verification only)
+MISTRAL_API_KEY=your-mistral-api-key-here
+
+# Available models:
+#   - mistral-large-latest: Mistral Large 3 (128K context)
+#   - devstral-small-latest: Devstral 2 - coding specialist (256K context)
+#   - codestral-latest: Codestral - code generation (256K context)
+
+# =============================================================================
+# Groq API (free tier - 30 RPM, ultra-fast inference)
+# =============================================================================
+# Get your Groq API key from: https://console.groq.com/keys
+# Free tier, no credit card required
+GROQ_API_KEY=your-groq-api-key-here
+
+# Available models:
+#   - llama-3.3-70b-versatile: Llama 3.3 70B (128K context, 300-800+ TPS)
+#   - qwen-qwq-32b: Qwen3 32B reasoning (128K context)
+
+# =============================================================================
+# OpenRouter API (aggregator - 27+ free models, single API key)
+# =============================================================================
+# Get your OpenRouter API key from: https://openrouter.ai/settings/keys
+# Free tier, no credit card required
+OPENROUTER_API_KEY=your-openrouter-api-key-here
+
+# Available models:
+#   - qwen/qwen3-coder: Qwen3 Coder (1M context, free)
+#   - deepseek/deepseek-chat-v4-0324:free: DeepSeek V4 Flash (1M context, free)
+
+# =============================================================================
+# DeepSeek API (near-free - $0.14-$0.28/MTok)
+# =============================================================================
+# Get your DeepSeek API key from: https://platform.deepseek.com/api_keys
+# 5M free tokens for new accounts, then extremely cheap
+DEEPSEEK_API_KEY=your-deepseek-api-key-here
+
+# Available models:
+#   - deepseek-chat: DeepSeek V3 - top-tier code analysis
+#   - deepseek-reasoner: DeepSeek R1 - advanced reasoning
+
+# =============================================================================
 # Server configuration
 # =============================================================================
 MCP_SERVER_HOST=127.0.0.1

--- a/mcp-second-opinion/README.md
+++ b/mcp-second-opinion/README.md
@@ -5,7 +5,7 @@ Multi-model code review MCP server for Claude Code.
 ## Features
 
 - **Code Review**: Get AI-powered second opinions on code issues
-- **Multi-Model Support**: Consult multiple LLMs (Gemini 3.1, Claude Sonnet/Haiku/Opus, GPT-5.3 Codex, o4-mini)
+- **Multi-Model Support**: Consult multiple LLMs (Gemini, Claude, GPT/Codex, Mistral, Groq, OpenRouter, DeepSeek)
 - **Session-Based**: Interactive multi-turn conversations for deeper analysis
 - **Visual Analysis**: Support for screenshot/image analysis (Playwright integration)
 - **Streamable HTTP**: Stateless transport - no persistent connection, resilient to disconnects
@@ -38,9 +38,13 @@ Copy `.env.example` to `.env` and configure:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `GEMINI_API_KEY` | Yes | Gemini API key |
-| `OPENAI_API_KEY` | No | OpenAI API key (for multi-model) |
-| `ANTHROPIC_API_KEY` | No | Anthropic API key (for Claude models) |
+| `GEMINI_API_KEY` | Any one | Google Gemini API key |
+| `OPENAI_API_KEY` | Any one | OpenAI API key (GPT, Codex, o-series) |
+| `ANTHROPIC_API_KEY` | Any one | Anthropic API key (Claude models) |
+| `MISTRAL_API_KEY` | Any one | Mistral API key (free tier - 1B tokens/month) |
+| `GROQ_API_KEY` | Any one | Groq API key (free tier - ultra-fast inference) |
+| `OPENROUTER_API_KEY` | Any one | OpenRouter API key (free tier - 27+ models) |
+| `DEEPSEEK_API_KEY` | Any one | DeepSeek API key (near-free - $0.14/MTok) |
 
 ## MCP Tools
 
@@ -120,7 +124,7 @@ The server starts but all LLM calls will fail. Add at least one key:
 
 ```bash
 cp .env.example .env
-# Edit .env - add GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY
+# Edit .env - add at least one API key (free-tier keys: MISTRAL, GROQ, OPENROUTER)
 ```
 
 ## License

--- a/mcp-second-opinion/src/config.py
+++ b/mcp-second-opinion/src/config.py
@@ -77,6 +77,10 @@ class _SecretStr:
 _gemini_api_key_secret = _SecretStr(os.getenv("GEMINI_API_KEY"))
 _openai_api_key_secret = _SecretStr(os.getenv("OPENAI_API_KEY"))
 _anthropic_api_key_secret = _SecretStr(os.getenv("ANTHROPIC_API_KEY"))
+_mistral_api_key_secret = _SecretStr(os.getenv("MISTRAL_API_KEY"))
+_groq_api_key_secret = _SecretStr(os.getenv("GROQ_API_KEY"))
+_openrouter_api_key_secret = _SecretStr(os.getenv("OPENROUTER_API_KEY"))
+_deepseek_api_key_secret = _SecretStr(os.getenv("DEEPSEEK_API_KEY"))
 
 
 class Config:
@@ -184,6 +188,51 @@ class Config:
     }
 
     # ==========================================================================
+    # Mistral API Configuration (free tier - 1B tokens/month)
+    # ==========================================================================
+    MISTRAL_API_KEY: Optional[str] = _mistral_api_key_secret.get_secret_value()
+    MISTRAL_BASE_URL: str = "https://api.mistral.ai/v1"
+
+    MISTRAL_PRICING: Dict[str, Dict[str, float]] = {
+        "mistral-large-latest": {"input": 2.00, "output": 6.00},
+        "devstral-small-latest": {"input": 0.10, "output": 0.30},
+        "codestral-latest": {"input": 0.30, "output": 0.90},
+    }
+
+    # ==========================================================================
+    # Groq API Configuration (free tier - 30 RPM, ultra-fast inference)
+    # ==========================================================================
+    GROQ_API_KEY: Optional[str] = _groq_api_key_secret.get_secret_value()
+    GROQ_BASE_URL: str = "https://api.groq.com/openai/v1"
+
+    GROQ_PRICING: Dict[str, Dict[str, float]] = {
+        "llama-3.3-70b-versatile": {"input": 0.59, "output": 0.79},
+        "qwen-qwq-32b": {"input": 0.29, "output": 0.39},
+    }
+
+    # ==========================================================================
+    # OpenRouter API Configuration (aggregator - 27+ free models)
+    # ==========================================================================
+    OPENROUTER_API_KEY: Optional[str] = _openrouter_api_key_secret.get_secret_value()
+    OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
+
+    OPENROUTER_PRICING: Dict[str, Dict[str, float]] = {
+        "qwen/qwen3-coder": {"input": 0.00, "output": 0.00},
+        "deepseek/deepseek-chat-v4-0324:free": {"input": 0.00, "output": 0.00},
+    }
+
+    # ==========================================================================
+    # DeepSeek API Configuration (near-free - $0.14-$0.28/MTok)
+    # ==========================================================================
+    DEEPSEEK_API_KEY: Optional[str] = _deepseek_api_key_secret.get_secret_value()
+    DEEPSEEK_BASE_URL: str = "https://api.deepseek.com"
+
+    DEEPSEEK_PRICING: Dict[str, Dict[str, float]] = {
+        "deepseek-chat": {"input": 0.14, "output": 0.28},
+        "deepseek-reasoner": {"input": 0.55, "output": 2.19},
+    }
+
+    # ==========================================================================
     # Available Models for Multi-Model Selection
     # ==========================================================================
     # All models available for second opinion consultation
@@ -194,12 +243,14 @@ class Config:
             "model_id": "gemini-3.1-pro-preview",
             "display_name": "Gemini 3.1 Pro",
             "description": "Google's latest, best for comprehensive analysis",
+            "free": False,
         },
         "gemini-2.5-pro": {
             "provider": "gemini",
             "model_id": "gemini-2.5-pro",
             "display_name": "Gemini 2.5 Pro",
             "description": "Stable, proven performance",
+            "free": False,
         },
         # Anthropic Claude models
         "claude-sonnet": {
@@ -207,18 +258,21 @@ class Config:
             "model_id": "claude-sonnet-4-6",
             "display_name": "Claude Sonnet 4.6",
             "description": "Fast, excellent for code review and analysis",
+            "free": False,
         },
         "claude-haiku": {
             "provider": "anthropic",
             "model_id": "claude-haiku-4-5-20251001",
             "display_name": "Claude Haiku 4.5",
             "description": "Fastest Claude, cost-effective for simpler tasks",
+            "free": False,
         },
         "claude-opus": {
             "provider": "anthropic",
             "model_id": "claude-opus-4-6",
             "display_name": "Claude Opus 4.6",
             "description": "Most capable Claude, best for complex reasoning",
+            "free": False,
         },
         # OpenAI GPT-4o family
         "gpt-4o": {
@@ -226,12 +280,14 @@ class Config:
             "model_id": "gpt-4o",
             "display_name": "GPT-4o",
             "description": "Fast multimodal model, great for code",
+            "free": False,
         },
         "gpt-4o-mini": {
             "provider": "openai",
             "model_id": "gpt-4o-mini",
             "display_name": "GPT-4o Mini",
             "description": "Fast, cost-effective for simpler tasks",
+            "free": False,
         },
         # OpenAI GPT-4 Turbo
         "gpt-4-turbo": {
@@ -239,6 +295,7 @@ class Config:
             "model_id": "gpt-4-turbo",
             "display_name": "GPT-4 Turbo",
             "description": "Best for complex reasoning tasks",
+            "free": False,
         },
         # OpenAI Codex models (uses Responses API)
         "codex": {
@@ -246,30 +303,35 @@ class Config:
             "model_id": "gpt-5.3-codex",
             "display_name": "GPT-5.3 Codex",
             "description": "Default Codex model for coding tasks",
+            "free": False,
         },
         "codex-max": {
             "provider": "openai",
             "model_id": "gpt-5.3-codex",
             "display_name": "GPT-5.3 Codex",
             "description": "Most capable agentic coding model (same as codex)",
+            "free": False,
         },
         "codex-mini": {
             "provider": "openai",
             "model_id": "gpt-5.2-codex",
             "display_name": "GPT-5.2 Codex",
             "description": "Cost-effective coding model",
+            "free": False,
         },
         "o3": {
             "provider": "openai",
             "model_id": "o3",
             "display_name": "o3",
             "description": "Advanced reasoning, powers Codex agent",
+            "free": False,
         },
         "o4-mini": {
             "provider": "openai",
             "model_id": "o4-mini",
             "display_name": "o4-mini",
             "description": "Fast reasoning model, successor to o3-mini",
+            "free": False,
         },
         # OpenAI o1 reasoning models
         "o1": {
@@ -277,12 +339,14 @@ class Config:
             "model_id": "o1",
             "display_name": "o1",
             "description": "Advanced reasoning, best for hard problems",
+            "free": False,
         },
         "o1-mini": {
             "provider": "openai",
             "model_id": "o1-mini",
             "display_name": "o1 Mini",
             "description": "Faster reasoning model",
+            "free": False,
         },
         # GPT-5.2 models
         "gpt-5.2": {
@@ -290,17 +354,87 @@ class Config:
             "model_id": "gpt-5.2",
             "display_name": "GPT-5.2",
             "description": "Latest GPT model, excellent reasoning",
+            "free": False,
         },
         "gpt-5.2-mini": {
             "provider": "openai",
             "model_id": "gpt-5.2-mini",
             "display_name": "GPT-5.2 Mini",
             "description": "Cost-effective GPT-5.2 variant",
+            "free": False,
+        },
+        # Mistral models (free tier - 1B tokens/month, no credit card)
+        "mistral-large": {
+            "provider": "mistral",
+            "model_id": "mistral-large-latest",
+            "display_name": "Mistral Large 3",
+            "description": "Best for comprehensive analysis (128K context)",
+            "free": True,
+        },
+        "devstral": {
+            "provider": "mistral",
+            "model_id": "devstral-small-latest",
+            "display_name": "Devstral 2",
+            "description": "Purpose-built coding model (256K context)",
+            "free": True,
+        },
+        "codestral": {
+            "provider": "mistral",
+            "model_id": "codestral-latest",
+            "display_name": "Codestral",
+            "description": "Mistral's code generation specialist (256K context)",
+            "free": True,
+        },
+        # Groq models (free tier - 30 RPM, ultra-fast inference)
+        "groq-llama-70b": {
+            "provider": "groq",
+            "model_id": "llama-3.3-70b-versatile",
+            "display_name": "Llama 3.3 70B (Groq)",
+            "description": "Fast inference, solid code review (128K context)",
+            "free": True,
+        },
+        "groq-qwen-32b": {
+            "provider": "groq",
+            "model_id": "qwen-qwq-32b",
+            "display_name": "Qwen3 32B (Groq)",
+            "description": "Strong reasoning on Groq's fast infra (128K context)",
+            "free": True,
+        },
+        # DeepSeek models (near-free - $0.14-$0.28/MTok)
+        "deepseek-v3": {
+            "provider": "deepseek",
+            "model_id": "deepseek-chat",
+            "display_name": "DeepSeek V3",
+            "description": "Top-tier code analysis, near-free pricing",
+            "free": False,
+        },
+        "deepseek-r1": {
+            "provider": "deepseek",
+            "model_id": "deepseek-reasoner",
+            "display_name": "DeepSeek R1",
+            "description": "Advanced reasoning, chain-of-thought coding",
+            "free": False,
+        },
+        # OpenRouter models (aggregator - free tier, 27+ models)
+        "openrouter-qwen-coder": {
+            "provider": "openrouter",
+            "model_id": "qwen/qwen3-coder",
+            "display_name": "Qwen3 Coder (OpenRouter)",
+            "description": "Top-tier free coding model (1M context)",
+            "free": True,
+        },
+        "openrouter-deepseek-flash": {
+            "provider": "openrouter",
+            "model_id": "deepseek/deepseek-chat-v4-0324:free",
+            "display_name": "DeepSeek V4 Flash (OpenRouter)",
+            "description": "Free DeepSeek via OpenRouter (1M context)",
+            "free": True,
         },
     }
 
     # Default models to use when none specified
-    DEFAULT_MODELS: List[str] = ["gemini-3-pro", "gpt-4o"]
+    # Mix of free and paid for broad coverage
+    DEFAULT_MODELS: List[str] = ["gemini-3-pro", "devstral", "groq-llama-70b"]
 
     # Token estimation (characters per token approximation)
     # English text averages ~4 characters per token
@@ -406,38 +540,56 @@ class Config:
     # Block internal/private networks (critical SSRF protection - never bypassed)
     FETCH_URL_BLOCK_PRIVATE: bool = True
 
+    # Provider API key map for dynamic availability checks
+    _PROVIDER_API_KEY_MAP: Dict[str, str] = {
+        "gemini": "GEMINI_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "mistral": "MISTRAL_API_KEY",
+        "groq": "GROQ_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+    }
+
     @classmethod
     def validate(cls) -> None:
         """Validate required configuration."""
-        has_gemini = bool(cls.GEMINI_API_KEY)
-        has_openai = bool(cls.OPENAI_API_KEY)
-        has_anthropic = bool(cls.ANTHROPIC_API_KEY)
+        has_any = any(
+            bool(getattr(cls, attr, None))
+            for attr in [
+                "GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                "MISTRAL_API_KEY", "GROQ_API_KEY", "OPENROUTER_API_KEY",
+                "DEEPSEEK_API_KEY",
+            ]
+        )
 
-        if not has_gemini and not has_openai and not has_anthropic:
+        if not has_any:
             raise ValueError(
-                "At least one API key is required. Set either:\n"
+                "At least one API key is required. Set any of:\n"
                 "  - GEMINI_API_KEY: https://aistudio.google.com/apikey\n"
                 "  - OPENAI_API_KEY: https://platform.openai.com/api-keys\n"
-                "  - ANTHROPIC_API_KEY: https://console.anthropic.com/settings/keys"
+                "  - ANTHROPIC_API_KEY: https://console.anthropic.com/settings/keys\n"
+                "  - MISTRAL_API_KEY: https://console.mistral.ai/api-keys\n"
+                "  - GROQ_API_KEY: https://console.groq.com/keys\n"
+                "  - OPENROUTER_API_KEY: https://openrouter.ai/settings/keys\n"
+                "  - DEEPSEEK_API_KEY: https://platform.deepseek.com/api_keys"
             )
 
-        if not has_gemini:
-            logger.warning(
-                "GEMINI_API_KEY not set - Gemini models will be unavailable. "
-                "Get your API key from https://aistudio.google.com/apikey"
-            )
-
-        if not has_openai:
-            logger.warning(
-                "OPENAI_API_KEY not set - OpenAI/Codex models will be unavailable. "
-                "Get your API key from https://platform.openai.com/api-keys"
-            )
-
-        if not has_anthropic:
-            logger.warning(
-                "ANTHROPIC_API_KEY not set - Claude models will be unavailable. "
-                "Get your API key from https://console.anthropic.com/settings/keys"
-            )
+        _key_info = {
+            "GEMINI_API_KEY": ("Gemini", "https://aistudio.google.com/apikey"),
+            "OPENAI_API_KEY": ("OpenAI/Codex", "https://platform.openai.com/api-keys"),
+            "ANTHROPIC_API_KEY": ("Claude", "https://console.anthropic.com/settings/keys"),
+            "MISTRAL_API_KEY": ("Mistral", "https://console.mistral.ai/api-keys"),
+            "GROQ_API_KEY": ("Groq", "https://console.groq.com/keys"),
+            "OPENROUTER_API_KEY": ("OpenRouter", "https://openrouter.ai/settings/keys"),
+            "DEEPSEEK_API_KEY": ("DeepSeek", "https://platform.deepseek.com/api_keys"),
+        }
+        for env_var, (name, url) in _key_info.items():
+            if not getattr(cls, env_var, None):
+                logger.warning(
+                    f"{env_var} not set - {name} models will be unavailable. "
+                    f"Get your API key from {url}"
+                )
 
     @classmethod
     def get_available_model_keys(cls) -> List[str]:
@@ -445,26 +597,26 @@ class Config:
         available = []
         for key, model_info in cls.AVAILABLE_MODELS.items():
             provider = model_info["provider"]
-            if provider == "gemini" and cls.GEMINI_API_KEY:
-                available.append(key)
-            elif provider == "openai" and cls.OPENAI_API_KEY:
-                available.append(key)
-            elif provider == "anthropic" and cls.ANTHROPIC_API_KEY:
+            api_key_attr = cls._PROVIDER_API_KEY_MAP.get(provider)
+            if api_key_attr and getattr(cls, api_key_attr, None):
                 available.append(key)
         return available
 
     @classmethod
     def get_pricing(cls, model_id: str) -> Dict[str, float]:
         """Get pricing for a model by its model_id."""
-        if model_id in cls.GEMINI_PRICING:
-            return cls.GEMINI_PRICING[model_id]
-        elif model_id in cls.OPENAI_PRICING:
-            return cls.OPENAI_PRICING[model_id]
-        elif model_id in cls.ANTHROPIC_PRICING:
-            return cls.ANTHROPIC_PRICING[model_id]
-        else:
-            # Default fallback pricing
-            return {"input": 10.00, "output": 30.00}
+        for pricing_table in [
+            cls.GEMINI_PRICING,
+            cls.OPENAI_PRICING,
+            cls.ANTHROPIC_PRICING,
+            cls.MISTRAL_PRICING,
+            cls.GROQ_PRICING,
+            cls.OPENROUTER_PRICING,
+            cls.DEEPSEEK_PRICING,
+        ]:
+            if model_id in pricing_table:
+                return pricing_table[model_id]
+        return {"input": 10.00, "output": 30.00}
 
     @classmethod
     def resolve_verbosity(cls, verbosity: str) -> tuple[str, int]:

--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -3,7 +3,8 @@
 Second Opinion MCP Server
 
 An MCP server that provides LLM-powered second opinions on challenging coding issues.
-Powered by Google Gemini, OpenAI (Codex + GPT-5.2), and Anthropic Claude.
+Powered by Google Gemini, OpenAI (Codex + GPT-5.2), Anthropic Claude,
+Mistral, Groq, OpenRouter, and DeepSeek.
 Supports multi-model consultation for comparing responses from different LLMs.
 """
 
@@ -83,6 +84,29 @@ if Config.ANTHROPIC_API_KEY:
     logger.info("Anthropic API configured successfully")
 else:
     logger.warning("ANTHROPIC_API_KEY not set - Claude models will be unavailable")
+
+# Configure OpenAI-compatible providers (Mistral, Groq, OpenRouter, DeepSeek)
+_openai_compatible_clients: Dict[str, openai.AsyncOpenAI] = {}
+
+_compat_providers = {
+    "mistral": (Config.MISTRAL_API_KEY, Config.MISTRAL_BASE_URL),
+    "groq": (Config.GROQ_API_KEY, Config.GROQ_BASE_URL),
+    "openrouter": (Config.OPENROUTER_API_KEY, Config.OPENROUTER_BASE_URL),
+    "deepseek": (Config.DEEPSEEK_API_KEY, Config.DEEPSEEK_BASE_URL),
+}
+
+for _provider_name, (_api_key, _base_url) in _compat_providers.items():
+    if _api_key:
+        _openai_compatible_clients[_provider_name] = openai.AsyncOpenAI(
+            api_key=_api_key,
+            base_url=_base_url,
+        )
+        logger.info(f"{_provider_name.title()} API configured successfully")
+    else:
+        logger.warning(
+            f"{_provider_name.upper()}_API_KEY not set - "
+            f"{_provider_name.title()} models will be unavailable"
+        )
 
 # Lock for thread-safe operations
 _model_lock: asyncio.Lock = asyncio.Lock()
@@ -493,6 +517,86 @@ async def get_anthropic_response(
 
 
 # =============================================================================
+# OpenAI-Compatible Provider Functions (Mistral, Groq, OpenRouter, DeepSeek)
+# =============================================================================
+
+
+async def get_openai_compatible_response(
+    prompt: str,
+    model_name: str,
+    provider: str,
+    max_tokens: int = Config.MAX_TOKENS,
+) -> tuple[str, str]:
+    """
+    Get streaming response from an OpenAI-compatible provider.
+
+    Args:
+        prompt: The prompt to send
+        model_name: The model to use
+        provider: Provider name (mistral, groq, openrouter, deepseek)
+        max_tokens: Maximum output tokens
+
+    Returns:
+        Tuple of (response text, model used)
+    """
+    client = _openai_compatible_clients.get(provider)
+    if not client:
+        raise ValueError(f"{provider.title()} API key not configured")
+
+    try:
+        return await _try_openai_compatible_model(client, prompt, model_name, provider, max_tokens=max_tokens)
+    except Exception as e:
+        logger.error(f"{provider.title()} model {model_name} failed: {e}")
+        raise
+
+
+@retry(
+    stop=stop_after_attempt(Config.MAX_RETRIES),
+    wait=wait_exponential(
+        min=Config.RETRY_MIN_WAIT,
+        max=Config.RETRY_MAX_WAIT,
+    ),
+    retry=retry_if_exception_type(Exception),
+    reraise=True,
+)
+async def _try_openai_compatible_model(
+    client: openai.AsyncOpenAI,
+    prompt: str,
+    model_name: str,
+    provider: str,
+    max_tokens: int = Config.MAX_TOKENS,
+) -> tuple[str, str]:
+    """Attempt to get a response from an OpenAI-compatible provider."""
+    try:
+        logger.info(f"Sending request to {provider}/{model_name}")
+
+        request_params = {
+            "model": model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": Config.TEMPERATURE,
+            "stream": True,
+            "max_tokens": max_tokens,
+        }
+
+        response = await client.chat.completions.create(**request_params)
+
+        full_response = []
+        async for chunk in response:
+            if chunk.choices and chunk.choices[0].delta.content:
+                content = chunk.choices[0].delta.content
+                full_response.append(content)
+                logger.debug(f"Received chunk: {len(content)} chars")
+
+        result = "".join(full_response)
+        logger.info(f"Completed streaming response from {provider}/{model_name}: {len(result)} chars")
+        return result, model_name
+
+    except Exception as e:
+        logger.error(f"Error getting response from {provider}/{model_name}: {e}")
+        raise
+
+
+# =============================================================================
 # Multi-Model Consultation Functions
 # =============================================================================
 
@@ -526,39 +630,26 @@ async def get_single_model_response(
 
     try:
         # Route to appropriate provider
+        api_key_attr = Config._PROVIDER_API_KEY_MAP.get(provider)
+        if api_key_attr and not getattr(Config, api_key_attr, None):
+            return {
+                "model_key": model_key,
+                "model_id": model_id,
+                "display_name": model_info["display_name"],
+                "success": False,
+                "error": f"{provider.title()} API key not configured",
+            }
+
         if provider == "gemini":
-            if not Config.GEMINI_API_KEY:
-                return {
-                    "model_key": model_key,
-                    "model_id": model_id,
-                    "display_name": model_info["display_name"],
-                    "success": False,
-                    "error": "Gemini API key not configured",
-                }
             response, model_used = await get_gemini_streaming_response(prompt, model_id, max_tokens=max_tokens)
-
         elif provider == "openai":
-            if not Config.OPENAI_API_KEY:
-                return {
-                    "model_key": model_key,
-                    "model_id": model_id,
-                    "display_name": model_info["display_name"],
-                    "success": False,
-                    "error": "OpenAI API key not configured",
-                }
             response, model_used = await get_openai_streaming_response(prompt, model_id, max_tokens=max_tokens)
-
         elif provider == "anthropic":
-            if not Config.ANTHROPIC_API_KEY:
-                return {
-                    "model_key": model_key,
-                    "model_id": model_id,
-                    "display_name": model_info["display_name"],
-                    "success": False,
-                    "error": "Anthropic API key not configured",
-                }
             response, model_used = await get_anthropic_response(prompt, model_id, max_tokens=max_tokens)
-
+        elif provider in _openai_compatible_clients:
+            response, model_used = await get_openai_compatible_response(
+                prompt, model_id, provider, max_tokens=max_tokens,
+            )
         else:
             return {
                 "model_key": model_key,
@@ -970,12 +1061,18 @@ async def health_check() -> dict:
     has_gemini = bool(Config.GEMINI_API_KEY)
     has_openai = bool(Config.OPENAI_API_KEY)
     has_anthropic = bool(Config.ANTHROPIC_API_KEY)
+    has_mistral = bool(Config.MISTRAL_API_KEY)
+    has_groq = bool(Config.GROQ_API_KEY)
+    has_openrouter = bool(Config.OPENROUTER_API_KEY)
+    has_deepseek = bool(Config.DEEPSEEK_API_KEY)
     available_models = Config.get_available_model_keys()
+
+    has_any = has_gemini or has_openai or has_anthropic or has_mistral or has_groq or has_openrouter or has_deepseek
 
     status = {
         "server_name": Config.SERVER_NAME,
         "server_version": Config.SERVER_VERSION,
-        "status": "healthy" if (has_gemini or has_openai or has_anthropic) else "no_api_keys",
+        "status": "healthy" if has_any else "no_api_keys",
         # Gemini
         "gemini_configured": has_gemini,
         "gemini_models": {
@@ -1000,27 +1097,29 @@ async def health_check() -> dict:
             "haiku": Config.ANTHROPIC_MODEL_HAIKU,
             "opus": Config.ANTHROPIC_MODEL_OPUS,
         } if has_anthropic else None,
+        # Free-tier providers
+        "mistral_configured": has_mistral,
+        "groq_configured": has_groq,
+        "openrouter_configured": has_openrouter,
+        "deepseek_configured": has_deepseek,
         # Available models for multi-model consultation
         "available_models": available_models,
         "default_models": Config.DEFAULT_MODELS,
     }
 
+    _key_info = {
+        "GEMINI_API_KEY": ("Gemini", "https://aistudio.google.com/apikey"),
+        "OPENAI_API_KEY": ("OpenAI/Codex", "https://platform.openai.com/api-keys"),
+        "ANTHROPIC_API_KEY": ("Claude", "https://console.anthropic.com/settings/keys"),
+        "MISTRAL_API_KEY": ("Mistral (free tier)", "https://console.mistral.ai/api-keys"),
+        "GROQ_API_KEY": ("Groq (free tier)", "https://console.groq.com/keys"),
+        "OPENROUTER_API_KEY": ("OpenRouter (free tier)", "https://openrouter.ai/settings/keys"),
+        "DEEPSEEK_API_KEY": ("DeepSeek (near-free)", "https://platform.deepseek.com/api_keys"),
+    }
     messages = []
-    if not has_gemini:
-        messages.append(
-            "GEMINI_API_KEY not set - Gemini models unavailable. "
-            "Get key from https://aistudio.google.com/apikey"
-        )
-    if not has_openai:
-        messages.append(
-            "OPENAI_API_KEY not set - OpenAI/Codex models unavailable. "
-            "Get key from https://platform.openai.com/api-keys"
-        )
-    if not has_anthropic:
-        messages.append(
-            "ANTHROPIC_API_KEY not set - Claude models unavailable. "
-            "Get key from https://console.anthropic.com/settings/keys"
-        )
+    for env_var, (name, url) in _key_info.items():
+        if not getattr(Config, env_var, None):
+            messages.append(f"{env_var} not set - {name} models unavailable. Get key from {url}")
 
     if messages:
         status["messages"] = messages
@@ -1030,7 +1129,7 @@ async def health_check() -> dict:
 
 @mcp.tool()
 async def list_available_models() -> dict:
-    """List models available for multi-model consultation with availability status."""
+    """List models available for multi-model consultation with availability and free-tier status."""
     available_keys = Config.get_available_model_keys()
 
     models = []
@@ -1042,6 +1141,7 @@ async def list_available_models() -> dict:
             "model_id": info["model_id"],
             "description": info["description"],
             "available": key in available_keys,
+            "free": info.get("free", False),
         })
 
     return {
@@ -1049,6 +1149,11 @@ async def list_available_models() -> dict:
         "default_models": Config.DEFAULT_MODELS,
         "gemini_configured": bool(Config.GEMINI_API_KEY),
         "openai_configured": bool(Config.OPENAI_API_KEY),
+        "anthropic_configured": bool(Config.ANTHROPIC_API_KEY),
+        "mistral_configured": bool(Config.MISTRAL_API_KEY),
+        "groq_configured": bool(Config.GROQ_API_KEY),
+        "openrouter_configured": bool(Config.OPENROUTER_API_KEY),
+        "deepseek_configured": bool(Config.DEEPSEEK_API_KEY),
     }
 
 
@@ -1685,29 +1790,25 @@ def _run_diagnose() -> int:
     warnings = []
 
     # Check API keys
-    has_gemini = bool(Config.GEMINI_API_KEY)
-    has_openai = bool(Config.OPENAI_API_KEY)
-    has_anthropic = bool(Config.ANTHROPIC_API_KEY)
+    _keys = {
+        "Gemini":     ("GEMINI_API_KEY",     Config.GEMINI_API_KEY),
+        "OpenAI":     ("OPENAI_API_KEY",     Config.OPENAI_API_KEY),
+        "Anthropic":  ("ANTHROPIC_API_KEY",  Config.ANTHROPIC_API_KEY),
+        "Mistral":    ("MISTRAL_API_KEY",    Config.MISTRAL_API_KEY),
+        "Groq":       ("GROQ_API_KEY",       Config.GROQ_API_KEY),
+        "OpenRouter": ("OPENROUTER_API_KEY", Config.OPENROUTER_API_KEY),
+        "DeepSeek":   ("DEEPSEEK_API_KEY",   Config.DEEPSEEK_API_KEY),
+    }
+    has_any = False
+    for label, (env_var, value) in _keys.items():
+        if value:
+            print(f"  {label + ' API key:':<21s}configured")
+            has_any = True
+        else:
+            warnings.append(f"{env_var} not set")
+            print(f"  {label + ' API key:':<21s}NOT SET")
 
-    if has_gemini:
-        print("  Gemini API key:    configured")
-    else:
-        warnings.append("GEMINI_API_KEY not set")
-        print("  Gemini API key:    NOT SET")
-
-    if has_openai:
-        print("  OpenAI API key:    configured")
-    else:
-        warnings.append("OPENAI_API_KEY not set")
-        print("  OpenAI API key:    NOT SET")
-
-    if has_anthropic:
-        print("  Anthropic API key: configured")
-    else:
-        warnings.append("ANTHROPIC_API_KEY not set")
-        print("  Anthropic API key: NOT SET")
-
-    if not (has_gemini or has_openai or has_anthropic):
+    if not has_any:
         errors.append("No API keys configured - server will start but all tool calls will fail")
 
     # Check .env file


### PR DESCRIPTION
## Summary

- Add 4 new OpenAI-compatible providers: **Mistral** (1B tokens/month free), **Groq** (ultra-fast inference, free), **OpenRouter** (27+ free models), **DeepSeek** (near-free $0.14/MTok)
- 9 new model entries in `AVAILABLE_MODELS` with `free` flag on all models for filtering
- Update `DEFAULT_MODELS` from `[gemini-3-pro, gpt-4o]` (both paid) to `[gemini-3-pro, devstral, groq-llama-70b]` (2 free + 1 paid)
- Generic `get_openai_compatible_response()` function reuses `openai.AsyncOpenAI` with custom `base_url` for all new providers

## Files Changed

- `mcp-second-opinion/src/config.py` - New API keys, model entries, pricing tables, provider map
- `mcp-second-opinion/src/server.py` - OpenAI-compatible client init, streaming response function, updated health check and model listing
- `mcp-second-opinion/.env.example` - New API key documentation
- `mcp-second-opinion/README.md` - Updated provider list and env var table

## Test plan

- [x] Python syntax verification passes
- [x] `make lint` passes (ruff)
- [x] `make test` passes (633 tests, 0 failures)
- [ ] Verify each provider responds with valid API keys set
- [ ] Verify `list_available_models` shows `free: true/false` correctly
- [ ] Verify `health_check` shows all 7 provider statuses

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)