### PR TITLE
[codex] fix Woodpecker deploy env bootstrap

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -160,6 +160,13 @@ steps:
   deploy-mcp:
     image: docker:cli
     depends_on: [validate, pre-deploy-guardrails]
+    environment:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
     commands:
       - apk add --no-cache docker-compose curl
       - echo "Deploying MCP containers..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ Core components and their locations:
 
 ## Docker Deployment
 
-MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar. Only AWS credentials are stored in the root `.env` file (gitignored) - no application secrets on disk. If the sidecar is unreachable or `AWS_SECRET_NAME` is not set, containers fall back to `env_file` variables for local development.
+MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar. Local development can store only AWS credentials in the root `.env` file (gitignored), while CI/deploy can inject the same variables through the job environment. No application secrets are stored on disk. If the sidecar is unreachable or `AWS_SECRET_NAME` is not set, containers fall back to `env_file` variables for local development.
 
 - **Secrets architecture:** `aws-secrets-agent` (Rust binary, port 2773) caches secrets in-memory (300s TTL) with SSRF token protection. MCP containers use `fetch-secrets.sh` entrypoint to resolve keys before starting.
-- **Required `.env` variables:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_TOKEN` (SSRF token)
+- **Required AWS credential variables:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_TOKEN` (SSRF token), supplied by local `.env` or CI/deploy environment
 - **AWS secrets used:** `codex_llm_apikeys` (second-opinion LLM keys), `essent-ai` (woodpecker-ci keys)
 - **Required IAM permissions:** `secretsmanager:GetSecretValue`, `secretsmanager:DescribeSecret` on the named secrets
 - **Validate setup:** `make docker-secrets-check` (checks AWS creds, verifies secrets exist)

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,12 @@ docker-check-env:
 		echo ""; \
 		echo "WARNING: .env file not found in $$(pwd)"; \
 		echo ""; \
-		echo "The aws-secrets-agent sidecar requires AWS credentials in .env:"; \
+		echo "For local runs, the aws-secrets-agent sidecar expects AWS credentials in .env:"; \
 		echo "  AWS_ACCESS_KEY_ID=..."; \
 		echo "  AWS_SECRET_ACCESS_KEY=..."; \
 		echo "  AWS_TOKEN=<ssrf-protection-token>"; \
 		echo ""; \
-		echo "Without .env, containers fall back to local env_file mode (no secrets fetched)."; \
+		echo "Without .env or equivalent environment variables, containers fall back to local env_file mode (no secrets fetched)."; \
 		echo "Run /cpp:init to configure interactively."; \
 		echo ""; \
 	elif ! grep -qE '^AWS_ACCESS_KEY_ID=.+' .env 2>/dev/null; then \
@@ -86,7 +86,7 @@ docker-secrets-check:
 		exit 1; \
 	fi
 	@. .env 2>/dev/null; \
-	for secret in claude-power-pack/mcp-keys essent-ai; do \
+	for secret in codex_llm_apikeys essent-ai; do \
 		if aws secretsmanager describe-secret --secret-id "$$secret" > /dev/null 2>&1; then \
 			echo "OK: Secret '$$secret' exists"; \
 		else \

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ uv sync --extra dev
 # Run quality checks
 make verify
 
-# Start MCP servers (requires .env with AWS credentials)
-# .env needs: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_TOKEN
+# Start MCP servers (local .env or CI env provides AWS credentials)
+# local .env needs: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_TOKEN
 make docker-secrets-check              # Validate AWS connectivity
 make docker-up PROFILE=core            # Second Opinion + Nano Banana
 make docker-up PROFILE="core browser"  # + Playwright
@@ -66,7 +66,7 @@ claude-power-pack/
   woodpecker/           Woodpecker CI server + agent deployment configs
   templates/            Makefile, workflow, and container templates
   scripts/              Shell utilities
-  tests/                496 unit tests
+  tests/                637 unit tests
   docker-compose.yml    MCP server orchestration
   .woodpecker.yml       CI pipeline (lint, test, typecheck, deploy)
   Makefile              Build interface for all operations
@@ -97,7 +97,7 @@ make docker-ps                    # container status
 make docker-down                  # stop all
 ```
 
-MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar (Rust binary, port 2773). Only AWS credentials are stored in the root `.env` file (gitignored) - no application secrets on disk.
+MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar (Rust binary, port 2773). Local development can store only AWS credentials in the root `.env` file (gitignored), while CI/deploy can inject the same variables through the job environment. Application secrets are not stored on disk.
 
 ```bash
 # Minimal .env (no application secrets):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@
 #   AWS_SECRET_ACCESS_KEY=...
 #   AWS_TOKEN=...               (SSRF token for secrets agent)
 #
+# CI/deploy can provide these as environment variables instead of a root .env.
+#
 # The aws-secrets-agent sidecar fetches LLM keys and other secrets
 # from AWS Secrets Manager at runtime. No application secrets on disk.
 
@@ -23,9 +25,16 @@ services:
     container_name: aws-secrets-agent
     env_file:
       - path: .env
-        required: true
+        required: false
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_REGION=us-east-1
+      - AWS_TOKEN=${AWS_TOKEN:-default-token}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "-H", "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN}", "http://localhost:2773/ping"]
+      test: ["CMD", "curl", "-sf", "-H", "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN:-default-token}", "http://localhost:2773/ping"]
       interval: 10s
       timeout: 3s
       start_period: 10s
@@ -56,6 +65,7 @@ services:
       - MCP_SERVER_HOST=0.0.0.0
       - AWS_SECRET_NAME=codex_llm_apikeys
       - SECRETS_AGENT_URL=http://aws-secrets-agent:2773
+      - AWS_TOKEN=${AWS_TOKEN:-default-token}
     volumes:
       - ./aws-secrets-agent/fetch-secrets.sh:/app/fetch-secrets.sh:ro
     entrypoint: ["/app/fetch-secrets.sh"]
@@ -151,6 +161,7 @@ services:
       - MCP_SERVER_HOST=0.0.0.0
       - AWS_SECRET_NAME=essent-ai
       - SECRETS_AGENT_URL=http://aws-secrets-agent:2773
+      - AWS_TOKEN=${AWS_TOKEN:-default-token}
     volumes:
       - ./aws-secrets-agent/fetch-secrets.sh:/app/fetch-secrets.sh:ro
     entrypoint: ["/app/fetch-secrets.sh"]

--- a/docs/AWS_SECRETS_SIDECAR.md
+++ b/docs/AWS_SECRETS_SIDECAR.md
@@ -5,7 +5,7 @@ The `aws-secrets-agent` is a Rust-based sidecar container that injects API keys 
 ## Architecture
 
 ```
-.env (AWS creds only)
+.env or CI environment (AWS creds only)
   |
   v
 aws-secrets-agent (port 2773)        <-- fetches from AWS Secrets Manager
@@ -20,7 +20,7 @@ MCP server (python server.py)        <-- secrets exported as env vars
 
 ## How It Works
 
-1. The `aws-secrets-agent` container starts and connects to AWS Secrets Manager using credentials from `.env`
+1. The `aws-secrets-agent` container starts and connects to AWS Secrets Manager using credentials from `.env` or the deploy environment
 2. It runs as a local HTTP daemon on port 2773, serving secrets to other containers on the Docker network
 3. Each MCP container uses `fetch-secrets.sh` as its entrypoint, which:
    - Checks if `AWS_SECRET_NAME` is set (skips fetch if not - local dev mode)
@@ -29,15 +29,17 @@ MCP server (python server.py)        <-- secrets exported as env vars
    - Falls back to existing `env_file` variables if the agent is unreachable
    - Execs the original command (e.g., `python server.py`)
 
-## Required `.env` File
+## Required Credentials
 
-Only AWS credentials are stored on disk:
+Local development can store only AWS credentials on disk:
 
 ```
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 AWS_TOKEN=my-ssrf-protection-token
 ```
+
+CI and deploy jobs can provide the same variables through the job environment. The root `.env` file is optional so a clean checkout can still run `docker compose` when credentials are injected by the platform.
 
 `AWS_TOKEN` is an arbitrary string used for SSRF protection - the sidecar validates it on every request. Choose any value and keep it consistent.
 
@@ -47,7 +49,7 @@ AWS_TOKEN=my-ssrf-protection-token
 
 | Secret Name | Used By | Expected Keys |
 |-------------|---------|---------------|
-| `claude-power-pack/mcp-keys` | mcp-second-opinion | `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` |
+| `codex_llm_apikeys` | mcp-second-opinion | `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRAL_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `DEEPSEEK_API_KEY` |
 | `essent-ai` | mcp-woodpecker-ci | `WOODPECKER_URL`, `WOODPECKER_API_TOKEN` |
 
 ### Required IAM Permissions
@@ -65,7 +67,7 @@ The AWS credentials in `.env` need:
         "secretsmanager:DescribeSecret"
       ],
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:ACCOUNT:secret:claude-power-pack/mcp-keys-*",
+        "arn:aws:secretsmanager:us-east-1:ACCOUNT:secret:codex_llm_apikeys-*",
         "arn:aws:secretsmanager:us-east-1:ACCOUNT:secret:essent-ai-*"
       ]
     }
@@ -77,8 +79,8 @@ The AWS credentials in `.env` need:
 
 ```bash
 aws secretsmanager create-secret \
-  --name claude-power-pack/mcp-keys \
-  --secret-string '{"GEMINI_API_KEY":"...","OPENAI_API_KEY":"...","ANTHROPIC_API_KEY":"..."}'
+  --name codex_llm_apikeys \
+  --secret-string '{"GEMINI_API_KEY":"...","OPENAI_API_KEY":"...","ANTHROPIC_API_KEY":"...","MISTRAL_API_KEY":"...","GROQ_API_KEY":"...","OPENROUTER_API_KEY":"...","DEEPSEEK_API_KEY":"..."}'
 
 aws secretsmanager create-secret \
   --name essent-ai \
@@ -93,7 +95,7 @@ make docker-secrets-check
 
 # Check running container secret source
 docker logs mcp-second-opinion 2>&1 | head -5
-# Should show: INFO: Loaded secrets from AWS Secrets Manager (claude-power-pack/mcp-keys)
+# Should show: INFO: Loaded secrets from AWS Secrets Manager (codex_llm_apikeys)
 ```
 
 ## Local Development (Without AWS)

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -1,0 +1,72 @@
+"""Tests for checked-in Docker Compose deployment config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _env_list_to_map(values: list[str]) -> dict[str, str | None]:
+    env: dict[str, str | None] = {}
+    for value in values:
+        if "=" in value:
+            key, raw = value.split("=", 1)
+            env[key] = raw
+        else:
+            env[value] = None
+    return env
+
+
+def _compose_services() -> dict[str, Any]:
+    compose_path = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+    compose = yaml.safe_load(compose_path.read_text())
+    return compose["services"]
+
+
+def _woodpecker_steps() -> dict[str, Any]:
+    pipeline_path = Path(__file__).resolve().parents[1] / ".woodpecker.yml"
+    pipeline = yaml.safe_load(pipeline_path.read_text())
+    return pipeline["steps"]
+
+
+def test_aws_secrets_agent_does_not_require_root_env_file() -> None:
+    services = _compose_services()
+    env_file = services["aws-secrets-agent"]["env_file"][0]
+
+    assert env_file["path"] == ".env"
+    assert env_file["required"] is False
+
+
+def test_aws_secrets_agent_accepts_ci_environment_credentials() -> None:
+    services = _compose_services()
+    env = _env_list_to_map(services["aws-secrets-agent"]["environment"])
+
+    assert "AWS_ACCESS_KEY_ID" in env
+    assert "AWS_SECRET_ACCESS_KEY" in env
+    assert "AWS_SESSION_TOKEN" in env
+    assert env["AWS_REGION"] == "us-east-1"
+    assert env["AWS_TOKEN"] == "${AWS_TOKEN:-default-token}"
+
+
+def test_secret_consumers_share_sidecar_token_default() -> None:
+    services = _compose_services()
+    agent_healthcheck = services["aws-secrets-agent"]["healthcheck"]["test"]
+
+    assert "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN:-default-token}" in agent_healthcheck
+    for service_name in ("mcp-second-opinion", "mcp-woodpecker-ci"):
+        env = _env_list_to_map(services[service_name]["environment"])
+        assert env["AWS_TOKEN"] == "${AWS_TOKEN:-default-token}"
+
+
+def test_deploy_pipeline_injects_aws_credentials_for_compose() -> None:
+    steps = _woodpecker_steps()
+    deploy_env = steps["deploy-mcp"]["environment"]
+
+    assert deploy_env["AWS_DEFAULT_REGION"] == "us-east-1"
+    assert deploy_env["AWS_REGION"] == "us-east-1"
+    assert deploy_env["AWS_ACCESS_KEY_ID"] == {"from_secret": "aws_access_key_id"}
+    assert deploy_env["AWS_SECRET_ACCESS_KEY"] == {
+        "from_secret": "aws_secret_access_key"
+    }


### PR DESCRIPTION
## Summary

- make the root `.env` optional for the `aws-secrets-agent` Compose service so clean CI checkouts do not fail before deploy starts
- pass AWS credentials from the Woodpecker deploy job into Docker Compose via secrets-backed environment variables
- keep the sidecar and secret-consuming MCP containers on the same default `AWS_TOKEN` when a deploy environment does not provide one
- update local docs and `docker-secrets-check` to use the current `codex_llm_apikeys` secret
- add regression coverage for the Compose and Woodpecker deploy secret wiring

## Root Cause

The mainline Woodpecker deploy was failing in `deploy-mcp` because `docker compose` required a root `.env` file for `aws-secrets-agent`. Woodpecker runs from a clean checkout where that file is intentionally absent, so Compose exited with `env file .../.env not found` before containers could start.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_docker_compose_config.py`
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- `make update_docs`

## Verification Gap

- `make secret-scan` could not run locally because `gitleaks` is not installed and the Docker fallback cannot access `/var/run/docker.sock` in this environment.