### PR TITLE
[codex] sync MCP component lockfiles

### DIFF
--- a/mcp-nano-banana/uv.lock
+++ b/mcp-nano-banana/uv.lock
@@ -587,13 +587,15 @@ wheels = [
 
 [[package]]
 name = "mcp-nano-banana"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "python-pptx" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -608,6 +610,8 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.6.0" },
     { name = "python-pptx", specifier = ">=1.0.0" },
+    { name = "starlette", specifier = ">=0.38.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/mcp-second-opinion/uv.lock
+++ b/mcp-second-opinion/uv.lock
@@ -685,7 +685,9 @@ dependencies = [
     { name = "httpx" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "starlette" },
     { name = "tenacity" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -696,7 +698,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "openai", specifier = ">=1.50.0" },
     { name = "pydantic", specifier = ">=2.6.0" },
+    { name = "starlette", specifier = ">=0.38.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- sync `mcp-nano-banana/uv.lock` with its current package version and direct `starlette` / `uvicorn` dependencies
- sync `mcp-second-opinion/uv.lock` with its direct `starlette` / `uvicorn` dependencies

## Why

The component `pyproject.toml` files already declare these values. This keeps the checked-in component lockfiles aligned with the declared metadata and dependencies.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv lock --check` in `mcp-nano-banana`
- `env UV_CACHE_DIR=/tmp/uv-cache uv lock --check` in `mcp-second-opinion`
- `git diff --check`