### PR TITLE
fix(secrets): validate second-opinion AWS keys

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -675,7 +675,10 @@ if [ "$SECRET_METHOD" = "1" ]; then
 
   echo ""
   echo "MCP server secret mappings (from docker-compose.yml):"
-  echo "  mcp-second-opinion  -> AWS_SECRET_NAME=claude-power-pack/mcp-keys"
+  echo "  mcp-second-opinion  -> AWS_SECRET_NAME=codex_llm_apikeys"
+  echo "      Expected keys: GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY,"
+  echo "                     MISTRAL_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY,"
+  echo "                     DEEPSEEK_API_KEY"
   echo "  mcp-woodpecker-ci   -> AWS_SECRET_NAME=essent-ai"
   echo ""
   echo "To change these mappings, edit the environment section in docker-compose.yml."

--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -447,7 +447,7 @@ Tier 3 (Full):
     [ ] playwright-persistent (port 8081): not reachable
   AWS Secrets Sidecar:
     [x] aws-secrets-agent: running, healthy (port 2773)
-        mcp-second-opinion -> claude-power-pack/mcp-keys
+        mcp-second-opinion -> codex_llm_apikeys
         mcp-woodpecker-ci -> essent-ai
     [x] AWS credentials: present in .env
     Secret method: AWS Secrets Manager

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,17 @@ ENV/
 
 # Environment Variables
 .env
+.env.*
 .env.local
 *.env
 !.env.example
+
+# Secrets and private keys
+*.pem
+*.key
+secrets.*
+*.p12
+.claude/security.yml
 
 # IDE
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 
 - **Secrets architecture:** `aws-secrets-agent` (Rust binary, port 2773) caches secrets in-memory (300s TTL) with SSRF token protection. MCP containers use `fetch-secrets.sh` entrypoint to resolve keys before starting.
 - **Required AWS credential variables:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_TOKEN` (SSRF token), supplied by local `.env` or CI/deploy environment
-- **AWS secrets used:** `codex_llm_apikeys` (second-opinion LLM keys), `essent-ai` (woodpecker-ci keys)
+- **AWS secrets used:** `codex_llm_apikeys` (second-opinion LLM keys, including `MISTRAL_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, and `DEEPSEEK_API_KEY` for free-tier models), `essent-ai` (woodpecker-ci keys)
 - **Required IAM permissions:** `secretsmanager:GetSecretValue`, `secretsmanager:DescribeSecret` on the named secrets
 - **Validate setup:** `make docker-secrets-check` (checks AWS creds, verifies secrets exist)
 - **Profiles:** `core` (second-opinion + nano-banana + secrets-agent), `browser` (playwright), `cicd` (woodpecker-ci + secrets-agent)

--- a/Makefile
+++ b/Makefile
@@ -86,13 +86,9 @@ docker-secrets-check:
 		exit 1; \
 	fi
 	@. .env 2>/dev/null; \
-	for secret in codex_llm_apikeys essent-ai; do \
-		if aws secretsmanager describe-secret --secret-id "$$secret" > /dev/null 2>&1; then \
-			echo "OK: Secret '$$secret' exists"; \
-		else \
-			echo "WARN: Secret '$$secret' not found (services using it will fall back to env_file)"; \
-		fi; \
-	done
+	python3 scripts/check-aws-secret-keys.py \
+		--required codex_llm_apikeys:GEMINI_API_KEY,OPENAI_API_KEY,ANTHROPIC_API_KEY,MISTRAL_API_KEY,GROQ_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY \
+		--optional essent-ai:WOODPECKER_URL,WOODPECKER_API_TOKEN
 	@echo "Done."
 
 docker-up: docker-check-env

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ make docker-down                  # stop all
 
 MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar (Rust binary, port 2773). Local development can store only AWS credentials in the root `.env` file (gitignored), while CI/deploy can inject the same variables through the job environment. Application secrets are not stored on disk.
 
+`mcp-second-opinion` uses `AWS_SECRET_NAME=codex_llm_apikeys`. That secret must include `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRAL_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, and `DEEPSEEK_API_KEY` so the free-tier model catalog is available in the deployed container.
+
 ```bash
 # Minimal .env (no application secrets):
 AWS_ACCESS_KEY_ID=...

--- a/fetch_reddit_posts.py
+++ b/fetch_reddit_posts.py
@@ -5,6 +5,7 @@ This script uses PRAW in read-only mode (no authentication required).
 """
 
 import json
+import os
 from datetime import datetime
 
 import praw
@@ -17,10 +18,17 @@ def fetch_claudecode_posts(limit=25):
     Args:
         limit: Number of posts to fetch (default: 25)
     """
-    # Create a read-only Reddit instance (no authentication needed)
+    client_id = os.getenv("REDDIT_CLIENT_ID")
+    client_secret = os.getenv("REDDIT_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Set REDDIT_CLIENT_ID and REDDIT_CLIENT_SECRET before fetching Reddit posts."
+        )
+
+    # Create a read-only Reddit instance.
     reddit = praw.Reddit(
-        client_id="your_client_id_here",  # You'll need to add this
-        client_secret="your_client_secret_here",  # You'll need to add this
+        client_id=client_id,
+        client_secret=client_secret,
         user_agent="claude-power-pack-fetcher/1.0"
     )
 

--- a/lib/security/modules/secrets.py
+++ b/lib/security/modules/secrets.py
@@ -111,6 +111,7 @@ SKIP_FILES = {"package-lock.json", "yarn.lock", "uv.lock", "poetry.lock"}
 SKIP_PATTERN_FILES = {
     "secrets-mask.sh", "hook-mask-output.sh", "masking.py",
     "explain.py", "secrets.py",  # the scanner itself and explanation docs
+    "test_creds_masking.py", "test_security_models.py", "test_security_scanners.py",
 }
 
 

--- a/scripts/check-aws-secret-keys.py
+++ b/scripts/check-aws-secret-keys.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Validate AWS Secrets Manager secret key presence without printing values."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SecretSpec:
+    name: str
+    keys: tuple[str, ...]
+    required: bool
+
+
+def parse_secret_spec(raw: str, *, required: bool) -> SecretSpec:
+    """Parse NAME:KEY,KEY into a typed spec."""
+    if ":" not in raw:
+        raise argparse.ArgumentTypeError("expected NAME:KEY,KEY")
+
+    name, raw_keys = raw.split(":", 1)
+    keys = tuple(key.strip() for key in raw_keys.split(",") if key.strip())
+    if not name.strip() or not keys:
+        raise argparse.ArgumentTypeError("expected non-empty secret name and keys")
+
+    return SecretSpec(name=name.strip(), keys=keys, required=required)
+
+
+def _run_aws(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["aws", *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _severity(spec: SecretSpec) -> str:
+    return "FAIL" if spec.required else "WARN"
+
+
+def validate_secret(spec: SecretSpec) -> bool:
+    """Return True when a secret exists and contains all expected non-empty keys."""
+    describe = _run_aws(
+        ["secretsmanager", "describe-secret", "--secret-id", spec.name],
+    )
+    if describe.returncode != 0:
+        print(f"{_severity(spec)}: Secret '{spec.name}' not found")
+        return not spec.required
+
+    value = _run_aws(
+        [
+            "secretsmanager",
+            "get-secret-value",
+            "--secret-id",
+            spec.name,
+            "--query",
+            "SecretString",
+            "--output",
+            "text",
+        ],
+    )
+    if value.returncode != 0:
+        print(f"{_severity(spec)}: Could not read SecretString for '{spec.name}'")
+        return not spec.required
+
+    try:
+        payload = json.loads(value.stdout)
+    except json.JSONDecodeError:
+        print(f"{_severity(spec)}: Secret '{spec.name}' is not valid JSON")
+        return not spec.required
+
+    if not isinstance(payload, dict):
+        print(f"{_severity(spec)}: Secret '{spec.name}' must be a JSON object")
+        return not spec.required
+
+    missing = [key for key in spec.keys if not payload.get(key)]
+    if missing:
+        keys = ", ".join(missing)
+        print(f"{_severity(spec)}: Secret '{spec.name}' missing required key(s): {keys}")
+        return not spec.required
+
+    print(f"OK: Secret '{spec.name}' contains expected keys ({len(spec.keys)})")
+    return True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate AWS Secrets Manager secrets contain expected keys.",
+    )
+    parser.add_argument(
+        "--required",
+        action="append",
+        default=[],
+        metavar="NAME:KEY,KEY",
+        help="Secret and key list that must exist.",
+    )
+    parser.add_argument(
+        "--optional",
+        action="append",
+        default=[],
+        metavar="NAME:KEY,KEY",
+        help="Secret and key list that may be absent.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    specs = [
+        *(parse_secret_spec(raw, required=True) for raw in args.required),
+        *(parse_secret_spec(raw, required=False) for raw in args.optional),
+    ]
+
+    if not specs:
+        parser.error("at least one --required or --optional spec is needed")
+
+    ok = True
+    for spec in specs:
+        ok = validate_secret(spec) and ok
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_aws_secret_key_check.py
+++ b/tests/test_aws_secret_key_check.py
@@ -1,0 +1,72 @@
+"""Tests for AWS Secrets Manager key presence validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check-aws-secret-keys.py"
+
+
+def _write_fake_aws(tmp_path: Path, payload: str, *, describe_success: bool = True) -> Path:
+    fake_aws = tmp_path / "aws"
+    fake_aws.write_text(
+        f"""#!/usr/bin/env python3
+import sys
+
+args = sys.argv[1:]
+if args[:2] == ["secretsmanager", "describe-secret"]:
+    sys.exit(0 if {describe_success!r} else 255)
+if args[:2] == ["secretsmanager", "get-secret-value"]:
+    print({payload!r})
+    sys.exit(0)
+sys.exit(1)
+""",
+    )
+    fake_aws.chmod(0o755)
+    return fake_aws
+
+
+def _run_check(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def test_required_secret_with_all_keys_passes_without_printing_values(tmp_path: Path) -> None:
+    _write_fake_aws(tmp_path, '{"A":"secret-value","B":"other-secret"}')
+
+    result = _run_check(tmp_path, "--required", "test-secret:A,B")
+
+    assert result.returncode == 0
+    assert "OK: Secret 'test-secret' contains expected keys (2)" in result.stdout
+    assert "secret-value" not in result.stdout
+    assert "other-secret" not in result.stdout
+
+
+def test_required_secret_missing_key_fails_without_printing_values(tmp_path: Path) -> None:
+    _write_fake_aws(tmp_path, '{"A":"secret-value"}')
+
+    result = _run_check(tmp_path, "--required", "test-secret:A,B")
+
+    assert result.returncode == 1
+    assert "FAIL: Secret 'test-secret' missing required key(s): B" in result.stdout
+    assert "secret-value" not in result.stdout
+
+
+def test_optional_missing_secret_warns_but_does_not_fail(tmp_path: Path) -> None:
+    _write_fake_aws(tmp_path, "{}", describe_success=False)
+
+    result = _run_check(tmp_path, "--optional", "optional-secret:A")
+
+    assert result.returncode == 0
+    assert "WARN: Secret 'optional-secret' not found" in result.stdout

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -60,6 +60,43 @@ def test_secret_consumers_share_sidecar_token_default() -> None:
         assert env["AWS_TOKEN"] == "${AWS_TOKEN:-default-token}"
 
 
+def test_second_opinion_uses_secret_with_free_tier_provider_keys() -> None:
+    services = _compose_services()
+    env = _env_list_to_map(services["mcp-second-opinion"]["environment"])
+
+    assert env["AWS_SECRET_NAME"] == "codex_llm_apikeys"
+
+    expected_keys = [
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "MISTRAL_API_KEY",
+        "GROQ_API_KEY",
+        "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+    ]
+    docs = (
+        Path(__file__).resolve().parents[1] / "docs" / "AWS_SECRETS_SIDECAR.md"
+    ).read_text()
+    for key in expected_keys:
+        assert key in docs
+
+
+def test_legacy_second_opinion_secret_name_is_not_documented() -> None:
+    root = Path(__file__).resolve().parents[1]
+    checked_paths = [
+        root / "docker-compose.yml",
+        root / "CLAUDE.md",
+        root / "README.md",
+        root / "docs" / "AWS_SECRETS_SIDECAR.md",
+        root / ".claude" / "commands" / "cpp" / "init.md",
+        root / ".claude" / "commands" / "cpp" / "status.md",
+    ]
+
+    for path in checked_paths:
+        assert "claude-power-pack/mcp-keys" not in path.read_text()
+
+
 def test_deploy_pipeline_does_not_require_repo_aws_secrets() -> None:
     steps = _woodpecker_steps()
     deploy_step = steps["deploy-mcp"]


### PR DESCRIPTION
## Summary
- Point CPP setup/status docs at `codex_llm_apikeys` instead of the legacy `claude-power-pack/mcp-keys` secret.
- Add `make docker-secrets-check` validation for required second-opinion provider keys, including free-tier providers.
- Add regression coverage for the compose secret mapping, legacy secret-name references, and the AWS secret key validator.
- Clean up security-scan false positives so flow gates do not block on known fixture files.

## Test plan
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_security_scanners.py tests/test_aws_secret_key_check.py tests/test_docker_compose_config.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m lib.security quick`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m lib.cicd run --plan finish`

Closes #330