### PR TITLE
fix(second-opinion): refresh free provider model catalog (Closes #328)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test lint format typecheck verify secret-scan update_docs clean \
        docker-build docker-check-env docker-secrets-check docker-up docker-down docker-logs docker-ps deploy \
-       bootstrap-check drift-check setup-woodpecker-cli codex-init codex-init-workspace
+       bootstrap-check drift-check setup-woodpecker-cli second-opinion-model-smoke codex-init codex-init-workspace
 
 ## Quality gates (used by /flow:finish)
 
@@ -30,6 +30,9 @@ secret-scan:
 ## Pre-deploy gate (runs all quality checks)
 
 verify: lint test typecheck
+
+second-opinion-model-smoke:
+	env UV_CACHE_DIR=$${UV_CACHE_DIR:-/tmp/uv-cache} uv run --directory mcp-second-opinion python scripts/smoke-model-catalog.py
 
 ## Documentation (used by /flow:auto and /flow:finish)
 

--- a/mcp-second-opinion/README.md
+++ b/mcp-second-opinion/README.md
@@ -114,6 +114,9 @@ cd /path/to/claude-power-pack/mcp-second-opinion
 
 # Or directly
 uv run python src/server.py --diagnose
+
+# From the repo root, smoke-test configured OpenAI-compatible model IDs
+make second-opinion-model-smoke
 ```
 
 This checks API keys, .env file, port availability, and available models.

--- a/mcp-second-opinion/scripts/smoke-model-catalog.py
+++ b/mcp-second-opinion/scripts/smoke-model-catalog.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Smoke-test advertised OpenAI-compatible model IDs with configured provider keys."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+try:
+    import openai
+except ImportError as exc:  # pragma: no cover - exercised only outside test envs without server deps
+    raise SystemExit(
+        "openai package is required. Run through uv from mcp-second-opinion, e.g. "
+        "`uv run --directory mcp-second-opinion python scripts/smoke-model-catalog.py`."
+    ) from exc
+
+Config = importlib.import_module("config").Config
+
+
+PROVIDER_CONFIG = {
+    "mistral": ("MISTRAL_API_KEY", Config.MISTRAL_BASE_URL),
+    "groq": ("GROQ_API_KEY", Config.GROQ_BASE_URL),
+    "openrouter": ("OPENROUTER_API_KEY", Config.OPENROUTER_BASE_URL),
+    "deepseek": ("DEEPSEEK_API_KEY", Config.DEEPSEEK_BASE_URL),
+}
+
+
+@dataclass(frozen=True)
+class CatalogModel:
+    key: str
+    provider: str
+    model_id: str
+
+
+async def smoke_model(model: CatalogModel, *, max_tokens: int, timeout: float) -> tuple[CatalogModel, str | None]:
+    """Return an error string when a one-token provider request fails."""
+    api_key_attr, base_url = PROVIDER_CONFIG[model.provider]
+    client = openai.AsyncOpenAI(api_key=getattr(Config, api_key_attr), base_url=base_url)
+
+    try:
+        await asyncio.wait_for(
+            client.chat.completions.create(
+                model=model.model_id,
+                messages=[{"role": "user", "content": "Reply with OK."}],
+                max_tokens=max_tokens,
+                temperature=0,
+            ),
+            timeout=timeout,
+        )
+    except Exception as exc:  # noqa: BLE001 - provider-specific SDK exceptions vary
+        return model, str(exc)
+
+    return model, None
+
+
+def select_models(providers: set[str], model_keys: set[str]) -> list[CatalogModel]:
+    """Select advertised models whose provider key is configured."""
+    selected = []
+    for key, info in Config.AVAILABLE_MODELS.items():
+        provider = info["provider"]
+        if provider not in providers:
+            continue
+        if model_keys and key not in model_keys:
+            continue
+
+        api_key_attr, _base_url = PROVIDER_CONFIG[provider]
+        if not getattr(Config, api_key_attr, None):
+            continue
+
+        selected.append(CatalogModel(key=key, provider=provider, model_id=info["model_id"]))
+
+    return selected
+
+
+async def run(args: argparse.Namespace) -> int:
+    providers = set(args.provider or PROVIDER_CONFIG)
+    unknown_providers = providers - set(PROVIDER_CONFIG)
+    if unknown_providers:
+        print(f"Unknown provider(s): {', '.join(sorted(unknown_providers))}", file=sys.stderr)
+        return 2
+
+    model_keys = set(args.model or [])
+    unknown_models = model_keys - set(Config.AVAILABLE_MODELS)
+    if unknown_models:
+        print(f"Unknown model key(s): {', '.join(sorted(unknown_models))}", file=sys.stderr)
+        return 2
+
+    selected = select_models(providers, model_keys)
+    configured_providers = {
+        provider
+        for provider, (api_key_attr, _base_url) in PROVIDER_CONFIG.items()
+        if getattr(Config, api_key_attr, None)
+    }
+    scoped_configured = configured_providers & providers
+
+    if not scoped_configured:
+        print("No scoped OpenAI-compatible provider API keys are configured; skipping model catalog smoke.")
+        return 0
+
+    if not selected:
+        print("No advertised model entries matched the configured scoped provider keys; skipping.")
+        return 0
+
+    failures = []
+    for model in selected:
+        print(f"smoke {model.provider}/{model.key} -> {model.model_id}")
+        _model, error = await smoke_model(model, max_tokens=args.max_tokens, timeout=args.timeout)
+        if error:
+            failures.append((model, error))
+            print(f"FAIL {model.key}: {error}", file=sys.stderr)
+        else:
+            print(f"OK   {model.key}")
+
+    if failures:
+        print("", file=sys.stderr)
+        print(f"{len(failures)} model catalog smoke check(s) failed:", file=sys.stderr)
+        for model, error in failures:
+            print(f"- {model.provider}/{model.key} ({model.model_id}): {error}", file=sys.stderr)
+        return 1
+
+    print(f"All {len(selected)} configured model catalog smoke check(s) passed.")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--provider",
+        action="append",
+        choices=sorted(PROVIDER_CONFIG),
+        help="Provider to check. May be repeated. Defaults to all OpenAI-compatible providers.",
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        help="Catalog model key to check. May be repeated. Defaults to all matching configured providers.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=1, help="Max output tokens for each provider request.")
+    parser.add_argument("--timeout", type=float, default=20.0, help="Per-model request timeout in seconds.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    return asyncio.run(run(parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp-second-opinion/src/config.py
+++ b/mcp-second-opinion/src/config.py
@@ -203,9 +203,8 @@ class Config:
     GROQ_PRICING: Dict[str, Dict[str, float]] = {
         "llama-3.3-70b-versatile": {"input": 0.59, "output": 0.79},
         "meta-llama/llama-4-scout-17b-16e-instruct": {"input": 0.11, "output": 0.34},
-        "meta-llama/llama-4-maverick-17b-128e-instruct": {"input": 0.20, "output": 0.60},
-        "deepseek-r1-distill-llama-70b": {"input": 0.75, "output": 0.99},
-        "qwen-qwq-32b": {"input": 0.29, "output": 0.39},
+        "openai/gpt-oss-120b": {"input": 0.15, "output": 0.75},
+        "qwen/qwen3-32b": {"input": 0.29, "output": 0.59},
     }
 
     # ==========================================================================
@@ -215,12 +214,12 @@ class Config:
     OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
 
     OPENROUTER_PRICING: Dict[str, Dict[str, float]] = {
-        "qwen/qwen3-coder": {"input": 0.00, "output": 0.00},
-        "deepseek/deepseek-chat-v4-0324:free": {"input": 0.00, "output": 0.00},
+        "qwen/qwen3-coder:free": {"input": 0.00, "output": 0.00},
+        "deepseek/deepseek-v4-flash:free": {"input": 0.00, "output": 0.00},
         "openai/gpt-oss-20b:free": {"input": 0.00, "output": 0.00},
         "openai/gpt-oss-120b:free": {"input": 0.00, "output": 0.00},
         "google/gemma-4-31b-it:free": {"input": 0.00, "output": 0.00},
-        "minimax/minimax-m2-5:free": {"input": 0.00, "output": 0.00},
+        "minimax/minimax-m2.5:free": {"input": 0.00, "output": 0.00},
     }
 
     # ==========================================================================
@@ -396,19 +395,11 @@ class Config:
             "free": True,
             "max_output_tokens": 32768,
         },
-        "groq-llama4-maverick": {
+        "groq-gpt-oss-120b": {
             "provider": "groq",
-            "model_id": "meta-llama/llama-4-maverick-17b-128e-instruct",
-            "display_name": "Llama 4 Maverick (Groq)",
-            "description": "Llama 4 128-expert MoE, strong reasoning (128K context)",
-            "free": True,
-            "max_output_tokens": 32768,
-        },
-        "groq-deepseek-r1": {
-            "provider": "groq",
-            "model_id": "deepseek-r1-distill-llama-70b",
-            "display_name": "DeepSeek R1 Distill (Groq)",
-            "description": "R1-distilled reasoning on Groq's fast infra",
+            "model_id": "openai/gpt-oss-120b",
+            "display_name": "GPT-OSS 120B (Groq)",
+            "description": "Strong reasoning replacement for deprecated Maverick/R1 Groq IDs",
             "free": True,
             "max_output_tokens": 32768,
         },
@@ -422,7 +413,7 @@ class Config:
         },
         "groq-qwen-32b": {
             "provider": "groq",
-            "model_id": "qwen-qwq-32b",
+            "model_id": "qwen/qwen3-32b",
             "display_name": "Qwen3 32B (Groq)",
             "description": "Strong reasoning on Groq's fast infra (128K context)",
             "free": True,
@@ -446,14 +437,14 @@ class Config:
         # OpenRouter models (aggregator - free tier)
         "openrouter-qwen-coder": {
             "provider": "openrouter",
-            "model_id": "qwen/qwen3-coder",
+            "model_id": "qwen/qwen3-coder:free",
             "display_name": "Qwen3 Coder (OpenRouter)",
             "description": "Top-tier free coding model (1M context)",
             "free": True,
         },
         "openrouter-deepseek-flash": {
             "provider": "openrouter",
-            "model_id": "deepseek/deepseek-chat-v4-0324:free",
+            "model_id": "deepseek/deepseek-v4-flash:free",
             "display_name": "DeepSeek V4 Flash (OpenRouter)",
             "description": "Free DeepSeek via OpenRouter (1M context)",
             "free": True,
@@ -481,7 +472,7 @@ class Config:
         },
         "openrouter-minimax-m2.5": {
             "provider": "openrouter",
-            "model_id": "minimax/minimax-m2-5:free",
+            "model_id": "minimax/minimax-m2.5:free",
             "display_name": "Minimax M2.5 (OpenRouter)",
             "description": "Quality score 70, 262K context, free",
             "free": True,
@@ -495,7 +486,7 @@ class Config:
         "gpt-5.5-pro",
         "claude-opus",
         "devstral",
-        "groq-llama4-maverick",
+        "groq-gpt-oss-120b",
         "openrouter-gpt-oss-20b",
         "openrouter-qwen-coder",
     ]

--- a/tests/test_second_opinion_model_catalog.py
+++ b/tests/test_second_opinion_model_catalog.py
@@ -1,0 +1,87 @@
+"""Tests for second-opinion model catalog freshness."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+STALE_PROVIDER_MODEL_IDS = {
+    "meta-llama/llama-4-maverick-17b-128e-instruct",
+    "deepseek-r1-distill-llama-70b",
+    "qwen-qwq-32b",
+    "deepseek/deepseek-chat-v4-0324:free",
+    "minimax/minimax-m2-5:free",
+}
+
+
+def _load_config():
+    """Load second-opinion config without requiring python-dotenv in the root test env."""
+    src_path = str(Path(__file__).resolve().parent.parent / "mcp-second-opinion" / "src")
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *_args, **_kwargs: None
+
+    with patch.dict(sys.modules, {"dotenv": dotenv_stub}):
+        sys.modules.pop("config", None)
+        sys.path.insert(0, src_path)
+        try:
+            return importlib.import_module("config").Config
+        finally:
+            sys.path.remove(src_path)
+            sys.modules.pop("config", None)
+
+
+Config = _load_config()
+
+
+def test_issue_328_stale_provider_ids_are_not_advertised_or_priced() -> None:
+    catalog_model_ids = {info["model_id"] for info in Config.AVAILABLE_MODELS.values()}
+    pricing_model_ids = set().union(
+        Config.GROQ_PRICING,
+        Config.OPENROUTER_PRICING,
+        Config.DEEPSEEK_PRICING,
+    )
+
+    assert STALE_PROVIDER_MODEL_IDS.isdisjoint(catalog_model_ids)
+    assert STALE_PROVIDER_MODEL_IDS.isdisjoint(pricing_model_ids)
+
+
+def test_default_models_reference_existing_catalog_entries() -> None:
+    assert set(Config.DEFAULT_MODELS) <= set(Config.AVAILABLE_MODELS)
+    assert "groq-llama4-maverick" not in Config.DEFAULT_MODELS
+
+
+def test_groq_catalog_uses_current_replacement_model_ids() -> None:
+    assert "groq-llama4-maverick" not in Config.AVAILABLE_MODELS
+    assert "groq-deepseek-r1" not in Config.AVAILABLE_MODELS
+    assert Config.AVAILABLE_MODELS["groq-gpt-oss-120b"]["model_id"] == "openai/gpt-oss-120b"
+    assert Config.AVAILABLE_MODELS["groq-qwen-32b"]["model_id"] == "qwen/qwen3-32b"
+
+
+def test_free_openrouter_catalog_entries_use_free_slugs() -> None:
+    openrouter_free_entries = {
+        key: info
+        for key, info in Config.AVAILABLE_MODELS.items()
+        if info["provider"] == "openrouter" and info.get("free")
+    }
+
+    assert openrouter_free_entries
+    for key, info in openrouter_free_entries.items():
+        assert info["model_id"].endswith(":free"), key
+
+
+def test_openai_compatible_catalog_entries_have_pricing() -> None:
+    pricing_tables = {
+        "mistral": Config.MISTRAL_PRICING,
+        "groq": Config.GROQ_PRICING,
+        "openrouter": Config.OPENROUTER_PRICING,
+        "deepseek": Config.DEEPSEEK_PRICING,
+    }
+
+    for key, info in Config.AVAILABLE_MODELS.items():
+        pricing_table = pricing_tables.get(info["provider"])
+        if pricing_table is None:
+            continue
+        assert info["model_id"] in pricing_table, key


### PR DESCRIPTION
## Summary

- replace decommissioned Groq catalog entries with current `openai/gpt-oss-120b` / `qwen/qwen3-32b` IDs
- update OpenRouter free-tier slugs for Qwen Coder, DeepSeek V4 Flash, and Minimax M2.5
- add a configured-provider model catalog smoke target plus unit tests to prevent stale IDs from being advertised again

## Validation

- `make verify` -> 651 passed, 1 skipped; ruff and mypy passed
- `make second-opinion-model-smoke` -> skipped cleanly because no scoped provider API keys are configured

Closes #328