### PR TITLE
fix(ci): replace persistent deploy with runtime smoke (Closes #338)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,9 +1,9 @@
 # Claude Power Pack - Woodpecker CI Pipeline
-# Runs quality gates, builds Docker containers, and deploys MCP servers
+# Runs quality gates, dry-run Docker builds, and ephemeral MCP runtime smoke tests.
 #
 # Pipeline:
-#   PR/push   -> secret-scan -> validate (lint+test+typecheck) -> dry-run builds
-#   main push -> above + deploy-mcp (rebuild + restart containers)
+#   PR/push -> secret-scan -> validate (lint+test+typecheck) -> conditional Docker builds
+#   MCP/compose/shared changes -> runtime-smoke (isolated compose up, health checks, teardown)
 
 when:
   - event: [push, pull_request]
@@ -23,6 +23,22 @@ steps:
       - uv run pytest
       - uv run mypy .
 
+  build-aws-secrets-agent:
+    image: woodpeckerci/plugin-docker-buildx
+    depends_on: [validate]
+    settings:
+      repo: aws-secrets-agent
+      dockerfile: aws-secrets-agent/Dockerfile
+      context: aws-secrets-agent
+      tags: latest
+      dry_run: true
+    when:
+      - event: [push, pull_request]
+        path:
+          - ".woodpecker.yml"
+          - "docker-compose.yml"
+          - "aws-secrets-agent/**"
+
   build-second-opinion:
     image: woodpeckerci/plugin-docker-buildx
     depends_on: [validate]
@@ -34,7 +50,12 @@ steps:
       dry_run: true
     when:
       - event: [push, pull_request]
-        path: "mcp-second-opinion/**"
+        path:
+          - ".woodpecker.yml"
+          - "docker-compose.yml"
+          - "aws-secrets-agent/**"
+          - "lib/**"
+          - "mcp-second-opinion/**"
 
   build-playwright:
     image: woodpeckerci/plugin-docker-buildx
@@ -47,7 +68,11 @@ steps:
       dry_run: true
     when:
       - event: [push, pull_request]
-        path: "mcp-playwright-persistent/**"
+        path:
+          - ".woodpecker.yml"
+          - "docker-compose.yml"
+          - "lib/**"
+          - "mcp-playwright-persistent/**"
 
   build-nano-banana:
     image: woodpeckerci/plugin-docker-buildx
@@ -60,7 +85,11 @@ steps:
       dry_run: true
     when:
       - event: [push, pull_request]
-        path: "mcp-nano-banana/**"
+        path:
+          - ".woodpecker.yml"
+          - "docker-compose.yml"
+          - "lib/**"
+          - "mcp-nano-banana/**"
 
   build-woodpecker-ci:
     image: woodpeckerci/plugin-docker-buildx
@@ -73,124 +102,87 @@ steps:
       dry_run: true
     when:
       - event: [push, pull_request]
-        path: "mcp-woodpecker-ci/**"
-
-  drift-check:
-    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
-    depends_on: [validate]
-    commands:
-      - scripts/drift-detect.sh || echo "WARN - drift detected (non-blocking on CI agent)"
-    when:
-      - event: push
-        branch: main
         path:
-          - "mcp-second-opinion/deploy/**"
-          - "mcp-playwright-persistent/deploy/**"
-          - "scripts/bash-prep.sh"
-          - "scripts/drift-detect.sh"
+          - ".woodpecker.yml"
+          - "docker-compose.yml"
+          - "aws-secrets-agent/**"
+          - "lib/**"
+          - "mcp-woodpecker-ci/**"
 
-  pre-deploy-guardrails:
+  runtime-smoke:
     image: docker:cli
     depends_on: [validate]
     commands:
-      - apk add --no-cache git curl
-      # Stale commit guard - verify we are deploying the latest
-      # git fetch may fail in CI if credentials are unavailable; retry once
-      # and treat fetch failure as non-blocking (deploy the checked-out commit)
+      - apk add --no-cache curl docker-compose
       - |
-        LOCAL=$(git rev-parse HEAD)
-        FETCH_OK=false
-        for attempt in 1 2; do
-          if git fetch origin main --quiet 2>/dev/null; then
-            FETCH_OK=true
-            break
+        set -eu
+
+        PROJECT="cpp-smoke-${CI_PIPELINE_NUMBER:-local}"
+
+        # Keep smoke runs independent from real developer stacks and real AWS secrets.
+        export AWS_ACCESS_KEY_ID=cpp-smoke-access-key
+        export AWS_SECRET_ACCESS_KEY=cpp-smoke-secret-key
+        export AWS_SESSION_TOKEN=cpp-smoke-session-token
+        export AWS_TOKEN=cpp-smoke-token
+        export AWS_SECRETS_AGENT_PORT_MAPPING=2773
+        export MCP_SECOND_OPINION_PORT_MAPPING=8080
+        export MCP_PLAYWRIGHT_PORT_MAPPING=8081
+        export MCP_NANO_BANANA_PORT_MAPPING=8084
+        export MCP_WOODPECKER_CI_PORT_MAPPING=8085
+        export SECOND_OPINION_AWS_SECRET_NAME=
+        export WOODPECKER_CI_AWS_SECRET_NAME=
+
+        cleanup() {
+          docker compose -p "$PROJECT" --profile core --profile browser --profile cicd down -v || true
+        }
+        trap cleanup EXIT INT TERM
+
+        if ! docker compose -p "$PROJECT" --profile core --profile browser --profile cicd up --build --wait; then
+          docker compose -p "$PROJECT" --profile core --profile browser --profile cicd ps || true
+          docker compose -p "$PROJECT" logs aws-secrets-agent || true
+          exit 1
+        fi
+        docker compose -p "$PROJECT" --profile core --profile browser --profile cicd ps
+
+        check_http() {
+          service="$1"
+          container_port="$2"
+          check_path="$3"
+          header=""
+          if [ "$#" -ge 4 ]; then
+            header="$4"
           fi
-          echo "WARN: git fetch attempt $attempt failed, retrying..."
-          sleep 2
-        done
-        if [ "$FETCH_OK" = "true" ]; then
-          REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "$LOCAL")
-          if [ "$LOCAL" != "$REMOTE" ]; then
-            echo "BLOCKED: Stale commit detected"
-            echo "  local=$LOCAL"
-            echo "  remote=$REMOTE"
-            echo "  Run 'git pull origin main' before deploying."
+
+          published="$(docker compose -p "$PROJECT" port "$service" "$container_port" | awk -F: 'END {print $NF}')"
+          if [ -z "$published" ]; then
+            echo "ERROR: no published port for $service:$container_port"
             exit 1
           fi
-          echo "OK: HEAD matches origin/main at ${LOCAL:0:12}"
-        else
-          echo "WARN: Could not fetch origin/main (no credentials?). Deploying checked-out commit ${LOCAL:0:12}."
-        fi
-      # Docker socket access check
-      - |
-        if [ ! -S /var/run/docker.sock ]; then
-          echo "BLOCKED: docker.sock not mounted"
-          ls -la /var/run/docker* 2>/dev/null || echo "  No docker files in /var/run/"
-          exit 1
-        fi
-        if ! docker info >/dev/null 2>&1; then
-          echo "BLOCKED: docker.sock exists but docker daemon unreachable"
-          ls -la /var/run/docker.sock
-          exit 1
-        fi
-        echo "OK: docker.sock accessible"
-        echo "AUDIT: docker.sock access by $(whoami) at $(date -Iseconds)"
-      # Deploy lock - prevent concurrent deploys
-      # BusyBox flock doesn't support -w (timeout), use -n (non-blocking) only
-      - |
-        LOCKFILE="/tmp/cpp-deploy.lock"
-        exec 9>"$LOCKFILE"
-        if ! flock -n 9; then
-          echo "BLOCKED: Another deploy is in progress (lock held)"
-          exit 1
-        fi
-        echo "OK: Deploy lock acquired"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      - event: push
-        branch: main
-        path:
-          - "mcp-second-opinion/**"
-          - "mcp-playwright-persistent/**"
-          - "mcp-nano-banana/**"
-          - "mcp-woodpecker-ci/**"
-          - "docker-compose.yml"
 
-  deploy-mcp:
-    image: docker:cli
-    depends_on: [validate, pre-deploy-guardrails]
-    commands:
-      - apk add --no-cache docker-compose curl
-      - echo "Deploying MCP containers..."
-      - docker compose --profile core --profile browser --profile cicd up -d --build --wait
-      - docker compose --profile core --profile browser --profile cicd ps
-      # Safe prune with time filter to avoid cache races with concurrent builds
-      - docker image prune -f --filter "until=1h"
-      - echo "Deploy complete."
-      # Capability check - verify services can actually serve, not just respond
-      - |
-        FAILED=0
-        for port in 8080 8081 8084; do
-          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:${port}/" 2>/dev/null || echo "000")
-          if [ "$STATUS" = "200" ]; then
-            echo "OK: port $port health check passed (HTTP $STATUS)"
+          url="http://127.0.0.1:$published$check_path"
+          if [ -n "$header" ]; then
+            curl -sf -H "$header" --max-time 10 "$url" >/dev/null
           else
-            echo "WARN: port $port returned HTTP $STATUS"
-            FAILED=$((FAILED + 1))
+            curl -sf --max-time 10 "$url" >/dev/null
           fi
-        done
-        if [ "$FAILED" -gt 0 ]; then
-          echo "WARNING: $FAILED service(s) not healthy after deploy"
-        fi
+          echo "OK: $service:$container_port$check_path via host port $published"
+        }
+
+        check_http aws-secrets-agent 2773 /ping "X-Aws-Parameters-Secrets-Token: $AWS_TOKEN"
+        check_http mcp-second-opinion 8080 /
+        check_http mcp-playwright-persistent 8081 /
+        check_http mcp-nano-banana 8084 /
+        check_http mcp-woodpecker-ci 8085 /
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     when:
-      - event: push
-        branch: main
+      - event: [push, pull_request]
         path:
+          - ".woodpecker.yml"
+          - "docker-compose.yml"
+          - "aws-secrets-agent/**"
+          - "lib/**"
           - "mcp-second-opinion/**"
           - "mcp-playwright-persistent/**"
           - "mcp-nano-banana/**"
           - "mcp-woodpecker-ci/**"
-          - "docker-compose.yml"

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -120,6 +120,9 @@ steps:
         PROJECT="cpp-smoke-${CI_PIPELINE_NUMBER:-local}"
 
         # Keep smoke runs independent from real developer stacks and real AWS secrets.
+        # The prefix gives every container a project-unique name so a smoke run never
+        # collides with a real stack (which uses the empty-prefix default names).
+        export CPP_CONTAINER_PREFIX="${PROJECT}-"
         export AWS_ACCESS_KEY_ID=cpp-smoke-access-key
         export AWS_SECRET_ACCESS_KEY=cpp-smoke-secret-key
         export AWS_SESSION_TOKEN=cpp-smoke-session-token
@@ -159,11 +162,18 @@ steps:
             exit 1
           fi
 
-          url="http://127.0.0.1:$published$check_path"
-          if [ -n "$header" ]; then
-            curl -sf -H "$header" --max-time 10 "$url" >/dev/null
+          # Woodpecker runs this step inside a Docker job container, so host
+          # published ports are not reachable via 127.0.0.1 from here. Assert
+          # the service HTTP endpoint from inside the service container, then
+          # report the published host port to confirm the CI-only random port
+          # mapping exists and cannot collide with a workstation stack.
+          url="http://127.0.0.1:$container_port$check_path"
+          if [ "$service" = "aws-secrets-agent" ]; then
+            docker compose -p "$PROJECT" exec -T "$service" \
+              curl -sf -H "$header" --max-time 10 "$url" >/dev/null
           else
-            curl -sf --max-time 10 "$url" >/dev/null
+            docker compose -p "$PROJECT" exec -T "$service" \
+              python -c "import urllib.request; urllib.request.urlopen('$url', timeout=10)" >/dev/null
           fi
           echo "OK: $service:$container_port$check_path via host port $published"
         }

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -122,7 +122,7 @@ steps:
         # Keep smoke runs independent from real developer stacks and real AWS secrets.
         # The prefix gives every container a project-unique name so a smoke run never
         # collides with a real stack (which uses the empty-prefix default names).
-        export CPP_CONTAINER_PREFIX="${PROJECT}-"
+        export CPP_CONTAINER_PREFIX="cpp-smoke-${CI_PIPELINE_NUMBER:-local}-"
         export AWS_ACCESS_KEY_ID=cpp-smoke-access-key
         export AWS_SECRET_ACCESS_KEY=cpp-smoke-secret-key
         export AWS_SESSION_TOKEN=cpp-smoke-session-token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,18 +56,11 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Rebuild/restart/wait for health:** `make docker-refresh PROFILE="core browser cicd"`
 - **Status/logs/stop:** `make docker-ps`, `make docker-logs`, `make docker-down`
 - **MCP connections:** Defined in project `.mcp.json` pointing to `127.0.0.1:{port}/sse` (SSE transport)
-- **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, conditional Docker builds
+- **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, conditional Docker builds, and isolated runtime smoke tests for MCP stack changes
 - **Secret scanning:** `make secret-scan` runs gitleaks locally (native binary or Docker fallback). Config in `.gitleaks.toml` with allowlists for doc/test false positives
-- **Auto-deploy:** On push to main, if `mcp-*/` or `docker-compose.yml` changed, Woodpecker rebuilds and restarts MCP containers via the local agent
+- **Runtime smoke:** CI uses a `cpp-smoke-$CI_PIPELINE_NUMBER` compose project with random host ports, validates service health, and runs `docker compose down -v` before exiting. CI must not deploy persistent containers or prune host images.
 - **Bootstrap checks:** `make bootstrap-check` verifies admin-only prerequisites (IAM roles, secrets provisioning) before deploy. Configure in `.claude/bootstrap.yaml`. Runs as the first step in the deploy pipeline - blocks with remediation if unsatisfied.
-- **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries, shared scripts) against repo templates. Runs as a pre-deploy gate in the CI pipeline. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
-- **Deploy guardrails:** Pre-deploy validation gates in the Woodpecker pipeline and `lib/cicd/deploy/guardrails.py`:
-  - Stale commit protection (HEAD must match origin/main before deploy)
-  - Deploy lock (flock-based, prevents concurrent deploys on shared Docker hosts)
-  - Capability-based readiness checks (validate services can serve, not just respond to health pings)
-  - Safe Docker prune (time-filtered cleanup under lock to avoid cache races)
-  - docker.sock access audit logging
-  - Shared script contract drift detection (fetch-secrets.sh, bash-prep.sh consistency across containers)
+- **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries, shared scripts) against repo templates. Run it manually when reconciling workstation-managed artifacts. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
 
 ## Commands Reference
 

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ bootstrap-check:
 drift-check:
 	@scripts/drift-detect.sh --fix
 
-## Deploy (used by Woodpecker CI and /flow:deploy)
+## Deploy (used by /flow:deploy and manual local deployments)
 
 deploy: docker-refresh
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Security scanning** (`/security:scan`) - Native vulnerability detection with git history analysis
 - **Secrets management** (`/secrets:*`) - Tiered credential storage (dotenv, env-file, AWS Secrets Manager) with audit logging and a web UI
 - **CI/CD integration** (`/cicd:*`) - Framework detection, Makefile generation, health checks, and IaC scaffolding
-- **Woodpecker CI** - Self-hosted pipeline with automated MCP server deployment, health-based verification, and programmatic status polling
+- **Woodpecker CI** - Self-hosted pipeline with Docker build checks, isolated MCP runtime smoke tests, and programmatic status polling
 - **Project scaffolding** (`/project:init`) - Zero-to-GitHub-repo setup with Makefile, CI pipeline, and Docker config
 - **Safety hooks** - PreToolUse blocks dangerous commands; PostToolUse masks secrets in output
 
@@ -69,7 +69,7 @@ claude-power-pack/
   scripts/              Shell utilities
   tests/                637 unit tests
   docker-compose.yml    MCP server orchestration
-  .woodpecker.yml       CI pipeline (lint, test, typecheck, deploy)
+  .woodpecker.yml       CI pipeline (lint, test, typecheck, Docker builds, runtime smoke)
   Makefile              Build interface for all operations
 ```
 
@@ -120,9 +120,8 @@ If the sidecar is unreachable or `AWS_SECRET_NAME` is not set on a container, it
 Woodpecker CI runs on every push and PR via a self-hosted agent:
 
 - **Validate:** lint (ruff) + test (pytest, 496 tests) + typecheck (mypy) in a single consolidated step
-- **Docker builds:** Conditional per-server dry-run builds when `mcp-*/` files change
-- **Auto-deploy:** On push to main, changed MCP servers are rebuilt and health-checked via `docker compose --wait`
-- **Disk cleanup:** Dangling images pruned after every deploy
+- **Docker builds:** Conditional per-server dry-run builds when MCP, sidecar, compose, or shared runtime files change
+- **Runtime smoke:** MCP stack changes run an isolated `docker compose` project with random host ports, verify HTTP health, then tear down containers and volumes
 - **CI verification:** `flow:auto` polls the Woodpecker API after merge to confirm the pipeline passes before deploying
 - **First-class Docker updates:** `cpp:update` detects Docker installs, runs `make docker-refresh PROFILE="core browser cicd"`, and fails if containers are unhealthy
 
@@ -145,11 +144,11 @@ Architecture: Woodpecker server on a dedicated VM, agent on the dev workstation,
 
 ### v5.1.0 (2026-03-07)
 
-- **Woodpecker CI pipeline** - Self-hosted CI with automated MCP server deployment
+- **Woodpecker CI pipeline** - Self-hosted CI with MCP server Docker build checks
+- **Runtime smoke tests** - CI brings the MCP stack up in an isolated compose project, checks service health, then tears it down
 - **CI verification in flow:auto** - New Step 7/8 polls Woodpecker or GitHub Actions after merge, blocks deploy on failure
 - **Consolidated pipeline** - Merged lint/test/typecheck into single validate step (eliminates 2x `uv sync`)
-- **Health-based deploys** - `docker compose --wait` replaces `sleep 5`, uses container healthchecks
-- **Disk cleanup** - `docker image prune -f` after every deploy
+- **Health-based runtime checks** - `docker compose --wait` validates container healthchecks during smoke runs
 - **Extended CI polling** - flow:auto timeout increased from 5 to 10 minutes
 - **Woodpecker v3 API fix** - Repo ID lookup for correct API path
 

--- a/aws-secrets-agent/Dockerfile
+++ b/aws-secrets-agent/Dockerfile
@@ -3,7 +3,11 @@ FROM rust:slim AS builder
 RUN apt-get update && apt-get install -y git pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-RUN git clone https://github.com/aws/aws-secretsmanager-agent.git .
+# Pin to a released tag. Upstream `main` is ahead of the latest release and has
+# regressed startup credential handling (the agent exits with CredentialsNotLoaded
+# even when placeholder creds are present), which breaks credential-less CI smoke
+# runs. v2.1.0 starts cleanly and serves /ping as a pure liveness probe.
+RUN git clone --depth 1 --branch v2.1.0 https://github.com/aws/aws-secretsmanager-agent.git .
 
 # Patch: bind to 0.0.0.0 instead of 127.0.0.1 for Docker networking
 RUN sed -i 's/\[127, 0, 0, 1\]/[0, 0, 0, 0]/' aws_secretsmanager_agent/src/main.rs

--- a/aws-secrets-agent/config.toml
+++ b/aws-secrets-agent/config.toml
@@ -4,4 +4,8 @@ region = "us-east-1"
 ttl_seconds = 300
 cache_size = 1000
 ssrf_env_variables = ["AWS_TOKEN"]
+# Skip the startup STS get_caller_identity check so the agent boots as a pure
+# liveness service (serving /ping) without valid AWS credentials. Real secret
+# fetches still require valid creds; this only affects startup validation and
+# lets credential-less CI smoke runs verify the stack wires up and comes healthy.
 validate_credentials = false

--- a/aws-secrets-agent/config.toml
+++ b/aws-secrets-agent/config.toml
@@ -4,3 +4,4 @@ region = "us-east-1"
 ttl_seconds = 300
 cache_size = 1000
 ssrf_env_variables = ["AWS_TOKEN"]
+validate_credentials = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
     build:
       context: ./aws-secrets-agent
     image: aws-secrets-agent:latest
+    # Stable name by default (workstation deploys + cpp:update model detection);
+    # CI smoke sets CPP_CONTAINER_PREFIX to keep parallel projects isolated.
+    container_name: ${CPP_CONTAINER_PREFIX:-}aws-secrets-agent
     ports:
       - "${AWS_SECRETS_AGENT_PORT_MAPPING:-2773:2773}"
     env_file:
@@ -61,6 +64,7 @@ services:
       context: ./mcp-second-opinion
       dockerfile: deploy/Dockerfile
     image: mcp-second-opinion:latest
+    container_name: ${CPP_CONTAINER_PREFIX:-}mcp-second-opinion
     ports:
       - "${MCP_SECOND_OPINION_PORT_MAPPING:-8080:8080}"
     env_file:
@@ -98,6 +102,7 @@ services:
       context: ./mcp-nano-banana
       dockerfile: deploy/Dockerfile
     image: mcp-nano-banana:latest
+    container_name: ${CPP_CONTAINER_PREFIX:-}mcp-nano-banana
     ports:
       - "${MCP_NANO_BANANA_PORT_MAPPING:-8084:8084}"
     environment:
@@ -152,6 +157,7 @@ services:
       context: ./mcp-woodpecker-ci
       dockerfile: deploy/Dockerfile
     image: mcp-woodpecker-ci:latest
+    container_name: ${CPP_CONTAINER_PREFIX:-}mcp-woodpecker-ci
     ports:
       - "${MCP_WOODPECKER_CI_PORT_MAPPING:-8085:8085}"
     env_file:
@@ -189,6 +195,7 @@ services:
       context: ./mcp-playwright-persistent
       dockerfile: deploy/Dockerfile
     image: mcp-playwright-persistent:latest
+    container_name: ${CPP_CONTAINER_PREFIX:-}mcp-playwright-persistent
     ports:
       - "${MCP_PLAYWRIGHT_PORT_MAPPING:-8081:8081}"
     shm_size: "2gb"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     build:
       context: ./aws-secrets-agent
     image: aws-secrets-agent:latest
-    container_name: aws-secrets-agent
+    ports:
+      - "${AWS_SECRETS_AGENT_PORT_MAPPING:-2773:2773}"
     env_file:
       - path: .env
         required: false
@@ -60,19 +61,16 @@ services:
       context: ./mcp-second-opinion
       dockerfile: deploy/Dockerfile
     image: mcp-second-opinion:latest
-    container_name: mcp-second-opinion
     ports:
-      - "8080:8080"
+      - "${MCP_SECOND_OPINION_PORT_MAPPING:-8080:8080}"
     env_file:
       - path: .env
         required: false
     environment:
       - MCP_SERVER_HOST=0.0.0.0
-      - AWS_SECRET_NAME=codex_llm_apikeys
+      - AWS_SECRET_NAME=${SECOND_OPINION_AWS_SECRET_NAME-codex_llm_apikeys}
       - SECRETS_AGENT_URL=http://aws-secrets-agent:2773
       - AWS_TOKEN=${AWS_TOKEN:-default-token}
-    volumes:
-      - ./aws-secrets-agent/fetch-secrets.sh:/app/fetch-secrets.sh:ro
     entrypoint: ["/app/fetch-secrets.sh"]
     command: ["python", "server.py"]
     depends_on:
@@ -100,9 +98,8 @@ services:
       context: ./mcp-nano-banana
       dockerfile: deploy/Dockerfile
     image: mcp-nano-banana:latest
-    container_name: mcp-nano-banana
     ports:
-      - "8084:8084"
+      - "${MCP_NANO_BANANA_PORT_MAPPING:-8084:8084}"
     environment:
       - MCP_SERVER_HOST=0.0.0.0
     healthcheck:
@@ -129,7 +126,6 @@ services:
   #     context: ./mcp-evaluate
   #     dockerfile: deploy/Dockerfile
   #   image: mcp-evaluate:latest
-  #   container_name: mcp-evaluate
   #   ports:
   #     - "8083:8083"
   #   env_file:
@@ -156,19 +152,16 @@ services:
       context: ./mcp-woodpecker-ci
       dockerfile: deploy/Dockerfile
     image: mcp-woodpecker-ci:latest
-    container_name: mcp-woodpecker-ci
     ports:
-      - "8085:8085"
+      - "${MCP_WOODPECKER_CI_PORT_MAPPING:-8085:8085}"
     env_file:
       - path: .env
         required: false
     environment:
       - MCP_SERVER_HOST=0.0.0.0
-      - AWS_SECRET_NAME=essent-ai
+      - AWS_SECRET_NAME=${WOODPECKER_CI_AWS_SECRET_NAME-essent-ai}
       - SECRETS_AGENT_URL=http://aws-secrets-agent:2773
       - AWS_TOKEN=${AWS_TOKEN:-default-token}
-    volumes:
-      - ./aws-secrets-agent/fetch-secrets.sh:/app/fetch-secrets.sh:ro
     entrypoint: ["/app/fetch-secrets.sh"]
     command: ["python", "server.py"]
     depends_on:
@@ -196,9 +189,8 @@ services:
       context: ./mcp-playwright-persistent
       dockerfile: deploy/Dockerfile
     image: mcp-playwright-persistent:latest
-    container_name: mcp-playwright-persistent
     ports:
-      - "8081:8081"
+      - "${MCP_PLAYWRIGHT_PORT_MAPPING:-8081:8081}"
     shm_size: "2gb"
     environment:
       - SERVER_HOST=0.0.0.0
@@ -218,7 +210,3 @@ services:
         reservations:
           cpus: "0.5"
           memory: 512M
-
-networks:
-  default:
-    name: mcp-net

--- a/docs/HOST_MANAGED_ARTIFACTS.md
+++ b/docs/HOST_MANAGED_ARTIFACTS.md
@@ -84,7 +84,7 @@ setup. The file is gitignored. Credential rotation requires re-running the boots
 These artifacts are fully managed by the repo and rebuilt on every deploy:
 
 - **Docker images** - Built from `mcp-*/deploy/Dockerfile` on every `make deploy`
-- **Docker Compose config** - `docker-compose.yml` read fresh on every `docker compose up`
+- **Docker Compose config** - `docker-compose.yml` read fresh by local `make docker-up`, `make deploy`, and CI runtime smoke tests
 - **CI pipeline** - `.woodpecker.yml` read fresh on every pipeline run
 - **CI task manifest** - `.claude/cicd_tasks.yml` read fresh by the deterministic runner
 - **Makefile targets** - Executed from repo checkout
@@ -97,12 +97,12 @@ These artifacts are fully managed by the repo and rebuilt on every deploy:
 | `install-service.sh` (both) | Service setup | Once | No - should be re-run when templates change |
 | `setup-go-binary.sh` | MCP server setup | Once | No (manual upgrade) |
 | `bootstrap-secrets.py` | Woodpecker setup | Once | No (manual credential rotation) |
-| `make deploy` | Every deploy | Every push to main | Yes - rebuilds containers from repo |
-| `.woodpecker.yml` deploy-mcp | Every main push | Automatic | Yes - runs from fresh checkout |
+| `make deploy` | Manual local deploy or `/flow:deploy` | Operator-controlled | Yes - rebuilds containers from repo |
+| `.woodpecker.yml` runtime-smoke | MCP stack CI validation | Relevant push/PR paths | No - validates an isolated stack, then tears it down |
 
 ## Drift Detection
 
-Run drift detection manually or as a CI gate:
+Run drift detection manually when reconciling workstation-managed artifacts:
 
 ```bash
 # Check for drift
@@ -112,9 +112,6 @@ make drift-check
 scripts/drift-detect.sh --fix
 ```
 
-The `drift-check` step is included in the Woodpecker pipeline as a pre-deploy gate
-and in the CI task manifest's deploy plan.
-
 The drift report includes deployment-model checks for MCP servers:
 
 - Docker/systemd conflicts for the same server
@@ -123,3 +120,7 @@ The drift report includes deployment-model checks for MCP servers:
 - port binding conflicts on MCP ports 8080-8089
 
 The script only reports and suggests remediation. Cleanup remains opt-in.
+
+The `drift_check` task remains available in the CI task manifest's deploy plan for
+operator-driven deploy workflows, but the Woodpecker CI pipeline does not run it as
+a pre-deploy gate.

--- a/docs/cicd-reliability-review-implementation.md
+++ b/docs/cicd-reliability-review-implementation.md
@@ -894,7 +894,7 @@ Here is the exhaustive analysis and concrete implementation plan.
 | Issue | Severity | Justification |
 | :--- | :--- | :--- |
 | **1. Deterministic Runner** | **CRITICAL** | Solves the core reliability issue of flow commands failing midway. |
-| **2. Deployment Patterns** | **CRITICAL** | Prevents production downtime during failed auto-deployments. |
+| **2. Deployment Patterns** | **CRITICAL** | Prevents production downtime during failed deployment attempts. |
 | **3. Schema Validation** | **HIGH** | Eliminates silent configuration failures and standardizes the contract. |
 | **4. Typed Task Manifest** | **HIGH** | Bridges the gap between shell scripts and reliable CI/CD orchestration. |
 | **6. Woodpecker Tweaks** | **MEDIUM** | Low-hanging fruit for security and reporting. |
@@ -1101,12 +1101,12 @@ steps:
       - pip install pytest pytest-cov
       - pytest --junitxml=reports/junit.xml # 2. Standardized reporting
   
-  deploy-mcp:
+  runtime-smoke:
     image: docker:24.0.5-dind
-    concurrency: 1 # 3. Woodpecker built-in concurrency lock
     commands:
-      # 4. Fallback file lock for host-level concurrency
-      - flock -n /tmp/deploy.lock -c "make deploy" 
+      # Isolated runtime check with no long-lived runtime side effects
+      - docker compose -p "cpp-smoke-${CI_PIPELINE_NUMBER}" --profile core up --build --wait
+      - docker compose -p "cpp-smoke-${CI_PIPELINE_NUMBER}" --profile core down -v
 ```
 **Tailscale ACL**: Document and enforce that the Woodpecker runner's Tailscale IP is tagged (e.g., `tag:ci-runner`) and the ACL restricts it to only access destination servers on port 22 (SSH) or 2376 (Docker).
 **Effort**: 1 day.
@@ -1571,4 +1571,3 @@ If you want, I can provide a **drop-in starter implementation skeleton** for:
 - updated `.woodpecker.yml` snippet ready to paste.
 
 ---
-

--- a/docs/cicd-reliability-synthesis.md
+++ b/docs/cicd-reliability-synthesis.md
@@ -274,11 +274,11 @@ image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim@sha256:<digest>
 
 Automate refresh via `cpp sync` or scheduled CI job using `crane digest`.
 
-### 2. Deploy concurrency lock
+### 2. Runtime smoke isolation
 
 ```bash
-# Simple flock approach in deploy-mcp step
-flock --timeout 300 /tmp/cpp-deploy.lock docker compose --profile core --profile browser up -d --build --wait
+# Isolated smoke project with no long-lived runtime side effects
+docker compose -p "cpp-smoke-${CI_PIPELINE_NUMBER:-local}" --profile core --profile browser up --build --wait
 ```
 
 ### 3. JUnit XML test reports

--- a/mcp-second-opinion/deploy/Dockerfile
+++ b/mcp-second-opinion/deploy/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=builder /app/.venv /app/.venv
 # Copy application code
 COPY --chown=mcpuser:mcpuser src/config.py src/prompts.py src/sessions.py src/server.py ./
 COPY --chown=mcpuser:mcpuser src/tools/ ./tools/
+COPY --chown=mcpuser:mcpuser deploy/fetch-secrets.sh ./fetch-secrets.sh
+RUN chmod 755 /app/fetch-secrets.sh
 
 # Switch to non-root user
 USER mcpuser

--- a/mcp-second-opinion/deploy/fetch-secrets.sh
+++ b/mcp-second-opinion/deploy/fetch-secrets.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+AGENT_URL="${SECRETS_AGENT_URL:-http://aws-secrets-agent:2773}"
+SECRET_ID="${AWS_SECRET_NAME:-}"
+TOKEN="${AWS_TOKEN:-default-token}"
+MAX_RETRIES=30
+RETRY_INTERVAL=2
+
+if [ -z "$SECRET_ID" ]; then
+    echo "INFO: AWS_SECRET_NAME not set - using env_file variables (local dev mode)"
+    exec "$@"
+fi
+
+i=0
+RESPONSE=""
+while [ "$i" -lt "$MAX_RETRIES" ]; do
+    RESPONSE=$(python3 -c "
+import urllib.request, sys
+req = urllib.request.Request(
+    '${AGENT_URL}/secretsmanager/get?secretId=${SECRET_ID}',
+    headers={'X-Aws-Parameters-Secrets-Token': '${TOKEN}'}
+)
+try:
+    resp = urllib.request.urlopen(req, timeout=5)
+    sys.stdout.write(resp.read().decode())
+except Exception:
+    sys.exit(1)
+" 2>/dev/null) && break
+    i=$((i + 1))
+    sleep "$RETRY_INTERVAL"
+done
+
+if [ -z "$RESPONSE" ]; then
+    echo "WARNING: Failed to fetch secrets from agent after ${MAX_RETRIES} retries" >&2
+    echo "WARNING: Falling back to env_file variables (if present)" >&2
+    exec "$@"
+fi
+
+eval "$(echo "$RESPONSE" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+secrets = json.loads(data['SecretString'])
+for k, v in secrets.items():
+    if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', k):
+        print(f'echo \"WARNING: skipping invalid key: {k}\" >&2', flush=True)
+        continue
+    safe_v = v.replace(\"'\", \"'\\\\''\" )
+    print(f\"export {k}='{safe_v}'\")
+")"
+
+echo "INFO: Loaded secrets from AWS Secrets Manager (${SECRET_ID})"
+exec "$@"

--- a/mcp-woodpecker-ci/deploy/Dockerfile
+++ b/mcp-woodpecker-ci/deploy/Dockerfile
@@ -34,6 +34,8 @@ COPY --from=builder /app/.venv /app/.venv
 
 # Copy application code
 COPY --chown=mcpuser:mcpuser src/config.py src/client.py src/server.py ./
+COPY --chown=mcpuser:mcpuser deploy/fetch-secrets.sh ./fetch-secrets.sh
+RUN chmod 755 /app/fetch-secrets.sh
 
 # Switch to non-root user
 USER mcpuser

--- a/mcp-woodpecker-ci/deploy/fetch-secrets.sh
+++ b/mcp-woodpecker-ci/deploy/fetch-secrets.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+AGENT_URL="${SECRETS_AGENT_URL:-http://aws-secrets-agent:2773}"
+SECRET_ID="${AWS_SECRET_NAME:-}"
+TOKEN="${AWS_TOKEN:-default-token}"
+MAX_RETRIES=30
+RETRY_INTERVAL=2
+
+if [ -z "$SECRET_ID" ]; then
+    echo "INFO: AWS_SECRET_NAME not set - using env_file variables (local dev mode)"
+    exec "$@"
+fi
+
+i=0
+RESPONSE=""
+while [ "$i" -lt "$MAX_RETRIES" ]; do
+    RESPONSE=$(python3 -c "
+import urllib.request, sys
+req = urllib.request.Request(
+    '${AGENT_URL}/secretsmanager/get?secretId=${SECRET_ID}',
+    headers={'X-Aws-Parameters-Secrets-Token': '${TOKEN}'}
+)
+try:
+    resp = urllib.request.urlopen(req, timeout=5)
+    sys.stdout.write(resp.read().decode())
+except Exception:
+    sys.exit(1)
+" 2>/dev/null) && break
+    i=$((i + 1))
+    sleep "$RETRY_INTERVAL"
+done
+
+if [ -z "$RESPONSE" ]; then
+    echo "WARNING: Failed to fetch secrets from agent after ${MAX_RETRIES} retries" >&2
+    echo "WARNING: Falling back to env_file variables (if present)" >&2
+    exec "$@"
+fi
+
+eval "$(echo "$RESPONSE" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+secrets = json.loads(data['SecretString'])
+for k, v in secrets.items():
+    if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', k):
+        print(f'echo \"WARNING: skipping invalid key: {k}\" >&2', flush=True)
+        continue
+    safe_v = v.replace(\"'\", \"'\\\\''\" )
+    print(f\"export {k}='{safe_v}'\")
+")"
+
+echo "INFO: Loaded secrets from AWS Secrets Manager (${SECRET_ID})"
+exec "$@"

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -133,8 +133,11 @@ def test_compose_stack_is_project_isolated() -> None:
     compose = yaml.safe_load(compose_path.read_text())
     services = compose["services"]
 
-    for service in services.values():
-        assert "container_name" not in service
+    # Container names default to the stable service name (empty prefix) so
+    # workstation deploys and cpp:update model detection can address them, while
+    # CI smoke runs set CPP_CONTAINER_PREFIX to keep parallel projects isolated.
+    for name, service in services.items():
+        assert service.get("container_name") == "${CPP_CONTAINER_PREFIX:-}" + name
     assert "networks" not in compose
     assert "volumes" not in services["mcp-second-opinion"]
     assert "volumes" not in services["mcp-woodpecker-ci"]
@@ -252,7 +255,9 @@ def test_woodpecker_runtime_smoke_is_ephemeral_and_tears_down() -> None:
     assert "export MCP_PLAYWRIGHT_PORT_MAPPING=8081" in commands
     assert "export MCP_NANO_BANANA_PORT_MAPPING=8084" in commands
     assert "docker compose -p \"$PROJECT\" port \"$service\" \"$container_port\"" in commands
-    assert "url=\"http://127.0.0.1:$published$check_path\"" in commands
+    assert "url=\"http://127.0.0.1:$container_port$check_path\"" in commands
+    assert 'docker compose -p "$PROJECT" exec -T "$service"' in commands
+    assert "urllib.request.urlopen('$url', timeout=10)" in commands
     assert "X-Aws-Parameters-Secrets-Token: $AWS_TOKEN" in commands
 
     assert "check_http aws-secrets-agent 2773 /ping" in commands

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -31,6 +31,10 @@ def _woodpecker_steps() -> dict[str, Any]:
     return pipeline["steps"]
 
 
+def _step_commands(step: dict[str, Any]) -> str:
+    return "\n".join(step.get("commands", []))
+
+
 def test_aws_secrets_agent_does_not_require_root_env_file() -> None:
     services = _compose_services()
     env_file = services["aws-secrets-agent"]["env_file"][0]
@@ -55,6 +59,7 @@ def test_secret_consumers_share_sidecar_token_default() -> None:
     agent_healthcheck = services["aws-secrets-agent"]["healthcheck"]["test"]
 
     assert "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN:-default-token}" in agent_healthcheck
+    assert services["aws-secrets-agent"]["healthcheck"]["start_period"] == "30s"
     for service_name in ("mcp-second-opinion", "mcp-woodpecker-ci"):
         env = _env_list_to_map(services[service_name]["environment"])
         assert env["AWS_TOKEN"] == "${AWS_TOKEN:-default-token}"
@@ -66,6 +71,7 @@ def test_aws_secrets_agent_healthcheck_allows_loaded_starts() -> None:
     agent = services["aws-secrets-agent"]
     healthcheck = agent["healthcheck"]
     dockerfile = (root / "aws-secrets-agent" / "Dockerfile").read_text()
+    config = (root / "aws-secrets-agent" / "config.toml").read_text()
 
     assert healthcheck["test"][-1] == "http://localhost:2773/ping"
     assert healthcheck["interval"] == "10s"
@@ -78,6 +84,7 @@ def test_aws_secrets_agent_healthcheck_allows_loaded_starts() -> None:
     assert "--start-period=30s" in dockerfile
     assert "--retries=5" in dockerfile
     assert "does not call AWS" in dockerfile
+    assert "validate_credentials = false" in config
 
     resources = agent["deploy"]["resources"]
     assert resources["limits"] == {"cpus": "0.5", "memory": "128M"}
@@ -88,7 +95,7 @@ def test_second_opinion_uses_secret_with_free_tier_provider_keys() -> None:
     services = _compose_services()
     env = _env_list_to_map(services["mcp-second-opinion"]["environment"])
 
-    assert env["AWS_SECRET_NAME"] == "codex_llm_apikeys"
+    assert env["AWS_SECRET_NAME"] == "${SECOND_OPINION_AWS_SECRET_NAME-codex_llm_apikeys}"
 
     expected_keys = [
         "GEMINI_API_KEY",
@@ -121,12 +128,49 @@ def test_legacy_second_opinion_secret_name_is_not_documented() -> None:
         assert "claude-power-pack/mcp-keys" not in path.read_text()
 
 
-def test_deploy_pipeline_does_not_require_repo_aws_secrets() -> None:
-    steps = _woodpecker_steps()
-    deploy_step = steps["deploy-mcp"]
+def test_compose_stack_is_project_isolated() -> None:
+    compose_path = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+    compose = yaml.safe_load(compose_path.read_text())
+    services = compose["services"]
 
-    assert "environment" not in deploy_step
-    assert "secrets" not in deploy_step
+    for service in services.values():
+        assert "container_name" not in service
+    assert "networks" not in compose
+    assert "volumes" not in services["mcp-second-opinion"]
+    assert "volumes" not in services["mcp-woodpecker-ci"]
+
+
+def test_secret_bootstrap_script_is_baked_into_secret_consuming_images() -> None:
+    root = Path(__file__).resolve().parents[1]
+    canonical = (root / "aws-secrets-agent" / "fetch-secrets.sh").read_text()
+
+    for service in ("mcp-second-opinion", "mcp-woodpecker-ci"):
+        dockerfile = (root / service / "deploy" / "Dockerfile").read_text()
+        fetch_script = (root / service / "deploy" / "fetch-secrets.sh").read_text()
+
+        assert fetch_script == canonical
+        assert "deploy/fetch-secrets.sh ./fetch-secrets.sh" in dockerfile
+        assert "chmod 755 /app/fetch-secrets.sh" in dockerfile
+
+
+def test_compose_uses_fixed_local_ports_with_ci_overrides() -> None:
+    services = _compose_services()
+
+    assert services["aws-secrets-agent"]["ports"] == [
+        "${AWS_SECRETS_AGENT_PORT_MAPPING:-2773:2773}"
+    ]
+    assert services["mcp-second-opinion"]["ports"] == [
+        "${MCP_SECOND_OPINION_PORT_MAPPING:-8080:8080}"
+    ]
+    assert services["mcp-playwright-persistent"]["ports"] == [
+        "${MCP_PLAYWRIGHT_PORT_MAPPING:-8081:8081}"
+    ]
+    assert services["mcp-nano-banana"]["ports"] == [
+        "${MCP_NANO_BANANA_PORT_MAPPING:-8084:8084}"
+    ]
+    assert services["mcp-woodpecker-ci"]["ports"] == [
+        "${MCP_WOODPECKER_CI_PORT_MAPPING:-8085:8085}"
+    ]
 
 
 def test_makefile_has_first_class_docker_refresh_target() -> None:
@@ -159,3 +203,73 @@ def test_cpp_init_prefers_docker_and_runs_health_gated_refresh() -> None:
     assert 'make docker-refresh PROFILE="core browser cicd"' in command
     assert "Docker containers rebuilt, restarted, and healthy" in command
     assert "skipping systemd service setup" in command
+
+
+def test_woodpecker_has_no_persistent_deploy_or_prune() -> None:
+    steps = _woodpecker_steps()
+    pipeline_text = (Path(__file__).resolve().parents[1] / ".woodpecker.yml").read_text()
+
+    assert "deploy-mcp" not in steps
+    assert "pre-deploy-guardrails" not in steps
+    assert "drift-check" not in steps
+    assert "docker image prune" not in pipeline_text
+
+
+def test_woodpecker_builds_aws_secrets_agent() -> None:
+    steps = _woodpecker_steps()
+    step = steps["build-aws-secrets-agent"]
+
+    assert step["settings"]["context"] == "aws-secrets-agent"
+    assert step["settings"]["dockerfile"] == "aws-secrets-agent/Dockerfile"
+    assert step["settings"]["dry_run"] is True
+    assert "aws-secrets-agent/**" in step["when"][0]["path"]
+
+
+def test_woodpecker_runtime_smoke_is_ephemeral_and_tears_down() -> None:
+    steps = _woodpecker_steps()
+    smoke = steps["runtime-smoke"]
+    commands = _step_commands(smoke)
+
+    assert smoke["depends_on"] == ["validate"]
+    assert "/var/run/docker.sock:/var/run/docker.sock" in smoke["volumes"]
+    assert 'PROJECT="cpp-smoke-${CI_PIPELINE_NUMBER:-local}"' in commands
+    assert "trap cleanup EXIT INT TERM" in commands
+    assert (
+        'if ! docker compose -p "$PROJECT" --profile core --profile browser '
+        "--profile cicd up --build --wait; then"
+    ) in commands
+    assert 'docker compose -p "$PROJECT" --profile core --profile browser --profile cicd down -v || true' in commands
+    assert 'docker compose -p "$PROJECT" logs aws-secrets-agent || true' in commands
+
+    assert "export AWS_ACCESS_KEY_ID=cpp-smoke-access-key" in commands
+    assert "export AWS_SECRET_ACCESS_KEY=cpp-smoke-secret-key" in commands
+    assert "export AWS_SESSION_TOKEN=cpp-smoke-session-token" in commands
+    assert "export AWS_TOKEN=cpp-smoke-token" in commands
+    assert "export SECOND_OPINION_AWS_SECRET_NAME=" in commands
+    assert "export WOODPECKER_CI_AWS_SECRET_NAME=" in commands
+    assert "export AWS_SECRETS_AGENT_PORT_MAPPING=2773" in commands
+    assert "export MCP_SECOND_OPINION_PORT_MAPPING=8080" in commands
+    assert "export MCP_PLAYWRIGHT_PORT_MAPPING=8081" in commands
+    assert "export MCP_NANO_BANANA_PORT_MAPPING=8084" in commands
+    assert "docker compose -p \"$PROJECT\" port \"$service\" \"$container_port\"" in commands
+    assert "url=\"http://127.0.0.1:$published$check_path\"" in commands
+    assert "X-Aws-Parameters-Secrets-Token: $AWS_TOKEN" in commands
+
+    assert "check_http aws-secrets-agent 2773 /ping" in commands
+    assert "check_http mcp-second-opinion 8080 /" in commands
+    assert "check_http mcp-playwright-persistent 8081 /" in commands
+    assert "check_http mcp-nano-banana 8084 /" in commands
+
+
+def test_woodpecker_smoke_path_gates_cover_shared_runtime_inputs() -> None:
+    steps = _woodpecker_steps()
+    smoke_paths = set(steps["runtime-smoke"]["when"][0]["path"])
+
+    assert ".woodpecker.yml" in smoke_paths
+    assert "docker-compose.yml" in smoke_paths
+    assert "aws-secrets-agent/**" in smoke_paths
+    assert "lib/**" in smoke_paths
+    assert "mcp-second-opinion/**" in smoke_paths
+    assert "mcp-playwright-persistent/**" in smoke_paths
+    assert "mcp-nano-banana/**" in smoke_paths
+    assert "mcp-woodpecker-ci/**" in smoke_paths

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -248,6 +248,7 @@ def test_woodpecker_runtime_smoke_is_ephemeral_and_tears_down() -> None:
     assert "export AWS_SECRET_ACCESS_KEY=cpp-smoke-secret-key" in commands
     assert "export AWS_SESSION_TOKEN=cpp-smoke-session-token" in commands
     assert "export AWS_TOKEN=cpp-smoke-token" in commands
+    assert 'export CPP_CONTAINER_PREFIX="cpp-smoke-${CI_PIPELINE_NUMBER:-local}-"' in commands
     assert "export SECOND_OPINION_AWS_SECRET_NAME=" in commands
     assert "export WOODPECKER_CI_AWS_SECRET_NAME=" in commands
     assert "export AWS_SECRETS_AGENT_PORT_MAPPING=2773" in commands


### PR DESCRIPTION
## Summary
- remove the persistent Woodpecker `deploy-mcp` flow, deploy guardrail steps, and host image pruning
- add CI coverage for `aws-secrets-agent` plus an isolated runtime smoke step that builds the MCP stack, uses random host ports, verifies service HTTP from inside each container, and always tears down with `down -v`
- make compose project isolation compatible with stable workstation container names through a CI-only `CPP_CONTAINER_PREFIX`
- pin `aws-secrets-agent` to release `v2.1.0` and disable startup credential validation so credential-less smoke runs can verify liveness without real AWS secrets
- update docs and tests so the repo no longer claims Woodpecker auto-deploys MCP containers

## Test Plan
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_docker_compose_config.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff check tests/test_docker_compose_config.py`
- `env UV_CACHE_DIR=/tmp/uv-cache make update_docs`
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- `env UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=/home/cooneycw/Projects/claude-power-pack-issue-338/lib uv run --extra dev python -m lib.cicd run --plan finish`

Closes #338