### PR TITLE
fix(cpp): make Docker refresh first-class (Closes #336)

### DIFF
--- a/.claude/commands/cpp/help.md
+++ b/.claude/commands/cpp/help.md
@@ -11,7 +11,7 @@ CPP provides commands for setting up and managing Claude Code enhancements.
 | Command | Description |
 |---------|-------------|
 | `/cpp:init` | Interactive setup wizard - install CPP components |
-| `/cpp:update` | Pull latest version, sync deps, offer tier upgrades |
+| `/cpp:update` | Pull latest version, sync deps, refresh Docker/systemd runtime, offer tier upgrades |
 | `/cpp:status` | Check current installation state |
 | `/cpp:help` | This help overview |
 
@@ -51,7 +51,8 @@ CPP uses a tiered installation model:
 ### Tier 3 - Full
 - **MCP Second Opinion** (port 8080): Gemini/OpenAI code review
 - **MCP Playwright** (port 8081): Persistent browser automation
-- **Systemd services**: Auto-start on boot (optional)
+- **Docker runtime**: First-class MCP container deployment via `make docker-refresh PROFILE="core browser cicd"`
+- **Systemd services**: Auto-start on boot (optional for native installs)
 
 ### Tier 4 - CI/CD
 - **Build System**: Framework detection, Makefile generation/validation (`/cicd:init`, `/cicd:check`)

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive setup wizard for Claude Power Pack
-allowed-tools: Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(cp:*), Bash(uv:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(claude mcp list:*), Bash(claude mcp add:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*)
+allowed-tools: Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(cp:*), Bash(uv:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(claude mcp list:*), Bash(claude mcp add:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*), Bash(git:*), Bash(docker:*), Bash(make:*), Bash(sleep:*)
 ---
 
 # Claude Power Pack Setup Wizard
@@ -578,25 +578,40 @@ echo "✓ Chromium browser installed"
 **First, detect the deployment mode:**
 
 ```bash
-# Detect deployment mode
-DEPLOY_MODE="native"
-if [ -f "$CPP_DIR/docker-compose.yml" ]; then
-  # Check if Docker containers are running for MCP servers
-  if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "mcp-second-opinion"; then
-    DEPLOY_MODE="docker"
-  elif sg docker -c "docker ps --format '{{.Names}}'" 2>/dev/null | grep -q "mcp-second-opinion"; then
-    DEPLOY_MODE="docker"
-  fi
-  # Also check if .mcp.json points to SSE (Docker-hosted)
-  if [ -f "$CPP_DIR/../.mcp.json" ] || [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/.mcp.json" ]; then
-    for mcp_json in "$CPP_DIR/../.mcp.json" "$(git rev-parse --show-toplevel 2>/dev/null)/.mcp.json"; do
-      if [ -f "$mcp_json" ] && grep -q '"type": "sse"' "$mcp_json" 2>/dev/null && grep -q '8080' "$mcp_json" 2>/dev/null; then
-        DEPLOY_MODE="docker"
-        break
-      fi
-    done
+# Detect deployment mode. Choose exactly one model:
+#   docker     - Docker Compose stack present, or new install with Docker available
+#   systemd    - existing systemd MCP services
+#   venv-only  - local venvs without managed restart
+DEPLOY_MODE="venv-only"
+DOCKER_READY=false
+DOCKER_STACK_PRESENT=false
+SYSTEMD_ACTIVE=false
+
+if command -v docker &>/dev/null && [ -f "$CPP_DIR/docker-compose.yml" ] && docker compose version &>/dev/null; then
+  DOCKER_READY=true
+  if docker compose --profile core --profile browser --profile cicd ps --format json 2>/dev/null | grep -q '"Service"'; then
+    DOCKER_STACK_PRESENT=true
+  elif docker ps -a --format '{{.Names}}' 2>/dev/null | grep -Eq '^(aws-secrets-agent|mcp-second-opinion|mcp-nano-banana|mcp-playwright-persistent|mcp-woodpecker-ci)$'; then
+    DOCKER_STACK_PRESENT=true
   fi
 fi
+
+for service in mcp-second-opinion mcp-playwright nano-banana; do
+  if systemctl is-active "$service" &>/dev/null || systemctl is-enabled "$service" &>/dev/null; then
+    SYSTEMD_ACTIVE=true
+    break
+  fi
+done
+
+if [ "$DOCKER_STACK_PRESENT" = "true" ]; then
+  DEPLOY_MODE="docker"
+elif [ "$SYSTEMD_ACTIVE" = "true" ]; then
+  DEPLOY_MODE="systemd"
+elif [ "$DOCKER_READY" = "true" ]; then
+  # Fresh installs prefer Docker when available.
+  DEPLOY_MODE="docker"
+fi
+
 echo "Deployment mode detected: $DEPLOY_MODE"
 ```
 
@@ -684,10 +699,14 @@ if [ "$SECRET_METHOD" = "1" ]; then
   echo "To change these mappings, edit the environment section in docker-compose.yml."
   echo ""
 
-  # Start containers with sidecar
-  echo "Starting MCP containers with AWS sidecar..."
-  make docker-down 2>/dev/null
-  make docker-up PROFILE=core
+  # Rebuild and restart containers with sidecar
+  echo "Refreshing MCP containers with AWS sidecar..."
+  make docker-refresh PROFILE="core browser cicd"
+  DOCKER_REFRESH_RC=$?
+  if [ "$DOCKER_REFRESH_RC" -ne 0 ]; then
+    echo "ERROR: Docker refresh failed or one or more containers are unhealthy."
+    exit "$DOCKER_REFRESH_RC"
+  fi
   echo ""
 
   # Verify secrets were loaded
@@ -706,7 +725,8 @@ fi
 
 **Path 2: Direct .env file (fallback or non-Docker)**
 
-This path runs when: `DEPLOY_MODE=native`, OR `AWS_SIDECAR_AVAILABLE=false`, OR the user chose option 2.
+This path runs when: `DEPLOY_MODE=venv-only`, OR `DEPLOY_MODE=systemd`, OR
+`AWS_SIDECAR_AVAILABLE=false`, OR the user chose option 2.
 
 Prompt the user for API keys:
 
@@ -768,19 +788,23 @@ if [ "$DEPLOY_MODE" = "docker" ]; then
 fi
 ```
 
-**If Docker mode (Path 2 only), offer to restart containers to pick up new keys:**
+**If Docker mode (Path 2 only), rebuild and restart containers to pick up new keys:**
 
 ```
-API keys configured. Docker containers need to be restarted to pick up the new keys.
-
-Restart MCP containers now? [Y/n]
+API keys configured. Docker containers will be rebuilt and restarted to pick up the new keys.
 ```
 
-If yes:
 ```bash
-cd "$CPP_DIR"
-make docker-down && make docker-up PROFILE=core
-echo "Docker containers restarted with new API keys"
+if [ "$DEPLOY_MODE" = "docker" ]; then
+  cd "$CPP_DIR"
+  make docker-refresh PROFILE="core browser cicd"
+  DOCKER_REFRESH_RC=$?
+  if [ "$DOCKER_REFRESH_RC" -ne 0 ]; then
+    echo "ERROR: Docker refresh failed or one or more containers are unhealthy."
+    exit "$DOCKER_REFRESH_RC"
+  fi
+  echo "Docker containers rebuilt, restarted, and healthy"
+fi
 ```
 
 Optional: Ask for OPENAI_API_KEY and ANTHROPIC_API_KEY for multi-model comparison.
@@ -1014,7 +1038,17 @@ echo "✓ Woodpecker CI MCP server installed and registered"
 
 ## Step 6: Systemd Services (Optional)
 
-After Tier 3 completes, offer systemd setup:
+After Tier 3 completes, offer systemd setup only when the selected deployment
+model is not Docker. Docker-model installs already rebuilt, restarted, and
+health-checked containers with `make docker-refresh PROFILE="core browser cicd"`.
+
+```bash
+if [ "$DEPLOY_MODE" = "docker" ]; then
+  echo "Docker deployment model selected - skipping systemd service setup."
+else
+  echo "Systemd service setup is available for native installs."
+fi
+```
 
 ```
 === Optional: Systemd Services ===
@@ -1074,6 +1108,10 @@ Secrets:
   Method: {AWS Secrets Manager sidecar | Direct .env}
   Validate: make docker-secrets-check
 
+Deployment:
+  Model: {docker|systemd|venv-only}
+  Docker refresh: make docker-refresh PROFILE="core browser cicd" (Docker model only)
+
 MCP Servers:
   • second-opinion (port 8080) - Gemini/OpenAI code review
   • playwright-persistent (port 8081) - Browser automation
@@ -1084,7 +1122,7 @@ Next Steps:
   1. Start MCP servers (if not using systemd or Docker):
      cd {CPP_DIR}/mcp-second-opinion && ./start-server.sh &
      cd {CPP_DIR}/mcp-playwright-persistent && ./start-server.sh &
-     Or for Docker: make docker-up PROFILE=core
+     Or for Docker: make docker-refresh PROFILE="core browser cicd"
 
   2. Restart your shell to apply prompt changes:
      source ~/.bashrc
@@ -1219,7 +1257,7 @@ else
         echo "✓ $NAME registered with Codex (http://127.0.0.1:${PORT}/mcp)"
       else
         echo "⚠ $NAME not reachable on port $PORT - skipping Codex registration"
-        echo "  Start containers first: make docker-up PROFILE=core"
+        echo "  Start containers first: make docker-refresh PROFILE=\"core browser cicd\""
       fi
     fi
   done

--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -1,6 +1,6 @@
 ---
 description: Update Claude Power Pack to the latest version
-allowed-tools: Bash(git:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(uv:*), Bash(claude mcp list:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*), Bash(ln:*), Bash(mkdir:*), Bash(cp:*), Bash(diff:*), Bash(find:*), Bash(grep:*), Bash(curl:*), Bash(ss:*), Bash(docker:*), AskUserQuestion
+allowed-tools: Bash(git:*), Bash(ls:*), Bash(test:*), Bash(readlink:*), Bash(cat:*), Bash(uv:*), Bash(claude mcp list:*), Bash(sudo systemctl:*), Bash(systemctl:*), Bash(command -v:*), Bash(ln:*), Bash(mkdir:*), Bash(cp:*), Bash(diff:*), Bash(find:*), Bash(grep:*), Bash(curl:*), Bash(ss:*), Bash(docker:*), Bash(make:*), Bash(python3:*), AskUserQuestion
 ---
 
 # Claude Power Pack Update
@@ -124,26 +124,112 @@ done
 
 ---
 
-## Step 5: Restart MCP Servers (if running via systemd)
+## Step 5: Detect Deployment Model and Refresh Runtime
+
+Choose exactly one runtime model for this machine. Do not run Docker and
+systemd restarts in the same update.
 
 ```bash
+cd "$CPP_DIR"
+
+DEPLOY_MODEL="venv-only"
+DOCKER_READY=false
+DOCKER_STACK_PRESENT=false
+DOCKER_STACK_CONFIGURED=false
+SYSTEMD_ACTIVE=false
+
+if command -v docker &>/dev/null && [ -f "$CPP_DIR/docker-compose.yml" ] && docker compose version &>/dev/null; then
+  DOCKER_READY=true
+
+  if docker compose --profile core --profile browser --profile cicd ps --format json 2>/dev/null | grep -q '"Service"'; then
+    DOCKER_STACK_PRESENT=true
+  elif docker ps -a --format '{{.Names}}' 2>/dev/null | grep -Eq '^(aws-secrets-agent|mcp-second-opinion|mcp-nano-banana|mcp-playwright-persistent|mcp-woodpecker-ci)$'; then
+    DOCKER_STACK_PRESENT=true
+  fi
+
+  if [ -f "$CPP_DIR/.env" ]; then
+    DOCKER_STACK_CONFIGURED=true
+  fi
+fi
+
 for service in mcp-second-opinion mcp-playwright nano-banana; do
-  if systemctl is-active $service &>/dev/null; then
-    echo ""
-    echo "Restarting $service..."
-    sudo systemctl restart $service
-    echo "Done: $service restarted"
+  if systemctl is-active "$service" &>/dev/null || systemctl is-enabled "$service" &>/dev/null; then
+    SYSTEMD_ACTIVE=true
+    break
   fi
 done
+
+if [ "$DOCKER_READY" = "true" ] && { [ "$DOCKER_STACK_PRESENT" = "true" ] || [ "$DOCKER_STACK_CONFIGURED" = "true" ]; }; then
+  DEPLOY_MODEL="docker"
+elif [ "$SYSTEMD_ACTIVE" = "true" ]; then
+  DEPLOY_MODEL="systemd"
+fi
+
+echo "Deployment model detected: $DEPLOY_MODEL"
 ```
 
-If servers are not running via systemd, remind the user to restart manually.
+### Docker Model
+
+For Docker workstations, rebuild changed images, restart the full MCP stack,
+wait for healthchecks, and print the post-update health summary.
+
+```bash
+if [ "$DEPLOY_MODEL" = "docker" ]; then
+  echo ""
+  echo "Refreshing Docker MCP stack..."
+  make docker-refresh PROFILE="core browser cicd"
+  DOCKER_REFRESH_RC=$?
+  if [ "$DOCKER_REFRESH_RC" -ne 0 ]; then
+    echo "ERROR: Docker refresh failed or one or more containers are unhealthy."
+    exit "$DOCKER_REFRESH_RC"
+  fi
+fi
+```
+
+### Systemd Model
+
+Keep the native systemd path for systemd workstations.
+
+```bash
+if [ "$DEPLOY_MODEL" = "systemd" ]; then
+  for service in mcp-second-opinion mcp-playwright nano-banana; do
+    if systemctl is-active "$service" &>/dev/null; then
+      echo ""
+      echo "Restarting $service..."
+      sudo systemctl restart "$service"
+      echo "Done: $service restarted"
+    fi
+  done
+fi
+```
+
+### Venv-Only Model
+
+```bash
+if [ "$DEPLOY_MODEL" = "venv-only" ]; then
+  echo ""
+  echo "No Docker containers or systemd services detected."
+  echo "Dependencies were synced; start MCP servers manually if needed."
+fi
+```
+
+Report the chosen model and the health/restart result to the user:
+
+```
+Runtime Refresh:
+  Model: {docker|systemd|venv-only}
+  Docker: rebuilt/restarted/healthy, or skipped
+  Systemd: restarted services, or skipped
+```
+
+If servers are not managed by Docker or systemd, remind the user to start them manually.
 
 ---
 
 ## Step 6: MCP Server Drift Detection
 
-**This is the key new step.** After pulling and restarting, scan for drift between what the repo ships and what is actually installed/running.
+After pulling and refreshing the selected runtime, scan for drift between what
+the repo ships and what is actually installed/running.
 
 ### 6a: Build Inventory
 
@@ -179,6 +265,14 @@ done
 echo ""
 echo "=== Installed MCP Inventory ==="
 
+echo "Docker containers:"
+if [ "$DOCKER_READY" = "true" ]; then
+  docker compose --profile core --profile browser --profile cicd ps 2>/dev/null || echo "  (unavailable)"
+else
+  echo "  (docker unavailable)"
+fi
+
+echo ""
 echo "Systemd services (mcp-* and nano-*):"
 systemctl list-units --type=service --all 2>/dev/null | grep -E '(mcp-|nano-|coordination)' || echo "  (none)"
 
@@ -199,15 +293,17 @@ Compare the inventories and classify each finding. Use the following logic:
 - `mcp-second-opinion` (port 8080, profile: core)
 - `mcp-nano-banana` (port 8084, profile: core)
 - `mcp-playwright-persistent` (port 8081, profile: browser)
+- `mcp-woodpecker-ci` (port 8085, profile: cicd)
 
 **Deprecated servers** (commented out in docker-compose.yml):
 - `mcp-evaluate` (deprecated - absorbed into /evaluate:issue skill)
 
 **For each known repo server**, check:
-1. Is there a systemd service installed? (`systemctl is-enabled <name>`)
-2. Is it registered in `claude mcp list`?
-3. Is the port listening?
-4. If systemd service exists, does it match the repo version? (diff the files)
+1. Is there a Docker container running/healthy?
+2. Is there a systemd service installed? (`systemctl is-enabled <name>`)
+3. Is it registered in `claude mcp list`?
+4. Is the port listening?
+5. If systemd service exists, does it match the repo version? (diff the files)
 
 **For each installed systemd service matching mcp-* or coordination**, check:
 1. Does a corresponding deploy/*.service file exist in the repo?
@@ -219,13 +315,14 @@ Build a drift report table:
 MCP Server Drift Report
 ========================
 
-Server                    Repo    Systemd   MCP Reg   Port    Status
----------------------------------------------------------------------
-mcp-second-opinion        yes     active    yes       8080    OK / STALE SERVICE
-mcp-nano-banana           yes     none      no        --      NEW - NOT INSTALLED
-mcp-playwright-persistent yes     active    yes       8081    OK / STALE SERVICE
-mcp-coordination          no      active    yes       8082    ORPHANED
-mcp-evaluate              depr.   none      no        --      OK (deprecated)
+Server                    Repo    Docker    Systemd   MCP Reg   Port    Status
+----------------------------------------------------------------------------
+mcp-second-opinion        yes     healthy   active    yes       8080    OK / STALE SERVICE
+mcp-nano-banana           yes     healthy   none      no        8084    NOT REGISTERED
+mcp-playwright-persistent yes     healthy   active    yes       8081    OK / STALE SERVICE
+mcp-woodpecker-ci         yes     healthy   none      yes       8085    OK
+mcp-coordination          no      none      active    yes       8082    ORPHANED
+mcp-evaluate              depr.   none      none      no        --      OK (deprecated)
 ```
 
 Status classifications:
@@ -233,7 +330,8 @@ Status classifications:
 - **STALE SERVICE** - installed but systemd unit differs from repo version
 - **NEW - NOT INSTALLED** - repo ships it but it is not installed
 - **ORPHANED** - installed/running but repo no longer ships it
-- **NOT RUNNING** - installed but service is not active
+- **NOT RUNNING** - installed but service/container is not active
+- **UNHEALTHY** - Docker container is running but healthcheck is failing
 - **NOT REGISTERED** - running but not in `claude mcp list`
 
 Present the drift report table to the user.
@@ -274,7 +372,7 @@ mcp-nano-banana is available in the repo but not installed.
 
 Options:
 - **Install via systemd** - Copy service file, enable, start, register with claude mcp
-- **Install via Docker** - Will be included in `make docker-up PROFILE=core` (if Docker available)
+- **Install via Docker** - Will be included in `make docker-refresh PROFILE="core browser cicd"` (if Docker model is active)
 - **Skip** - Do not install now
 
 If they choose systemd:
@@ -384,7 +482,7 @@ Your current installation: Tier {TIER}
 Available upgrades:
   Tier 1 (Minimal): Commands + Skills symlinks
   Tier 2 (Standard): + Scripts, hooks, shell prompt, permission profiles
-  Tier 3 (Full): + MCP servers (uv, API keys, systemd)
+  Tier 3 (Full): + MCP servers (Docker or systemd, uv, API keys)
 
 Would you like to upgrade to a higher tier?
 ```
@@ -416,8 +514,9 @@ Changes pulled:
 Dependencies:
   {synced servers or "No MCP venvs to update"}
 
-MCP Servers:
-  {restarted services or "Not running via systemd"}
+Runtime:
+  Model: {docker|systemd|venv-only}
+  {Docker containers rebuilt/restarted/healthy, systemd services restarted, or venv-only no restart}
 
 MCP Drift:
   {drift summary - e.g. "1 new server installed, 1 orphan removed, 2 service files updated"
@@ -435,8 +534,9 @@ Run /cpp:status for full installation details.
 - Uncommitted changes in CPP are auto-stashed before pull
 - Symlinked commands/skills are automatically updated by the git pull
 - MCP server dependencies are synced if venvs exist
-- Running systemd services are automatically restarted
-- MCP drift detection compares repo state against installed systemd services, claude mcp registrations, and listening ports
+- Docker workstations rebuild and restart containers with `make docker-refresh PROFILE="core browser cicd"` and fail if healthchecks fail
+- Running systemd services are automatically restarted on systemd-model machines
+- MCP drift detection compares repo state against Docker containers, installed systemd services, claude mcp registrations, and listening ports
 - Orphaned services (removed from repo) are flagged for cleanup
 - New servers are offered for installation via systemd or Docker
 - Stale service files are diffed and can be updated with backup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Profiles:** `core` (second-opinion + nano-banana + secrets-agent), `browser` (playwright), `cicd` (woodpecker-ci + secrets-agent)
 - **Start:** `make docker-up PROFILE=core`
 - **All profiles:** `make docker-up PROFILE="core browser cicd"`
+- **Rebuild/restart/wait for health:** `make docker-refresh PROFILE="core browser cicd"`
 - **Status/logs/stop:** `make docker-ps`, `make docker-logs`, `make docker-down`
 - **MCP connections:** Defined in project `.mcp.json` pointing to `127.0.0.1:{port}/sse` (SSE transport)
 - **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, conditional Docker builds
@@ -149,7 +150,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/dockers` - Docker container status, health, project linkages
 - `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD)
 - `/cpp:status` - Check installation state
-- `/cpp:update` - Pull latest, sync deps
+- `/cpp:update` - Pull latest, sync deps, then refresh the detected runtime model (Docker rebuild/restart/health, systemd restart, or venv-only)
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
 - `/happy-check` - Check happy-cli version (optional)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test lint format typecheck verify secret-scan update_docs clean \
-       docker-build docker-check-env docker-secrets-check docker-up docker-down docker-logs docker-ps deploy \
+       docker-build docker-check-env docker-secrets-check docker-up docker-refresh docker-health docker-down docker-logs docker-ps deploy \
        bootstrap-check drift-check setup-woodpecker-cli second-opinion-model-smoke codex-init codex-init-workspace
 
 ## Quality gates (used by /flow:finish)
@@ -43,12 +43,15 @@ update_docs:
 ## Docker (MCP server containers)
 ## Usage: make docker-up PROFILE=core
 ##        make docker-up PROFILE="core browser"
+##        make docker-refresh PROFILE="core browser cicd"
 ## Profiles: core (second-opinion + nano-banana), browser, coord
 
 PROFILE ?= core
+DOCKER_UP_FLAGS ?= -d
+DOCKER_PROFILES = $(foreach p,$(PROFILE),--profile $(p))
 
 docker-build:
-	$(foreach p,$(PROFILE),docker compose --profile $(p) build;)
+	docker compose $(DOCKER_PROFILES) build
 
 docker-check-env:
 	@if [ ! -f .env ]; then \
@@ -95,7 +98,15 @@ docker-secrets-check:
 	@echo "Done."
 
 docker-up: docker-check-env
-	$(foreach p,$(PROFILE),docker compose --profile $(p) up -d;)
+	docker compose $(DOCKER_PROFILES) up $(DOCKER_UP_FLAGS)
+
+docker-refresh:
+	@$(MAKE) docker-up PROFILE="$(PROFILE)" DOCKER_UP_FLAGS="-d --build --wait"
+	@$(MAKE) docker-health PROFILE="$(PROFILE)"
+
+docker-health:
+	docker compose $(DOCKER_PROFILES) ps
+	@python3 scripts/docker-health-check.py --profiles "$(PROFILE)"
 
 docker-down:
 	docker compose --profile core --profile browser --profile cicd --profile coord down
@@ -118,9 +129,7 @@ drift-check:
 
 ## Deploy (used by Woodpecker CI and /flow:deploy)
 
-deploy: docker-build docker-up
-	@sleep 5
-	@$(MAKE) docker-ps
+deploy: docker-refresh
 
 ## Woodpecker CLI setup
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ make verify
 make docker-secrets-check              # Validate AWS connectivity
 make docker-up PROFILE=core            # Second Opinion + Nano Banana
 make docker-up PROFILE="core browser"  # + Playwright
+make docker-refresh PROFILE="core browser cicd"  # Rebuild, restart, wait for health
 
 # Initialize in a target project
 cd ~/Projects/my-project
@@ -93,6 +94,7 @@ MCP servers run as Docker containers organized by profile:
 ```bash
 make docker-up PROFILE=core       # second-opinion + nano-banana
 make docker-up PROFILE="core browser"  # + playwright
+make docker-refresh PROFILE="core browser cicd"  # rebuild/restart with health gate
 make docker-ps                    # container status
 make docker-down                  # stop all
 ```
@@ -122,6 +124,7 @@ Woodpecker CI runs on every push and PR via a self-hosted agent:
 - **Auto-deploy:** On push to main, changed MCP servers are rebuilt and health-checked via `docker compose --wait`
 - **Disk cleanup:** Dangling images pruned after every deploy
 - **CI verification:** `flow:auto` polls the Woodpecker API after merge to confirm the pipeline passes before deploying
+- **First-class Docker updates:** `cpp:update` detects Docker installs, runs `make docker-refresh PROFILE="core browser cicd"`, and fails if containers are unhealthy
 
 Architecture: Woodpecker server on a dedicated VM, agent on the dev workstation, connected via gRPC over Tailscale. Web UI at `woodpecker.essent-ai.com` via Cloudflare tunnel.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@
 #   make docker-up PROFILE="core browser"            # + Playwright
 #   make docker-up PROFILE="core cicd"               # + Woodpecker CI
 #   make docker-build PROFILE=core                   # Build images only
+#   make docker-refresh PROFILE="core browser cicd"  # Rebuild, restart, wait healthy
 #   make docker-down                                 # Stop all services
 #   make docker-ps                                   # Show container status
 #

--- a/scripts/docker-health-check.py
+++ b/scripts/docker-health-check.py
@@ -1,0 +1,112 @@
+"""Fail if Docker Compose services are not running and healthy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def _decode_compose_ps(raw: str) -> list[dict[str, Any]]:
+    text = raw.strip()
+    if not text:
+        return []
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        rows: list[dict[str, Any]] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+        return rows
+
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, dict)]
+    if isinstance(data, dict):
+        return [data]
+    return []
+
+
+def _compose_ps(profiles: list[str]) -> list[dict[str, Any]]:
+    cmd = ["docker", "compose"]
+    for profile in profiles:
+        cmd.extend(["--profile", profile])
+    cmd.extend(["ps", "--format", "json"])
+
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "docker compose ps failed"
+        raise RuntimeError(stderr)
+    return _decode_compose_ps(result.stdout)
+
+
+def _service_name(row: dict[str, Any]) -> str:
+    return str(row.get("Service") or row.get("Name") or row.get("ID") or "unknown")
+
+
+def _state(row: dict[str, Any]) -> str:
+    return str(row.get("State") or row.get("Status") or "unknown").lower()
+
+
+def _health(row: dict[str, Any]) -> str:
+    return str(row.get("Health") or row.get("HealthStatus") or "").lower()
+
+
+def _is_healthy(row: dict[str, Any]) -> bool:
+    state = _state(row)
+    health = _health(row)
+
+    if "running" not in state and "up" not in state:
+        return False
+    if health in {"unhealthy", "starting"}:
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--profiles",
+        default="core",
+        help="Space-separated Docker Compose profiles to inspect",
+    )
+    args = parser.parse_args()
+
+    profiles = [profile for profile in args.profiles.split() if profile]
+    try:
+        rows = _compose_ps(profiles)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if not rows:
+        print("ERROR: no Docker Compose services found for requested profiles", file=sys.stderr)
+        return 1
+
+    print("")
+    print("Docker health summary:")
+    failed: list[str] = []
+    for row in rows:
+        service = _service_name(row)
+        state = _state(row) or "unknown"
+        health = _health(row) or "no healthcheck"
+        ok = _is_healthy(row)
+        marker = "OK" if ok else "FAIL"
+        print(f"  {marker} {service}: state={state}, health={health}")
+        if not ok:
+            failed.append(service)
+
+    if failed:
+        print("")
+        print("ERROR: unhealthy Docker services: " + ", ".join(failed), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -103,3 +103,35 @@ def test_deploy_pipeline_does_not_require_repo_aws_secrets() -> None:
 
     assert "environment" not in deploy_step
     assert "secrets" not in deploy_step
+
+
+def test_makefile_has_first_class_docker_refresh_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    makefile = (root / "Makefile").read_text()
+
+    assert "docker-refresh:" in makefile
+    assert 'DOCKER_UP_FLAGS="-d --build --wait"' in makefile
+    assert "docker-health:" in makefile
+    assert "scripts/docker-health-check.py" in makefile
+
+
+def test_cpp_update_refreshes_detected_docker_runtime() -> None:
+    root = Path(__file__).resolve().parents[1]
+    command = (root / ".claude" / "commands" / "cpp" / "update.md").read_text()
+
+    assert 'DEPLOY_MODEL="docker"' in command
+    assert 'DEPLOY_MODEL="systemd"' in command
+    assert 'make docker-refresh PROFILE="core browser cicd"' in command
+    assert "Docker refresh failed" in command
+    assert "Do not run Docker and\nsystemd restarts in the same update" in command
+
+
+def test_cpp_init_prefers_docker_and_runs_health_gated_refresh() -> None:
+    root = Path(__file__).resolve().parents[1]
+    command = (root / ".claude" / "commands" / "cpp" / "init.md").read_text()
+
+    assert "# Fresh installs prefer Docker when available." in command
+    assert 'DEPLOY_MODE="systemd"' in command
+    assert 'make docker-refresh PROFILE="core browser cicd"' in command
+    assert "Docker containers rebuilt, restarted, and healthy" in command
+    assert "skipping systemd service setup" in command


### PR DESCRIPTION
## Summary
- Add `make docker-refresh PROFILE="core browser cicd"` to rebuild, restart, wait for health, and print a Docker health summary.
- Update `/cpp:update` to detect exactly one runtime model and use Docker refresh, systemd restart, or venv-only handling.
- Update `/cpp:init` to prefer Docker for fresh installs when available and health-gate Docker restarts after API key setup.
- Document the Docker refresh path in CPP command help, README, CLAUDE.md, and docker-compose usage notes.

## Test plan
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- `env UV_CACHE_DIR=/tmp/uv-cache make update_docs`

Closes #336