### PR TITLE
fix(cpp): detect conflicting MCP deployment remnants (Closes #337)

### DIFF
--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -127,10 +127,19 @@ done
 ## Step 5: Detect Deployment Model and Refresh Runtime
 
 Choose exactly one runtime model for this machine. Do not run Docker and
-systemd restarts in the same update.
+systemd restarts in the same update. Before refreshing anything, run the drift
+check so failed/orphaned systemd units are surfaced instead of revived when
+Docker is the active serving model.
+
+Only restart systemd services when the selected model is systemd, and never
+restart failed units without user approval from the remediation step.
 
 ```bash
 cd "$CPP_DIR"
+
+if [ -x "$CPP_DIR/scripts/drift-detect.sh" ]; then
+  "$CPP_DIR/scripts/drift-detect.sh" --fix || DRIFT_FOUND=true
+fi
 
 DEPLOY_MODEL="venv-only"
 DOCKER_READY=false
@@ -198,6 +207,8 @@ if [ "$DEPLOY_MODEL" = "systemd" ]; then
       echo "Restarting $service..."
       sudo systemctl restart "$service"
       echo "Done: $service restarted"
+    elif systemctl is-failed "$service" &>/dev/null; then
+      echo "WARNING: $service is failed. Resolve via the drift remediation prompts instead of restarting blindly."
     fi
   done
 fi
@@ -327,12 +338,22 @@ mcp-evaluate              depr.   none      none      no        --      OK (depr
 
 Status classifications:
 - **OK** - repo server is installed, registered, and running
+- **CONFLICT** - Docker and systemd both provide the same server
+- **FAILED SYSTEMD** - systemd unit is failed or stuck activating
+- **PORT CONFLICT** - multiple listener processes are bound to the same MCP port
 - **STALE SERVICE** - installed but systemd unit differs from repo version
 - **NEW - NOT INSTALLED** - repo ships it but it is not installed
 - **ORPHANED** - installed/running but repo no longer ships it
 - **NOT RUNNING** - installed but service/container is not active
 - **UNHEALTHY** - Docker container is running but healthcheck is failing
 - **NOT REGISTERED** - running but not in `claude mcp list`
+
+Use `scripts/drift-detect.sh --fix` as the authoritative report for:
+
+- Docker/systemd deployment-model conflicts
+- orphaned MCP systemd units such as `mcp-coordination`
+- failed MCP systemd units
+- port double-binding on MCP ports 8080-8089
 
 Present the drift report table to the user.
 
@@ -358,6 +379,38 @@ fi
 For each drift finding, offer the user actionable options using AskUserQuestion.
 
 **Only show this if drift was detected.** If everything is clean, skip to Step 8.
+
+### For CONFLICT findings (Docker + systemd for one server)
+
+Default recommendation: converge on Docker. Ask once per server:
+
+```
+{server} is served by Docker and also has systemd unit(s): {units}.
+Keeping both models can cause failed units, stale restarts, or port conflicts.
+```
+
+Options:
+- **Use Docker** - Stop, disable, and remove the listed systemd unit files; keep Docker running
+- **Keep systemd** - Stop/remove the Docker container for this server manually
+- **Skip** - Leave both models in place for now
+
+If they choose Docker:
+1. Stop and disable each losing unit (`systemctl --user ...` for user units, `sudo systemctl ...` for system units)
+2. Remove the unit file
+3. Reload the matching systemd manager
+4. Remove stale Claude MCP registrations if they point to the losing model
+5. Re-run `scripts/drift-detect.sh --fix` and verify no conflict remains
+
+### For FAILED SYSTEMD findings
+
+If Docker is active for the same server, recommend the same Docker convergence
+cleanup. If Docker is not active, offer to inspect logs before restart:
+
+```
+journalctl --user -u {unit} -n 80 --no-pager
+```
+
+Do not silently restart failed units.
 
 ### For NEW servers (in repo, not installed):
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ update_docs:
 ## Usage: make docker-up PROFILE=core
 ##        make docker-up PROFILE="core browser"
 ##        make docker-refresh PROFILE="core browser cicd"
-## Profiles: core (second-opinion + nano-banana), browser, coord
+## Profiles: core (second-opinion + nano-banana), browser, cicd
 
 PROFILE ?= core
 DOCKER_UP_FLAGS ?= -d
@@ -109,13 +109,13 @@ docker-health:
 	@python3 scripts/docker-health-check.py --profiles "$(PROFILE)"
 
 docker-down:
-	docker compose --profile core --profile browser --profile cicd --profile coord down
+	docker compose --profile core --profile browser --profile cicd down
 
 docker-logs:
-	docker compose --profile core --profile browser --profile cicd --profile coord logs -f
+	docker compose --profile core --profile browser --profile cicd logs -f
 
 docker-ps:
-	docker compose --profile core --profile browser --profile cicd --profile coord ps
+	docker compose --profile core --profile browser --profile cicd ps
 
 ## Bootstrap dependency check (admin-only prerequisites)
 

--- a/docs/HOST_MANAGED_ARTIFACTS.md
+++ b/docs/HOST_MANAGED_ARTIFACTS.md
@@ -25,13 +25,19 @@ The `install-service.sh` scripts generate units from templates using `sed` subst
 (`${SERVICE_USER}`, `${MCP_SERVER_DIR}`, `${UV_BIN}`). Once installed, the unit is static.
 
 **Detection:** `scripts/drift-detect.sh` regenerates the expected unit from the template
-and compares it against the installed version.
+and compares it against the installed version. It also inventories MCP systemd units
+that no longer have a repo template, such as legacy `mcp-coordination.service` or
+old alias units, and reports them as orphaned.
 
 **Reconciliation:** Re-run the appropriate install script:
 ```bash
 mcp-second-opinion/scripts/install-service.sh
 mcp-playwright-persistent/deploy/install-service.sh
 ```
+
+When Docker containers are active for the same MCP server, the default convergence
+model is Docker. Use `scripts/drift-detect.sh --fix` to print opt-in cleanup
+commands for the losing systemd units before removing them.
 
 ### 2. System Tuning (sysctl)
 
@@ -108,3 +114,12 @@ scripts/drift-detect.sh --fix
 
 The `drift-check` step is included in the Woodpecker pipeline as a pre-deploy gate
 and in the CI task manifest's deploy plan.
+
+The drift report includes deployment-model checks for MCP servers:
+
+- Docker/systemd conflicts for the same server
+- failed or stuck MCP systemd units
+- orphaned MCP systemd units that the repo no longer ships
+- port binding conflicts on MCP ports 8080-8089
+
+The script only reports and suggests remediation. Cleanup remains opt-in.

--- a/scripts/drift-detect.sh
+++ b/scripts/drift-detect.sh
@@ -34,12 +34,196 @@ SKIP_COUNT=0
 CHECK_COUNT=0
 FIX_MODE=false
 
+# MCP deployment model inventory. Keep this explicit so legacy unit aliases can
+# be handled as deployment remnants instead of being mistaken for new servers.
+MCP_SERVERS=(
+    "mcp-second-opinion"
+    "mcp-nano-banana"
+    "mcp-playwright-persistent"
+    "mcp-woodpecker-ci"
+)
+declare -A MCP_DOCKER_CONTAINERS=(
+    ["mcp-second-opinion"]="mcp-second-opinion"
+    ["mcp-nano-banana"]="mcp-nano-banana"
+    ["mcp-playwright-persistent"]="mcp-playwright-persistent"
+    ["mcp-woodpecker-ci"]="mcp-woodpecker-ci"
+)
+declare -A MCP_SYSTEMD_UNITS=(
+    ["mcp-second-opinion"]="mcp-second-opinion"
+    ["mcp-nano-banana"]="nano-banana mcp-nano-banana"
+    ["mcp-playwright-persistent"]="mcp-playwright mcp-playwright-persistent"
+    ["mcp-woodpecker-ci"]=""
+)
+declare -A MCP_PORTS=(
+    ["mcp-second-opinion"]="8080"
+    ["mcp-nano-banana"]="8084"
+    ["mcp-playwright-persistent"]="8081"
+    ["mcp-woodpecker-ci"]="8085"
+)
+declare -A MCP_REGISTRATIONS=(
+    ["mcp-second-opinion"]="second-opinion mcp-second-opinion"
+    ["mcp-nano-banana"]="nano-banana mcp-nano-banana"
+    ["mcp-playwright-persistent"]="playwright-persistent mcp-playwright mcp-playwright-persistent"
+    ["mcp-woodpecker-ci"]="woodpecker-ci mcp-woodpecker-ci"
+)
+declare -A DOCKER_STATUS=()
+
 # --- Helpers ---
 info()  { echo -e "${BLUE}info${NC}  $*"; }
 ok()    { echo -e "${GREEN}ok${NC}    $*"; CHECK_COUNT=$((CHECK_COUNT + 1)); }
 drift() { echo -e "${RED}DRIFT${NC} $*"; DRIFT_COUNT=$((DRIFT_COUNT + 1)); CHECK_COUNT=$((CHECK_COUNT + 1)); }
 skip()  { echo -e "${YELLOW}skip${NC}  $*"; SKIP_COUNT=$((SKIP_COUNT + 1)); }
 fix()   { if $FIX_MODE; then echo -e "       ${YELLOW}fix:${NC} $*"; fi; }
+
+systemd_unit_path() {
+    local unit="$1"
+    local user_path="$HOME/.config/systemd/user/${unit}.service"
+    local system_path="/etc/systemd/system/${unit}.service"
+
+    if [[ -f "$user_path" ]]; then
+        echo "$user_path"
+    elif [[ -f "$system_path" ]]; then
+        echo "$system_path"
+    fi
+}
+
+systemd_unit_state() {
+    local unit="$1"
+    local state=""
+
+    if command -v systemctl &>/dev/null; then
+        state=$(systemctl --user is-active "$unit" 2>/dev/null || true)
+        case "$state" in
+            active|activating|deactivating|failed|inactive)
+                echo "$state"
+                return
+                ;;
+        esac
+
+        state=$(systemctl is-active "$unit" 2>/dev/null || true)
+        case "$state" in
+            active|activating|deactivating|failed|inactive)
+                echo "$state"
+                return
+                ;;
+        esac
+    fi
+
+    if [[ -n "$(systemd_unit_path "$unit")" ]]; then
+        echo "installed"
+    else
+        echo "not-found"
+    fi
+}
+
+is_systemd_unit_present() {
+    local unit="$1"
+    local state
+    state=$(systemd_unit_state "$unit")
+    [[ "$state" != "not-found" ]]
+}
+
+repo_ships_systemd_unit() {
+    local unit="$1"
+    find "$REPO_ROOT" -path "*/deploy/${unit}.service" -o -path "*/deploy/${unit}.service.template" 2>/dev/null | grep -q .
+}
+
+canonical_server_for_unit() {
+    local unit="$1"
+    case "$unit" in
+        mcp-second-opinion) echo "mcp-second-opinion" ;;
+        nano-banana|mcp-nano-banana) echo "mcp-nano-banana" ;;
+        mcp-playwright|mcp-playwright-persistent) echo "mcp-playwright-persistent" ;;
+        mcp-woodpecker-ci) echo "mcp-woodpecker-ci" ;;
+        *) echo "" ;;
+    esac
+}
+
+primary_registration_for_unit() {
+    local unit="$1"
+    local server
+    server=$(canonical_server_for_unit "$unit")
+
+    if [[ -n "$server" ]]; then
+        echo "${MCP_REGISTRATIONS[$server]%% *}"
+    else
+        echo "$unit"
+    fi
+}
+
+fix_remove_systemd_unit() {
+    local unit="$1"
+    local path="$2"
+    local registration
+    registration=$(primary_registration_for_unit "$unit")
+
+    fix "Opt-in Docker convergence for $unit:"
+    if [[ "$path" == "$HOME/.config/systemd/user/"* ]]; then
+        fix "systemctl --user stop $unit || true"
+        fix "systemctl --user disable $unit || true"
+        fix "rm -f $path"
+        fix "systemctl --user daemon-reload"
+    elif [[ -n "$path" ]]; then
+        fix "sudo systemctl stop $unit || true"
+        fix "sudo systemctl disable $unit || true"
+        fix "sudo rm -f $path"
+        fix "sudo systemctl daemon-reload"
+    else
+        fix "systemctl --user stop $unit || sudo systemctl stop $unit || true"
+        fix "systemctl --user disable $unit || sudo systemctl disable $unit || true"
+        fix "Remove the installed ${unit}.service file, then reload systemd"
+    fi
+    fix "claude mcp remove $registration || true"
+}
+
+collect_docker_status() {
+    DOCKER_STATUS=()
+    command -v docker &>/dev/null || return
+
+    local line name status
+    local compose_file="$REPO_ROOT/docker-compose.yml"
+    if [[ -f "$compose_file" ]]; then
+        while IFS= read -r line; do
+            [[ -n "$line" ]] || continue
+            name="${line%%:*}"
+            status="${line#*:}"
+            [[ -n "$name" && "$name" != "$status" ]] || continue
+            DOCKER_STATUS["$name"]="$status"
+        done < <(docker compose -f "$compose_file" \
+            --profile core --profile browser --profile cicd \
+            ps --format '{{.Name}}:{{.Status}}' 2>/dev/null || true)
+    fi
+
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        name="${line%%:*}"
+        status="${line#*:}"
+        [[ -n "$name" && "$name" != "$status" ]] || continue
+        DOCKER_STATUS["$name"]="${DOCKER_STATUS[$name]:-$status}"
+    done < <(docker ps --format '{{.Names}}:{{.Status}}' 2>/dev/null || true)
+}
+
+is_docker_container_running() {
+    local container="$1"
+    local status="${DOCKER_STATUS[$container]:-}"
+    [[ -n "$status" && "$status" != *"Exited"* && "$status" != *"Created"* && "$status" != *"Dead"* ]]
+}
+
+list_installed_mcp_units() {
+    {
+        find "$HOME/.config/systemd/user" /etc/systemd/system \
+            -maxdepth 1 -type f \
+            \( -name 'mcp-*.service' -o -name 'nano-*.service' -o -name '*coordination*.service' \) \
+            -printf '%f\n' 2>/dev/null || true
+
+        if command -v systemctl &>/dev/null; then
+            systemctl --user list-units --type=service --all --no-legend --no-pager 2>/dev/null | awk '{print $1}' || true
+            systemctl list-units --type=service --all --no-legend --no-pager 2>/dev/null | awk '{print $1}' || true
+            systemctl --user list-unit-files --type=service --no-legend --no-pager 2>/dev/null | awk '{print $1}' || true
+            systemctl list-unit-files --type=service --no-legend --no-pager 2>/dev/null | awk '{print $1}' || true
+        fi
+    } | sed 's/\.service$//' | grep -E '^(mcp-|nano-|.*coordination)' | sort -u
+}
 
 usage() {
     cat <<'EOF'
@@ -57,6 +241,7 @@ Categories checked:
   3. Go binary        - ~/go/bin/woodpecker-mcp version currency
   4. Docker containers - running container health status
   5. Shared scripts   - cross-container script consistency (fetch-secrets.sh, bash-prep.sh)
+  6. MCP deployment models - Docker/systemd conflicts, failed/orphaned units, port bindings
 
 Exit codes:
   0 - No drift (or no artifacts installed to check)
@@ -113,6 +298,16 @@ check_systemd_unit() {
     if [[ ! -f "$installed_path" ]]; then
         skip "$service_name - not installed (no systemd unit found)"
         return
+    fi
+
+    local state
+    state=$(systemd_unit_state "$service_name")
+    if [[ "$state" == "failed" ]]; then
+        drift "systemd - unit $service_name is failed"
+        fix_remove_systemd_unit "$service_name" "$installed_path"
+    elif [[ "$state" == "activating" ]]; then
+        drift "systemd - unit $service_name is stuck activating"
+        fix_remove_systemd_unit "$service_name" "$installed_path"
     fi
 
     local installed
@@ -223,30 +418,141 @@ check_docker_compose() {
         return
     fi
 
-    # Check for stale containers (running but image differs from what compose would build)
-    local running_containers
-    running_containers=$(docker compose -f "$compose_file" \
-        --profile core --profile browser --profile cicd \
-        ps --format '{{.Name}}:{{.Status}}' 2>/dev/null || true)
+    collect_docker_status
 
-    if [[ -z "$running_containers" ]]; then
+    if (( ${#DOCKER_STATUS[@]} == 0 )); then
         skip "docker - no containers running"
         return
     fi
 
     # Check each running container's image ID vs what compose config expects
     local has_drift=false
-    while IFS=: read -r name status; do
+    local name status
+    for name in "${!DOCKER_STATUS[@]}"; do
+        status="${DOCKER_STATUS[$name]}"
         if [[ "$status" == *"unhealthy"* ]]; then
             drift "docker - container $name is unhealthy"
             has_drift=true
         fi
-    done <<< "$running_containers"
+    done
 
     if ! $has_drift; then
         ok "docker - all running containers healthy"
     else
         fix "Re-run: make deploy PROFILE=\"core browser cicd\""
+    fi
+}
+
+# --- MCP deployment model conflicts ---
+check_mcp_deployment_models() {
+    collect_docker_status
+
+    local has_issue=false
+    local server container docker_running units unit present_units state path
+
+    for server in "${MCP_SERVERS[@]}"; do
+        container="${MCP_DOCKER_CONTAINERS[$server]:-}"
+        docker_running=false
+        if [[ -n "$container" ]] && is_docker_container_running "$container"; then
+            docker_running=true
+        fi
+
+        present_units=()
+        units="${MCP_SYSTEMD_UNITS[$server]:-}"
+        for unit in $units; do
+            if is_systemd_unit_present "$unit"; then
+                present_units+=("$unit")
+                state=$(systemd_unit_state "$unit")
+                path=$(systemd_unit_path "$unit")
+                if [[ "$state" == "failed" ]]; then
+                    drift "systemd - unit $unit is failed ($server)"
+                    fix_remove_systemd_unit "$unit" "$path"
+                    has_issue=true
+                elif [[ "$state" == "activating" ]]; then
+                    drift "systemd - unit $unit is stuck activating ($server)"
+                    fix_remove_systemd_unit "$unit" "$path"
+                    has_issue=true
+                fi
+            fi
+        done
+
+        if $docker_running && (( ${#present_units[@]} > 0 )); then
+            drift "deployment model conflict - $server has Docker container $container and systemd unit(s): ${present_units[*]}"
+            fix "Default convergence is Docker for $server. Stop, disable, and remove the systemd unit(s) below, then re-run this check."
+            for unit in "${present_units[@]}"; do
+                fix_remove_systemd_unit "$unit" "$(systemd_unit_path "$unit")"
+            done
+            has_issue=true
+        fi
+    done
+
+    if ! $has_issue; then
+        ok "mcp deployment models - no Docker/systemd conflicts or failed units"
+    fi
+}
+
+check_orphaned_systemd_units() {
+    local has_orphan=false
+    local unit path state
+
+    while IFS= read -r unit; do
+        [[ -n "$unit" ]] || continue
+        if repo_ships_systemd_unit "$unit"; then
+            continue
+        fi
+
+        path=$(systemd_unit_path "$unit")
+        state=$(systemd_unit_state "$unit")
+        drift "orphaned systemd unit $unit - repo no longer ships it (state: $state)"
+        fix_remove_systemd_unit "$unit" "$path"
+        has_orphan=true
+    done < <(list_installed_mcp_units)
+
+    if ! $has_orphan; then
+        ok "orphaned systemd units - none detected"
+    fi
+}
+
+check_mcp_port_bindings() {
+    if ! command -v ss &>/dev/null; then
+        skip "ports - ss not available"
+        return
+    fi
+
+    local output
+    output=$(ss -tlnp 2>/dev/null | grep -E ':(808[0-9])\b' || true)
+    if [[ -z "$output" ]]; then
+        skip "ports - no MCP listeners on 8080-8089"
+        return
+    fi
+
+    local has_conflict=false
+    local port proc
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    while IFS= read -r line; do
+        port=$(echo "$line" | grep -oE ':(808[0-9])\b' | head -1 | tr -d ':' || true)
+        [[ -n "$port" ]] || continue
+        proc=$(echo "$line" | sed -n 's/.*users:((\"\([^\"]*\)\".*/\1/p')
+        [[ -n "$proc" ]] || proc="unknown"
+        echo "$proc" >> "$tmp_dir/$port"
+    done <<< "$output"
+
+    for file in "$tmp_dir"/*; do
+        [[ -f "$file" ]] || continue
+        port="$(basename "$file")"
+        local proc_count
+        proc_count=$(sort -u "$file" | wc -l | tr -d ' ')
+        if (( proc_count > 1 )); then
+            drift "port binding conflict - port $port has multiple listener processes: $(sort -u "$file" | paste -sd ', ' -)"
+            fix "Stop the losing provider for port $port, then re-run scripts/drift-detect.sh --fix"
+            has_conflict=true
+        fi
+    done
+    rm -rf "$tmp_dir"
+
+    if ! $has_conflict; then
+        ok "ports - no double-binding detected on 8080-8089"
     fi
 }
 
@@ -368,6 +674,14 @@ main() {
     echo -e "${BOLD}Shared Script Contracts${NC}"
     echo "------------------------------------------------"
     check_shared_scripts
+    echo ""
+
+    # Category 6: MCP deployment model consistency
+    echo -e "${BOLD}MCP Deployment Models${NC}"
+    echo "------------------------------------------------"
+    check_mcp_deployment_models
+    check_orphaned_systemd_units
+    check_mcp_port_bindings
     echo ""
 
     # Summary

--- a/tests/test_drift_detect.py
+++ b/tests/test_drift_detect.py
@@ -1,0 +1,149 @@
+"""Regression tests for MCP deployment-model drift detection."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DRIFT_SCRIPT = ROOT / "scripts" / "drift-detect.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_drift_detect_flags_docker_systemd_conflicts_and_orphans(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    user_units = home / ".config" / "systemd" / "user"
+    user_units.mkdir(parents=True)
+    (user_units / "mcp-second-opinion.service").write_text("[Service]\nExecStart=fake\n", encoding="utf-8")
+    (user_units / "mcp-playwright-persistent.service").write_text("[Service]\nExecStart=fake\n", encoding="utf-8")
+    (user_units / "mcp-coordination.service").write_text("[Service]\nExecStart=fake\n", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "uv",
+        """
+        #!/usr/bin/env bash
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "docker",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "--version" ]]; then
+          echo "Docker version 26.0.0"
+          exit 0
+        fi
+        if [[ "$1" == "compose" && "$2" == "version" ]]; then
+          echo "Docker Compose version v2.27.0"
+          exit 0
+        fi
+        if [[ "$1" == "compose" && "$*" == *" ps "* ]]; then
+          echo "mcp-second-opinion:Up (healthy)"
+          echo "mcp-playwright-persistent:Up (healthy)"
+          exit 0
+        fi
+        if [[ "$1" == "ps" ]]; then
+          echo "mcp-second-opinion:Up 2 hours (healthy)"
+          echo "mcp-playwright-persistent:Up 2 hours (healthy)"
+          exit 0
+        fi
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "systemctl",
+        """
+        #!/usr/bin/env bash
+        args="$*"
+        if [[ "$args" == *"is-active mcp-second-opinion"* ]]; then
+          echo "active"
+          exit 0
+        fi
+        if [[ "$args" == *"is-active mcp-playwright-persistent"* ]]; then
+          echo "failed"
+          exit 3
+        fi
+        if [[ "$args" == *"is-active mcp-coordination"* ]]; then
+          echo "activating"
+          exit 3
+        fi
+        if [[ "$args" == *"is-active"* ]]; then
+          echo "inactive"
+          exit 3
+        fi
+        if [[ "$args" == *"list-units"* ]]; then
+          echo "mcp-second-opinion.service loaded active running fake"
+          echo "mcp-playwright-persistent.service loaded failed failed fake"
+          echo "mcp-coordination.service loaded activating auto-restart fake"
+          exit 0
+        fi
+        if [[ "$args" == *"list-unit-files"* ]]; then
+          echo "mcp-second-opinion.service enabled"
+          echo "mcp-playwright-persistent.service enabled"
+          echo "mcp-coordination.service enabled"
+          exit 0
+        fi
+        exit 1
+        """,
+    )
+    _write_executable(
+        bin_dir / "ss",
+        """
+        #!/usr/bin/env bash
+        cat <<'EOF'
+        State Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+        LISTEN 0 4096 0.0.0.0:8081 0.0.0.0:* users:(("docker-proxy",pid=100,fd=4))
+        LISTEN 0 4096 127.0.0.1:8081 0.0.0.0:* users:(("python",pid=200,fd=5))
+        EOF
+        """,
+    )
+    _write_executable(
+        bin_dir / "sysctl",
+        """
+        #!/usr/bin/env bash
+        case "$2" in
+          vm.swappiness) echo 10 ;;
+          vm.vfs_cache_pressure) echo 50 ;;
+          fs.inotify.max_user_watches) echo 524288 ;;
+          fs.inotify.max_user_instances) echo 512 ;;
+          *) echo unknown ;;
+        esac
+        """,
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "USER": "tester",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(DRIFT_SCRIPT), "--fix"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    output = result.stdout
+    assert "deployment model conflict - mcp-second-opinion" in output
+    assert "systemd - unit mcp-playwright-persistent is failed" in output
+    assert "orphaned systemd unit mcp-coordination" in output
+    assert "port binding conflict - port 8081" in output
+    assert "Default convergence is Docker" in output
+    assert "claude mcp remove second-opinion" in output


### PR DESCRIPTION
## Summary
- add executable MCP deployment-model drift checks for Docker/systemd conflicts, failed or stuck MCP units, orphaned units, and port double-binding
- emit opt-in Docker-convergence cleanup commands for losing systemd units and stale Claude MCP registrations
- update `/cpp:update`, host artifact docs, and Docker profile references to match the Docker-first model

## Test plan
- [x] `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- [x] `env UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=/home/cooneycw/Projects/claude-power-pack-issue-337/lib:$PYTHONPATH uv run --extra dev python -m lib.cicd run --plan finish`

Closes #337