### PR TITLE
fix(secrets): harden aws agent healthcheck (Closes #339)

### DIFF
--- a/aws-secrets-agent/Dockerfile
+++ b/aws-secrets-agent/Dockerfile
@@ -27,7 +27,9 @@ USER agent
 
 EXPOSE 2773
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+# Keep these timings in sync with docker-compose.yml. /ping is a local
+# liveness probe only; it does not call AWS or fetch cached secrets.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
     CMD curl -sf -H "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN}" http://localhost:2773/ping || exit 1
 
 ENTRYPOINT ["./aws-secrets-agent", "--config", "config.toml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,21 +35,25 @@ services:
       - AWS_REGION=us-east-1
       - AWS_TOKEN=${AWS_TOKEN:-default-token}
     healthcheck:
+      # /ping is a local liveness probe in the AWS agent: it verifies the
+      # daemon is listening and does not call AWS or fetch cached secrets.
+      # The longer grace period and modestly larger budget avoid false
+      # unhealthy states during cold starts while CI builds images in parallel.
       test: ["CMD", "curl", "-sf", "-H", "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN:-default-token}", "http://localhost:2773/ping"]
       interval: 10s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
+      timeout: 5s
+      start_period: 30s
+      retries: 5
     restart: unless-stopped
     profiles: ["core", "cicd"]
     deploy:
       resources:
         limits:
+          cpus: "0.5"
+          memory: 128M
+        reservations:
           cpus: "0.25"
           memory: 64M
-        reservations:
-          cpus: "0.1"
-          memory: 32M
 
   mcp-second-opinion:
     build:

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -60,6 +60,30 @@ def test_secret_consumers_share_sidecar_token_default() -> None:
         assert env["AWS_TOKEN"] == "${AWS_TOKEN:-default-token}"
 
 
+def test_aws_secrets_agent_healthcheck_allows_loaded_starts() -> None:
+    root = Path(__file__).resolve().parents[1]
+    services = _compose_services()
+    agent = services["aws-secrets-agent"]
+    healthcheck = agent["healthcheck"]
+    dockerfile = (root / "aws-secrets-agent" / "Dockerfile").read_text()
+
+    assert healthcheck["test"][-1] == "http://localhost:2773/ping"
+    assert healthcheck["interval"] == "10s"
+    assert healthcheck["timeout"] == "5s"
+    assert healthcheck["start_period"] == "30s"
+    assert healthcheck["retries"] == 5
+
+    assert "--interval=10s" in dockerfile
+    assert "--timeout=5s" in dockerfile
+    assert "--start-period=30s" in dockerfile
+    assert "--retries=5" in dockerfile
+    assert "does not call AWS" in dockerfile
+
+    resources = agent["deploy"]["resources"]
+    assert resources["limits"] == {"cpus": "0.5", "memory": "128M"}
+    assert resources["reservations"] == {"cpus": "0.25", "memory": "64M"}
+
+
 def test_second_opinion_uses_secret_with_free_tier_provider_keys() -> None:
     services = _compose_services()
     env = _env_list_to_map(services["mcp-second-opinion"]["environment"])


### PR DESCRIPTION
## Summary
- give the aws-secrets-agent healthcheck a longer cold-start grace period plus wider timeout/retry budget in compose and the image Dockerfile
- raise the sidecar resource budget to reduce false unhealthy states under concurrent image builds
- document that `/ping` is a local liveness probe and add regression coverage for the healthcheck timings and resources

## Root Cause
The sidecar was resource-constrained and had only a short startup grace period. Under concurrent image builds, Docker could mark it unhealthy before the Rust agent had enough CPU/time to bind and answer `/ping`, which caused all dependent MCP containers to abort.

## Test Plan
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- `make update_docs`

Closes #339