### PR TITLE
fix(secrets): harden aws sidecar credential startup (Closes #344)

### DIFF
--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -285,21 +285,40 @@ done
 # Check AWS Secrets Manager sidecar
 echo ""
 echo "AWS Secrets Sidecar:"
-SIDECAR_CONTAINER=$(docker ps --format '{{.Names}}' 2>/dev/null | grep "aws-secrets-agent" || true)
+SIDECAR_CONTAINER=$(docker ps -a --format '{{.Names}}' 2>/dev/null | grep "aws-secrets-agent" || true)
 if [ -n "$SIDECAR_CONTAINER" ]; then
+  SIDECAR_STATE=$(docker inspect --format='{{.State.Status}}' aws-secrets-agent 2>/dev/null || echo "unknown")
   SIDECAR_HEALTH=$(docker inspect --format='{{.State.Health.Status}}' aws-secrets-agent 2>/dev/null || echo "unknown")
+  SIDECAR_RESTARTS=$(docker inspect --format='{{.RestartCount}}' aws-secrets-agent 2>/dev/null || echo "unknown")
   if [ "$SIDECAR_HEALTH" = "healthy" ]; then
-    echo "  [x] aws-secrets-agent: running, healthy (port 2773)"
+    echo "  [x] aws-secrets-agent: $SIDECAR_STATE, healthy (port 2773)"
   else
-    echo "  [~] aws-secrets-agent: running, status=$SIDECAR_HEALTH"
+    echo "  [~] aws-secrets-agent: state=$SIDECAR_STATE, health=$SIDECAR_HEALTH, restarts=$SIDECAR_RESTARTS"
+  fi
+  BAKED_AWS_KEY=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' aws-secrets-agent 2>/dev/null | grep '^AWS_ACCESS_KEY_ID=' | cut -d= -f2-)
+  BAKED_AWS_SECRET=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' aws-secrets-agent 2>/dev/null | grep '^AWS_SECRET_ACCESS_KEY=' | cut -d= -f2-)
+  if [ -z "$BAKED_AWS_KEY" ] || [ -z "$BAKED_AWS_SECRET" ]; then
+    echo "  [!] aws-secrets-agent baked AWS credentials are empty/missing"
   fi
   # Show which MCP containers use the sidecar
+  CREATED_SECRET_CONTAINERS=""
   for container in mcp-second-opinion mcp-woodpecker-ci; do
     SECRET_NAME=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' "$container" 2>/dev/null | grep "^AWS_SECRET_NAME=" | cut -d= -f2)
+    CONTAINER_STATE=$(docker inspect --format='{{.State.Status}}' "$container" 2>/dev/null || echo "missing")
     if [ -n "$SECRET_NAME" ]; then
-      echo "    $container -> $SECRET_NAME"
+      echo "    $container -> $SECRET_NAME (state=$CONTAINER_STATE)"
+      if [ "$CONTAINER_STATE" = "created" ]; then
+        CREATED_SECRET_CONTAINERS="$CREATED_SECRET_CONTAINERS $container"
+      fi
     fi
   done
+  if [ -n "$CREATED_SECRET_CONTAINERS" ] && [ "$SIDECAR_HEALTH" != "healthy" ]; then
+    echo "  [!] Detected sidecar dependency strand: $CREATED_SECRET_CONTAINERS"
+    echo "      Secret-dependent containers are Created with no logs while aws-secrets-agent is not healthy."
+    echo "      Docker Compose captured sidecar env at container create time; restart will not reload fixed creds."
+    echo "      If .env or shell AWS creds are now valid, run:"
+    echo "      cd $CPP_DIR && docker compose --profile core --profile cicd up -d --force-recreate aws-secrets-agent mcp-second-opinion mcp-woodpecker-ci"
+  fi
   # Check AWS credential validity
   if [ -f "$CPP_DIR/.env" ] && grep -qE '^AWS_ACCESS_KEY_ID=.+' "$CPP_DIR/.env" 2>/dev/null; then
     echo "  [x] AWS credentials: present in .env"

--- a/.claude/commands/dockers.md
+++ b/.claude/commands/dockers.md
@@ -121,6 +121,7 @@ Present a structured report:
 Based on findings, suggest relevant actions:
 
 - **No API keys:** Create `.env` in claude-power-pack root with `GEMINI_API_KEY=...`, then `make docker-down && make docker-up PROFILE=core`. Or run `/cpp:init` to configure interactively.
+- **Sidecar dependency strand:** If `aws-secrets-agent` is restarting/unhealthy and secret-dependent containers such as `mcp-second-opinion` or `mcp-woodpecker-ci` are `Created` with no logs, fix `.env` or shell AWS credentials and run `docker compose --profile core --profile cicd up -d --force-recreate aws-secrets-agent mcp-second-opinion mcp-woodpecker-ci`.
 - **Unhealthy containers:** `make docker-down && make docker-up PROFILE=core`
 - **Missing profiles:** `make docker-up PROFILE=browser` (if browser not running)
 - **No MCP containers:** `make docker-build PROFILE=core && make docker-up PROFILE=core`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **All profiles:** `make docker-up PROFILE="core browser cicd"`
 - **Rebuild/restart/wait for health:** `make docker-refresh PROFILE="core browser cicd"`
 - **Status/logs/stop:** `make docker-ps`, `make docker-logs`, `make docker-down`
+- **Empty AWS credential guard:** `make docker-up` refuses to create `aws-secrets-agent` when `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` resolves empty. If a stale sidecar was already created with empty creds, fix env and force-recreate `aws-secrets-agent` plus secret-dependent MCP containers.
 - **MCP connections:** Defined in project `.mcp.json` pointing to `127.0.0.1:{port}/sse` (SSE transport)
 - **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, conditional Docker builds
 - **Secret scanning:** `make secret-scan` runs gitleaks locally (native binary or Docker fallback). Config in `.gitleaks.toml` with allowlists for doc/test false positives

--- a/Makefile
+++ b/Makefile
@@ -54,25 +54,7 @@ docker-build:
 	docker compose $(DOCKER_PROFILES) build
 
 docker-check-env:
-	@if [ ! -f .env ]; then \
-		echo ""; \
-		echo "WARNING: .env file not found in $$(pwd)"; \
-		echo ""; \
-		echo "For local runs, the aws-secrets-agent sidecar expects AWS credentials in .env:"; \
-		echo "  AWS_ACCESS_KEY_ID=..."; \
-		echo "  AWS_SECRET_ACCESS_KEY=..."; \
-		echo "  AWS_TOKEN=<ssrf-protection-token>"; \
-		echo ""; \
-		echo "Without .env or equivalent environment variables, containers fall back to local env_file mode (no secrets fetched)."; \
-		echo "Run /cpp:init to configure interactively."; \
-		echo ""; \
-	elif ! grep -qE '^AWS_ACCESS_KEY_ID=.+' .env 2>/dev/null; then \
-		echo ""; \
-		echo "WARNING: .env exists but is missing AWS_ACCESS_KEY_ID."; \
-		echo "The aws-secrets-agent needs AWS credentials to fetch secrets."; \
-		echo "Containers will fall back to env_file variables if present."; \
-		echo ""; \
-	fi
+	@python3 scripts/check-docker-aws-env.py --profiles "$(PROFILE)"
 
 docker-secrets-check:
 	@echo "Checking AWS Secrets Manager connectivity..."

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ AWS_TOKEN=my-ssrf-token
 make docker-secrets-check
 ```
 
-If the sidecar is unreachable or `AWS_SECRET_NAME` is not set on a container, it falls back to `env_file` variables for local development. See `aws-secrets-agent/` and `docs/AWS_SECRETS_SIDECAR.md` for details.
+If the sidecar is unreachable or `AWS_SECRET_NAME` is not set on a container, it falls back to `env_file` variables for local development. `make docker-up` refuses to create the sidecar when required AWS credential variables resolve empty, because Docker Compose bakes env at container create time. See `aws-secrets-agent/` and `docs/AWS_SECRETS_SIDECAR.md` for details.
 
 ## CI/CD
 

--- a/aws-secrets-agent/Dockerfile
+++ b/aws-secrets-agent/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR /app
 
 COPY --from=builder /build/target/release/aws_secretsmanager_agent ./aws-secrets-agent
 COPY config.toml ./config.toml
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
 
 USER agent
 
@@ -32,4 +34,4 @@ EXPOSE 2773
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
     CMD curl -sf -H "X-Aws-Parameters-Secrets-Token: ${AWS_TOKEN}" http://localhost:2773/ping || exit 1
 
-ENTRYPOINT ["./aws-secrets-agent", "--config", "config.toml"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/aws-secrets-agent/entrypoint.sh
+++ b/aws-secrets-agent/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+missing=""
+for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+    eval "value=\${$name:-}"
+    if [ -z "$value" ]; then
+        if [ -n "$missing" ]; then
+            missing="$missing, $name"
+        else
+            missing="$name"
+        fi
+    fi
+done
+
+if [ -n "$missing" ]; then
+    echo "ERROR: aws-secrets-agent cannot start: AWS credentials empty/missing ($missing)." >&2
+    echo "ERROR: Docker Compose captures environment at container create time; restart will not reload fixed creds." >&2
+    echo "ERROR: Fix .env or shell env, then force-recreate the sidecar and dependent MCP containers:" >&2
+    echo "ERROR:   docker compose --profile core --profile cicd up -d --force-recreate aws-secrets-agent mcp-second-opinion mcp-woodpecker-ci" >&2
+    exit 78
+fi
+
+exec ./aws-secrets-agent --config config.toml

--- a/docs/AWS_SECRETS_SIDECAR.md
+++ b/docs/AWS_SECRETS_SIDECAR.md
@@ -147,6 +147,8 @@ The sidecar builds the [upstream AWS agent](https://github.com/aws/aws-secretsma
 |---------|-------|-----|
 | `no_api_keys` in health_check | Secrets not loaded | Check `docker logs aws-secrets-agent` for AWS auth errors |
 | `Failed to fetch secrets after 30 retries` | Agent not healthy | Run `make docker-secrets-check`, verify AWS creds |
+| `aws-secrets-agent cannot start: AWS credentials empty/missing` | Sidecar was created with empty `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` | Fix `.env` or shell AWS env, then run `docker compose --profile core --profile cicd up -d --force-recreate aws-secrets-agent mcp-second-opinion mcp-woodpecker-ci` |
+| Secret-dependent MCP containers stay `Created` with no logs | `aws-secrets-agent` is unhealthy before dependents can start | Run `make docker-health PROFILE="core cicd"` for the force-recreate remedy |
 | Container starts but keys are stale | Secret cache TTL | Wait 300s or restart `aws-secrets-agent` |
 | `FAIL: AWS credentials invalid` | Expired or wrong creds | Refresh `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in `.env` |
 | `WARNING: skipping invalid key` | Secret JSON key has invalid chars | Fix the key name in AWS Secrets Manager |

--- a/scripts/check-docker-aws-env.py
+++ b/scripts/check-docker-aws-env.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate Docker AWS credential inputs before creating aws-secrets-agent."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Mapping
+
+AWS_SIDECAR_PROFILES = {"core", "cicd"}
+REQUIRED_AWS_ENV = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def _profiles_need_aws(profiles: list[str]) -> bool:
+    return bool(AWS_SIDECAR_PROFILES.intersection(profiles))
+
+
+def _validate_credentials(
+    env_file_values: Mapping[str, str],
+    environ: Mapping[str, str],
+) -> list[str]:
+    errors: list[str] = []
+
+    for name in REQUIRED_AWS_ENV:
+        if name in environ:
+            if not environ[name].strip():
+                errors.append(
+                    f"{name} is set but empty in the shell environment. Docker Compose will bake "
+                    "that empty value into aws-secrets-agent and override .env."
+                )
+            continue
+
+        if name not in env_file_values:
+            errors.append(f"{name} is missing from both the shell environment and .env.")
+        elif not env_file_values[name].strip():
+            errors.append(f"{name} is present but empty in .env.")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--profiles",
+        default="core",
+        help="Space-separated Docker Compose profiles requested by make docker-up",
+    )
+    parser.add_argument(
+        "--env-file",
+        default=".env",
+        type=Path,
+        help="Path to the Docker env file",
+    )
+    args = parser.parse_args()
+
+    profiles = [profile for profile in args.profiles.split() if profile]
+    if not _profiles_need_aws(profiles):
+        print("OK: requested Docker profiles do not start aws-secrets-agent")
+        return 0
+
+    env_file_values = _parse_env_file(args.env_file)
+    errors = _validate_credentials(env_file_values, os.environ)
+
+    if errors:
+        print("ERROR: aws-secrets-agent requires non-empty AWS credentials before Docker Compose starts.")
+        for error in errors:
+            print(f"  - {error}")
+        print("")
+        print("Fix: set non-empty AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in .env or the shell.")
+        print("If a stale sidecar was already created with empty creds, force-recreate it after fixing env:")
+        print(
+            "  docker compose --profile core --profile cicd up -d --force-recreate "
+            "aws-secrets-agent mcp-second-opinion mcp-woodpecker-ci"
+        )
+        return 1
+
+    print("OK: AWS credentials available for aws-secrets-agent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docker-health-check.py
+++ b/scripts/docker-health-check.py
@@ -8,6 +8,11 @@ import subprocess
 import sys
 from typing import Any
 
+SECRET_DEPENDENTS_BY_PROFILE = {
+    "core": ["mcp-second-opinion"],
+    "cicd": ["mcp-woodpecker-ci"],
+}
+
 
 def _decode_compose_ps(raw: str) -> list[dict[str, Any]]:
     text = raw.strip()
@@ -68,6 +73,47 @@ def _is_healthy(row: dict[str, Any]) -> bool:
     return True
 
 
+def _secret_dependents_for_profiles(profiles: list[str]) -> list[str]:
+    dependents: list[str] = []
+    for profile in profiles:
+        for service in SECRET_DEPENDENTS_BY_PROFILE.get(profile, []):
+            if service not in dependents:
+                dependents.append(service)
+    return dependents
+
+
+def _is_created_or_waiting(row: dict[str, Any]) -> bool:
+    state = _state(row)
+    return "created" in state or "waiting" in state
+
+
+def _sidecar_dependency_warning(rows: list[dict[str, Any]], profiles: list[str]) -> str | None:
+    rows_by_service = {_service_name(row): row for row in rows}
+    agent = rows_by_service.get("aws-secrets-agent")
+    if agent is None or _is_healthy(agent):
+        return None
+
+    requested_dependents = _secret_dependents_for_profiles(profiles)
+    stranded = [
+        service
+        for service in requested_dependents
+        if service in rows_by_service and _is_created_or_waiting(rows_by_service[service])
+    ]
+    if not stranded:
+        return None
+
+    profile_flags = " ".join(f"--profile {profile}" for profile in profiles)
+    services = " ".join(["aws-secrets-agent", *stranded])
+    return (
+        "Detected aws-secrets-agent dependency strand: "
+        + ", ".join(stranded)
+        + " are waiting for a sidecar that is not healthy.\n"
+        + "Docker Compose captures environment at container create time; restart will not reload fixed creds.\n"
+        + "Fix .env or shell AWS credentials, then run:\n"
+        + f"  docker compose {profile_flags} up -d --force-recreate {services}"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -103,6 +149,10 @@ def main() -> int:
 
     if failed:
         print("")
+        warning = _sidecar_dependency_warning(rows, profiles)
+        if warning:
+            print(warning, file=sys.stderr)
+            print("", file=sys.stderr)
         print("ERROR: unhealthy Docker services: " + ", ".join(failed), file=sys.stderr)
         return 1
     return 0

--- a/tests/test_docker_aws_env_check.py
+++ b/tests/test_docker_aws_env_check.py
@@ -1,0 +1,87 @@
+"""Tests for Docker AWS credential preflight validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check-docker-aws-env.py"
+
+
+def _run_check(
+    tmp_path: Path,
+    *args: str,
+    env_updates: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        env.pop(name, None)
+    if env_updates:
+        env.update(env_updates)
+
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--env-file", str(tmp_path / ".env"), *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def test_browser_profile_does_not_require_aws_credentials(tmp_path: Path) -> None:
+    result = _run_check(tmp_path, "--profiles", "browser")
+
+    assert result.returncode == 0
+    assert "do not start aws-secrets-agent" in result.stdout
+
+
+def test_core_profile_requires_nonempty_aws_credentials(tmp_path: Path) -> None:
+    result = _run_check(tmp_path, "--profiles", "core")
+
+    assert result.returncode == 1
+    assert "AWS_ACCESS_KEY_ID is missing" in result.stdout
+    assert "AWS_SECRET_ACCESS_KEY is missing" in result.stdout
+    assert "--force-recreate aws-secrets-agent" in result.stdout
+
+
+def test_env_file_credentials_pass_without_printing_values(tmp_path: Path) -> None:
+    secret = "super-secret-value"
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+                f"AWS_SECRET_ACCESS_KEY={secret}",
+            ]
+        )
+    )
+
+    result = _run_check(tmp_path, "--profiles", "core cicd")
+
+    assert result.returncode == 0
+    assert "OK: AWS credentials available" in result.stdout
+    assert secret not in result.stdout
+
+
+def test_empty_shell_env_overrides_valid_env_file_and_fails(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+                "AWS_SECRET_ACCESS_KEY=valid-but-redacted",
+            ]
+        )
+    )
+
+    result = _run_check(
+        tmp_path,
+        "--profiles",
+        "core",
+        env_updates={"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": "from-shell"},
+    )
+
+    assert result.returncode == 1
+    assert "AWS_ACCESS_KEY_ID is set but empty in the shell environment" in result.stdout
+    assert "valid-but-redacted" not in result.stdout

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -84,6 +84,18 @@ def test_aws_secrets_agent_healthcheck_allows_loaded_starts() -> None:
     assert resources["reservations"] == {"cpus": "0.25", "memory": "64M"}
 
 
+def test_aws_secrets_agent_entrypoint_fails_loud_on_empty_credentials() -> None:
+    root = Path(__file__).resolve().parents[1]
+    dockerfile = (root / "aws-secrets-agent" / "Dockerfile").read_text()
+    entrypoint = (root / "aws-secrets-agent" / "entrypoint.sh").read_text()
+
+    assert "COPY entrypoint.sh ./entrypoint.sh" in dockerfile
+    assert 'ENTRYPOINT ["./entrypoint.sh"]' in dockerfile
+    assert "AWS_ACCESS_KEY_ID" in entrypoint
+    assert "AWS_SECRET_ACCESS_KEY" in entrypoint
+    assert "force-recreate aws-secrets-agent" in entrypoint
+
+
 def test_second_opinion_uses_secret_with_free_tier_provider_keys() -> None:
     services = _compose_services()
     env = _env_list_to_map(services["mcp-second-opinion"]["environment"])
@@ -137,6 +149,16 @@ def test_makefile_has_first_class_docker_refresh_target() -> None:
     assert 'DOCKER_UP_FLAGS="-d --build --wait"' in makefile
     assert "docker-health:" in makefile
     assert "scripts/docker-health-check.py" in makefile
+    assert "scripts/check-docker-aws-env.py" in makefile
+
+
+def test_cpp_status_surfaces_stale_sidecar_env_bake() -> None:
+    root = Path(__file__).resolve().parents[1]
+    command = (root / ".claude" / "commands" / "cpp" / "status.md").read_text()
+
+    assert "Detected sidecar dependency strand" in command
+    assert "Created with no logs" in command
+    assert "--force-recreate aws-secrets-agent" in command
 
 
 def test_cpp_update_refreshes_detected_docker_runtime() -> None:

--- a/tests/test_docker_health_check.py
+++ b/tests/test_docker_health_check.py
@@ -1,0 +1,44 @@
+"""Tests for Docker health summary diagnostics."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "docker-health-check.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("docker_health_check", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sidecar_dependency_warning_recommends_force_recreate() -> None:
+    module = _load_script()
+    rows = [
+        {"Service": "aws-secrets-agent", "State": "restarting", "Health": "unhealthy"},
+        {"Service": "mcp-second-opinion", "State": "created", "Health": ""},
+        {"Service": "mcp-nano-banana", "State": "running", "Health": "healthy"},
+    ]
+
+    warning = module._sidecar_dependency_warning(rows, ["core"])
+
+    assert warning is not None
+    assert "mcp-second-opinion" in warning
+    assert "Docker Compose captures environment at container create time" in warning
+    assert "docker compose --profile core up -d --force-recreate aws-secrets-agent mcp-second-opinion" in warning
+
+
+def test_sidecar_dependency_warning_skips_when_agent_is_healthy() -> None:
+    module = _load_script()
+    rows = [
+        {"Service": "aws-secrets-agent", "State": "running", "Health": "healthy"},
+        {"Service": "mcp-second-opinion", "State": "created", "Health": ""},
+    ]
+
+    assert module._sidecar_dependency_warning(rows, ["core"]) is None


### PR DESCRIPTION
## Summary
- add a Docker AWS credential preflight for `make docker-up` so `aws-secrets-agent` is not created with empty required creds
- wrap the sidecar entrypoint with a clear empty/missing credential error and force-recreate guidance
- extend Docker health/status diagnostics to detect Created secret-dependent containers stranded behind an unhealthy sidecar

## Tests
- `make verify`
- `sudo -n docker run --rm -v /home/cooneycw/Projects/claude-power-pack-issue-344:/repo zricethezav/gitleaks:latest detect --source /repo --config /repo/.gitleaks.toml --no-git --verbose`

Closes #344