### PR TITLE
fix(second-opinion): default OpenAI model to gpt-5.2 (Closes #358)

### DIFF
--- a/mcp-second-opinion/src/config.py
+++ b/mcp-second-opinion/src/config.py
@@ -483,7 +483,7 @@ class Config:
     # Top paid model per major provider + best free alternatives
     DEFAULT_MODELS: List[str] = [
         "gemini-3-pro",
-        "gpt-5.5-pro",
+        "gpt-5.2",
         "claude-opus",
         "devstral",
         "groq-gpt-oss-120b",


### PR DESCRIPTION
## Summary

Swaps the OpenAI representative in `DEFAULT_MODELS` (`mcp-second-opinion/src/config.py`) from `gpt-5.5-pro` to `gpt-5.2`. The default multi-model panel was using the priciest OpenAI option, which is overkill.

| Model | input /1M | output /1M |
|---|---:|---:|
| `gpt-5.5-pro` (old default) | \$5.00 | \$20.00 |
| `gpt-5.2` (new default) | \$1.75 | \$14.00 |

~2.9x cheaper input, ~1.4x cheaper output per default consultation, with `gpt-5.2` still a strong reasoning model. `gpt-5.5`/`gpt-5.5-pro` remain available for callers who explicitly request them.

## Test plan

- `make lint` - clean
- `make test` - 670 passed, 1 skipped (incl. `test_second_opinion_model_catalog`)
- `gpt-5.2` is a valid defined model key (`config.py:339`), so no-models-specified multi-model calls now resolve to it.

Closes #358