### PR TITLE
fix(second-opinion): stream Anthropic responses to avoid 10-min limit (Closes #355)

### DIFF
--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -476,7 +476,7 @@ async def get_anthropic_response(
     max_tokens: int = Config.MAX_TOKENS,
 ) -> tuple[str, str]:
     """
-    Get a response from the Anthropic Claude API.
+    Get a streaming response from the Anthropic Claude API.
 
     Args:
         prompt: The prompt to send
@@ -493,22 +493,48 @@ async def get_anthropic_response(
         raise ValueError("Anthropic API key not configured")
 
     try:
+        return await _try_anthropic_model(prompt, model_name, max_tokens=max_tokens)
+    except Exception as e:
+        logger.error(f"Anthropic model {model_name} failed: {e}")
+        raise
+
+
+@retry(
+    stop=stop_after_attempt(Config.MAX_RETRIES),
+    wait=wait_exponential(
+        min=Config.RETRY_MIN_WAIT,
+        max=Config.RETRY_MAX_WAIT,
+    ),
+    retry=retry_if_exception_type(Exception),
+    reraise=True,
+)
+async def _try_anthropic_model(
+    prompt: str,
+    model_name: str,
+    max_tokens: int = Config.MAX_TOKENS,
+) -> tuple[str, str]:
+    """
+    Attempt to get a streaming response from a specific Claude model.
+
+    Streaming is required: the Anthropic SDK refuses non-streaming requests
+    whose worst-case generation time (estimated from max_tokens) could exceed
+    10 minutes, which trips on every detailed/in_depth review.
+    """
+    try:
         logger.info(f"Sending request to Anthropic {model_name}")
 
-        message = await _anthropic_client.messages.create(
+        result = ""
+        async with _anthropic_client.messages.stream(
             model=model_name,
             max_tokens=max_tokens,
             messages=[{"role": "user", "content": prompt}],
             temperature=Config.TEMPERATURE,
-        )
+        ) as stream:
+            async for text in stream.text_stream:
+                result += text
+                logger.debug(f"Received chunk: {len(text)} chars")
 
-        # Extract text from response
-        result = ""
-        for block in message.content:
-            if hasattr(block, "text"):
-                result += block.text
-
-        logger.info(f"Completed response from {model_name}: {len(result)} chars")
+        logger.info(f"Completed streaming response from {model_name}: {len(result)} chars")
         return result, model_name
 
     except Exception as e:


### PR DESCRIPTION
## Summary

The Anthropic path in `mcp-second-opinion` called `messages.create()` **non-streaming**. The Anthropic SDK refuses non-streaming requests whose worst-case generation time (estimated from `max_tokens`) could exceed 10 minutes. With `VERBOSITY_MAX_TOKENS` at `detailed: 49152` / `in_depth: 65536`, this tripped on **every** detailed/in_depth Claude call, making all three Anthropic models (opus/sonnet/haiku) effectively unusable for real reviews.

## Changes

- Convert `get_anthropic_response` to streaming via `async with _anthropic_client.messages.stream(...) as stream: async for text in stream.text_stream`.
- Refactor into a `@retry(stop_after_attempt, wait_exponential)`-decorated `_try_anthropic_model` helper, mirroring the Gemini / OpenAI / OpenAI-compatible providers (Anthropic was previously the only provider with no retry decorator).
- No call-site changes: `get_anthropic_response(prompt, model_id, max_tokens=...)` signature is unchanged.

## Test plan

- `make lint` - passes (ruff)
- `make test` - 670 passed, 1 skipped
- Manual: `claude-opus` / `claude-sonnet` should now succeed at `detailed` and `in_depth` (no "Streaming is required" error path remains).

Closes #355