### PR TITLE
fix(second-opinion): default Opus to claude-opus-4-6 not 4-8 (Closes #359)

### DIFF
--- a/mcp-second-opinion/src/config.py
+++ b/mcp-second-opinion/src/config.py
@@ -168,14 +168,14 @@ class Config:
     # Anthropic Claude Models - Updated May 2026
     ANTHROPIC_MODEL_SONNET: str = "claude-sonnet-4-6"
     ANTHROPIC_MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
-    ANTHROPIC_MODEL_OPUS: str = "claude-opus-4-8"
+    ANTHROPIC_MODEL_OPUS: str = "claude-opus-4-6"
 
     # Fallback
     ANTHROPIC_MODEL_FALLBACK: str = "claude-haiku-4-5-20251001"
 
     # Anthropic API Pricing (per million tokens) - Updated 2026-05
     ANTHROPIC_PRICING: Dict[str, Dict[str, float]] = {
-        "claude-opus-4-8": {"input": 5.00, "output": 25.00},
+        "claude-opus-4-6": {"input": 5.00, "output": 25.00},
         "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
         "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
     }
@@ -270,8 +270,8 @@ class Config:
         },
         "claude-opus": {
             "provider": "anthropic",
-            "model_id": "claude-opus-4-8",
-            "display_name": "Claude Opus 4.8",
+            "model_id": "claude-opus-4-6",
+            "display_name": "Claude Opus 4.6",
             "description": "Most capable Claude, 1M context, improved agentic coding",
             "free": False,
         },


### PR DESCRIPTION
## Summary

`claude-opus` resolved to `claude-opus-4-8` (the most expensive Anthropic tier) and is in `DEFAULT_MODELS`, so it was the Anthropic model used in the default panel. This restores the cheaper `claude-opus-4-6` as the default.

Changes in `mcp-second-opinion/src/config.py`:
- `ANTHROPIC_MODEL_OPUS` -> `claude-opus-4-6`
- Pricing key -> `claude-opus-4-6` (`$5/$25`, matching the rate that existed before the 4-8 bump in #323, so cost reporting no longer falls back to defaults)
- `AVAILABLE_MODELS["claude-opus"]["model_id"]` -> `claude-opus-4-6`
- `display_name` -> "Claude Opus 4.6"

## Test plan
- `make lint` - passed
- `make test` - 670 passed, 1 skipped (incl. `test_second_opinion_model_catalog.py`)
- Verified no remaining `claude-opus-4-8` references in the repo

Companion to #358 (default model choices) and #355 (Opus streaming bug).

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)