### PR TITLE
fix(secrets): fail closed when a required secret fetch fails (Closes #347)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Core components and their locations:
 
 ## Docker Deployment
 
-MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar. Local development can store only AWS credentials in the root `.env` file (gitignored), while CI/deploy can inject the same variables through the job environment. No application secrets are stored on disk. If the sidecar is unreachable or `AWS_SECRET_NAME` is not set, containers fall back to `env_file` variables for local development.
+MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar. Local development can store only AWS credentials in the root `.env` file (gitignored), while CI/deploy can inject the same variables through the job environment. No application secrets are stored on disk. If `AWS_SECRET_NAME` is not set, containers use `env_file` variables (local dev mode). If `AWS_SECRET_NAME` is set but the fetch or parse fails, containers **fail closed** - they exit non-zero and never start keyless (issue #347). Set `ALLOW_ENV_FALLBACK=true` (e.g. via `docker-compose.dev.yml`) to opt into env-file fallback for local development.
 
 - **Secrets architecture:** `aws-secrets-agent` (Rust binary, port 2773) caches secrets in-memory (300s TTL) with SSRF token protection. MCP containers use `fetch-secrets.sh` entrypoint to resolve keys before starting.
 - **Required AWS credential variables:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_TOKEN` (SSRF token), supplied by local `.env` or CI/deploy environment

--- a/aws-secrets-agent/fetch-secrets.sh
+++ b/aws-secrets-agent/fetch-secrets.sh
@@ -1,21 +1,51 @@
 #!/bin/sh
 set -e
 
+# Resolve secrets from the aws-secrets-agent sidecar, then exec the server.
+#
+# Security posture: FAIL CLOSED. When a secret is required (AWS_SECRET_NAME is
+# set) and the fetch or parse fails, this script exits non-zero instead of
+# starting a keyless server. A keyless server still passes a liveness ("/")
+# healthcheck, which lets "docker compose up --wait" tear down the known-good
+# container and route to the broken one (issue #346 "killer chain").
+#
+# For local development ONLY, set ALLOW_ENV_FALLBACK=true to restore the old
+# behaviour of starting with whatever env_file variables happen to be present.
+#
+# Tunables (all optional):
+#   SECRETS_AGENT_URL            sidecar base URL (default http://aws-secrets-agent:2773)
+#   AWS_SECRET_NAME              secret to fetch; unset = local dev passthrough
+#   AWS_TOKEN                    SSRF protection token (default default-token)
+#   SECRETS_FETCH_MAX_RETRIES    fetch attempts before giving up (default 30)
+#   SECRETS_FETCH_RETRY_INTERVAL seconds between attempts (default 2)
+#   ALLOW_ENV_FALLBACK           true = start anyway on fetch/parse failure (dev only)
+#   REQUIRED_SECRET_KEYS         space-separated keys that must be present + non-empty
+
 AGENT_URL="${SECRETS_AGENT_URL:-http://aws-secrets-agent:2773}"
 SECRET_ID="${AWS_SECRET_NAME:-}"
 TOKEN="${AWS_TOKEN:-default-token}"
-MAX_RETRIES=30
-RETRY_INTERVAL=2
+MAX_RETRIES="${SECRETS_FETCH_MAX_RETRIES:-30}"
+RETRY_INTERVAL="${SECRETS_FETCH_RETRY_INTERVAL:-2}"
+ALLOW_ENV_FALLBACK="${ALLOW_ENV_FALLBACK:-false}"
+REQUIRED_SECRET_KEYS="${REQUIRED_SECRET_KEYS:-}"
+
+# Start with whatever env_file variables exist. Only reached on the local-dev
+# passthrough or the explicit ALLOW_ENV_FALLBACK opt-in.
+start_with_env_fallback() {
+    echo "WARNING: starting with env_file variables only - server may be keyless (LOCAL DEV)" >&2
+    exec "$@"
+}
 
 if [ -z "$SECRET_ID" ]; then
     echo "INFO: AWS_SECRET_NAME not set - using env_file variables (local dev mode)"
     exec "$@"
 fi
 
+ERR_FILE="${TMPDIR:-/tmp}/fetch-secrets-err.$$"
 i=0
 RESPONSE=""
 while [ "$i" -lt "$MAX_RETRIES" ]; do
-    RESPONSE=$(python3 -c "
+    if RESPONSE=$(python3 -c "
 import urllib.request, sys
 req = urllib.request.Request(
     '${AGENT_URL}/secretsmanager/get?secretId=${SECRET_ID}',
@@ -24,30 +54,70 @@ req = urllib.request.Request(
 try:
     resp = urllib.request.urlopen(req, timeout=5)
     sys.stdout.write(resp.read().decode())
-except Exception:
+except Exception as exc:
+    sys.stderr.write('%s: %s' % (type(exc).__name__, exc))
     sys.exit(1)
-" 2>/dev/null) && break
+" 2>"$ERR_FILE"); then
+        break
+    fi
+    RESPONSE=""
     i=$((i + 1))
     sleep "$RETRY_INTERVAL"
 done
 
 if [ -z "$RESPONSE" ]; then
-    echo "WARNING: Failed to fetch secrets from agent after ${MAX_RETRIES} retries" >&2
-    echo "WARNING: Falling back to env_file variables (if present)" >&2
-    exec "$@"
+    echo "ERROR: failed to fetch secret '${SECRET_ID}' from ${AGENT_URL} after ${MAX_RETRIES} attempts" >&2
+    if [ -s "$ERR_FILE" ]; then
+        echo "ERROR: last fetch error: $(cat "$ERR_FILE")" >&2
+    fi
+    rm -f "$ERR_FILE"
+    if [ "$ALLOW_ENV_FALLBACK" = "true" ]; then
+        echo "WARNING: ALLOW_ENV_FALLBACK=true - ignoring secret fetch failure" >&2
+        start_with_env_fallback "$@"
+    fi
+    echo "FATAL: refusing to start without required secret '${SECRET_ID}' (set ALLOW_ENV_FALLBACK=true to override for local dev)" >&2
+    exit 1
 fi
+rm -f "$ERR_FILE"
 
-eval "$(echo "$RESPONSE" | python3 -c "
+SECRET_EXPORTS=$(echo "$RESPONSE" | python3 -c "
 import sys, json, re
-data = json.load(sys.stdin)
-secrets = json.loads(data['SecretString'])
+try:
+    data = json.load(sys.stdin)
+    secrets = json.loads(data['SecretString'])
+except Exception as exc:
+    sys.stderr.write('parse error: %s: %s' % (type(exc).__name__, exc))
+    sys.exit(1)
 for k, v in secrets.items():
     if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', k):
         print(f'echo \"WARNING: skipping invalid key: {k}\" >&2', flush=True)
         continue
     safe_v = v.replace(\"'\", \"'\\\\''\" )
     print(f\"export {k}='{safe_v}'\")
-")"
+") || {
+    echo "FATAL: failed to parse secret payload for '${SECRET_ID}'" >&2
+    if [ "$ALLOW_ENV_FALLBACK" = "true" ]; then
+        echo "WARNING: ALLOW_ENV_FALLBACK=true - ignoring secret parse failure" >&2
+        start_with_env_fallback "$@"
+    fi
+    exit 1
+}
+eval "$SECRET_EXPORTS"
+
+# Fail closed if any explicitly-required key is missing or empty after load.
+if [ -n "$REQUIRED_SECRET_KEYS" ]; then
+    missing=""
+    for key in $REQUIRED_SECRET_KEYS; do
+        eval "value=\${$key:-}"
+        if [ -z "$value" ]; then
+            missing="$missing $key"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        echo "FATAL: required secret keys missing or empty after fetch:${missing}" >&2
+        exit 1
+    fi
+fi
 
 echo "INFO: Loaded secrets from AWS Secrets Manager (${SECRET_ID})"
 exec "$@"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,17 @@
+# Local development override (issue #347).
+#
+# Opts the secret-consuming MCP servers into env_file fallback so they still
+# start when the aws-secrets-agent is unreachable or AWS credentials are absent.
+# This re-enables the fail-open behaviour that the base config closes - NEVER use
+# it in CI or on a workstation deploy.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+services:
+  mcp-second-opinion:
+    environment:
+      - ALLOW_ENV_FALLBACK=true
+
+  mcp-woodpecker-ci:
+    environment:
+      - ALLOW_ENV_FALLBACK=true

--- a/docs/AWS_SECRETS_SIDECAR.md
+++ b/docs/AWS_SECRETS_SIDECAR.md
@@ -26,8 +26,31 @@ MCP server (python server.py)        <-- secrets exported as env vars
    - Checks if `AWS_SECRET_NAME` is set (skips fetch if not - local dev mode)
    - Queries the sidecar for the named secret
    - Parses the JSON secret value and exports each key-value pair as an environment variable
-   - Falls back to existing `env_file` variables if the agent is unreachable
+   - **Fails closed** if a required secret cannot be fetched or parsed: it exits non-zero instead of starting a keyless server (unless `ALLOW_ENV_FALLBACK=true`)
    - Execs the original command (e.g., `python server.py`)
+
+### Fail-closed behaviour (issue #347)
+
+When `AWS_SECRET_NAME` is set, a failed fetch or parse is treated as fatal: the
+entrypoint exits non-zero and the container never starts. This prevents the
+"killer chain" (#346) where a keyless server passes the liveness (`/`)
+healthcheck and `docker compose up --wait` tears down the known-good container.
+
+The entrypoint honours these optional tunables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ALLOW_ENV_FALLBACK` | `false` | `true` re-enables the old fail-open behaviour (start with `env_file` variables on fetch/parse failure). **Local dev only.** |
+| `REQUIRED_SECRET_KEYS` | _(empty)_ | Space-separated keys that must be present and non-empty after the fetch, or the entrypoint fails closed. |
+| `SECRETS_FETCH_MAX_RETRIES` | `30` | Fetch attempts before giving up. |
+| `SECRETS_FETCH_RETRY_INTERVAL` | `2` | Seconds between attempts. |
+
+For convenience, `docker-compose.dev.yml` sets `ALLOW_ENV_FALLBACK=true` for the
+secret-consuming services:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
 
 ## Required Credentials
 
@@ -111,7 +134,7 @@ If you don't have AWS credentials or prefer local development:
    ```
 3. The `fetch-secrets.sh` entrypoint will skip the fetch and pass through to the server
 
-Alternatively, if `AWS_SECRET_NAME` is set but the agent is unreachable, the entrypoint warns and falls back to `env_file` variables.
+Alternatively, if `AWS_SECRET_NAME` is set but the agent is unreachable, the entrypoint **fails closed** by default (exits non-zero, never starts keyless). For local development, set `ALLOW_ENV_FALLBACK=true` - either in your shell or via `docker-compose.dev.yml` - to start with `env_file` variables instead.
 
 ## Sidecar Configuration
 
@@ -147,6 +170,7 @@ The sidecar builds the [upstream AWS agent](https://github.com/aws/aws-secretsma
 |---------|-------|-----|
 | `no_api_keys` in health_check | Secrets not loaded | Check `docker logs aws-secrets-agent` for AWS auth errors |
 | `Failed to fetch secrets after 30 retries` | Agent not healthy | Run `make docker-secrets-check`, verify AWS creds |
+| `FATAL: refusing to start without required secret` | Required secret fetch/parse failed (fail-closed) | Fix the sidecar/AWS creds; for local dev set `ALLOW_ENV_FALLBACK=true` |
 | `aws-secrets-agent cannot start: AWS credentials empty/missing` | Sidecar was created with empty `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` | Fix `.env` or shell AWS env, then run `docker compose --profile core --profile cicd up -d --force-recreate aws-secrets-agent mcp-second-opinion mcp-woodpecker-ci` |
 | Secret-dependent MCP containers stay `Created` with no logs | `aws-secrets-agent` is unhealthy before dependents can start | Run `make docker-health PROFILE="core cicd"` for the force-recreate remedy |
 | Container starts but keys are stale | Secret cache TTL | Wait 300s or restart `aws-secrets-agent` |

--- a/mcp-second-opinion/deploy/fetch-secrets.sh
+++ b/mcp-second-opinion/deploy/fetch-secrets.sh
@@ -1,21 +1,51 @@
 #!/bin/sh
 set -e
 
+# Resolve secrets from the aws-secrets-agent sidecar, then exec the server.
+#
+# Security posture: FAIL CLOSED. When a secret is required (AWS_SECRET_NAME is
+# set) and the fetch or parse fails, this script exits non-zero instead of
+# starting a keyless server. A keyless server still passes a liveness ("/")
+# healthcheck, which lets "docker compose up --wait" tear down the known-good
+# container and route to the broken one (issue #346 "killer chain").
+#
+# For local development ONLY, set ALLOW_ENV_FALLBACK=true to restore the old
+# behaviour of starting with whatever env_file variables happen to be present.
+#
+# Tunables (all optional):
+#   SECRETS_AGENT_URL            sidecar base URL (default http://aws-secrets-agent:2773)
+#   AWS_SECRET_NAME              secret to fetch; unset = local dev passthrough
+#   AWS_TOKEN                    SSRF protection token (default default-token)
+#   SECRETS_FETCH_MAX_RETRIES    fetch attempts before giving up (default 30)
+#   SECRETS_FETCH_RETRY_INTERVAL seconds between attempts (default 2)
+#   ALLOW_ENV_FALLBACK           true = start anyway on fetch/parse failure (dev only)
+#   REQUIRED_SECRET_KEYS         space-separated keys that must be present + non-empty
+
 AGENT_URL="${SECRETS_AGENT_URL:-http://aws-secrets-agent:2773}"
 SECRET_ID="${AWS_SECRET_NAME:-}"
 TOKEN="${AWS_TOKEN:-default-token}"
-MAX_RETRIES=30
-RETRY_INTERVAL=2
+MAX_RETRIES="${SECRETS_FETCH_MAX_RETRIES:-30}"
+RETRY_INTERVAL="${SECRETS_FETCH_RETRY_INTERVAL:-2}"
+ALLOW_ENV_FALLBACK="${ALLOW_ENV_FALLBACK:-false}"
+REQUIRED_SECRET_KEYS="${REQUIRED_SECRET_KEYS:-}"
+
+# Start with whatever env_file variables exist. Only reached on the local-dev
+# passthrough or the explicit ALLOW_ENV_FALLBACK opt-in.
+start_with_env_fallback() {
+    echo "WARNING: starting with env_file variables only - server may be keyless (LOCAL DEV)" >&2
+    exec "$@"
+}
 
 if [ -z "$SECRET_ID" ]; then
     echo "INFO: AWS_SECRET_NAME not set - using env_file variables (local dev mode)"
     exec "$@"
 fi
 
+ERR_FILE="${TMPDIR:-/tmp}/fetch-secrets-err.$$"
 i=0
 RESPONSE=""
 while [ "$i" -lt "$MAX_RETRIES" ]; do
-    RESPONSE=$(python3 -c "
+    if RESPONSE=$(python3 -c "
 import urllib.request, sys
 req = urllib.request.Request(
     '${AGENT_URL}/secretsmanager/get?secretId=${SECRET_ID}',
@@ -24,30 +54,70 @@ req = urllib.request.Request(
 try:
     resp = urllib.request.urlopen(req, timeout=5)
     sys.stdout.write(resp.read().decode())
-except Exception:
+except Exception as exc:
+    sys.stderr.write('%s: %s' % (type(exc).__name__, exc))
     sys.exit(1)
-" 2>/dev/null) && break
+" 2>"$ERR_FILE"); then
+        break
+    fi
+    RESPONSE=""
     i=$((i + 1))
     sleep "$RETRY_INTERVAL"
 done
 
 if [ -z "$RESPONSE" ]; then
-    echo "WARNING: Failed to fetch secrets from agent after ${MAX_RETRIES} retries" >&2
-    echo "WARNING: Falling back to env_file variables (if present)" >&2
-    exec "$@"
+    echo "ERROR: failed to fetch secret '${SECRET_ID}' from ${AGENT_URL} after ${MAX_RETRIES} attempts" >&2
+    if [ -s "$ERR_FILE" ]; then
+        echo "ERROR: last fetch error: $(cat "$ERR_FILE")" >&2
+    fi
+    rm -f "$ERR_FILE"
+    if [ "$ALLOW_ENV_FALLBACK" = "true" ]; then
+        echo "WARNING: ALLOW_ENV_FALLBACK=true - ignoring secret fetch failure" >&2
+        start_with_env_fallback "$@"
+    fi
+    echo "FATAL: refusing to start without required secret '${SECRET_ID}' (set ALLOW_ENV_FALLBACK=true to override for local dev)" >&2
+    exit 1
 fi
+rm -f "$ERR_FILE"
 
-eval "$(echo "$RESPONSE" | python3 -c "
+SECRET_EXPORTS=$(echo "$RESPONSE" | python3 -c "
 import sys, json, re
-data = json.load(sys.stdin)
-secrets = json.loads(data['SecretString'])
+try:
+    data = json.load(sys.stdin)
+    secrets = json.loads(data['SecretString'])
+except Exception as exc:
+    sys.stderr.write('parse error: %s: %s' % (type(exc).__name__, exc))
+    sys.exit(1)
 for k, v in secrets.items():
     if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', k):
         print(f'echo \"WARNING: skipping invalid key: {k}\" >&2', flush=True)
         continue
     safe_v = v.replace(\"'\", \"'\\\\''\" )
     print(f\"export {k}='{safe_v}'\")
-")"
+") || {
+    echo "FATAL: failed to parse secret payload for '${SECRET_ID}'" >&2
+    if [ "$ALLOW_ENV_FALLBACK" = "true" ]; then
+        echo "WARNING: ALLOW_ENV_FALLBACK=true - ignoring secret parse failure" >&2
+        start_with_env_fallback "$@"
+    fi
+    exit 1
+}
+eval "$SECRET_EXPORTS"
+
+# Fail closed if any explicitly-required key is missing or empty after load.
+if [ -n "$REQUIRED_SECRET_KEYS" ]; then
+    missing=""
+    for key in $REQUIRED_SECRET_KEYS; do
+        eval "value=\${$key:-}"
+        if [ -z "$value" ]; then
+            missing="$missing $key"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        echo "FATAL: required secret keys missing or empty after fetch:${missing}" >&2
+        exit 1
+    fi
+fi
 
 echo "INFO: Loaded secrets from AWS Secrets Manager (${SECRET_ID})"
 exec "$@"

--- a/mcp-woodpecker-ci/deploy/fetch-secrets.sh
+++ b/mcp-woodpecker-ci/deploy/fetch-secrets.sh
@@ -1,21 +1,51 @@
 #!/bin/sh
 set -e
 
+# Resolve secrets from the aws-secrets-agent sidecar, then exec the server.
+#
+# Security posture: FAIL CLOSED. When a secret is required (AWS_SECRET_NAME is
+# set) and the fetch or parse fails, this script exits non-zero instead of
+# starting a keyless server. A keyless server still passes a liveness ("/")
+# healthcheck, which lets "docker compose up --wait" tear down the known-good
+# container and route to the broken one (issue #346 "killer chain").
+#
+# For local development ONLY, set ALLOW_ENV_FALLBACK=true to restore the old
+# behaviour of starting with whatever env_file variables happen to be present.
+#
+# Tunables (all optional):
+#   SECRETS_AGENT_URL            sidecar base URL (default http://aws-secrets-agent:2773)
+#   AWS_SECRET_NAME              secret to fetch; unset = local dev passthrough
+#   AWS_TOKEN                    SSRF protection token (default default-token)
+#   SECRETS_FETCH_MAX_RETRIES    fetch attempts before giving up (default 30)
+#   SECRETS_FETCH_RETRY_INTERVAL seconds between attempts (default 2)
+#   ALLOW_ENV_FALLBACK           true = start anyway on fetch/parse failure (dev only)
+#   REQUIRED_SECRET_KEYS         space-separated keys that must be present + non-empty
+
 AGENT_URL="${SECRETS_AGENT_URL:-http://aws-secrets-agent:2773}"
 SECRET_ID="${AWS_SECRET_NAME:-}"
 TOKEN="${AWS_TOKEN:-default-token}"
-MAX_RETRIES=30
-RETRY_INTERVAL=2
+MAX_RETRIES="${SECRETS_FETCH_MAX_RETRIES:-30}"
+RETRY_INTERVAL="${SECRETS_FETCH_RETRY_INTERVAL:-2}"
+ALLOW_ENV_FALLBACK="${ALLOW_ENV_FALLBACK:-false}"
+REQUIRED_SECRET_KEYS="${REQUIRED_SECRET_KEYS:-}"
+
+# Start with whatever env_file variables exist. Only reached on the local-dev
+# passthrough or the explicit ALLOW_ENV_FALLBACK opt-in.
+start_with_env_fallback() {
+    echo "WARNING: starting with env_file variables only - server may be keyless (LOCAL DEV)" >&2
+    exec "$@"
+}
 
 if [ -z "$SECRET_ID" ]; then
     echo "INFO: AWS_SECRET_NAME not set - using env_file variables (local dev mode)"
     exec "$@"
 fi
 
+ERR_FILE="${TMPDIR:-/tmp}/fetch-secrets-err.$$"
 i=0
 RESPONSE=""
 while [ "$i" -lt "$MAX_RETRIES" ]; do
-    RESPONSE=$(python3 -c "
+    if RESPONSE=$(python3 -c "
 import urllib.request, sys
 req = urllib.request.Request(
     '${AGENT_URL}/secretsmanager/get?secretId=${SECRET_ID}',
@@ -24,30 +54,70 @@ req = urllib.request.Request(
 try:
     resp = urllib.request.urlopen(req, timeout=5)
     sys.stdout.write(resp.read().decode())
-except Exception:
+except Exception as exc:
+    sys.stderr.write('%s: %s' % (type(exc).__name__, exc))
     sys.exit(1)
-" 2>/dev/null) && break
+" 2>"$ERR_FILE"); then
+        break
+    fi
+    RESPONSE=""
     i=$((i + 1))
     sleep "$RETRY_INTERVAL"
 done
 
 if [ -z "$RESPONSE" ]; then
-    echo "WARNING: Failed to fetch secrets from agent after ${MAX_RETRIES} retries" >&2
-    echo "WARNING: Falling back to env_file variables (if present)" >&2
-    exec "$@"
+    echo "ERROR: failed to fetch secret '${SECRET_ID}' from ${AGENT_URL} after ${MAX_RETRIES} attempts" >&2
+    if [ -s "$ERR_FILE" ]; then
+        echo "ERROR: last fetch error: $(cat "$ERR_FILE")" >&2
+    fi
+    rm -f "$ERR_FILE"
+    if [ "$ALLOW_ENV_FALLBACK" = "true" ]; then
+        echo "WARNING: ALLOW_ENV_FALLBACK=true - ignoring secret fetch failure" >&2
+        start_with_env_fallback "$@"
+    fi
+    echo "FATAL: refusing to start without required secret '${SECRET_ID}' (set ALLOW_ENV_FALLBACK=true to override for local dev)" >&2
+    exit 1
 fi
+rm -f "$ERR_FILE"
 
-eval "$(echo "$RESPONSE" | python3 -c "
+SECRET_EXPORTS=$(echo "$RESPONSE" | python3 -c "
 import sys, json, re
-data = json.load(sys.stdin)
-secrets = json.loads(data['SecretString'])
+try:
+    data = json.load(sys.stdin)
+    secrets = json.loads(data['SecretString'])
+except Exception as exc:
+    sys.stderr.write('parse error: %s: %s' % (type(exc).__name__, exc))
+    sys.exit(1)
 for k, v in secrets.items():
     if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', k):
         print(f'echo \"WARNING: skipping invalid key: {k}\" >&2', flush=True)
         continue
     safe_v = v.replace(\"'\", \"'\\\\''\" )
     print(f\"export {k}='{safe_v}'\")
-")"
+") || {
+    echo "FATAL: failed to parse secret payload for '${SECRET_ID}'" >&2
+    if [ "$ALLOW_ENV_FALLBACK" = "true" ]; then
+        echo "WARNING: ALLOW_ENV_FALLBACK=true - ignoring secret parse failure" >&2
+        start_with_env_fallback "$@"
+    fi
+    exit 1
+}
+eval "$SECRET_EXPORTS"
+
+# Fail closed if any explicitly-required key is missing or empty after load.
+if [ -n "$REQUIRED_SECRET_KEYS" ]; then
+    missing=""
+    for key in $REQUIRED_SECRET_KEYS; do
+        eval "value=\${$key:-}"
+        if [ -z "$value" ]; then
+            missing="$missing $key"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        echo "FATAL: required secret keys missing or empty after fetch:${missing}" >&2
+        exit 1
+    fi
+fi
 
 echo "INFO: Loaded secrets from AWS Secrets Manager (${SECRET_ID})"
 exec "$@"

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -159,6 +159,13 @@ def test_secret_bootstrap_script_is_baked_into_secret_consuming_images() -> None
     root = Path(__file__).resolve().parents[1]
     canonical = (root / "aws-secrets-agent" / "fetch-secrets.sh").read_text()
 
+    # Fail-closed posture (issue #347): a required-secret fetch failure must
+    # exit non-zero rather than exec a keyless server, and the env_file fallback
+    # must be gated behind an explicit opt-in.
+    assert "ALLOW_ENV_FALLBACK" in canonical
+    assert "refusing to start without required secret" in canonical
+    assert "exit 1" in canonical
+
     for service in ("mcp-second-opinion", "mcp-woodpecker-ci"):
         dockerfile = (root / service / "deploy" / "Dockerfile").read_text()
         fetch_script = (root / service / "deploy" / "fetch-secrets.sh").read_text()

--- a/tests/test_fetch_secrets.py
+++ b/tests/test_fetch_secrets.py
@@ -1,0 +1,166 @@
+"""Tests for the fail-closed fetch-secrets.sh entrypoint (issue #347).
+
+These run the real shell script as a subprocess against a mock secrets agent so
+the security-critical control flow (fail closed vs. opt-in fallback) is exercised
+end to end, not just asserted on file contents. Failure modes are driven through
+the mock (HTTP error / unreachable) rather than a dead TCP port so the retry loop
+never blocks the test on connect timeouts.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import socket
+import subprocess
+import threading
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "aws-secrets-agent" / "fetch-secrets.sh"
+
+# Variables the entrypoint reads - scrubbed from the inherited environment so an
+# ambient value cannot mask a failure, and forced to fast values for retries.
+_CONTROL_VARS = {
+    "AWS_SECRET_NAME",
+    "SECRETS_AGENT_URL",
+    "AWS_TOKEN",
+    "ALLOW_ENV_FALLBACK",
+    "REQUIRED_SECRET_KEYS",
+    "SECRETS_FETCH_MAX_RETRIES",
+    "SECRETS_FETCH_RETRY_INTERVAL",
+}
+
+
+def _run(env_extra: dict[str, str], args: list[str], timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in os.environ.items() if k not in _CONTROL_VARS}
+    env["SECRETS_FETCH_MAX_RETRIES"] = "2"
+    env["SECRETS_FETCH_RETRY_INTERVAL"] = "0"
+    env.update(env_extra)
+    return subprocess.run(
+        ["sh", str(SCRIPT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+class _BaseHandler(http.server.BaseHTTPRequestHandler):
+    secret_payload: dict[str, str] | None = None
+    status_code: int = 200
+
+    def do_GET(self) -> None:  # noqa: N802 (http.server API)
+        cls = type(self)
+        if cls.status_code != 200:
+            self.send_response(cls.status_code)
+            self.end_headers()
+            return
+        body = json.dumps({"SecretString": json.dumps(cls.secret_payload or {})}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: object) -> None:  # silence test noise
+        pass
+
+
+def _serve(
+    payload: dict[str, str] | None = None, status_code: int = 200
+) -> tuple[http.server.HTTPServer, str]:
+    handler = type(
+        "_Handler",
+        (_BaseHandler,),
+        {"secret_payload": payload, "status_code": status_code},
+    )
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    return server, url
+
+
+def _free_port_url() -> str:
+    """A loopback URL whose port has no listener (connection refused, fast)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return f"http://127.0.0.1:{port}"
+
+
+def test_local_dev_mode_without_secret_name_execs() -> None:
+    result = _run({"AWS_SECRET_NAME": ""}, ["echo", "STARTED"])
+    assert result.returncode == 0
+    assert "STARTED" in result.stdout
+
+
+def test_fails_closed_when_required_secret_unreachable() -> None:
+    result = _run(
+        {"AWS_SECRET_NAME": "demo_secret", "SECRETS_AGENT_URL": _free_port_url()},
+        ["echo", "SHOULD_NOT_START"],
+    )
+    assert result.returncode != 0
+    assert "SHOULD_NOT_START" not in result.stdout
+    assert "FATAL" in result.stderr
+
+
+def test_dev_fallback_opt_in_starts_anyway() -> None:
+    result = _run(
+        {
+            "AWS_SECRET_NAME": "demo_secret",
+            "SECRETS_AGENT_URL": _free_port_url(),
+            "ALLOW_ENV_FALLBACK": "true",
+        },
+        ["echo", "STARTED_ANYWAY"],
+    )
+    assert result.returncode == 0
+    assert "STARTED_ANYWAY" in result.stdout
+
+
+def test_http_error_fails_fast() -> None:
+    server, url = _serve(status_code=404)
+    try:
+        result = _run(
+            {"AWS_SECRET_NAME": "demo_secret", "SECRETS_AGENT_URL": url},
+            ["echo", "SHOULD_NOT_START"],
+        )
+    finally:
+        server.shutdown()
+    assert result.returncode != 0
+    assert "SHOULD_NOT_START" not in result.stdout
+    assert "FATAL" in result.stderr
+
+
+def test_success_exports_secret_values() -> None:
+    server, url = _serve(payload={"DEMO_TOKEN_VALUE": "abc123"})
+    try:
+        result = _run(
+            {"AWS_SECRET_NAME": "demo_secret", "SECRETS_AGENT_URL": url},
+            ["sh", "-c", "echo VALUE=$DEMO_TOKEN_VALUE"],
+        )
+    finally:
+        server.shutdown()
+    assert result.returncode == 0
+    assert "VALUE=abc123" in result.stdout
+    assert "Loaded secrets from AWS Secrets Manager" in result.stdout
+
+
+def test_required_keys_enforced_when_missing() -> None:
+    server, url = _serve(payload={"DEMO_TOKEN_VALUE": "abc123"})
+    try:
+        result = _run(
+            {
+                "AWS_SECRET_NAME": "demo_secret",
+                "SECRETS_AGENT_URL": url,
+                "REQUIRED_SECRET_KEYS": "DEMO_TOKEN_VALUE ABSENT_VALUE",
+            },
+            ["echo", "SHOULD_NOT_START"],
+        )
+    finally:
+        server.shutdown()
+    assert result.returncode != 0
+    assert "SHOULD_NOT_START" not in result.stdout
+    assert "ABSENT_VALUE" in result.stderr


### PR DESCRIPTION
## Summary

Closes #347 (P0/CRITICAL, first child of epic #346).

`fetch-secrets.sh` previously exec'd the MCP server even when the secret fetch
failed, starting a **keyless** container that still passed the liveness (`/`)
healthcheck - the root of the #346 "killer chain" where `docker compose up
--wait` tears down the known-good container and routes to the broken one.

This makes the entrypoint **fail closed**: when `AWS_SECRET_NAME` is set and the
fetch or parse fails, it exits non-zero and never starts keyless.

## Changes

- **fetch-secrets.sh** (all 3 byte-identical copies - canonical + 2 deploy):
  - Fail closed on fetch/parse failure (`exit 1`) instead of exec'ing keyless
  - `ALLOW_ENV_FALLBACK=true` opt-in to restore env-file fallback (local dev)
  - Optional `REQUIRED_SECRET_KEYS` post-fetch presence/non-empty check
  - Surface (no longer swallow with `2>/dev/null`) the last fetch error
  - New tunables `SECRETS_FETCH_MAX_RETRIES` / `SECRETS_FETCH_RETRY_INTERVAL`
- **tests/test_fetch_secrets.py** (new): end-to-end coverage via a mock agent
- **tests/test_docker_compose_config.py**: assert canonical keeps fail-closed posture
- **docker-compose.dev.yml** (new): `ALLOW_ENV_FALLBACK=true` for local dev
- **docs/AWS_SECRETS_SIDECAR.md** + **CLAUDE.md**: document the new behaviour

## Why CI is unaffected

The runtime-smoke job runs with `SECOND_OPINION_AWS_SECRET_NAME=` /
`WOODPECKER_CI_AWS_SECRET_NAME=` (empty), so `AWS_SECRET_NAME` resolves empty and
the script takes the local-dev passthrough - no fetch, no fail-closed.

## Test plan

- `ruff check .` - pass
- `pytest` - 678 passed, 1 skipped (6 new fail-closed tests)
- `mypy .` - pass (109 files)
- `gitleaks` - no leaks
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` - `ALLOW_ENV_FALLBACK` applied to both services
- All 3 `fetch-secrets.sh` copies byte-identical (drift-check clean)

## Acceptance criteria

- [x] Required-secret fetch failure exits non-zero; container never reports healthy
- [x] Local dev fallback works only via explicit `ALLOW_ENV_FALLBACK=true` opt-in
- [x] Tests cover: required+unreachable fails, 404 fails fast, success execs with env populated, required-keys missing fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
