### PR TITLE
build(docker): pin base images + uv by digest, drop :latest for deployables (Closes #348)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ desktop.ini
 !package.json
 !tsconfig.json
 !.claude/hooks.json
+!renovate.json
 node_modules/
 .claude/settings*.json
 .claude/plans/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -10,12 +10,12 @@ when:
 
 steps:
   secret-scan:
-    image: zricethezav/gitleaks:latest
+    image: zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
     commands:
       - gitleaks detect --source . --config .gitleaks.toml --verbose
 
   validate:
-    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim@sha256:4f5d923c9dcea037f57bda425dd209f3ec643da2f0b74227f68d09dab0b3bb36
     depends_on: [secret-scan]
     commands:
       - uv sync --extra dev --frozen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Runtime smoke:** CI uses a `cpp-smoke-$CI_PIPELINE_NUMBER` compose project with random host ports, validates service health, and runs `docker compose down -v` before exiting. CI must not deploy persistent containers or prune host images.
 - **Bootstrap checks:** `make bootstrap-check` verifies admin-only prerequisites (IAM roles, secrets provisioning) before deploy. Configure in `.claude/bootstrap.yaml`. Runs as the first step in the deploy pipeline - blocks with remediation if unsatisfied.
 - **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries, shared scripts) against repo templates. Run it manually when reconciling workstation-managed artifacts. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
+- **Reproducible builds:** Every base image and build tool (python, rust, debian, `uv`, gitleaks, woodpecker server/agent) is pinned by version tag plus `@sha256:` digest in the Dockerfiles, `.woodpecker.yml`, and infra compose files - never `:latest`. Deployable images are tagged with `CPP_IMAGE_TAG` (the short git SHA, set by the Makefile) instead of `:latest`, so each image traces to a commit and rollbacks have provenance. `renovate.json` rotates the pinned digests on a weekly schedule so pinning never freezes security updates.
 
 ## Commands Reference
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ PROFILE ?= core
 DOCKER_UP_FLAGS ?= -d
 DOCKER_PROFILES = $(foreach p,$(PROFILE),--profile $(p))
 
+# Immutable, traceable tag for deployable images (consumed by docker-compose.yml
+# as ${CPP_IMAGE_TAG}). Defaults to the short git SHA so every built image maps
+# to a commit; falls back to "dev" outside a git checkout. Override with
+# `make docker-refresh CPP_IMAGE_TAG=<tag>`.
+CPP_IMAGE_TAG ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo dev)
+export CPP_IMAGE_TAG
+
 docker-build:
 	docker compose $(DOCKER_PROFILES) build
 

--- a/aws-secrets-agent/Dockerfile
+++ b/aws-secrets-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim AS builder
+FROM rust:1.96.0-slim@sha256:26abcef3d79b8d890c4ceb17093154573e1f6479cf6dd7c1450043b8458350f6 AS builder
 
 RUN apt-get update && apt-get install -y git pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
@@ -15,9 +15,9 @@ RUN sed -i 's/\[127, 0, 0, 1\]/[0, 0, 0, 0]/' aws_secretsmanager_agent/src/main.
 # Patch: remove TTL=1 restriction that blocks cross-container traffic
 RUN sed -i '/set_ttl/d' aws_secretsmanager_agent/src/server.rs
 
-RUN cargo build --release
+RUN cargo build --release --locked
 
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
 
 RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,17 @@
 #
 # The aws-secrets-agent sidecar fetches LLM keys and other secrets
 # from AWS Secrets Manager at runtime. No application secrets on disk.
+#
+# Image tags: deployable images are tagged with CPP_IMAGE_TAG (set by the
+# Makefile to the short git SHA) so every build is traceable to a commit and
+# rollbacks have provenance. Never use :latest here. It defaults to "dev" for
+# ad-hoc local/CI builds where no commit tag is exported.
 
 services:
   aws-secrets-agent:
     build:
       context: ./aws-secrets-agent
-    image: aws-secrets-agent:latest
+    image: aws-secrets-agent:${CPP_IMAGE_TAG:-dev}
     # Stable name by default (workstation deploys + cpp:update model detection);
     # CI smoke sets CPP_CONTAINER_PREFIX to keep parallel projects isolated.
     container_name: ${CPP_CONTAINER_PREFIX:-}aws-secrets-agent
@@ -63,7 +68,7 @@ services:
     build:
       context: ./mcp-second-opinion
       dockerfile: deploy/Dockerfile
-    image: mcp-second-opinion:latest
+    image: mcp-second-opinion:${CPP_IMAGE_TAG:-dev}
     container_name: ${CPP_CONTAINER_PREFIX:-}mcp-second-opinion
     ports:
       - "${MCP_SECOND_OPINION_PORT_MAPPING:-8080:8080}"
@@ -101,7 +106,7 @@ services:
     build:
       context: ./mcp-nano-banana
       dockerfile: deploy/Dockerfile
-    image: mcp-nano-banana:latest
+    image: mcp-nano-banana:${CPP_IMAGE_TAG:-dev}
     container_name: ${CPP_CONTAINER_PREFIX:-}mcp-nano-banana
     ports:
       - "${MCP_NANO_BANANA_PORT_MAPPING:-8084:8084}"
@@ -130,7 +135,7 @@ services:
   #   build:
   #     context: ./mcp-evaluate
   #     dockerfile: deploy/Dockerfile
-  #   image: mcp-evaluate:latest
+  #   image: mcp-evaluate:${CPP_IMAGE_TAG:-dev}
   #   ports:
   #     - "8083:8083"
   #   env_file:
@@ -156,7 +161,7 @@ services:
     build:
       context: ./mcp-woodpecker-ci
       dockerfile: deploy/Dockerfile
-    image: mcp-woodpecker-ci:latest
+    image: mcp-woodpecker-ci:${CPP_IMAGE_TAG:-dev}
     container_name: ${CPP_CONTAINER_PREFIX:-}mcp-woodpecker-ci
     ports:
       - "${MCP_WOODPECKER_CI_PORT_MAPPING:-8085:8085}"
@@ -194,7 +199,7 @@ services:
     build:
       context: ./mcp-playwright-persistent
       dockerfile: deploy/Dockerfile
-    image: mcp-playwright-persistent:latest
+    image: mcp-playwright-persistent:${CPP_IMAGE_TAG:-dev}
     container_name: ${CPP_CONTAINER_PREFIX:-}mcp-playwright-persistent
     ports:
       - "${MCP_PLAYWRIGHT_PORT_MAPPING:-8081:8081}"

--- a/mcp-evaluate/deploy/Dockerfile
+++ b/mcp-evaluate/deploy/Dockerfile
@@ -1,10 +1,10 @@
 # Evaluate MCP Server - Dockerfile
 # Multi-stage build using uv for dependency management
 
-FROM python:3.11-slim AS builder
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17@sha256:03bdc89bb9798628846e60c3a9ad19006c8c3c724ccd2985a33145c039a0577b /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
 # Final stage
-FROM python:3.11-slim
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/mcp-nano-banana/deploy/Dockerfile
+++ b/mcp-nano-banana/deploy/Dockerfile
@@ -1,10 +1,10 @@
 # Nano-Banana MCP Server - Dockerfile
 # Multi-stage build using uv for dependency management
 
-FROM python:3.11-slim AS builder
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17@sha256:03bdc89bb9798628846e60c3a9ad19006c8c3c724ccd2985a33145c039a0577b /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
 # Final stage
-FROM python:3.11-slim
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/mcp-playwright-persistent/deploy/Dockerfile
+++ b/mcp-playwright-persistent/deploy/Dockerfile
@@ -1,10 +1,10 @@
 # Playwright Persistent MCP Server - Dockerfile
 # Multi-stage build using uv for dependency management
 
-FROM python:3.11-slim AS builder
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17@sha256:03bdc89bb9798628846e60c3a9ad19006c8c3c724ccd2985a33145c039a0577b /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
 # Final stage
-FROM python:3.11-slim
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/mcp-second-opinion/deploy/Dockerfile
+++ b/mcp-second-opinion/deploy/Dockerfile
@@ -1,10 +1,10 @@
 # Second Opinion MCP Server - Dockerfile
 # Multi-stage build using uv for dependency management
 
-FROM python:3.11-slim AS builder
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17@sha256:03bdc89bb9798628846e60c3a9ad19006c8c3c724ccd2985a33145c039a0577b /uv /usr/local/bin/uv
 
 # Set working directory
 WORKDIR /app
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
 # Final stage
-FROM python:3.11-slim
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/mcp-second-opinion/deploy/docker-compose.yml
+++ b/mcp-second-opinion/deploy/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: second-opinion-mcp:latest
+    image: second-opinion-mcp:${CPP_IMAGE_TAG:-dev}
     container_name: second-opinion-mcp
     environment:
       # Pass GEMINI_API_KEY from host environment or .env file

--- a/mcp-woodpecker-ci/deploy/Dockerfile
+++ b/mcp-woodpecker-ci/deploy/Dockerfile
@@ -1,10 +1,10 @@
 # Woodpecker CI MCP Server - Dockerfile
 # Multi-stage build using uv for dependency management
 
-FROM python:3.11-slim AS builder
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17@sha256:03bdc89bb9798628846e60c3a9ad19006c8c3c724ccd2985a33145c039a0577b /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
 # Final stage
-FROM python:3.11-slim
+FROM python:3.11.15-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests"
+  ],
+  "timezone": "America/Toronto",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "dockerfile": {
+    "enabled": true
+  },
+  "docker-compose": {
+    "enabled": true
+  },
+  "woodpecker": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Rotate all pinned base-image and tool digests together so reproducible pins stay current without freezing security updates.",
+      "matchManagers": ["dockerfile", "docker-compose", "woodpecker"],
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"],
+      "groupName": "container image digests"
+    },
+    {
+      "description": "Locally-built deployable images are tagged from the git SHA (CPP_IMAGE_TAG), not pulled from a registry. Renovate cannot and must not try to update them.",
+      "matchManagers": ["docker-compose"],
+      "matchPackageNames": [
+        "aws-secrets-agent",
+        "mcp-second-opinion",
+        "mcp-nano-banana",
+        "mcp-woodpecker-ci",
+        "mcp-playwright-persistent",
+        "second-opinion-mcp"
+      ],
+      "enabled": false
+    }
+  ]
+}

--- a/woodpecker/docker-compose.agent.yml
+++ b/woodpecker/docker-compose.agent.yml
@@ -4,7 +4,7 @@
 
 services:
   woodpecker-agent:
-    image: woodpeckerci/woodpecker-agent:v3.13.0
+    image: woodpeckerci/woodpecker-agent:v3.13.0@sha256:a983b1016217ad94cdab48d732ec97b5b1f72718725d651183d7ec885f7caf35
     container_name: woodpecker-agent
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/woodpecker/docker-compose.yml
+++ b/woodpecker/docker-compose.yml
@@ -4,7 +4,7 @@
 
 services:
   woodpecker-server:
-    image: woodpeckerci/woodpecker-server:v3.13.0
+    image: woodpeckerci/woodpecker-server:v3.13.0@sha256:428eb0965754e25e67b8b086648438858b4fa64487b1cd3cc8e4101b396e459a
     container_name: woodpecker-server
     ports:
       - "9000:8000"


### PR DESCRIPTION
## Summary

Makes Docker builds reproducible and gives deployable images provenance, per #348 (part of #346).

Every base image and build tool is now pinned by **version tag + `@sha256:` digest**, and deployable images no longer use `:latest`.

### Pinned by digest (registry-verified at time of PR)
| Image | Was | Now |
|---|---|---|
| python (5 Dockerfiles) | `python:3.11-slim` | `python:3.11.15-slim@sha256:a3ab0b96…` |
| uv (5 `COPY --from`) | `ghcr.io/astral-sh/uv:latest` | `…uv:0.11.17@sha256:03bdc89b…` |
| rust (agent builder) | `rust:slim` | `rust:1.96.0-slim@sha256:26abcef3…` |
| debian (agent runtime) | `debian:trixie-slim` | `…@sha256:b6e2a152…` |
| uv CI helper | `…uv:python3.11-bookworm-slim` | `…@sha256:4f5d923c…` |
| gitleaks (CI) | `zricethezav/gitleaks:latest` | `…:v8.30.1@sha256:c00b6bd0…` (same digest `latest` pointed to) |
| woodpecker server/agent | `:v3.13.0` | `:v3.13.0@sha256:…` |

### Deployables off `:latest`
- `docker-compose.yml` + `mcp-second-opinion/deploy/docker-compose.yml` now tag locally-built images `${CPP_IMAGE_TAG:-dev}`.
- `Makefile` derives `CPP_IMAGE_TAG` from `git rev-parse --short HEAD` and exports it, so each built image traces to a commit and rollbacks have provenance.

### Other
- `cargo build --release --locked` in `aws-secrets-agent` for a reproducible Rust dependency graph.
- **`renovate.json`** rotates the pinned digests on a weekly schedule (`dockerfile` / `docker-compose` / `woodpecker` managers) so pinning never freezes security updates. Locally-built deployable image names are excluded from registry lookups. On first run Renovate will also propose digest pins for the remaining floating CI tool tags (`woodpeckerci/plugin-docker-buildx`, `docker:cli`).
- `.gitignore` exception so `renovate.json` is tracked (was caught by `*.json`).
- `CLAUDE.md`: documents the reproducible-build / image-pinning policy.

## Acceptance
- [x] No `:latest` in any Dockerfile `FROM`/`COPY --from` or compose `image:` for deployables (verified: repo-wide `:latest` scan returns none).
- [x] Rebuilding the same commit yields the same base layers (all inputs digest-pinned).

## Test plan
- `make lint` — clean
- `make test` — 670 passed, 1 skipped (incl. `test_docker_compose_config`)
- `make typecheck` — no issues
- YAML/JSON validated for all touched compose, `.woodpecker.yml`, and `renovate.json`
- All digests resolved + verified against the live Docker/ghcr registry APIs (python index digest cross-checked against the authoritative registry manifest).

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)