### PR TITLE
ci: authenticate Docker Hub pulls to fix 429 rate-limit failures (Closes #370)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,6 +32,11 @@ steps:
       context: aws-secrets-agent
       tags: latest
       dry_run: true
+      # Authenticate base-image pulls to avoid Docker Hub anonymous 429s (#370).
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_token
     when:
       - event: [push, pull_request]
         path:
@@ -48,6 +53,11 @@ steps:
       context: mcp-second-opinion
       tags: latest
       dry_run: true
+      # Authenticate base-image pulls to avoid Docker Hub anonymous 429s (#370).
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_token
     when:
       - event: [push, pull_request]
         path:
@@ -66,6 +76,11 @@ steps:
       context: mcp-playwright-persistent
       tags: latest
       dry_run: true
+      # Authenticate base-image pulls to avoid Docker Hub anonymous 429s (#370).
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_token
     when:
       - event: [push, pull_request]
         path:
@@ -83,6 +98,11 @@ steps:
       context: mcp-nano-banana
       tags: latest
       dry_run: true
+      # Authenticate base-image pulls to avoid Docker Hub anonymous 429s (#370).
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_token
     when:
       - event: [push, pull_request]
         path:
@@ -100,6 +120,11 @@ steps:
       context: mcp-woodpecker-ci
       tags: latest
       dry_run: true
+      # Authenticate base-image pulls to avoid Docker Hub anonymous 429s (#370).
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_token
     when:
       - event: [push, pull_request]
         path:
@@ -112,8 +137,15 @@ steps:
   runtime-smoke:
     image: docker:cli
     depends_on: [validate]
+    environment:
+      DOCKERHUB_USERNAME:
+        from_secret: dockerhub_username
+      DOCKERHUB_TOKEN:
+        from_secret: dockerhub_token
     commands:
       - apk add --no-cache curl docker-compose
+      # Authenticate Docker Hub before compose pulls base images (#370).
+      - sh scripts/ci-docker-login.sh
       - |
         set -eu
 

--- a/scripts/ci-docker-login.sh
+++ b/scripts/ci-docker-login.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Authenticate Docker Hub for the runtime-smoke step so compose base-image pulls
+# are not subject to the anonymous pull rate limit (issue #370). Kept in a script
+# file rather than inline because Woodpecker mangles nested quotes in inline
+# commands. Non-fatal when the secret is absent (e.g. forked PRs): the build
+# simply pulls unauthenticated, preserving prior behaviour.
+set -eu
+
+if [ -n "${DOCKERHUB_TOKEN:-}" ] && [ -n "${DOCKERHUB_USERNAME:-}" ]; then
+  echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+  echo "INFO: authenticated to Docker Hub as $DOCKERHUB_USERNAME"
+else
+  echo "INFO: DOCKERHUB_USERNAME/DOCKERHUB_TOKEN not set; pulling unauthenticated"
+fi

--- a/tests/test_ci_dockerhub_auth.py
+++ b/tests/test_ci_dockerhub_auth.py
@@ -1,0 +1,60 @@
+"""Tests for Docker Hub pull authentication in CI (issue #370).
+
+Concurrent push + PR pipelines pulling base images unauthenticated tripped
+Docker Hub's anonymous rate limit (429). These assert the auth wiring stays in
+place: every buildx build step logs in via secrets, and runtime-smoke logs in
+before compose pulls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _steps() -> dict[str, Any]:
+    return yaml.safe_load((REPO / ".woodpecker.yml").read_text())["steps"]
+
+
+def test_all_buildx_steps_authenticate_docker_hub() -> None:
+    steps = _steps()
+    build_steps = [
+        name
+        for name, step in steps.items()
+        if str(step.get("image", "")).startswith("woodpeckerci/plugin-docker-buildx")
+    ]
+    assert build_steps, "expected at least one buildx build step"
+    for name in build_steps:
+        settings = steps[name]["settings"]
+        assert settings["username"] == {"from_secret": "dockerhub_username"}, name
+        assert settings["password"] == {"from_secret": "dockerhub_token"}, name
+
+
+def test_runtime_smoke_logs_in_before_pulling() -> None:
+    smoke = _steps()["runtime-smoke"]
+    env = smoke["environment"]
+    assert env["DOCKERHUB_USERNAME"] == {"from_secret": "dockerhub_username"}
+    assert env["DOCKERHUB_TOKEN"] == {"from_secret": "dockerhub_token"}
+
+    commands = smoke["commands"]
+    login_idx = next(i for i, c in enumerate(commands) if "ci-docker-login.sh" in c)
+    # Login must run before whatever triggers compose pulls - robust to both the
+    # inline smoke block and the scripts/runtime-smoke.sh form (#350).
+    pull_idx = next(
+        i
+        for i, c in enumerate(commands)
+        if "runtime-smoke.sh" in c or "docker compose" in c or "up --build" in c
+    )
+    assert login_idx < pull_idx
+
+
+def test_login_script_uses_password_stdin_and_is_non_fatal() -> None:
+    body = (REPO / "scripts" / "ci-docker-login.sh").read_text()
+    assert "--password-stdin" in body
+    # Never echo the token to argv; never hard-fail when the secret is absent.
+    assert "-p " not in body
+    assert "DOCKERHUB_TOKEN:-" in body


### PR DESCRIPTION
## Summary

Concurrent `push` + `pull_request` pipelines for the same commit each ran five `--pull=true` buildx builds **unauthenticated**, tripping Docker Hub's anonymous pull rate limit (429 — seen in pipeline #303, `build-*` steps). Authenticate base-image pulls with a free **read-only** Docker Hub token stored as Woodpecker secrets.

## Changes

- `build-*` buildx steps: `username`/`password` via `from_secret` (`dockerhub_username`, `dockerhub_token`).
- `runtime-smoke`: inject the same secrets and `docker login` before compose pulls, via `scripts/ci-docker-login.sh` (script file — Woodpecker mangles nested quotes inline; non-fatal when the secret is absent, e.g. forked PRs).
- `tests/test_ci_dockerhub_auth.py` locks the wiring.

## Secrets (already configured on the repo, Push + Pull Request events)

- `dockerhub_username`
- `dockerhub_token` (read-only access token)

## Test plan

- `make test` → 682 passed, 1 skipped; ruff clean.
- This PR's own Woodpecker pipeline is the real proof: `build-*` steps should pull authenticated (no "Guest mode enabled" / 429).

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)