### PR TITLE
[codex] Return second-opinion model responses as completed

### DIFF
--- a/mcp-second-opinion/src/server.py
+++ b/mcp-second-opinion/src/server.py
@@ -12,6 +12,7 @@ import argparse
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple
 
 import anthropic
@@ -689,13 +690,19 @@ async def get_single_model_response(
     Returns:
         Dict with response, model info, tokens, cost, and success status
     """
+    started_at = perf_counter()
+
+    def _with_elapsed(result: Dict[str, Any]) -> Dict[str, Any]:
+        result["elapsed_seconds"] = round(perf_counter() - started_at, 3)
+        return result
+
     model_info = Config.AVAILABLE_MODELS.get(model_key)
     if not model_info:
-        return {
+        return _with_elapsed({
             "model_key": model_key,
             "success": False,
             "error": f"Unknown model key: {model_key}",
-        }
+        })
 
     provider = model_info["provider"]
     model_id = model_info["model_id"]
@@ -714,13 +721,13 @@ async def get_single_model_response(
         # Route to appropriate provider
         api_key_attr = Config._PROVIDER_API_KEY_MAP.get(provider)
         if api_key_attr and not getattr(Config, api_key_attr, None):
-            return {
+            return _with_elapsed({
                 "model_key": model_key,
                 "model_id": model_id,
                 "display_name": model_info["display_name"],
                 "success": False,
                 "error": f"{provider.title()} API key not configured",
-            }
+            })
 
         async def _dispatch() -> Tuple[str, str]:
             if provider == "gemini":
@@ -748,24 +755,24 @@ async def get_single_model_response(
                 _dispatch(), timeout=Config.MODEL_RESPONSE_TIMEOUT,
             )
         except _UnknownProviderError:
-            return {
+            return _with_elapsed({
                 "model_key": model_key,
                 "success": False,
                 "error": f"Unknown provider: {provider}",
-            }
+            })
         except asyncio.TimeoutError:
             logger.error(
                 "Timed out after %ss waiting on %s/%s",
                 Config.MODEL_RESPONSE_TIMEOUT, provider, model_id,
             )
-            return {
+            return _with_elapsed({
                 "model_key": model_key,
                 "model_id": model_id,
                 "display_name": model_info["display_name"],
                 "provider": provider,
                 "success": False,
                 "error": f"Timed out after {Config.MODEL_RESPONSE_TIMEOUT}s",
-            }
+            })
 
         # Calculate tokens and cost
         input_tokens = len(prompt) // Config.CHARS_PER_TOKEN
@@ -774,7 +781,7 @@ async def get_single_model_response(
         cost = (input_tokens / 1_000_000) * pricing["input"] + \
                (output_tokens / 1_000_000) * pricing["output"]
 
-        return {
+        return _with_elapsed({
             "model_key": model_key,
             "model_id": model_used,
             "display_name": model_info["display_name"],
@@ -787,18 +794,18 @@ async def get_single_model_response(
                 "total": input_tokens + output_tokens,
             },
             "cost": round(cost, 5),
-        }
+        })
 
     except Exception as e:
         logger.error(f"Error getting response from {model_key}: {e}")
-        return {
+        return _with_elapsed({
             "model_key": model_key,
             "model_id": model_id,
             "display_name": model_info["display_name"],
             "provider": provider,
             "success": False,
             "error": str(e),
-        }
+        })
 
 
 async def get_multi_model_responses(
@@ -832,34 +839,53 @@ async def get_multi_model_responses(
             "invalid_models": invalid_keys,
         }
 
-    # Run all model requests in parallel
-    tasks = [get_single_model_response(prompt, key, max_tokens=max_tokens) for key in valid_keys]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+    # Run all model requests in parallel and drain them in completion order.
+    batch_started_at = perf_counter()
+
+    async def _run_model_request(model_key: str) -> Dict[str, Any]:
+        started_at = perf_counter()
+        try:
+            result = await get_single_model_response(prompt, model_key, max_tokens=max_tokens)
+        except Exception as e:
+            logger.error(f"Unhandled error getting response from {model_key}: {e}")
+            result = {
+                "model_key": model_key,
+                "success": False,
+                "error": str(e),
+            }
+
+        result.setdefault("model_key", model_key)
+        result.setdefault("elapsed_seconds", round(perf_counter() - started_at, 3))
+        result["completed_at_seconds"] = round(perf_counter() - batch_started_at, 3)
+        return result
+
+    tasks = [
+        asyncio.create_task(_run_model_request(key), name=f"second-opinion:{key}")
+        for key in valid_keys
+    ]
 
     # Process results
     responses = []
     total_cost = 0.0
     successful_count = 0
 
-    for result in results:
-        if isinstance(result, Exception):
-            responses.append({
-                "success": False,
-                "error": str(result),
-            })
-        else:
-            responses.append(result)
-            if result.get("success"):
-                successful_count += 1
-                total_cost += result.get("cost", 0)
+    for completed_task in asyncio.as_completed(tasks):
+        result = await completed_task
+        result["completion_order"] = len(responses) + 1
+        responses.append(result)
+        if result.get("success"):
+            successful_count += 1
+            total_cost += result.get("cost", 0)
 
     return {
         "success": successful_count > 0,
         "responses": responses,
+        "response_order": "completion",
         "models_consulted": len(valid_keys),
         "models_successful": successful_count,
         "invalid_models": invalid_keys if invalid_keys else None,
         "total_cost": round(total_cost, 5),
+        "total_elapsed_seconds": round(perf_counter() - batch_started_at, 3),
     }
 
 

--- a/tests/test_second_opinion_completion_order.py
+++ b/tests/test_second_opinion_completion_order.py
@@ -1,0 +1,169 @@
+"""Tests for multi-model second-opinion completion-order results."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _load_second_opinion_server(monkeypatch):
+    """Load server.py with component-only provider SDKs stubbed."""
+    src_path = Path(__file__).parents[1] / "mcp-second-opinion" / "src"
+
+    for env_var in (
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "MISTRAL_API_KEY",
+        "GROQ_API_KEY",
+        "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    class NoopFastMCP:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def custom_route(self, *args, **kwargs):
+            return lambda func: func
+
+        def tool(self, *args, **kwargs):
+            return lambda func: func
+
+        def run(self, *args, **kwargs):
+            pass
+
+    class NoopClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class JSONResponse:
+        def __init__(self, content, status_code=200):
+            self.content = content
+            self.status_code = status_code
+
+    def retry(*args, **kwargs):
+        return lambda func: func
+
+    fastmcp = types.ModuleType("fastmcp")
+    fastmcp.FastMCP = NoopFastMCP
+
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *args, **kwargs: None
+
+    anthropic = types.ModuleType("anthropic")
+    anthropic.AsyncAnthropic = NoopClient
+
+    openai = types.ModuleType("openai")
+    openai.AsyncOpenAI = NoopClient
+
+    google = types.ModuleType("google")
+    genai = types.ModuleType("google.genai")
+    genai.Client = NoopClient
+    genai_types = types.ModuleType("google.genai.types")
+    genai.types = genai_types
+    google.genai = genai
+
+    starlette = types.ModuleType("starlette")
+    starlette_requests = types.ModuleType("starlette.requests")
+    starlette_requests.Request = type("Request", (), {})
+    starlette_responses = types.ModuleType("starlette.responses")
+    starlette_responses.JSONResponse = JSONResponse
+
+    tenacity = types.ModuleType("tenacity")
+    tenacity.retry = retry
+    tenacity.retry_if_exception_type = lambda *args, **kwargs: None
+    tenacity.stop_after_attempt = lambda *args, **kwargs: None
+    tenacity.wait_exponential = lambda *args, **kwargs: None
+
+    prompts = types.ModuleType("prompts")
+    prompts.build_code_review_prompt = lambda *args, **kwargs: "prompt"
+    prompts.scan_for_secrets = lambda *args, **kwargs: []
+
+    sessions = types.ModuleType("sessions")
+    sessions.get_session_manager = lambda: object()
+
+    tools = types.ModuleType("tools")
+    tools.FETCH_URL_DECLARATION = object()
+    tools.WEB_SEARCH_DECLARATION = object()
+    tools.approve_domain = lambda *args, **kwargs: None
+    tools.fetch_url = lambda *args, **kwargs: None
+    tools.get_approved_domains = lambda *args, **kwargs: []
+    tools.revoke_domain = lambda *args, **kwargs: None
+    tools.web_search = lambda *args, **kwargs: None
+
+    monkeypatch.setitem(sys.modules, "fastmcp", fastmcp)
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv)
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic)
+    monkeypatch.setitem(sys.modules, "openai", openai)
+    monkeypatch.setitem(sys.modules, "google", google)
+    monkeypatch.setitem(sys.modules, "google.genai", genai)
+    monkeypatch.setitem(sys.modules, "google.genai.types", genai_types)
+    monkeypatch.setitem(sys.modules, "starlette", starlette)
+    monkeypatch.setitem(sys.modules, "starlette.requests", starlette_requests)
+    monkeypatch.setitem(sys.modules, "starlette.responses", starlette_responses)
+    monkeypatch.setitem(sys.modules, "tenacity", tenacity)
+    monkeypatch.setitem(sys.modules, "prompts", prompts)
+    monkeypatch.setitem(sys.modules, "sessions", sessions)
+    monkeypatch.setitem(sys.modules, "tools", tools)
+
+    sys.modules.pop("server", None)
+    sys.modules.pop("config", None)
+    monkeypatch.syspath_prepend(str(src_path))
+    return importlib.import_module("server")
+
+
+def test_multi_model_responses_are_drained_in_completion_order(monkeypatch):
+    server = _load_second_opinion_server(monkeypatch)
+    valid_models = ["slow", "fast", "medium"]
+    delays = {
+        "slow": 0.03,
+        "fast": 0.0,
+        "medium": 0.01,
+    }
+
+    monkeypatch.setattr(server.Config, "get_available_model_keys", staticmethod(lambda: valid_models))
+
+    async def fake_single_model_response(prompt, model_key, max_tokens=server.Config.MAX_TOKENS):
+        await asyncio.sleep(delays[model_key])
+        return {
+            "model_key": model_key,
+            "success": True,
+            "response": f"{model_key} response",
+            "cost": 0.01,
+            "elapsed_seconds": delays[model_key],
+        }
+
+    monkeypatch.setattr(server, "get_single_model_response", fake_single_model_response)
+
+    result = asyncio.run(
+        server.get_multi_model_responses(
+            "prompt",
+            ["slow", "fast", "medium", "invalid"],
+            max_tokens=1,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["response_order"] == "completion"
+    assert result["invalid_models"] == ["invalid"]
+    assert [response["model_key"] for response in result["responses"]] == ["fast", "medium", "slow"]
+    assert [response["completion_order"] for response in result["responses"]] == [1, 2, 3]
+    assert all("elapsed_seconds" in response for response in result["responses"])
+    assert all("completed_at_seconds" in response for response in result["responses"])
+    assert result["total_elapsed_seconds"] >= result["responses"][-1]["completed_at_seconds"]
+
+
+def test_single_model_response_includes_elapsed_for_invalid_model(monkeypatch):
+    server = _load_second_opinion_server(monkeypatch)
+
+    result = asyncio.run(server.get_single_model_response("prompt", "missing-model"))
+
+    assert result["success"] is False
+    assert result["model_key"] == "missing-model"
+    assert "elapsed_seconds" in result
+    assert result["elapsed_seconds"] >= 0


### PR DESCRIPTION
## Summary

- drain multi-model second-opinion tasks with `asyncio.as_completed` so returned responses are ordered by completion
- add per-model `elapsed_seconds`, `completed_at_seconds`, `completion_order`, response ordering metadata, and batch elapsed timing
- add a regression test with stubbed provider SDKs to verify completion-order behavior without requiring component-only dependencies

Closes #357

## Validation

- `uv run --extra dev pytest tests/test_second_opinion_completion_order.py tests/test_second_opinion_timeout.py tests/test_second_opinion_token_limits.py tests/test_second_opinion_model_catalog.py`
- `uv run --extra dev ruff check mcp-second-opinion/src/server.py tests/test_second_opinion_completion_order.py`
- `make lint`
- `make test` (699 passed, 1 skipped)
- `make typecheck`

## Verification gap

- `make secret-scan` could not run in this environment because `gitleaks` is not installed and Docker socket access is denied for the current user.
