### PR TITLE
ci(smoke): retry in-container readiness probes with diagnostics on failure

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -182,6 +182,34 @@ steps:
         fi
         docker compose -p "$PROJECT" --profile core --profile browser --profile cicd ps
 
+        # Run an in-container probe with bounded retries. A service can pass the
+        # compose `--wait` readiness gate yet briefly refuse a fresh connection
+        # (restart backoff, keep-alive churn) - a hard fail on the first refusal
+        # made this smoke flaky. Retry a few times, and on giving up dump
+        # diagnostics (status, recent logs, one stderr-visible attempt) so a
+        # genuine failure is debuggable instead of a bare non-zero exit.
+        probe_until_ok() {
+          probe_service="$1"
+          shift
+          attempt=1
+          max_attempts=10
+          while :; do
+            if docker compose -p "$PROJECT" exec -T "$probe_service" "$@" >/dev/null 2>&1; then
+              return 0
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "ERROR: $probe_service probe failed after $max_attempts attempts; diagnostics:"
+              docker compose -p "$PROJECT" ps || true
+              docker compose -p "$PROJECT" logs --tail 50 "$probe_service" || true
+              echo "--- final probe attempt (stderr shown) ---"
+              docker compose -p "$PROJECT" exec -T "$probe_service" "$@" || true
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            sleep 3
+          done
+        }
+
         check_http() {
           service="$1"
           container_port="$2"
@@ -199,8 +227,8 @@ steps:
           # report the published host port to confirm the CI-only random port
           # mapping exists and cannot collide with a workstation stack.
           url="http://127.0.0.1:$container_port$check_path"
-          docker compose -p "$PROJECT" exec -T "$service" \
-            python -c "import urllib.request; urllib.request.urlopen('$url', timeout=10)" >/dev/null
+          probe_until_ok "$service" \
+            python -c "import urllib.request; urllib.request.urlopen('$url', timeout=10)"
           echo "OK: $service:$container_port$check_path via host port $published"
         }
 
@@ -222,8 +250,8 @@ steps:
           fi
 
           url="http://127.0.0.1:$container_port$check_path"
-          docker compose -p "$PROJECT" exec -T "$service" \
-            curl -sf -H "$header" --max-time 10 "$url" >/dev/null
+          probe_until_ok "$service" \
+            curl -sf -H "$header" --max-time 10 "$url"
           echo "OK (internal only): $service:$container_port$check_path"
         }
 

--- a/tests/test_ci_smoke_retry.py
+++ b/tests/test_ci_smoke_retry.py
@@ -1,0 +1,45 @@
+"""Tests for bounded-retry hardening of the runtime-smoke probes.
+
+A service can pass the compose `--wait` readiness gate yet briefly refuse a
+fresh in-container connection, which made the smoke flaky when the probe
+hard-failed on the first refusal. The smoke now retries via a shared
+`probe_until_ok` helper; these tests guard that wiring against regression.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _smoke_block() -> str:
+    steps = yaml.safe_load((REPO / ".woodpecker.yml").read_text())["steps"]
+    commands = steps["runtime-smoke"]["commands"]
+    # The check functions live in the single large heredoc-style shell command.
+    return next(c for c in commands if "check_http()" in c)
+
+
+def test_probe_helper_retries_with_a_bounded_attempt_count() -> None:
+    block = _smoke_block()
+    assert "probe_until_ok()" in block
+    assert "max_attempts=10" in block
+    # Retries must be bounded and eventually exit non-zero, not loop forever.
+    assert "attempt -ge" in block.replace('"', "")
+    assert "exit 1" in block
+
+
+def test_both_probes_go_through_the_retry_helper() -> None:
+    block = _smoke_block()
+    # Neither check function should call `docker compose exec` for its probe
+    # directly any more - both must funnel through probe_until_ok.
+    assert block.count("probe_until_ok ") >= 2, "both check functions must retry"
+
+
+def test_probe_failure_dumps_diagnostics() -> None:
+    block = _smoke_block()
+    assert "docker compose -p \"$PROJECT\" ps" in block
+    assert "logs --tail" in block


### PR DESCRIPTION
## Summary

The `runtime-smoke` probes hard-failed on the **first** refused connection. A service can pass the compose `--wait` readiness gate yet briefly refuse a fresh in-container connection (restart backoff, keep-alive churn), which made the smoke step **intermittently fail** — notably the last (`mcp-woodpecker-ci`) probe, surfacing as `/bin/sh: 3: parameter not set` and a bare non-zero exit across many PRs.

#354 already rewrote the buggy variadic `$4`/`$#` handling (splitting `check_http` / `check_internal_http`), which removed the most-correlated failure path. This adds the remaining defense: **bounded retries + diagnostics**, so a transient readiness race no longer fails the build, and a *genuine* failure is debuggable.

## Changes

- New shared `probe_until_ok` helper: retries the in-container probe up to **10×** (3s apart) before giving up.
- On exhaustion it dumps `docker compose ps`, the failing service's recent logs (`logs --tail 50`), and **one stderr-visible probe attempt** — instead of an opaque exit code.
- Both `check_http` (MCP `/readyz`) and `check_internal_http` (agent `/ping`) now funnel through the helper; their port-mapping assertions (must-be-published / must-NOT-be-published) are unchanged.
- `tests/test_ci_smoke_retry.py` guards the wiring against regression.

## Test plan

- `uv run --extra dev pytest tests/test_ci_smoke_retry.py` — 3 passed.
- YAML validated (`yaml.safe_load`).
- This PR exercises `runtime-smoke` itself (touches `.woodpecker.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #375