### PR TITLE
fix(deploy): add transactional docker refresh rollback (Closes #353)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,11 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Profiles:** `core` (second-opinion + nano-banana + secrets-agent), `browser` (playwright), `cicd` (woodpecker-ci + secrets-agent)
 - **Start:** `make docker-up PROFILE=core`
 - **All profiles:** `make docker-up PROFILE="core browser cicd"`
-- **Rebuild/restart/wait for health:** `make docker-refresh PROFILE="core browser cicd"`
+- **Rebuild/restart/wait for health:** `make docker-refresh PROFILE="core browser cicd"` snapshots current image IDs as `:previous` and restores them if the candidate stack fails `--wait`
 - **Status/logs/stop:** `make docker-ps`, `make docker-logs`, `make docker-down`
 - **Liveness vs readiness:** each MCP server serves `/` (liveness: process is up) and `/readyz` (readiness: required secrets/config actually loaded). Compose healthchecks - the `docker compose up --wait` release gate - probe `/readyz`, so a live-but-keyless container (e.g. a failed secret fetch) is reported unhealthy and `--wait` fails instead of greenlighting it. Secret-bearing servers (`mcp-second-opinion`, `mcp-woodpecker-ci`) report ready only once their provider keys load; `mcp-nano-banana` and `mcp-playwright-persistent` have no required secrets, so readiness equals liveness. CI/deploy without a live secrets-agent can inject keys via the LLM/Woodpecker env passthroughs in `docker-compose.yml`; the agent overrides them at runtime.
 - **Empty AWS credential guard:** `make docker-up` refuses to create `aws-secrets-agent` when `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` resolves empty. If a stale sidecar was already created with empty creds, fix env and force-recreate `aws-secrets-agent` plus secret-dependent MCP containers.
+- **Deploy preflight:** `make deploy` runs `scripts/assert-prod-env.sh`; production deploys reject `default-token` even if local-dev opt-out is set, and require `SECOND_OPINION_AWS_SECRET_NAME` for `core` plus `WOODPECKER_CI_AWS_SECRET_NAME` for `cicd`.
 - **MCP connections:** Defined in project `.mcp.json` pointing to `127.0.0.1:{port}/sse` (SSE transport)
 - **Woodpecker CI** runs on push/PR: secret-scan (gitleaks), lint, test, typecheck, Dockerfile lint, compose policy checks, image builds, image CVE scans, SBOM generation, and isolated runtime smoke tests for MCP stack changes
 - **Secret scanning:** `make secret-scan` runs gitleaks locally (native binary or Docker fallback). Config in `.gitleaks.toml` with allowlists for doc/test false positives

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ docker-secrets-check:
 docker-up: docker-check-env
 	docker compose $(DOCKER_PROFILES) up $(DOCKER_UP_FLAGS)
 
-docker-refresh:
-	@$(MAKE) docker-up PROFILE="$(PROFILE)" DOCKER_UP_FLAGS="-d --build --wait"
+docker-refresh: docker-check-env
+	@scripts/docker-refresh-transactional.sh --profiles "$(PROFILE)"
 	@$(MAKE) docker-health PROFILE="$(PROFILE)"
 
 docker-health:
@@ -118,7 +118,9 @@ drift-check:
 
 ## Deploy (used by /flow:deploy and manual local deployments)
 
-deploy: docker-refresh
+deploy:
+	@scripts/assert-prod-env.sh --profiles "$(PROFILE)"
+	@$(MAKE) docker-refresh PROFILE="$(PROFILE)"
 
 ## Woodpecker CLI setup
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ MCP servers run as Docker containers organized by profile:
 ```bash
 make docker-up PROFILE=core       # second-opinion + nano-banana
 make docker-up PROFILE="core browser"  # + playwright
-make docker-refresh PROFILE="core browser cicd"  # rebuild/restart with health gate
+make docker-refresh PROFILE="core browser cicd"  # transactional rebuild/restart with health gate
 make docker-ps                    # container status
 make docker-down                  # stop all
 ```
@@ -108,12 +108,13 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 AWS_TOKEN=my-ssrf-token   # must be unique; the preflight rejects empty or "default-token"
+SECOND_OPINION_AWS_SECRET_NAME=codex_llm_apikeys
 
 # Validate before first start:
 make docker-secrets-check
 ```
 
-App containers carry no AWS credentials; they reach the sidecar over the compose network with only the SSRF token. `make docker-up` refuses to create the sidecar when required AWS credential variables resolve empty or `AWS_TOKEN` is the insecure default (set `CPP_ALLOW_DEFAULT_TOKEN=1` for offline local dev only). For host-side debugging or a fully offline `.env` fallback, layer in `docker-compose.dev.yml` (binds the agent to `127.0.0.1`, restores `.env` for app containers, and sets `ALLOW_ENV_FALLBACK=true`). See `aws-secrets-agent/` and `docs/AWS_SECRETS_SIDECAR.md` for details.
+App containers carry no AWS credentials; they reach the sidecar over the compose network with only the SSRF token. `make docker-up` refuses to create the sidecar when required AWS credential variables resolve empty or `AWS_TOKEN` is the insecure default (set `CPP_ALLOW_DEFAULT_TOKEN=1` for offline local dev only). `make deploy` is stricter: it always rejects `default-token`, requires explicit secret-name variables for secret-consuming profiles, snapshots the current image IDs as `:previous`, and restores them if the candidate stack fails `docker compose --wait`. For host-side debugging or a fully offline `.env` fallback, layer in `docker-compose.dev.yml` (binds the agent to `127.0.0.1`, restores `.env` for app containers, and sets `ALLOW_ENV_FALLBACK=true`). See `aws-secrets-agent/` and `docs/AWS_SECRETS_SIDECAR.md` for details.
 
 ## CI/CD
 

--- a/docs/AWS_SECRETS_SIDECAR.md
+++ b/docs/AWS_SECRETS_SIDECAR.md
@@ -31,7 +31,8 @@ MCP server (python server.py)        <-- secrets exported as env vars
 - `AWS_TOKEN` must be a unique, non-default value. `make docker-up` preflight
   (`scripts/check-docker-aws-env.py`) refuses to start when it resolves to empty
   or the insecure `default-token` (set `CPP_ALLOW_DEFAULT_TOKEN=1` for offline
-  local dev only).
+  local dev only). `make deploy` always rejects `default-token` and requires
+  explicit secret-name variables for secret-consuming profiles.
 - The agent and app containers run with `no-new-privileges:true`, and the agent
   image runs as the non-root `agent` user. (`cap_drop: ALL` is intentionally not
   applied to the agent: the upstream binary fails to exec under an empty
@@ -94,7 +95,9 @@ AWS_TOKEN=my-ssrf-protection-token
 
 CI and deploy jobs can provide the same variables through the job environment. The root `.env` file is optional so a clean checkout can still run `docker compose` when credentials are injected by the platform.
 
-`AWS_TOKEN` is an arbitrary string used for SSRF protection - the sidecar validates it on every request. Choose a unique, non-guessable value and keep it consistent across the agent and its consumers. The `make docker-up` preflight rejects an empty or `default-token` value.
+`AWS_TOKEN` is an arbitrary string used for SSRF protection - the sidecar validates it on every request. Choose a unique, non-guessable value and keep it consistent across the agent and its consumers. The `make docker-up` preflight rejects an empty or `default-token` value, while `make deploy` additionally requires `SECOND_OPINION_AWS_SECRET_NAME` for the `core` profile and `WOODPECKER_CI_AWS_SECRET_NAME` for the `cicd` profile.
+
+`make docker-refresh` is transactional for workstation deploys. Before a rebuild, it tags each currently running compose service image as `:previous`. If the candidate stack fails `docker compose --wait`, the failed stack is stopped and the previously running services are restarted with `CPP_IMAGE_TAG=previous`; the target still exits non-zero so `/flow:deploy` and CI treat the deploy as failed.
 
 ## AWS Secrets Manager Setup
 

--- a/scripts/assert-prod-env.sh
+++ b/scripts/assert-prod-env.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Strict deploy-time environment preflight for Docker production refreshes.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PROFILE_VALUE="${PROFILE:-core}"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/assert-prod-env.sh [--profiles "core browser cicd"] [--env-file .env]
+
+Checks:
+  - AWS credentials and AWS_TOKEN are present for sidecar profiles
+  - AWS_TOKEN is never the insecure default token for deploys
+  - Secret-consuming profiles set explicit AWS Secrets Manager secret names
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profiles)
+      PROFILE_VALUE="${2:-}"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+python3 "$SCRIPT_DIR/check-docker-aws-env.py" --profiles "$PROFILE_VALUE" --env-file "$ENV_FILE"
+
+profiles_need_sidecar=false
+required_secret_vars=()
+for profile in $PROFILE_VALUE; do
+  case "$profile" in
+    core)
+      profiles_need_sidecar=true
+      required_secret_vars+=(SECOND_OPINION_AWS_SECRET_NAME)
+      ;;
+    cicd)
+      profiles_need_sidecar=true
+      required_secret_vars+=(WOODPECKER_CI_AWS_SECRET_NAME)
+      ;;
+  esac
+done
+
+resolve_env_value() {
+  local name="$1"
+  if printenv "$name" >/dev/null 2>&1; then
+    printenv "$name"
+    return
+  fi
+
+  python3 - "$ENV_FILE" "$name" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+name = sys.argv[2]
+if not path.exists():
+    raise SystemExit(0)
+
+for raw_line in path.read_text().splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        continue
+    if line.startswith("export "):
+        line = line[len("export "):].strip()
+    if "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    if key.strip() != name:
+        continue
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    print(value)
+    break
+PY
+}
+
+errors=()
+
+if [[ "$profiles_need_sidecar" == true ]]; then
+  aws_token="$(resolve_env_value AWS_TOKEN)"
+  if [[ -z "${aws_token//[[:space:]]/}" ]]; then
+    errors+=("AWS_TOKEN is required for production deploy profiles.")
+  elif [[ "$aws_token" == "default-token" ]]; then
+    errors+=("AWS_TOKEN must not be the insecure default 'default-token' for deploys.")
+  fi
+fi
+
+seen_secret_vars=""
+for var_name in "${required_secret_vars[@]}"; do
+  if [[ " $seen_secret_vars " == *" $var_name "* ]]; then
+    continue
+  fi
+  seen_secret_vars="$seen_secret_vars $var_name"
+  value="$(resolve_env_value "$var_name")"
+  if [[ -z "${value//[[:space:]]/}" ]]; then
+    errors+=("$var_name must be set to the AWS Secrets Manager secret name for deploys.")
+  fi
+done
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "ERROR: production deploy environment is incomplete." >&2
+  for error in "${errors[@]}"; do
+    echo "  - $error" >&2
+  done
+  exit 1
+fi
+
+echo "OK: production Docker deploy environment is explicit and non-default."

--- a/scripts/docker-refresh-transactional.sh
+++ b/scripts/docker-refresh-transactional.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Rebuild and restart the Docker Compose stack with a rollback image snapshot.
+#
+# Before replacing containers, this script tags each currently running service
+# image as :previous. If docker compose --wait fails, it tears down the failed
+# candidate stack and restarts the captured services with CPP_IMAGE_TAG=previous.
+
+set -Eeuo pipefail
+
+PROFILE_VALUE="${PROFILE:-core}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/docker-refresh-transactional.sh [--profiles "core browser cicd"]
+
+Environment:
+  PROFILE        Space-separated Docker Compose profiles (default: core)
+  CPP_IMAGE_TAG  Candidate image tag consumed by docker-compose.yml
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profiles)
+      PROFILE_VALUE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+profile_args=()
+for profile in $PROFILE_VALUE; do
+  profile_args+=(--profile "$profile")
+done
+
+compose() {
+  docker compose "${profile_args[@]}" "$@"
+}
+
+image_repo_from_ref() {
+  local image_ref="$1"
+  local tail
+
+  if [[ "$image_ref" == *@* ]]; then
+    printf '%s\n' "${image_ref%@*}"
+    return
+  fi
+
+  tail="${image_ref##*/}"
+  if [[ "$tail" == *:* ]]; then
+    printf '%s\n' "${image_ref%:*}"
+  else
+    printf '%s\n' "$image_ref"
+  fi
+}
+
+current_containers=()
+if ! mapfile -t current_containers < <(compose ps -q 2>/dev/null); then
+  current_containers=()
+fi
+
+rollback_services=()
+
+for container_id in "${current_containers[@]}"; do
+  [[ -n "$container_id" ]] || continue
+
+  service_name="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$container_id")"
+  image_ref="$(docker inspect --format '{{ .Config.Image }}' "$container_id")"
+  image_id="$(docker inspect --format '{{ .Image }}' "$container_id")"
+
+  if [[ -z "$service_name" || -z "$image_ref" || -z "$image_id" ]]; then
+    echo "ERROR: could not inspect current compose container $container_id" >&2
+    exit 1
+  fi
+
+  previous_ref="$(image_repo_from_ref "$image_ref"):previous"
+  echo "Snapshotting $service_name image $image_id as $previous_ref"
+  docker image tag "$image_id" "$previous_ref"
+  rollback_services+=("$service_name")
+done
+
+echo "Starting candidate stack for profiles: ${PROFILE_VALUE:-<none>}"
+if compose up -d --build --wait --remove-orphans; then
+  echo "Docker refresh complete."
+  exit 0
+else
+  refresh_exit=$?
+fi
+
+echo "ERROR: candidate stack failed health wait. Rolling back to :previous images." >&2
+
+compose down || echo "WARNING: failed to stop candidate stack before rollback" >&2
+
+if [[ ${#rollback_services[@]} -eq 0 ]]; then
+  echo "ERROR: no previous running services were available to roll back." >&2
+  exit "$refresh_exit"
+fi
+
+if CPP_IMAGE_TAG=previous docker compose "${profile_args[@]}" up -d --wait --no-build --remove-orphans "${rollback_services[@]}"; then
+  echo "Rollback complete. Previous stack restored." >&2
+else
+  echo "ERROR: rollback to :previous images failed." >&2
+  exit 1
+fi
+
+exit "$refresh_exit"

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -1,0 +1,229 @@
+"""Tests for Docker deploy preflight and transactional refresh scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSERT_PROD_ENV = ROOT / "scripts" / "assert-prod-env.sh"
+TRANSACTIONAL_REFRESH = ROOT / "scripts" / "docker-refresh-transactional.sh"
+
+
+def _clean_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_TOKEN",
+        "CPP_ALLOW_DEFAULT_TOKEN",
+        "SECOND_OPINION_AWS_SECRET_NAME",
+        "WOODPECKER_CI_AWS_SECRET_NAME",
+        "PROFILE",
+        "CPP_IMAGE_TAG",
+    ):
+        env.pop(name, None)
+    return env
+
+
+def _run_assert_prod_env(
+    tmp_path: Path,
+    *args: str,
+    env_updates: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = _clean_env()
+    if env_updates:
+        env.update(env_updates)
+    return subprocess.run(
+        [str(ASSERT_PROD_ENV), "--env-file", str(tmp_path / ".env"), *args],
+        check=False,
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def test_assert_prod_env_requires_explicit_secret_name(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "AWS_ACCESS_KEY_ID=fake-access-key-id",
+                "AWS_SECRET_ACCESS_KEY=fake-secret-access-key",
+                "AWS_TOKEN=unique-token",
+            ]
+        )
+    )
+
+    result = _run_assert_prod_env(tmp_path, "--profiles", "core")
+
+    assert result.returncode == 1
+    assert "SECOND_OPINION_AWS_SECRET_NAME must be set" in result.stderr
+
+
+def test_assert_prod_env_rejects_default_token_even_with_local_optout(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "AWS_ACCESS_KEY_ID=fake-access-key-id",
+                "AWS_SECRET_ACCESS_KEY=fake-secret-access-key",
+                "AWS_TOKEN=default-token",
+                "SECOND_OPINION_AWS_SECRET_NAME=codex_llm_apikeys",
+            ]
+        )
+    )
+
+    result = _run_assert_prod_env(
+        tmp_path,
+        "--profiles",
+        "core",
+        env_updates={"CPP_ALLOW_DEFAULT_TOKEN": "1"},
+    )
+
+    assert result.returncode == 1
+    assert "must not be the insecure default" in result.stderr
+
+
+def test_assert_prod_env_passes_with_explicit_secret_names(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "AWS_ACCESS_KEY_ID=fake-access-key-id",
+                "AWS_SECRET_ACCESS_KEY=fake-secret-access-key",
+                "AWS_TOKEN=unique-token",
+                "SECOND_OPINION_AWS_SECRET_NAME=codex_llm_apikeys",
+                "WOODPECKER_CI_AWS_SECRET_NAME=essent-ai",
+            ]
+        )
+    )
+
+    result = _run_assert_prod_env(tmp_path, "--profiles", "core cicd")
+
+    assert result.returncode == 0
+    assert "production Docker deploy environment is explicit" in result.stdout
+
+
+def _write_fake_docker(tmp_path: Path) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "docker.log"
+    docker = bin_dir / "docker"
+    docker.write_text(
+        textwrap.dedent(
+            f"""\
+            #!{sys.executable}
+            import os
+            import sys
+
+            args = sys.argv[1:]
+            log = os.environ["FAKE_DOCKER_LOG"]
+            with open(log, "a", encoding="utf-8") as fh:
+                fh.write(
+                    "CPP_IMAGE_TAG="
+                    + os.environ.get("CPP_IMAGE_TAG", "")
+                    + " args="
+                    + " ".join(args)
+                    + "\\n"
+                )
+
+            if args[:1] == ["compose"]:
+                if args[-2:] == ["ps", "-q"]:
+                    print("cid-agent")
+                    print("cid-opinion")
+                    raise SystemExit(0)
+                if "up" in args and "--build" in args:
+                    raise SystemExit(int(os.environ.get("FAKE_REFRESH_EXIT", "0")))
+                if "down" in args:
+                    raise SystemExit(0)
+                if "up" in args and "--no-build" in args:
+                    raise SystemExit(int(os.environ.get("FAKE_ROLLBACK_EXIT", "0")))
+                raise SystemExit(0)
+
+            if args[:1] == ["inspect"]:
+                fmt = args[args.index("--format") + 1]
+                cid = args[-1]
+                services = {{
+                    "cid-agent": "aws-secrets-agent",
+                    "cid-opinion": "mcp-second-opinion",
+                }}
+                images = {{
+                    "cid-agent": "aws-secrets-agent:old-good",
+                    "cid-opinion": "mcp-second-opinion:old-good",
+                }}
+                image_ids = {{
+                    "cid-agent": "sha256:agentold",
+                    "cid-opinion": "sha256:opinionold",
+                }}
+                if "com.docker.compose.service" in fmt:
+                    print(services[cid])
+                elif ".Config.Image" in fmt:
+                    print(images[cid])
+                elif ".Image" in fmt:
+                    print(image_ids[cid])
+                raise SystemExit(0)
+
+            if args[:2] == ["image", "tag"]:
+                raise SystemExit(0)
+
+            raise SystemExit(0)
+            """
+        )
+    )
+    docker.chmod(0o755)
+    return bin_dir, log_path
+
+
+def _run_transactional_refresh(
+    tmp_path: Path,
+    refresh_exit: int,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    bin_dir, log_path = _write_fake_docker(tmp_path)
+    env = _clean_env()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "FAKE_DOCKER_LOG": str(log_path),
+            "FAKE_REFRESH_EXIT": str(refresh_exit),
+            "FAKE_ROLLBACK_EXIT": "0",
+        }
+    )
+    result = subprocess.run(
+        [str(TRANSACTIONAL_REFRESH), "--profiles", "core"],
+        check=False,
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    return result, log_path.read_text()
+
+
+def test_transactional_refresh_rolls_back_to_previous_images_on_wait_failure(
+    tmp_path: Path,
+) -> None:
+    result, log = _run_transactional_refresh(tmp_path, refresh_exit=17)
+
+    assert result.returncode == 17
+    assert "args=image tag sha256:agentold aws-secrets-agent:previous" in log
+    assert "args=image tag sha256:opinionold mcp-second-opinion:previous" in log
+    assert (
+        "CPP_IMAGE_TAG=previous args=compose --profile core up -d --wait "
+        "--no-build --remove-orphans aws-secrets-agent mcp-second-opinion"
+    ) in log
+    assert "Rollback complete" in result.stderr
+
+
+def test_transactional_refresh_success_does_not_run_rollback(tmp_path: Path) -> None:
+    result, log = _run_transactional_refresh(tmp_path, refresh_exit=0)
+
+    assert result.returncode == 0
+    assert "--no-build" not in log
+    assert "Docker refresh complete" in result.stdout

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -297,7 +297,8 @@ def test_makefile_has_first_class_docker_refresh_target() -> None:
     makefile = (root / "Makefile").read_text()
 
     assert "docker-refresh:" in makefile
-    assert 'DOCKER_UP_FLAGS="-d --build --wait"' in makefile
+    assert "scripts/docker-refresh-transactional.sh" in makefile
+    assert "scripts/assert-prod-env.sh" in makefile
     assert "docker-health:" in makefile
     assert "scripts/docker-health-check.py" in makefile
     assert "scripts/check-docker-aws-env.py" in makefile


### PR DESCRIPTION
## Summary
- Add a transactional Docker refresh wrapper that snapshots running service images as `:previous` and restores them if candidate `docker compose --wait` fails.
- Add a deploy-only production env preflight requiring non-default `AWS_TOKEN` and explicit secret-name variables for secret-consuming profiles.
- Wire deploy/refresh Makefile targets to the new scripts and document the rollback/preflight behavior.

## Test plan
- `make lint`
- `uv run --extra dev pytest`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m lib.cicd run --plan finish`

Closes #353