### PR TITLE
fix(ci): make image-security path filter superset runtime-smoke (Closes #384)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -118,11 +118,18 @@ steps:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     when:
+      # MUST stay a superset of runtime-smoke's paths: runtime-smoke
+      # depends_on image-security, so any change that triggers the smoke step
+      # must also trigger this one, or Woodpecker errors the whole pipeline
+      # with "depends on unknown step 'image-security'" (issue #384).
       - event: [push, pull_request]
         path:
           - ".woodpecker.yml"
           - "docker-compose.yml"
+          - "docker-compose.smoke.yml"
           - "scripts/ci-docker-login.sh"
+          - "scripts/runtime-smoke.sh"
+          - "scripts/fake-secrets-agent.py"
           - "aws-secrets-agent/**"
           - "lib/**"
           - "mcp-second-opinion/**"

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -599,3 +599,19 @@ def test_woodpecker_smoke_path_gates_cover_shared_runtime_inputs() -> None:
     assert "mcp-playwright-persistent/**" in smoke_paths
     assert "mcp-nano-banana/**" in smoke_paths
     assert "mcp-woodpecker-ci/**" in smoke_paths
+
+
+def test_image_security_path_filter_supersets_runtime_smoke() -> None:
+    # Issue #384: runtime-smoke depends_on image-security. If a change triggers
+    # runtime-smoke's path filter but not image-security's, Woodpecker errors
+    # the whole pipeline with "depends on unknown step 'image-security'". The
+    # dependency's path filter must therefore be a superset of the dependent's.
+    steps = _woodpecker_steps()
+    image_paths = set(steps["image-security"]["when"][0]["path"])
+    smoke_paths = set(steps["runtime-smoke"]["when"][0]["path"])
+
+    missing = smoke_paths - image_paths
+    assert not missing, (
+        "image-security.when.path must superset runtime-smoke.when.path "
+        f"(runtime-smoke depends_on image-security); missing: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

`runtime-smoke` declares `depends_on: [image-security]`, but the two steps had
divergent `when.path` filters. `runtime-smoke` triggered on three paths that
`image-security` did not list:

- `docker-compose.smoke.yml`
- `scripts/runtime-smoke.sh`
- `scripts/fake-secrets-agent.py`

A change touching only one of those (e.g. #375's edit to
`scripts/runtime-smoke.sh`) included `runtime-smoke` but path-filtered out
`image-security`, so Woodpecker errored the whole pipeline before any step ran:

```
step 'runtime-smoke' depends on unknown step 'image-security'
```

Observed on pipelines #370, #371, and #373; `main` went red after #382 merged.

## Changes

- **`.woodpecker.yml`**: added the three smoke-only paths to `image-security`'s
  `when.path` so it is a superset of `runtime-smoke`'s. Any change that triggers
  the dependent now also triggers its dependency.
- **`tests/test_docker_compose_config.py`**: added a regression test asserting
  `image-security.when.path` superset `runtime-smoke.when.path`, so the
  dependency can never dangle again.

## Test plan

- `make lint` - passes
- `make test` - 714 passed, 1 skipped (includes new regression test)
- Verified `runtime-smoke.when.path ⊆ image-security.when.path` holds.

## Acceptance

- [x] A change touching only `scripts/runtime-smoke.sh` (or the other two
  smoke paths) triggers both steps; the pipeline assembles without a config error.
- [x] A test guards the superset relationship.

Closes #384