### PR TITLE
[codex] Update status and version for Docker-only release

### DIFF
--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -357,20 +357,71 @@ else
   echo "      Run /cpp:init or create manually"
 fi
 
-# Check systemd services
+# Report supported deployment model
 echo ""
-echo "Systemd Services:"
-for service in mcp-second-opinion mcp-playwright-persistent mcp-woodpecker-ci; do
-  if systemctl is-enabled $service &>/dev/null; then
-    if systemctl is-active $service &>/dev/null; then
-      echo "  [x] $service: enabled, running"
+echo "Deployment Model:"
+echo "  [x] Docker (local build)"
+echo "      Refresh with: /cpp:update"
+
+# Check legacy systemd services
+echo ""
+echo "Legacy Systemd (migration required):"
+KNOWN_LEGACY_SYSTEMD_UNITS=$(cat <<'EOF'
+mcp-second-opinion
+second-opinion
+mcp-playwright
+mcp-playwright-persistent
+playwright-persistent
+nano-banana
+mcp-nano-banana
+mcp-woodpecker-ci
+woodpecker-ci
+mcp-evaluate
+evaluate
+mcp-coordination
+coordination
+EOF
+)
+DISCOVERED_LEGACY_SYSTEMD_UNITS="$(
+  {
+    printf '%s\n' "$KNOWN_LEGACY_SYSTEMD_UNITS"
+    find "$HOME/.config/systemd/user" /etc/systemd/system -maxdepth 1 -type f \
+      \( -name 'mcp-*.service' -o -name 'nano-*.service' -o -name '*coordination*.service' \) \
+      -printf '%f\n' 2>/dev/null || true
+    systemctl --user list-units --type=service --all --no-legend --no-pager 2>/dev/null | awk '{print $1}' || true
+    systemctl list-units --type=service --all --no-legend --no-pager 2>/dev/null | awk '{print $1}' || true
+  } | sed 's/\.service$//' | grep -E '^(mcp-|nano-|.*coordination|second-opinion|playwright-persistent|woodpecker-ci|evaluate|coordination)$' | sort -u
+)"
+LEGACY_SYSTEMD_FOUND=0
+for unit in $DISCOVERED_LEGACY_SYSTEMD_UNITS; do
+  USER_PATH="$HOME/.config/systemd/user/${unit}.service"
+  SYSTEM_PATH="/etc/systemd/system/${unit}.service"
+
+  USER_ACTIVE=$(systemctl --user is-active "$unit" 2>/dev/null || true)
+  USER_ENABLED=$(systemctl --user is-enabled "$unit" 2>/dev/null || true)
+  if [ -f "$USER_PATH" ] || [ "$USER_ACTIVE" = "active" ] || [ "$USER_ENABLED" = "enabled" ]; then
+    LEGACY_SYSTEMD_FOUND=1
+    if [ "$USER_ACTIVE" = "active" ]; then
+      echo "  [!] user:$unit active, enabled=${USER_ENABLED:-unknown} - run /cpp:update to migrate to Docker"
     else
-      echo "  [~] $service: enabled, stopped"
+      echo "  [~] user:$unit active=${USER_ACTIVE:-inactive}, enabled=${USER_ENABLED:-unknown} - run /cpp:update to remove legacy unit"
     fi
-  else
-    echo "  [ ] $service: not installed"
+  fi
+
+  SYSTEM_ACTIVE=$(systemctl is-active "$unit" 2>/dev/null || true)
+  SYSTEM_ENABLED=$(systemctl is-enabled "$unit" 2>/dev/null || true)
+  if [ -f "$SYSTEM_PATH" ] || [ "$SYSTEM_ACTIVE" = "active" ] || [ "$SYSTEM_ENABLED" = "enabled" ]; then
+    LEGACY_SYSTEMD_FOUND=1
+    if [ "$SYSTEM_ACTIVE" = "active" ]; then
+      echo "  [!] system:$unit active, enabled=${SYSTEM_ENABLED:-unknown} - run /cpp:update to migrate to Docker"
+    else
+      echo "  [~] system:$unit active=${SYSTEM_ACTIVE:-inactive}, enabled=${SYSTEM_ENABLED:-unknown} - run /cpp:update to remove legacy unit"
+    fi
   fi
 done
+if [ "$LEGACY_SYSTEMD_FOUND" -eq 0 ]; then
+  echo "  none (ok)"
+fi
 ```
 
 ## Step 5: Check Tier 4 (CI/CD)
@@ -434,8 +485,9 @@ fi
 Based on the checks above, report:
 
 1. **Current tier level** - Which tier is fully installed
-2. **Missing components** - What needs to be installed
-3. **Recommendation** - Suggest running `/cpp:init` if incomplete
+2. **Deployment model** - Always report `Docker (local build)` for Tier 3 runtime
+3. **Missing components** - What needs to be installed
+4. **Recommendation** - Suggest running `/cpp:init` if incomplete, or `/cpp:update` if legacy systemd units remain
 
 Example output format:
 
@@ -470,7 +522,10 @@ Tier 3 (Full):
         mcp-woodpecker-ci -> essent-ai
     [x] AWS credentials: present in .env
     Secret method: AWS Secrets Manager
-  [ ] Systemd: not installed
+  Deployment Model:
+    [x] Docker (local build)
+  Legacy Systemd (migration required):
+    none (ok)
   Status: Partial
 
 Tier 4 (CI/CD):
@@ -483,7 +538,8 @@ Tier 4 (CI/CD):
 
 ---------------------------------
 Current Level: Tier 2 (Standard)
-Missing: Shell prompt, mcp-playwright-persistent, systemd, CI pipeline, Dockerfile
+Deployment Model: Docker (local build)
+Missing: Shell prompt, mcp-playwright-persistent, CI pipeline, Dockerfile
 
 Run /cpp:init to complete setup
 =================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [6.0.0] - 2026-05-31
+
+### Breaking
+
+- Docker with local builds is now the only supported MCP deployment model.
+- Legacy systemd and venv-only MCP runtimes are removed as supported paths.
+
+### Changed
+
+- `/cpp:status` reports the deployment model as `Docker (local build)`.
+- `/cpp:status` relabels systemd checks as `Legacy Systemd (migration required)`, reports `none (ok)` when clean, and points active legacy services to `/cpp:update`.
+- `/cpp:update` is the migration path for tearing down legacy systemd units before Docker refresh.
+
 ## [5.2.0] - 2026-03-08
 
 ### Added - C4 Diagram QA Framework

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ Core components and their locations:
 
 ## Docker Deployment
 
+Docker with local builds is the only supported MCP runtime in 6.0.0. Legacy systemd and venv-only runtime paths are removed; run `/cpp:update` to migrate any existing systemd units before refreshing containers.
+
 MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-secrets-agent` sidecar. Local development can store only AWS credentials in the root `.env` file (gitignored), while CI/deploy can inject the same variables through the job environment. No application secrets are stored on disk. If `AWS_SECRET_NAME` is not set, containers use `env_file` variables (local dev mode). If `AWS_SECRET_NAME` is set but the fetch or parse fails, containers **fail closed** - they exit non-zero and never start keyless (issue #347). Set `ALLOW_ENV_FALLBACK=true` (e.g. via `docker-compose.dev.yml`) to opt into env-file fallback for local development.
 
 - **Secrets architecture:** `aws-secrets-agent` (Rust binary, port 2773) caches secrets in-memory (300s TTL) with SSRF token protection. The agent is internal-only (`expose:`, never host-published) and is the only container that receives AWS credentials; MCP containers use `fetch-secrets.sh` entrypoint to resolve keys with just the SSRF token. Use `docker-compose.dev.yml` (loopback publish + `.env` fallback + `ALLOW_ENV_FALLBACK`) for host-side debugging / offline local dev only.
@@ -64,7 +66,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Runtime smoke:** CI uses a `cpp-smoke-$CI_PIPELINE_NUMBER` compose project with random host ports (driven by `scripts/runtime-smoke.sh`), validates service health, asserts the agent is reachable cross-container at `http://aws-secrets-agent:2773` (proving the `0.0.0.0` bind), exercises the client's real fetch/parse/export path via a hermetic fake agent (`scripts/fake-secrets-agent.py` + `docker-compose.smoke.yml`) with a non-empty `AWS_SECRET_NAME`, and drives a secret through the **REAL** `aws-secrets-agent` binary against a LocalStack Secrets Manager (real AWS SDK `GetSecretValue` via `AWS_ENDPOINT_URL`, no production credentials) so a consumer actually receives a genuinely-fetched secret (issue #377). In-container readiness probes are retried (up to 10x, 3s apart) so a transient post-`--wait` connection refusal does not fail the build; on genuine exhaustion the step dumps `docker compose ps` and the failing service's recent logs (issue #375). It runs `docker compose down -v` before exiting. CI must not deploy persistent containers or prune host images.
 - **Image security gates:** CI runs hadolint over every Dockerfile, validates `docker compose config --quiet`, blocks rendered `:latest`, `default-token`, and host-published agent port regressions, then scans built images for fixed HIGH/CRITICAL CVEs and writes SPDX/CycloneDX SBOMs to `artifacts/sbom/`.
 - **Bootstrap checks:** `make bootstrap-check` verifies admin-only prerequisites (IAM roles, secrets provisioning) before deploy. Configure in `.claude/bootstrap.yaml`. Runs as the first step in the deploy pipeline - blocks with remediation if unsatisfied.
-- **Drift detection:** `make drift-check` compares host-installed artifacts (systemd units, sysctl, Go binaries, shared scripts) against repo templates. Run it manually when reconciling workstation-managed artifacts. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
+- **Drift detection:** `make drift-check` compares host-installed artifacts against repo templates and treats remaining systemd MCP units as legacy migration findings. Run it manually when reconciling workstation-managed artifacts. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
 - **Reproducible builds:** Every base image and build tool (python, rust, debian, `uv`, gitleaks, woodpecker server/agent) is pinned by version tag plus `@sha256:` digest in the Dockerfiles, `.woodpecker.yml`, and infra compose files - never `:latest`. Deployable images are tagged with `CPP_IMAGE_TAG` (the short git SHA, set by the Makefile) instead of `:latest`, so each image traces to a commit and rollbacks have provenance. `renovate.json` rotates the pinned digests on a weekly schedule so pinning never freezes security updates.
 
 ## Commands Reference
@@ -148,7 +150,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/dockers` - Docker container status, health, project linkages
 - `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD)
 - `/cpp:status` - Check installation state
-- `/cpp:update` - Pull latest, sync deps, then refresh the detected runtime model (Docker rebuild/restart/health, systemd restart, or venv-only)
+- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, then refresh Docker local-build runtime
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
 - `/happy-check` - Check happy-cli version (optional)
 
@@ -189,4 +191,4 @@ Tiered: dotenv-global (`~/.config/claude-power-pack/secrets/`) -> env-file -> AW
 
 ## Version
 
-Current version: 5.2.0
+Current version: 6.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Power Pack
 
-**v5.2.0** - A productivity toolkit for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that adds workflow automation, MCP servers, security scanning, secrets management, and CI/CD integration.
+**v6.0.0** - A productivity toolkit for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that adds workflow automation, MCP servers, security scanning, secrets management, and CI/CD integration.
 
 ## What It Does
 
@@ -129,6 +129,12 @@ Woodpecker CI runs on every push and PR via a self-hosted agent:
 Architecture: Woodpecker server on a dedicated VM, agent on the dev workstation, connected via gRPC over Tailscale. Web UI at `woodpecker.essent-ai.com` via Cloudflare tunnel.
 
 ## Changelog
+
+### v6.0.0 (2026-05-31)
+
+- **Breaking change: Docker-only MCP deployment** - Docker with local builds is now the only supported Tier 3 runtime
+- **Legacy systemd migration** - `cpp:update` detects legacy MCP systemd units and guides teardown before Docker refresh
+- **Status clarity** - `cpp:status` reports `Docker (local build)` and labels remaining systemd units as migration-required legacy state
 
 ### v5.2.0 (2026-03-08)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-power-pack"
-version = "5.2.0"
+version = "6.0.0"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "claude-power-pack"
-version = "5.2.0"
+version = "6.0.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Update `/cpp:status` to report `Docker (local build)` as the supported deployment model.
- Relabel systemd status as `Legacy Systemd (migration required)`, including `/cpp:update` guidance for active or installed legacy units and `none (ok)` when clean.
- Bump the root project version to `6.0.0` in `pyproject.toml`, `uv.lock`, `README.md`, and `CLAUDE.md`.
- Add 6.0.0 breaking-change notes to `CHANGELOG.md` and README changelog.

Closes #381.

## Validation

- `sed -n '360,424p' .claude/commands/cpp/status.md | bash`
- `make update_docs`
- `git diff --check`
- `env UV_CACHE_DIR=/tmp/uv-cache make verify` - ruff, 719 pytest tests, mypy

## Notes

Rebased on latest `origin/main`, which already includes issue #380 Docker-only init work.