### PR TITLE
feat(codex): add Tier 5 Codex Orchestration commands (Closes #390)

### DIFF
--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -1,0 +1,421 @@
+---
+description: Full issue lifecycle delegated to Codex - worktree, implement, review, quality gates, PR
+allowed-tools: Bash(codex:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(mkdir:*), Bash(cd:*), Bash(pwd), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(make:*), Bash(sleep:*)
+---
+
+# Codex Auto: Full Issue Lifecycle via Codex CLI
+
+Mirrors `/flow:auto` but delegates implementation (Step 3) to Codex CLI.
+Claude Code acts as supervisor/reviewer while Codex writes the code.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+
+## Instructions
+
+When the user invokes `/codex:auto <ISSUE>`, perform these steps sequentially. Stop immediately if any step fails.
+
+Report at the start:
+
+```
+Codex Auto: Issue #<ISSUE> - Full Lifecycle
+
+Step 1/7: Start (create worktree and branch)
+Step 2/7: Analyze (understand issue, build Codex prompt)
+Step 3/7: Execute Codex (delegate implementation to Codex CLI)
+Step 4/7: Review (Claude reviews Codex's diff)
+Step 5/7: Quality Gates (lint, test, security - with fix loop)
+Step 6/7: Finish (commit, push, create PR)
+Step 7/7: Cleanup (optional merge + worktree removal)
+
+Proceeding...
+```
+
+---
+
+### Step 1: Start - Create Worktree
+
+**CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master.**
+
+```bash
+ISSUE_NUM="<ISSUE>"
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+
+# Fetch issue details
+gh issue view "$ISSUE_NUM" --json number,title,state,body
+```
+
+- If issue is not OPEN, warn the user and ask whether to proceed.
+- Extract the title for branch naming.
+
+```bash
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
+BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+WORKTREE_DIR="../${REPO}-issue-${ISSUE_NUM}"
+```
+
+**Check for existing work:**
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" =~ issue-${ISSUE_NUM}- ]]; then
+    # Already in the right worktree
+    true
+fi
+
+git worktree list | grep "issue-${ISSUE_NUM}"
+git fetch origin
+git branch -r | grep "issue-${ISSUE_NUM}-"
+```
+
+- **Already on issue branch:** Use current directory.
+- **Worktree exists:** `cd` into the existing worktree directory.
+- **Remote branch exists:** Create worktree tracking the remote branch.
+- **Neither exists:** Create fresh from `origin/main`.
+
+#### Verification Gate (MANDATORY)
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "ERROR: Still on main/master. STOP."
+    exit 1
+fi
+echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
+```
+
+Report: `Step 1/7: Start complete - worktree at {path}, on branch {branch}`
+
+---
+
+### Step 2: Analyze - Build Codex Prompt
+
+Working from the worktree, analyze the issue and build a comprehensive prompt for Codex.
+
+1. **Parse the issue body:**
+   - Extract acceptance criteria (checkbox items `- [ ]`)
+   - Identify referenced files, components, or areas
+   - Note any dependencies or constraints
+
+2. **Explore the codebase:**
+   - Read files referenced in the issue
+   - Understand existing patterns and conventions
+   - Identify all files that need to be created or modified
+
+3. **Build the Codex prompt:**
+   Construct a detailed prompt that includes:
+   - Issue title and full body
+   - Acceptance criteria (extracted)
+   - Project conventions from CLAUDE.md (if present)
+   - Relevant file paths and their current content summaries
+   - Testing expectations (from Makefile targets)
+   - Specific instructions: "Implement the changes described in the issue. Follow existing code conventions. Create or modify only the files necessary."
+
+4. **Report the prompt to the user:**
+
+```
+Step 2/7: Analysis Complete
+
+Issue #42: "Fix login redirect loop"
+
+Acceptance Criteria:
+  - [ ] Login redirects to dashboard after auth
+  - [ ] Invalid sessions redirect to /login
+  - [ ] Tests pass
+
+Codex Prompt Summary:
+  - Context: 3 files referenced, CLAUDE.md conventions included
+  - Scope: Modify src/auth/login.py, tests/test_auth.py, config/routes.py
+  - Testing: make lint + make test available
+
+Proceeding to Codex execution...
+```
+
+Report: `Step 2/7: Analyze complete - Codex prompt built ({N} files referenced)`
+
+---
+
+### Step 3: Execute Codex - Delegate Implementation
+
+Run Codex CLI in the worktree with full sandbox access (safe in disposable worktree).
+
+```bash
+# Verify Codex is available
+if ! command -v codex &>/dev/null; then
+    echo "ERROR: Codex CLI not found."
+    echo "Install with: npm install -g @openai/codex"
+    echo "Then configure: codex login"
+    exit 1
+fi
+```
+
+Execute Codex with JSONL monitoring:
+
+```bash
+WORKTREE_PATH=$(pwd)
+
+codex exec \
+    --json \
+    -C "$WORKTREE_PATH" \
+    --sandbox danger-full-access \
+    "$CODEX_PROMPT" 2>&1 | tee /tmp/codex-output-${ISSUE_NUM}.jsonl
+```
+
+**Monitor the JSONL stream** - parse and report:
+- Plan steps and progress
+- File changes / diffs
+- Agent messages
+- Errors
+
+```bash
+# After execution, check exit code
+CODEX_EXIT=$?
+if [ "$CODEX_EXIT" -ne 0 ]; then
+    echo "ERROR: Codex execution failed (exit code: $CODEX_EXIT)"
+    echo "Last 20 lines of output:"
+    tail -20 /tmp/codex-output-${ISSUE_NUM}.jsonl
+    exit 1
+fi
+```
+
+**Parse JSONL output** for summary:
+
+```bash
+# Count file changes
+FILES_CHANGED=$(git diff --name-only | wc -l)
+LINES_ADDED=$(git diff --stat | tail -1 | grep -oP '\d+ insertion' | grep -oP '\d+' || echo "0")
+LINES_REMOVED=$(git diff --stat | tail -1 | grep -oP '\d+ deletion' | grep -oP '\d+' || echo "0")
+
+echo "Codex made changes to $FILES_CHANGED file(s): +$LINES_ADDED -$LINES_REMOVED"
+```
+
+If Codex made no changes, STOP and report.
+
+Report: `Step 3/7: Execute Codex complete - {N} files changed (+{added} -{removed})`
+
+---
+
+### Step 4: Review - Claude Reviews Codex's Diff
+
+Cross-model review: Claude Code reviews what Codex wrote.
+
+1. **Read the full diff:**
+   ```bash
+   git diff
+   ```
+
+2. **Review for:**
+   - Correctness: Does the implementation match the issue requirements?
+   - Conventions: Does it follow the project's coding style?
+   - Security: Any injection, XSS, or other vulnerabilities?
+   - Completeness: Are all acceptance criteria addressed?
+   - Test coverage: Are tests updated or added?
+
+3. **Report review findings:**
+
+```
+Step 4/7: Review Complete
+
+Codex Diff Review:
+  Files changed: 3
+  Correctness: PASS - all acceptance criteria addressed
+  Conventions: PASS - matches existing code style
+  Security: PASS - no vulnerabilities detected
+  Completeness: PASS - tests included
+
+Issues found: 0
+
+Proceeding to quality gates...
+```
+
+If review finds CRITICAL issues that Codex cannot fix via re-prompt (e.g., fundamentally wrong approach), STOP and report. Offer to either re-prompt Codex or hand off to manual implementation.
+
+Report: `Step 4/7: Review complete - {PASS|N issues found}`
+
+---
+
+### Step 5: Quality Gates - Lint, Test, Security (with Fix Loop)
+
+Run the deterministic quality gate runner:
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+    RUNNER_EXIT=$?
+fi
+```
+
+**Fallback:** Run `make lint` and `make test` directly if runner unavailable.
+
+**Fix Loop (max 2 retries):**
+
+If quality gates fail:
+
+1. **Extract the error output** from the failed step.
+2. **Build a fix prompt** for Codex with the error context:
+   ```
+   The following quality gate failed after your implementation:
+
+   [ERROR OUTPUT]
+
+   Fix the issues while preserving the original implementation intent.
+   Only change what is necessary to make the quality gates pass.
+   ```
+3. **Re-execute Codex** with the fix prompt:
+   ```bash
+   codex exec \
+       --json \
+       -C "$WORKTREE_PATH" \
+       --sandbox danger-full-access \
+       "$FIX_PROMPT" 2>&1 | tee /tmp/codex-fix-${ISSUE_NUM}-${RETRY}.jsonl
+   ```
+4. **Re-run quality gates.**
+5. If still failing after 2 retries, STOP and report.
+
+```
+RETRY_COUNT=0
+MAX_RETRIES=2
+
+while [ "$RUNNER_EXIT" -ne 0 ] && [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    echo "Quality gates failed. Re-prompting Codex (attempt $RETRY_COUNT/$MAX_RETRIES)..."
+
+    # Build fix prompt with error context
+    # Re-execute Codex
+    # Re-run quality gates
+
+    if [ "$RUNNER_EXIT" -eq 0 ]; then
+        echo "Quality gates passed after $RETRY_COUNT fix attempt(s)."
+    fi
+done
+
+if [ "$RUNNER_EXIT" -ne 0 ]; then
+    echo "ERROR: Quality gates still failing after $MAX_RETRIES retries."
+    echo "Manual intervention required."
+    exit 1
+fi
+```
+
+Report: `Step 5/7: Quality gates passed (attempt {N}/{MAX})`
+
+---
+
+### Step 6: Finish - Commit, Push, Create PR
+
+```bash
+BRANCH=$(git branch --show-current)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+```
+
+1. **Commit** the changes:
+   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+   - Note Codex as implementer in the commit body
+
+2. **Push** the branch:
+   ```bash
+   git push -u origin "$BRANCH"
+   ```
+
+3. **Create PR** if no PR exists:
+   ```bash
+   gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
+   ```
+   - PR body includes:
+     - Summary of changes
+     - Note that implementation was delegated to Codex CLI
+     - Claude Code review findings
+     - Test plan
+     - `Closes #N`
+
+Report: `Step 6/7: Finish complete - PR #{N} created`
+
+---
+
+### Step 7: Cleanup (Optional)
+
+Ask the user if they want to merge and clean up now, or leave the PR for review:
+
+```
+PR #{N} created. What would you like to do?
+
+  1. Merge now (squash-merge, clean up worktree)
+  2. Leave for review (keep worktree, manual merge later)
+```
+
+If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 6:
+
+1. Squash-merge the PR
+2. Update local main
+3. **cd to main repo BEFORE removing worktree** (critical)
+4. Remove worktree and branch
+5. Close issue if still open
+
+If leave for review, report the PR URL and worktree location.
+
+Report: `Step 7/7: Cleanup complete - PR merged, worktree removed` or `Step 7/7: PR #{N} left for review`
+
+---
+
+### Final Summary
+
+```
+Codex Auto Complete
+
+  Issue:      #{N} - {title}
+  Implementer: Codex CLI (codex exec)
+  Reviewer:    Claude Code (cross-model review)
+  Changes:    Modified {N} files ({summary})
+  Fix Loop:   {N} retry(s) needed / no retries needed
+  PR:         #{N} (created / squash-merged)
+  Branch:     issue-{N}-{slug} (active / deleted)
+  Worktree:   {path} (active / removed)
+  Location:   {current working directory}
+```
+
+---
+
+## Error Handling
+
+At each step, if something fails:
+
+```
+Codex Auto stopped at Step N/7: {Step Name}
+
+  Failed: [description of what failed]
+  Fix:    [actionable suggestion]
+
+  To resume manually:
+    /flow:start {ISSUE}     (if step 1 failed)
+    [investigate]            (if step 2 failed)
+    /codex:exec "<prompt>"   (if step 3 failed)
+    [review diff manually]   (if step 4 failed)
+    /flow:check              (if step 5 failed)
+    /flow:finish             (if step 6 failed)
+    /flow:merge              (if step 7 failed)
+```
+
+Key failure scenarios:
+- **Codex not installed:** Stop at step 3, suggest `npm install -g @openai/codex`
+- **Codex execution fails:** Stop at step 3, show last 20 lines of JSONL output
+- **Codex makes no changes:** Stop at step 3, suggest reviewing the prompt
+- **Review finds critical issues:** Stop at step 4, offer to re-prompt or hand off
+- **Quality gates fail after retries:** Stop at step 5, show error output
+- **Push/PR fails:** Stop at step 6, suggest manual resolution
+
+## Notes
+
+- Codex CLI runs with `--sandbox danger-full-access` which is safe in a disposable worktree
+- `--json` flag streams JSONL events for monitoring plan steps, diffs, and messages
+- Cross-model review catches issues that same-model review might miss
+- Fix loop re-prompts Codex with error context, max 2 retries before stopping
+- Worktree cleanup follows the same safe pattern as flow:auto (cd out before removing)

--- a/.claude/commands/codex/exec.md
+++ b/.claude/commands/codex/exec.md
@@ -1,0 +1,100 @@
+---
+description: One-shot Codex execution in current directory with JSONL monitoring
+allowed-tools: Bash(codex:*), Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(pwd), Bash(tee:*)
+---
+
+# Codex Exec: One-Shot Codex Execution
+
+Run Codex CLI in the current directory with JSONL monitoring.
+For quick tasks without the full issue lifecycle.
+
+## Arguments
+
+- `PROMPT` (required): The task prompt for Codex (e.g., `"Add input validation to the login form"`)
+
+## Instructions
+
+When the user invokes `/codex:exec <PROMPT>`, perform these steps:
+
+### Step 1: Verify Codex Availability
+
+```bash
+if ! command -v codex &>/dev/null; then
+    echo "ERROR: Codex CLI not found."
+    echo "Install with: npm install -g @openai/codex"
+    echo "Then configure: codex login"
+    exit 1
+fi
+
+CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
+echo "Codex CLI: $CODEX_VERSION"
+echo "Working directory: $(pwd)"
+```
+
+### Step 2: Execute Codex
+
+Run Codex with JSONL output for structured monitoring:
+
+```bash
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUTPUT_FILE="/tmp/codex-exec-${TIMESTAMP}.jsonl"
+
+codex exec \
+    --json \
+    --sandbox danger-full-access \
+    "$PROMPT" 2>&1 | tee "$OUTPUT_FILE"
+
+CODEX_EXIT=$?
+```
+
+### Step 3: Monitor and Report
+
+**While Codex runs**, parse the JSONL stream and report:
+
+- **Plan steps:** What Codex plans to do
+- **File changes:** Which files are being created or modified
+- **Messages:** Agent reasoning and progress
+- **Errors:** Any failures during execution
+
+### Step 4: Summary
+
+After Codex completes:
+
+```bash
+if [ "$CODEX_EXIT" -ne 0 ]; then
+    echo ""
+    echo "Codex execution failed (exit code: $CODEX_EXIT)"
+    echo "Output saved to: $OUTPUT_FILE"
+    exit 1
+fi
+
+# Show changes
+echo ""
+echo "=== Changes ==="
+git diff --stat 2>/dev/null || echo "(not a git repo or no changes)"
+echo ""
+echo "=== Diff ==="
+git diff 2>/dev/null || echo "(no diff available)"
+```
+
+Report:
+
+```
+Codex Exec Complete
+
+  Prompt:    "{prompt summary}"
+  Duration:  {time}
+  Changes:   {N} files modified (+{added} -{removed})
+  Output:    {output_file}
+
+Review the changes above. Use git add/commit to keep them,
+or git checkout -- . to discard.
+```
+
+## Notes
+
+- Runs in the CURRENT directory (not a worktree) - changes are applied directly
+- Uses `--sandbox danger-full-access` - Codex can run any commands
+- JSONL output is saved to /tmp for later inspection
+- No automatic commit - user reviews and commits manually
+- For full issue lifecycle with review and quality gates, use `/codex:auto`

--- a/.claude/commands/codex/help.md
+++ b/.claude/commands/codex/help.md
@@ -1,0 +1,83 @@
+---
+description: Codex Orchestration commands overview
+---
+
+# Codex Orchestration Commands
+
+Claude Code acts as supervisor/reviewer while Codex CLI implements features.
+Cross-model implementation and review - Claude manages the workflow, Codex writes the code.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/codex:auto <ISSUE>` | Full issue lifecycle delegated to Codex - worktree, implement, review, quality gates, PR |
+| `/codex:exec <PROMPT>` | One-shot Codex execution in current directory with JSONL monitoring |
+| `/codex:status` | Check Codex CLI installation, config, and readiness |
+| `/codex:help` | This help overview |
+
+## Architecture
+
+```
+Claude Code (supervisor)            Codex CLI (implementer)
+  1. Read GH issue
+  2. Create worktree + branch
+  3. Build prompt from issue     --> 4. codex exec --json -C <worktree>
+  5. Monitor JSONL stream        <-- 6. Plan, code, test
+  7. Review Codex's diff
+  8. Run quality gates (lint/test/security)
+  9. If gates fail, re-prompt   --> 10. Fix with error context (max 2 retries)
+  11. Commit, push, create PR
+```
+
+## Quick Start
+
+```bash
+# Check if Codex is ready
+/codex:status
+
+# Run a quick one-shot task
+/codex:exec "Add input validation to the login form"
+
+# Full issue lifecycle
+/codex:auto 42
+```
+
+## Prerequisites
+
+- **Codex CLI**: `npm install -g @openai/codex`
+- **OpenAI API key**: `codex login` or set `OPENAI_API_KEY`
+- **Verify**: `codex doctor`
+
+## How It Differs From /flow:auto
+
+| Aspect | `/flow:auto` | `/codex:auto` |
+|--------|-------------|---------------|
+| Implementer | Claude Code | Codex CLI |
+| Reviewer | (self) | Claude Code (cross-model) |
+| Sandbox | N/A | `danger-full-access` (worktree) |
+| Fix loop | Manual | Automatic re-prompt (max 2) |
+| Monitoring | Direct | JSONL event stream |
+
+## Installation
+
+Run `/cpp:init` and select **Tier 5 (Codex)** to:
+1. Verify Codex CLI installation
+2. Run `codex doctor`
+3. Verify OpenAI API key
+4. Optionally register CPP MCP servers with Codex
+
+Or install manually:
+```bash
+npm install -g @openai/codex
+codex login
+codex doctor
+```
+
+## Notes
+
+- Codex runs with `--sandbox danger-full-access` - safe in disposable worktrees
+- `--json` flag provides structured JSONL output for monitoring
+- Cross-model review catches issues that single-model review might miss
+- Quality gate fix loop re-prompts Codex with error context (max 2 retries)
+- All worktree cleanup follows the same safe patterns as `/flow:auto`

--- a/.claude/commands/codex/status.md
+++ b/.claude/commands/codex/status.md
@@ -1,0 +1,140 @@
+---
+description: Check Codex CLI installation, config, and readiness
+allowed-tools: Bash(codex:*), Bash(command -v:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(npm:*), Bash(node:*), Bash(test:*), Bash(head:*)
+---
+
+# Codex Status: Check Codex CLI Readiness
+
+Check Codex CLI installation, configuration, and MCP server registrations.
+
+## Instructions
+
+When the user invokes `/codex:status`, run these checks and report:
+
+### Step 1: Check Codex CLI
+
+```bash
+echo "=== Codex CLI ==="
+echo ""
+
+# Check if installed
+if command -v codex &>/dev/null; then
+    CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
+    CODEX_PATH=$(command -v codex)
+    echo "[x] Codex CLI: $CODEX_VERSION"
+    echo "    Path: $CODEX_PATH"
+else
+    echo "[ ] Codex CLI: not installed"
+    echo "    Install with: npm install -g @openai/codex"
+    echo ""
+    echo "Status: NOT READY"
+    exit 0
+fi
+```
+
+### Step 2: Check Codex Doctor
+
+```bash
+echo ""
+echo "=== Codex Doctor ==="
+echo ""
+
+DOCTOR_OUTPUT=$(codex doctor 2>&1 || true)
+echo "$DOCTOR_OUTPUT"
+
+if echo "$DOCTOR_OUTPUT" | grep -qi "error\|fail\|missing"; then
+    echo ""
+    echo "[!] codex doctor reported issues - resolve before using /codex:auto"
+else
+    echo ""
+    echo "[x] codex doctor: all checks passed"
+fi
+```
+
+### Step 3: Check Codex Configuration
+
+```bash
+echo ""
+echo "=== Codex Configuration ==="
+echo ""
+
+# Check config file
+CODEX_CONFIG="$HOME/.codex/config.toml"
+if [ -f "$CODEX_CONFIG" ]; then
+    echo "[x] Config: $CODEX_CONFIG"
+    # Show model config (without exposing keys)
+    grep -E '^(model|provider)' "$CODEX_CONFIG" 2>/dev/null | head -5 || echo "    (no model/provider settings found)"
+else
+    echo "[ ] Config: $CODEX_CONFIG not found"
+    echo "    Run: codex login"
+fi
+
+# Check for OpenAI API key
+if [ -n "$OPENAI_API_KEY" ]; then
+    echo "[x] OPENAI_API_KEY: set in environment"
+else
+    echo "[ ] OPENAI_API_KEY: not set in environment"
+    echo "    Set via: export OPENAI_API_KEY=... or codex login"
+fi
+```
+
+### Step 4: Check MCP Registrations
+
+```bash
+echo ""
+echo "=== MCP Registrations (Codex) ==="
+echo ""
+
+if command -v codex &>/dev/null; then
+    CODEX_MCP=$(codex mcp list 2>/dev/null || echo "")
+    if [ -n "$CODEX_MCP" ]; then
+        for server in second-opinion playwright-persistent nano-banana; do
+            if echo "$CODEX_MCP" | grep -q "$server"; then
+                echo "[x] $server: registered with Codex"
+            else
+                echo "[ ] $server: not registered with Codex"
+            fi
+        done
+    else
+        echo "[ ] No MCP servers registered with Codex"
+        echo "    Register via /cpp:init (Tier 5) or manually:"
+        echo "    codex mcp add <name> --url http://127.0.0.1:<port>/mcp"
+    fi
+fi
+```
+
+### Step 5: Summary
+
+```bash
+echo ""
+echo "==================================="
+
+# Determine readiness
+READY=true
+if ! command -v codex &>/dev/null; then READY=false; fi
+if [ -z "$OPENAI_API_KEY" ] && ! [ -f "$HOME/.codex/config.toml" ]; then READY=false; fi
+
+if [ "$READY" = "true" ]; then
+    echo "Status: READY"
+    echo ""
+    echo "Commands available:"
+    echo "  /codex:auto <ISSUE>  - Full issue lifecycle via Codex"
+    echo "  /codex:exec <PROMPT> - One-shot Codex execution"
+else
+    echo "Status: NOT READY"
+    echo ""
+    echo "To set up:"
+    echo "  1. npm install -g @openai/codex"
+    echo "  2. codex login (or set OPENAI_API_KEY)"
+    echo "  3. codex doctor"
+    echo "  4. /cpp:init (select Tier 5 for MCP registration)"
+fi
+
+echo "==================================="
+```
+
+## Notes
+
+- This command is read-only - it checks state but does not modify anything
+- Run `/cpp:init` and select Tier 5 to install and configure Codex
+- Codex CLI requires Node.js and an OpenAI API key

--- a/.claude/commands/cpp/help.md
+++ b/.claude/commands/cpp/help.md
@@ -25,6 +25,7 @@ CPP uses a tiered installation model:
 | 2 | **Standard** | + Scripts, hooks, shell prompt |
 | 3 | **Full** | + MCP servers (uv, API keys) |
 | 4 | **CI/CD** | + Build system, health checks, pipelines, containers |
+| 5 | **Codex** | + Codex CLI orchestration (cross-model implementation and review) |
 
 ## Quick Start
 
@@ -61,6 +62,12 @@ CPP uses a tiered installation model:
 - **CI/CD Pipelines**: GitHub Actions workflow generation (`/cicd:pipeline`)
 - **Containers**: Dockerfile and docker-compose generation (`/cicd:container`)
 
+### Tier 5 - Codex
+- **Codex Auto** (`/codex:auto`): Full issue lifecycle delegated to Codex CLI
+- **Codex Exec** (`/codex:exec`): One-shot Codex execution with JSONL monitoring
+- **Cross-model review**: Claude reviews Codex's implementation
+- **Fix loop**: Automatic re-prompt on quality gate failure (max 2 retries)
+
 ## CI/CD Commands (Tier 4)
 
 | Command | Purpose |
@@ -72,6 +79,15 @@ CPP uses a tiered installation model:
 | `/cicd:pipeline` | Generate GitHub Actions CI/CD workflows |
 | `/cicd:container` | Generate Dockerfile and docker-compose.yml |
 | `/cicd:help` | CI/CD command overview |
+
+## Codex Orchestration Commands (Tier 5)
+
+| Command | Purpose |
+|---------|---------|
+| `/codex:auto <ISSUE>` | Full issue lifecycle delegated to Codex CLI |
+| `/codex:exec <PROMPT>` | One-shot Codex execution with JSONL monitoring |
+| `/codex:status` | Check Codex CLI installation and readiness |
+| `/codex:help` | Codex commands overview |
 
 ## Related Documentation
 

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -95,8 +95,9 @@ Ask the user which tier they want to install using the AskUserQuestion tool:
 | 2 | **Standard** | + Scripts, hooks, shell prompt |
 | 3 | **Full** | + MCP servers (Docker local builds, API keys) |
 | 4 | **CI/CD** | + Build system, health checks, pipelines, containers |
+| 5 | **Codex** | + Codex CLI orchestration (cross-model implementation and review) |
 
-Default recommendation: **Standard** for most users, **Full** for MCP-powered workflows, **CI/CD** for projects needing build automation.
+Default recommendation: **Standard** for most users, **Full** for MCP-powered workflows, **CI/CD** for projects needing build automation, **Codex** for cross-model implementation workflows.
 
 ---
 
@@ -357,6 +358,31 @@ This will make the following changes:
     rm .github/workflows/ci.yml
     rm Dockerfile docker-compose.yml .dockerignore
     claude mcp remove woodpecker-ci
+
+Proceed? [y/N]
+```
+
+### Tier 5 Disclosure (Codex)
+
+```
+=== Tier 5: Codex Orchestration ===
+
+This will make the following changes:
+
+  [Tier 1 + 2 + 3 + 4 - All CI/CD components]
+    (see above)
+
+  [Tier 5 - Codex CLI]
+    - Requires: Codex CLI (npm install -g @openai/codex)
+    - Requires: OpenAI API key (codex login)
+    - Installs: /codex:auto, /codex:exec, /codex:status, /codex:help commands
+    - Optional: Register CPP MCP servers with Codex
+
+  Disk usage: ~0 MB (commands via symlink)
+
+  To undo:
+    # Tier 1+2+3+4 cleanup (see above)
+    npm uninstall -g @openai/codex
 
 Proceed? [y/N]
 ```
@@ -1018,6 +1044,114 @@ claude mcp add --transport stdio -s user woodpecker-ci -- "$BINARY" serve
 echo "✓ Woodpecker CI MCP server installed and registered"
 ```
 
+### Tier 5 Execution (Codex Orchestration)
+
+#### 5a. Check Codex CLI
+
+```bash
+echo ""
+echo "=== Tier 5: Codex Orchestration ==="
+echo ""
+
+if command -v codex &>/dev/null; then
+  CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
+  echo "[x] Codex CLI: $CODEX_VERSION"
+else
+  echo "[ ] Codex CLI: not installed"
+  echo ""
+  echo "Install Codex CLI?"
+  echo "  npm install -g @openai/codex"
+  echo ""
+  # Ask user if they want to install
+  # If yes:
+  npm install -g @openai/codex
+  if command -v codex &>/dev/null; then
+    echo "Codex CLI installed"
+  else
+    echo "WARNING: Codex CLI installation failed"
+    echo "  Try: sudo npm install -g @openai/codex"
+    echo "  Codex commands will not work until installed"
+  fi
+fi
+```
+
+#### 5b. Run Codex Doctor
+
+```bash
+if command -v codex &>/dev/null; then
+  echo ""
+  echo "Running codex doctor..."
+  DOCTOR_OUTPUT=$(codex doctor 2>&1 || true)
+  echo "$DOCTOR_OUTPUT"
+
+  if echo "$DOCTOR_OUTPUT" | grep -qi "error\|fail\|missing"; then
+    echo ""
+    echo "WARNING: codex doctor reported issues. Resolve before using /codex:auto."
+  else
+    echo "[x] codex doctor: all checks passed"
+  fi
+fi
+```
+
+#### 5c. Verify OpenAI API Key
+
+```bash
+if command -v codex &>/dev/null; then
+  echo ""
+  echo "=== OpenAI API Key ==="
+
+  CODEX_CONFIG="$HOME/.codex/config.toml"
+  if [ -f "$CODEX_CONFIG" ] || [ -n "$OPENAI_API_KEY" ]; then
+    echo "[x] OpenAI API key: configured"
+  else
+    echo "[ ] OpenAI API key: not configured"
+    echo ""
+    echo "Configure with one of:"
+    echo "  codex login                    (interactive)"
+    echo "  export OPENAI_API_KEY=sk-...   (environment variable)"
+    echo ""
+    echo "Codex commands require an OpenAI API key to function."
+  fi
+fi
+```
+
+#### 5d. Register MCP Servers with Codex (Optional)
+
+This reuses the logic from Step 7 (Optional Extras) section 8b, but is now part of the Tier 5 flow:
+
+```bash
+if command -v codex &>/dev/null; then
+  echo ""
+  echo "=== Codex MCP Registration ==="
+  echo ""
+  echo "Register Claude Power Pack MCP servers with Codex?"
+  echo "MCP servers expose streamable HTTP at /mcp for Codex compatibility."
+  echo ""
+  # Ask user if they want to register - use AskUserQuestion
+  # If yes:
+  CODEX_LIST=$(codex mcp list 2>/dev/null || echo "")
+
+  for entry in "second-opinion:8080" "playwright-persistent:8081" "nano-banana:8084"; do
+    NAME="${entry%%:*}"
+    PORT="${entry#*:}"
+    if echo "$CODEX_LIST" | grep -q "$NAME"; then
+      echo "-> $NAME already registered with Codex (skipped)"
+    else
+      if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1; then
+        codex mcp add "$NAME" --url "http://127.0.0.1:${PORT}/mcp"
+        echo "Registered $NAME with Codex (http://127.0.0.1:${PORT}/mcp)"
+      else
+        echo "WARNING: $NAME not reachable on port $PORT - skipping Codex registration"
+        echo "  Start containers first: make docker-refresh PROFILE=\"core browser cicd\""
+      fi
+    fi
+  done
+
+  echo ""
+  echo "Restart Codex for tools to become available."
+fi
+```
+
 ---
 
 ## Step 6: Installation Summary
@@ -1032,6 +1166,7 @@ Installed:
   ✓ Tier 2: Scripts, hooks, shell prompt
   ✓ Tier 3: Docker MCP stack, API keys
   ✓ Tier 4: CI/CD build system, health checks, pipeline, containers
+  ✓ Tier 5: Codex CLI orchestration
 
 Permission Profile: {PROFILE_NAME}
   Auto-approved: {AUTO_APPROVE_SUMMARY}

--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -480,7 +480,69 @@ else
 fi
 ```
 
-## Step 6: Summary
+## Step 6: Check Tier 5 (Codex Orchestration)
+
+Check Codex CLI installation, configuration, and MCP registrations:
+
+```bash
+echo ""
+echo "Tier 5 (Codex):"
+
+# Check Codex CLI
+if command -v codex &>/dev/null; then
+  CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
+  echo "  [x] Codex CLI: $CODEX_VERSION"
+else
+  echo "  [ ] Codex CLI: not installed"
+fi
+
+# Check codex doctor
+if command -v codex &>/dev/null; then
+  DOCTOR_OUTPUT=$(codex doctor 2>&1 || true)
+  if echo "$DOCTOR_OUTPUT" | grep -qi "error\|fail\|missing"; then
+    echo "  [!] codex doctor: issues detected"
+  else
+    echo "  [x] codex doctor: passed"
+  fi
+fi
+
+# Check OpenAI API key
+CODEX_CONFIG="$HOME/.codex/config.toml"
+if [ -n "$OPENAI_API_KEY" ]; then
+  echo "  [x] OpenAI API key: set in environment"
+elif [ -f "$CODEX_CONFIG" ]; then
+  echo "  [x] OpenAI API key: configured in $CODEX_CONFIG"
+else
+  echo "  [ ] OpenAI API key: not configured"
+fi
+
+# Check Codex MCP registrations
+if command -v codex &>/dev/null; then
+  CODEX_MCP=$(codex mcp list 2>/dev/null || echo "")
+  for server in second-opinion playwright-persistent nano-banana; do
+    if echo "$CODEX_MCP" | grep -q "$server"; then
+      echo "  [x] Codex MCP: $server registered"
+    else
+      echo "  [ ] Codex MCP: $server not registered"
+    fi
+  done
+fi
+
+# Check Codex commands available
+if [ -d ".claude/commands/codex" ] || [ -L ".claude/commands" ]; then
+  CODEX_CMDS=0
+  for cmd in auto exec status help; do
+    if [ -f ".claude/commands/codex/${cmd}.md" ]; then
+      CODEX_CMDS=$((CODEX_CMDS + 1))
+    fi
+  done
+  echo "  [x] Codex commands: $CODEX_CMDS/4 available"
+else
+  echo "  [ ] Codex commands: not installed"
+fi
+```
+
+## Step 8: Summary
 
 Based on the checks above, report:
 
@@ -535,6 +597,16 @@ Tier 4 (CI/CD):
   [ ] CI pipeline: no workflows found
   [ ] Dockerfile: not found
   Status: Partial
+
+Tier 5 (Codex):
+  [x] Codex CLI: 0.137.0
+  [x] codex doctor: passed
+  [x] OpenAI API key: set in environment
+  [x] Codex MCP: second-opinion registered
+  [x] Codex MCP: playwright-persistent registered
+  [x] Codex MCP: nano-banana registered
+  [x] Codex commands: 4/4 available
+  Status: Complete
 
 ---------------------------------
 Current Level: Tier 2 (Standard)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `python -m lib.cicd run --plan <name>` - Execute CI/CD plan deterministically (finish, check, deploy)
 - `python -m lib.cicd.bootstrap check` - Check admin-only bootstrap dependencies (config: `.claude/bootstrap.yaml`)
 
+### Codex Orchestration
+- `/codex:auto <ISSUE>` - Full issue lifecycle delegated to Codex CLI (worktree, implement, review, quality gates, PR)
+- `/codex:exec <PROMPT>` - One-shot Codex execution in current directory with JSONL monitoring
+- `/codex:status` - Check Codex CLI installation, config, and readiness
+- `/codex:help` - Codex commands overview
+
 ### Security
 - `/security:scan` - Full scan: native + external tools
 - `/security:quick` - Fast scan: native only (zero deps)
@@ -148,7 +154,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 
 ### Other
 - `/dockers` - Docker container status, health, project linkages
-- `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD)
+- `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD, Codex)
 - `/cpp:status` - Check installation state
 - `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, then refresh Docker local-build runtime
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
@@ -191,4 +197,4 @@ Tiered: dotenv-global (`~/.config/claude-power-pack/secrets/`) -> env-file -> AW
 
 ## Version
 
-Current version: 6.0.0
+Current version: 7.0.0


### PR DESCRIPTION
## Summary

- Add `/codex:auto`, `/codex:exec`, `/codex:status`, `/codex:help` commands for cross-model implementation (Claude supervises, Codex CLI implements)
- Update `/cpp:init` with Tier 5 installation steps (Codex CLI check, doctor, API key, MCP registration)
- Update `/cpp:status` with Tier 5 readiness checks
- Update `/cpp:help` with Tier 5 tier listing and Codex command table
- Update `CLAUDE.md` Commands Reference with Codex Orchestration section
- Bump version to 7.0.0

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (729 passed, 1 skipped)
- [ ] Verify `/codex:status` reports Codex CLI readiness
- [ ] Verify `/codex:help` displays command overview
- [ ] Verify `/cpp:status` includes Tier 5 section
- [ ] Verify `/cpp:help` lists Tier 5 and Codex commands
- [ ] Verify `/cpp:init` offers Tier 5 selection

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)