### PR TITLE
chore(skills): deprecate Wiki.js scaffolding skills; GitHub Issues is the only scaffolding backend (Closes #394)

### DIFF
--- a/.claude/deprecated-skills.yaml
+++ b/.claude/deprecated-skills.yaml
@@ -1,0 +1,40 @@
+# Deprecated skill families retired from Claude Power Pack.
+#
+# Scaffolding in CPP is GitHub Issues only, driven by the flow-auto skillset.
+# Wiki.js and Plane were never part of the supported workflow. The wiki-* skills
+# below were produced by an older, manifest-driven generation architecture
+# (source: manifests/wiki/*.yaml) that no longer exists in this repo, so they
+# linger as unmanaged orphans in ~/.claude/skills/ on machines that installed
+# an earlier CPP.
+#
+# This file is the deprecation list of record. The /cpp:update skill-orphan
+# prune (issue #395) consumes it to offer guarded removal of matching generated
+# skills. Adding a family here does NOT auto-delete anything: removal is always
+# user-confirmed.
+#
+# Schema: version + a list of deprecated families. Each family lists the exact
+# generated skill directory names so the prune can match them under
+# ~/.claude/skills/ without a fragile repo diff.
+
+version: 1
+
+deprecated:
+  - family: wiki
+    reason: >-
+      Wiki.js scaffolding and integration is out of scope for CPP. GitHub Issues
+      (via the flow-auto skillset) is the only supported scaffolding backend.
+    replacement: GitHub Issues via /flow:auto
+    skills:
+      - wiki-search
+      - wiki-create-page
+      - wiki-update-page
+    # One-time manual cleanup until the #395 prune lands. Safe: these are
+    # generated artifacts, not user content.
+    cleanup: |
+      rm -rf ~/.claude/skills/wiki-search \
+             ~/.claude/skills/wiki-create-page \
+             ~/.claude/skills/wiki-update-page
+
+# Plane has no entry: it was never integrated as a CPP skill or command, so
+# there is nothing installed to remove. It is recorded here only to make the
+# "GitHub Issues is the sole scaffolding backend" decision explicit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/github:issue-update` - Update existing issue
 - `/github:issue-close` - Close issue with optional comment
 
+**Scaffolding backend:** GitHub Issues (driven by the `flow-auto` skillset) is the only supported scaffolding/issue backend. Wiki.js and Plane are out of scope and are not part of CPP. Retired skill families are recorded in `.claude/deprecated-skills.yaml`; the legacy `wiki-*` skills installed by older CPP versions are pruned via `/cpp:update` (see issue #395).
+
 ### CI/CD
 - `/cicd:init` - Detect framework, generate Makefile and cicd.yml
 - `/cicd:check` - Validate Makefile against CPP standards

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "claude-power-pack"
-version = "6.0.0"
+version = "7.1.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Scaffolding in CPP is GitHub Issues only (via the `flow-auto` skillset). This PR makes that explicit and seeds cleanup of the orphaned Wiki.js skills.
- Add `.claude/deprecated-skills.yaml` as the deprecation list of record. Declares the `wiki` family (`wiki-search`, `wiki-create-page`, `wiki-update-page`) with its replacement (GitHub Issues via `/flow:auto`) and a one-time cleanup command. Consumed by the `/cpp:update` skill-orphan prune (#395); removal is always user-confirmed.
- `CLAUDE.md`: document GitHub Issues (`flow-auto`) as the only supported scaffolding backend; Wiki.js and Plane are out of scope.

## Context
The repo source tree and full git history are already clean of Plane and Wiki.js (only a generic "stale wiki page" metaphor in `infra-discover.md`). The remnants live outside the repo: three globally-installed `wiki-*` skills generated by an older, manifest-driven CPP architecture (`source: manifests/wiki/*.yaml`) that no longer exists here. Plane was never integrated, so nothing is installed to remove.

## Grill-yourself
Skipped (trivial): 2 files, ~42 insertions, no Python, no allowlist paths.

## Quality gates
- `make lint` (ruff): All checks passed
- `make verify` (lint + test + typecheck): **729 passed, 1 skipped**; mypy: no issues in 116 source files
- `.claude/deprecated-skills.yaml` parses (PyYAML); ASCII hyphens only

## Test plan
- [ ] Confirm `.claude/deprecated-skills.yaml` schema is acceptable for the #395 prune consumer
- [ ] Confirm the CLAUDE.md scaffolding-backend wording

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)