### PR TITLE
feat(flow): add /flow:eli5 plan + necessity gate for /flow:auto (Closes #398)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -1,6 +1,6 @@
 # Flow: Auto - Full Issue Lifecycle in One Shot
 
-Complete end-to-end workflow: start worktree → analyze issue → implement → finish (PR) → merge → deploy.
+Complete end-to-end workflow: start worktree → analyze issue → ELI5 plan + necessity gate → implement → finish (PR) → merge → deploy.
 
 ## Arguments
 
@@ -15,14 +15,15 @@ Report at the start:
 ```
 Flow Auto: Issue #42 - Full Lifecycle
 
-Step 1/8: Start (create worktree and branch)
-Step 2/8: Analyze (understand issue and codebase)
-Step 3/8: Implement (write the code)
-Step 4/8: Update Docs (regenerate C4 diagrams, review CLAUDE.md/README.md)
-Step 5/8: Finish (lint, test, commit, push, create PR)
-Step 6/8: Merge (squash-merge PR, clean up worktree)
-Step 7/8: Verify CI (confirm pipeline passes on main)
-Step 8/8: Deploy (make deploy, if target exists)
+Step 1/9: Start (create worktree and branch)
+Step 2/9: Analyze (understand issue and codebase)
+Step 3/9: ELI5 (plain-language intent + necessity verdict + plan approval gate)
+Step 4/9: Implement (write the code)
+Step 5/9: Update Docs (regenerate C4 diagrams, review CLAUDE.md/README.md)
+Step 6/9: Finish (lint, test, commit, push, create PR)
+Step 7/9: Merge (squash-merge PR, clean up worktree)
+Step 8/9: Verify CI (confirm pipeline passes on main)
+Step 9/9: Deploy (make deploy, if target exists)
 
 Proceeding...
 ```
@@ -100,7 +101,7 @@ echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
 
 **If this verification fails, STOP immediately. Report the failure using the error template at the bottom of this file. Do NOT proceed to Step 2.**
 
-Report: `Step 1/8: Start complete - worktree at {path}, verified on branch {branch}`
+Report: `Step 1/9: Start complete - worktree at {path}, verified on branch {branch}`
 
 ---
 
@@ -125,7 +126,7 @@ Working from the worktree, analyze the issue and codebase to form an implementat
 4. **Report the plan to the user:**
 
 ```
-Step 2/8: Analysis Complete
+Step 2/9: Analysis Complete
 
 Issue #42: "Fix login redirect loop"
 
@@ -142,16 +143,45 @@ Implementation Plan:
 Files to modify: 3
 Estimated scope: Small
 
-Proceeding to implementation...
+Proceeding to ELI5 review...
 ```
 
-Report: `Step 2/8: Analyze complete - {N} files to modify`
+Report: `Step 2/9: Analyze complete - {N} files to modify`
 
 ---
 
-### Step 3: Implement - Write the Code
+### Step 3: ELI5 - Plan + Necessity Gate (Approval Checkpoint)
 
-Execute the implementation plan from Step 2:
+Before writing any code, run the `/flow:eli5` review (see `.claude/commands/flow/eli5.md`) using the issue and the Step 2 analysis. This is the post-analysis, pre-implementation communication and approval gate. Produce the three-section reviewer report:
+
+1. **ELI5 overview of intent** - what the issue is really trying to accomplish, in plain language a reviewer can sanity-check for a misread.
+2. **Necessity / staleness analysis** - whether the issue is still worth doing given anything merged since it was filed. Anchor the check to the issue's creation date:
+   ```bash
+   ISSUE_DATE=$(gh issue view "$ISSUE_NUM" --json createdAt --jq '.createdAt')
+   git log --since="$ISSUE_DATE" --oneline -- <relevant/paths>
+   gh pr list --state merged --search "merged:>=${ISSUE_DATE%%T*}" --json number,title,mergedAt
+   gh issue list --state all --search "<key terms>" --json number,title,state
+   ```
+   Output one verdict with evidence: **Still needed / Partially addressed / No longer needed / Needs reframing**.
+3. **Proposed changes (pending approval)** - the files and edits that will close the issue, framed as a plan awaiting reviewer approval.
+
+**This is a gate:**
+
+- **Verdict `No longer needed`** -> do NOT implement. Recommend closing the issue with an evidence-based comment and **STOP**:
+  ```bash
+  gh issue close "$ISSUE_NUM" --comment "Closed via /flow:auto ELI5 review - <reason; cite superseding PR/issue>."
+  ```
+  Run the close only with reviewer assent; surface the recommendation either way.
+- **Verdict `Partially addressed` or `Needs reframing`** -> the plan to approve is the adjusted one (remaining work / corrected approach), not the original issue body.
+- **Approval:** By default, **pause and wait for reviewer approval** of the plan before continuing to Step 4. For unattended runs, accept `--yes` (alias `--auto-approve`) on `/flow:auto`, or an `eli5: auto-approve` trailer in the issue body or HEAD commit message, to proceed without pausing. Auto-approve never overrides a `No longer needed` verdict.
+
+Report: `Step 3/9: ELI5 complete - verdict: {Still needed|Partially addressed|No longer needed|Needs reframing}; approval: {granted|auto-granted|close recommended}`
+
+---
+
+### Step 4: Implement - Write the Code
+
+Execute the approved plan from the Step 3 ELI5 gate:
 
 1. **Make all code changes** in the worktree.
 2. **Follow existing conventions** - match the code style, patterns, and structure of the project.
@@ -162,11 +192,11 @@ If implementation hits a blocker that cannot be resolved:
 - **STOP** and report the blocker.
 - Suggest manual intervention.
 
-Report: `Step 3/8: Implement complete - {summary of changes}`
+Report: `Step 4/9: Implement complete - {summary of changes}`
 
 ---
 
-### Step 4: Update Docs - Regenerate C4 Diagrams and Review Docs
+### Step 5: Update Docs - Regenerate C4 Diagrams and Review Docs
 
 If the Makefile has an `update_docs` target:
 
@@ -192,11 +222,11 @@ Then perform these documentation tasks:
 
 If no `update_docs` target exists in the Makefile, skip this step.
 
-Report: `Step 4/8: Update Docs complete - {N} files updated` or `Step 4/8: Update Docs skipped (no Makefile target)`
+Report: `Step 5/9: Update Docs complete - {N} files updated` or `Step 5/9: Update Docs skipped (no Makefile target)`
 
 ---
 
-### Step 5: Finish - Quality Gates, Commit, Push, PR
+### Step 6: Finish - Quality Gates, Commit, Push, PR
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -244,11 +274,11 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
    - PR body: Summary of changes + test plan + `Closes #N`
    - Analyze all commits on the branch to draft the summary.
 
-Report: `Step 5/8: Finish complete - PR #XX created`
+Report: `Step 6/9: Finish complete - PR #XX created`
 
 ---
 
-### Step 6: Merge - Squash-Merge and Clean Up
+### Step 7: Merge - Squash-Merge and Clean Up
 
 1. **Merge the PR:**
    ```bash
@@ -272,13 +302,13 @@ Report: `Step 5/8: Finish complete - PR #XX created`
 
    **CRITICAL: You MUST `cd` to the main repo BEFORE removing the worktree. NEVER remove a worktree while your working directory is inside it - this kills all subsequent bash commands. Execute these as SEPARATE Bash calls, not in a single script.**
 
-   **Step 6a - Exit the worktree (separate Bash call):**
+   **Step 7a - Exit the worktree (separate Bash call):**
    ```bash
    cd "$MAIN_REPO"
    pwd  # Verify you are in the main repo
    ```
 
-   **Step 6b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
+   **Step 7b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
    ```bash
    if [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
        ~/.claude/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
@@ -288,7 +318,7 @@ Report: `Step 5/8: Finish complete - PR #XX created`
    fi
    ```
 
-   **Step 6c - Verify working directory is valid:**
+   **Step 7c - Verify working directory is valid:**
    ```bash
    pwd  # MUST show main repo path, NOT the deleted worktree
    git status  # MUST succeed - if this fails, your CWD was deleted
@@ -309,11 +339,11 @@ Report: `Step 5/8: Finish complete - PR #XX created`
    fi
    ```
 
-Report: `Step 6/8: Merge complete - worktree cleaned up`
+Report: `Step 7/9: Merge complete - worktree cleaned up`
 
 ---
 
-### Step 7: Verify CI (after merge)
+### Step 8: Verify CI (after merge)
 
 After merging to main, verify that the CI pipeline passes before deploying.
 
@@ -427,15 +457,15 @@ If neither `WOODPECKER_API_TOKEN` is set nor GitHub Actions runs are found, skip
 WARNING: No CI system detected. Skipping verification.
 ```
 
-- If CI **passes**: proceed to Step 8.
+- If CI **passes**: proceed to Step 9.
 - If CI **fails**: **STOP**. Report the failure and exit. Do not deploy broken code.
 - If CI **not found** after timeout: warn and proceed (non-blocking).
 
-Report: `Step 7/8: Verify CI complete - pipeline #{N} passed` or `Step 7/8: Verify CI skipped (no CI detected)`
+Report: `Step 8/9: Verify CI complete - pipeline #{N} passed` or `Step 8/9: Verify CI skipped (no CI detected)`
 
 ---
 
-### Step 8: Deploy (optional)
+### Step 9: Deploy (optional)
 
 Only if a Makefile with a `deploy` target exists in the main repo:
 
@@ -452,7 +482,7 @@ else
 fi
 ```
 
-Report: `Step 8/8: Deploy complete` or `Step 8/8: Deploy skipped (no Makefile target)`
+Report: `Step 9/9: Deploy complete` or `Step 9/9: Deploy skipped (no Makefile target)`
 
 ---
 
@@ -462,6 +492,7 @@ Report: `Step 8/8: Deploy complete` or `Step 8/8: Deploy skipped (no Makefile ta
 Flow Auto Complete
 
   Issue:    #42 - Fix login bug
+  ELI5:     Still needed (plan approved)
   Changes:  Modified 3 files (src/auth/login.py, tests/test_auth.py, config/routes.py)
   PR:       #78 (squash-merged)
   Branch:   issue-42-fix-login (deleted)
@@ -478,7 +509,7 @@ Flow Auto Complete
 At each step, if something fails:
 
 ```
-Flow Auto stopped at Step N/8: {Step Name}
+Flow Auto stopped at Step N/9: {Step Name}
 
   Failed: [description of what failed]
   Fix:    [actionable suggestion]
@@ -486,25 +517,28 @@ Flow Auto stopped at Step N/8: {Step Name}
   To resume manually:
     /flow:start N    (if step 1 failed)
     [investigate]    (if step 2 failed)
-    [implement]      (if step 3 failed)
-    /documentation:c4 (if step 4 failed)
-    /flow:finish     (if step 5 failed)
-    /flow:merge      (if step 6 failed)
-    [check CI dashboard] (if step 7 failed)
-    /flow:deploy     (if step 8 failed)
+    /flow:eli5 N     (if step 3 failed)
+    [implement]      (if step 4 failed)
+    /documentation:c4 (if step 5 failed)
+    /flow:finish     (if step 6 failed)
+    /flow:merge      (if step 7 failed)
+    [check CI dashboard] (if step 8 failed)
+    /flow:deploy     (if step 9 failed)
 ```
 
 Key failure scenarios:
 - **Issue not found:** Stop at step 1
 - **Issue closed:** Warn at step 1, ask to proceed
 - **Analysis unclear:** Stop at step 2, ask user for clarification
-- **Implementation blocker:** Stop at step 3, report what's blocking
-- **Doc update fails:** Non-blocking at step 4, warn and continue
-- **Lint/test fails:** Stop at step 5, show test output
-- **Push fails:** Stop at step 5, suggest `git pull --rebase`
-- **PR merge conflicts:** Stop at step 6, suggest manual resolution
-- **CI pipeline fails:** Stop at step 7, link to pipeline/run for investigation
-- **CI not detected:** Non-blocking at step 7, warn and continue to deploy
+- **ELI5 verdict `No longer needed`:** Stop at step 3, recommend closing the issue instead of implementing
+- **Plan rejected at ELI5 gate:** Stop at step 3, revise the plan (or close) before proceeding
+- **Implementation blocker:** Stop at step 4, report what's blocking
+- **Doc update fails:** Non-blocking at step 5, warn and continue
+- **Lint/test fails:** Stop at step 6, show test output
+- **Push fails:** Stop at step 6, suggest `git pull --rebase`
+- **PR merge conflicts:** Stop at step 7, suggest manual resolution
+- **CI pipeline fails:** Stop at step 8, link to pipeline/run for investigation
+- **CI not detected:** Non-blocking at step 8, warn and continue to deploy
 - **Deploy fails:** Report but don't roll back (deploy is best-effort)
 - **Inside worktree being removed:** `worktree-remove.sh` handles this safely
 
@@ -512,7 +546,8 @@ Key failure scenarios:
 
 - This is the "one command to ship" - takes an issue number and delivers it end-to-end
 - The analyze step ensures Claude understands the issue before writing code
+- The ELI5 step (Step 3) is a human checkpoint: it restates intent in plain language, verifies the issue is still worth doing, and gates implementation on plan approval. Use `--yes` (or an `eli5: auto-approve` trailer) for fully unattended runs; a `No longer needed` verdict never auto-implements
 - Each step builds on the previous one; there's no skipping
 - The deploy step is always optional - it only runs if a deploy target exists
 - After completion, the user is in the main repo on the main branch
-- For step-by-step control, use individual commands: `/flow:start`, `/flow:finish`, `/flow:merge`, `/flow:deploy`
+- For step-by-step control, use individual commands: `/flow:start`, `/flow:eli5`, `/flow:finish`, `/flow:merge`, `/flow:deploy`

--- a/.claude/commands/flow/eli5.md
+++ b/.claude/commands/flow/eli5.md
@@ -1,0 +1,122 @@
+# Flow: ELI5 - Post-Analysis Plan + Necessity Gate
+
+The post-analysis, pre-implementation communication and approval gate. Restates an issue's intent in plain language, checks whether the issue is still worth doing given code merged since it was filed, and presents the proposed changes for reviewer approval before any code is written.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+- `--yes` (optional, alias `--auto-approve`): skip the interactive approval pause for unattended runs. The ELI5 report is still produced and recorded. A `No longer needed` verdict is NEVER auto-approved - it always stops for a human decision.
+
+## What this is for
+
+`/flow:auto` jumps from analysis straight to implementation with only a terse implementer-facing plan in between. That gives a human reviewer no clear, plain-language checkpoint to approve, redirect, or reject before effort is spent. Two gaps in particular:
+
+1. **No staleness / necessity check.** An issue filed weeks ago may already be solved (or made obsolete) by code merged since. The default flow assumes the issue is still valid and just implements it.
+2. **No reviewer-friendly intent summary.** The implementer-term plan is not the fastest way for a reviewer to catch a misread of intent.
+
+`/flow:eli5` closes both gaps: it tells the reviewer, in their language, what the issue means, whether it is still worth doing, and what will change - then waits for approval.
+
+## Instructions
+
+When the user invokes `/flow:eli5 <ISSUE>`, perform the following. This command is read-only with respect to the codebase: it inspects and reports, it does not write implementation code.
+
+### Step 1: Gather context
+
+If this command is being run as a step inside `/flow:auto`, reuse the analysis already produced by the Analyze step and skip re-reading the codebase. When run standalone, gather context first:
+
+```bash
+ISSUE_NUM="$1"
+# Pull the body AND the creation timestamp - the timestamp drives staleness.
+gh issue view "$ISSUE_NUM" --json number,title,state,body,createdAt,labels,closedAt
+ISSUE_DATE=$(gh issue view "$ISSUE_NUM" --json createdAt --jq '.createdAt')
+```
+
+- Parse acceptance criteria (`- [ ]` items), referenced files/components, and any task IDs or dependencies.
+- Read the files the issue references and the surrounding patterns so the proposed-changes section is concrete.
+
+### Step 2: Produce the three-section report
+
+Emit all three sections every time. Do not skip a section even if it is short.
+
+**Section A - ELI5 overview of intent.** A plain-language restatement of what the issue is trying to accomplish and why, free of implementation jargon. Two to four sentences a non-author reviewer can sanity-check for a misread of intent.
+
+**Section B - Necessity / staleness analysis.** Assess whether the issue is still necessary given the current code and anything merged *after* it was filed. Inspect post-filing history explicitly:
+
+```bash
+# Commits landed since the issue was filed (global, then scoped to the files
+# the issue touches - substitute the relevant paths).
+git log --since="$ISSUE_DATE" --oneline
+git log --since="$ISSUE_DATE" --oneline -- <relevant/paths>
+
+# Pull requests merged since the issue was filed.
+gh pr list --state merged --search "merged:>=${ISSUE_DATE%%T*}" \
+    --json number,title,mergedAt
+
+# Duplicate / superseding issues (open or closed).
+gh issue list --state all --search "<key terms from the issue>" \
+    --json number,title,state,closedAt
+```
+
+Explicitly check for: (a) work already merged that closes or partially closes the issue, (b) design changes that make the original ask obsolete or misframed, (c) duplicate or superseding issues. Then output one verdict, with the evidence (commits, PRs, files, issue numbers) behind it:
+
+| Verdict | Meaning |
+|---------|---------|
+| **Still needed** | Nothing since filing addresses it; proceed as written |
+| **Partially addressed** | Some of the ask already landed; implement only the remainder (list what is left) |
+| **No longer needed** | Already solved or made obsolete; recommend closing instead of implementing |
+| **Needs reframing** | The surrounding design changed enough that the plan is wrong; restate the corrected approach |
+
+**Section C - Proposed changes (pending approval).** An overview of the changes proposed to close the issue, framed as a plan awaiting reviewer approval: files to create or modify, the gist of each change, scope estimate, and notable risks or edge cases. No code is written until this plan is approved.
+
+### Step 3: The approval gate
+
+The verdict drives what happens next:
+
+- **No longer needed** -> do NOT implement, even with `--yes`. Recommend closing the issue and provide a ready-to-paste closing comment citing the evidence:
+  ```bash
+  gh issue close "$ISSUE_NUM" --comment "<evidence-based reason; reference the superseding PR/issue>"
+  ```
+  Surface the recommendation and STOP. Closing is the reviewer's call.
+- **Still needed**, **Partially addressed**, or **Needs reframing** -> present Section C and gate on approval:
+  - **Default (interactive):** pause and ask the reviewer to approve, redirect, or reject the plan. Only proceed once approved. For `Partially addressed` / `Needs reframing`, the approved plan is the adjusted one, not the original issue body.
+  - **`--yes` / `--auto-approve`, or an `eli5: auto-approve` trailer in the issue body or HEAD commit message:** proceed without pausing, but still print the full report for the record and note that approval was auto-granted.
+
+## Output format
+
+```
+Flow ELI5: Issue #398
+
+== A. What this issue actually wants (ELI5) ==
+{plain-language intent, 2-4 sentences}
+
+== B. Is it still needed? ==
+Verdict: Still needed | Partially addressed | No longer needed | Needs reframing
+
+Evidence (since {ISSUE_DATE}):
+  - commits:  {sha list or "none touching <paths>"}
+  - PRs:      {merged PR numbers or "none"}
+  - dup/super:{issue numbers or "none"}
+Reasoning: {1-3 sentences tying evidence to the verdict}
+
+== C. Proposed changes (pending approval) ==
+  1. {file} - {what changes and why}
+  2. {file} - {what changes and why}
+Scope: {N files, ~L lines}
+Risks: {edge cases / unknowns}
+
+Approval: REQUIRED (interactive) | AUTO-GRANTED (--yes) | N/A (No longer needed -> close recommended)
+```
+
+## When run inside /flow:auto
+
+`/flow:auto` invokes `/flow:eli5` as the step between Analyze and Implement and treats it as an approval gate:
+
+- Verdict **No longer needed** -> `/flow:auto` stops and surfaces the close-issue recommendation instead of implementing.
+- Verdicts **Still needed / Partially addressed / Needs reframing** -> `/flow:auto` pauses for approval unless invoked with `--yes` (or an `eli5: auto-approve` trailer is present), then proceeds to Implement using the approved plan.
+
+## Notes
+
+- This command is the communication and approval checkpoint: intent in the reviewer's language, an honest necessity verdict, and the plan that is about to be executed.
+- It never writes implementation code; the only mutating action it suggests is `gh issue close` on a `No longer needed` verdict, and that is a recommendation for the reviewer to run.
+- The staleness check is only meaningful when it inspects history *after* the issue's `createdAt`; always anchor `git log --since` and the PR/issue searches to that timestamp.
+- For step-by-step control outside the full lifecycle, run `/flow:eli5 <ISSUE>` on its own before deciding whether to `/flow:start`.

--- a/.claude/commands/flow/help.md
+++ b/.claude/commands/flow/help.md
@@ -7,13 +7,14 @@ Streamlined worktree-based development workflow. No locks, no Redis - just git.
 | Command | Purpose |
 |---------|---------|
 | `/flow:start <issue>` | Create worktree and branch from a GitHub issue |
+| `/flow:eli5 <issue>` | Plain-language intent + necessity/staleness verdict + plan approval gate (pre-implementation) |
 | `/flow:status` | Show all active worktrees with issue/PR state |
 | `/flow:check` | Run quality checks (lint, test, security) without committing |
 | `/flow:finish` | Run quality gates, commit, push, and create PR |
 | `/flow:merge` | Merge PR, clean up worktree and branch |
 | `/flow:deploy [target]` | Run Makefile deploy target |
 | `/flow:sync` | Push WIP branch to remote for cross-machine pickup |
-| `/flow:auto <issue>` | Full lifecycle: start → analyze → implement → update docs → finish → merge → deploy |
+| `/flow:auto <issue>` | Full lifecycle: start → analyze → ELI5 (plan + necessity gate) → implement → update docs → finish → merge → deploy |
 | `/flow:cleanup` | Prune stale worktree references and delete merged branches |
 | `/flow:doctor` | Diagnose workflow environment and readiness |
 | `/flow:help` | This help page |
@@ -23,8 +24,10 @@ Streamlined worktree-based development workflow. No locks, no Redis - just git.
 ```
 /flow:auto 42
   ↓
-  start → analyze → implement → update docs → finish → merge → deploy
+  start → analyze → ELI5 (plan + necessity gate) → implement → update docs → finish → merge → deploy
 ```
+
+The ELI5 step is an approval checkpoint: it restates the issue's intent in plain language, gives a necessity verdict (Still needed / Partially addressed / No longer needed / Needs reframing) with evidence from code merged since the issue was filed, and waits for plan approval before any code is written. Run `/flow:auto <issue> --yes` (or add an `eli5: auto-approve` trailer) for unattended runs; a `No longer needed` verdict always stops for a human decision.
 
 Or step by step:
 ```

--- a/.specify/grills/2026-06-28-issue-398.md
+++ b/.specify/grills/2026-06-28-issue-398.md
@@ -1,0 +1,76 @@
+# Grill-yourself transcript - Issue #398
+
+- Date: 2026-06-28
+- Issue: #398 - add `flow-eli5` skill (post-analysis, pre-implementation plan + necessity gate for `/flow:auto`)
+- Interviewer: inline self-interrogation (second-opinion MCP not running; fallback path per flow-auto Step 3)
+- Verdict: **yes-with-caveats**
+
+## Plan grilled
+
+Add a new slash command `/flow:eli5 <ISSUE>` at `.claude/commands/flow/eli5.md`
+that runs after Analyze and before Implement and emits a reviewer-facing report
+with three sections (ELI5 intent, necessity/staleness verdict with evidence,
+proposed changes pending approval). Wire it into `.claude/commands/flow/auto.md`
+as a new Step 3 (renumber 8 -> 9), make it an approval gate, route a
+"No longer needed" verdict to a close-issue recommendation, and update the
+documented command lists (`flow/help.md`, `CLAUDE.md`, `README.md`) plus
+`CHANGELOG.md`.
+
+## Pre-grill empirical de-risking
+
+- Confirmed the source of truth for a slash command is
+  `.claude/commands/flow/<name>.md`; `/cpp:init` symlinks `.claude/commands`
+  into a project (init.md), so creating `eli5.md` makes `/flow:eli5` invocable
+  with no extra wiring.
+- Confirmed there is NO positive skill/command registry file and NO forward
+  generator: the manifest-driven generator was retired (skill-drift.py header,
+  CHANGELOG "retired `manifests/` source"). The generated `~/.claude/skills/`
+  artifacts are legacy and untracked by any repo source.
+- Confirmed no test enumerates flow commands; adding `eli5.md` breaks nothing
+  (`make verify` is ruff/pytest/mypy over Python only).
+- `git log --since=<issue createdAt>` is empty (issue filed today), so #398
+  itself is not stale - but the command I am writing must still implement the
+  post-filing history check as a general capability.
+
+## Findings incorporated (caveats)
+
+- **C1 - "skill registry" = documented lists, not a generated SKILL.md.** With
+  no forward generator and no positive registry, hand-creating a
+  `~/.claude/skills/flow-eli5/SKILL.md` would produce an un-sourced artifact the
+  drift tooling cannot reconcile. The acceptance criterion is satisfied by
+  updating the registries of record: `flow/help.md`, `CLAUDE.md` Workflow
+  section, and `README.md`. The repo command file IS the source.
+- **C2 - approval gate must not break unattended runs.** `/flow:auto` is the
+  "one command to ship" and is frequently run unattended. Default = require
+  approval (per the issue), but provide explicit bypasses: a `--yes` /
+  `auto-approve` argument and an `eli5: auto-approve` issue-body/commit trailer.
+  Even under auto-approve, a **No longer needed** verdict never auto-implements:
+  it STOPS and routes to the close-issue recommendation.
+- **C3 - staleness MUST inspect post-filing history (hard AC).** eli5.md
+  specifies concrete mechanics: read `createdAt` via `gh issue view`, then
+  `git log --since=<createdAt>` (global and path-scoped to the issue's files),
+  `gh pr list --search "merged:>=<date>"`, and a duplicate/superseding scan via
+  `gh issue list --search`. Verdict enum is exactly the four the issue names,
+  each with cited evidence (commits/PRs/files).
+- **C4 - renumbering correctness.** auto.md goes 8 -> 9 steps. Every reference
+  must move: intro report block, each `### Step N` header, each
+  `Report: Step N/8` line, the error-handling "stopped at Step N/8" block + its
+  resume map, the final summary, and Notes. Post-edit verification: grep for
+  stale `/8` and `Step [0-9]/8` tokens before commit.
+- **C5 - no em/en dashes (CLAUDE.md core directive).** The issue body uses em
+  dashes; new content must use ASCII hyphens. Arrows (`->`, `→`, `↓`) already
+  appear in flow files and are fine. Post-edit verification: grep for U+2014 /
+  U+2013 in changed files before commit.
+- **C6 - standalone invocability.** `/flow:eli5 <ISSUE>` must work outside
+  `/flow:auto`, so eli5.md gathers its own minimal context (fetch issue, locate
+  worktree-or-repo, analyze) rather than assuming Step 2 ran; when invoked
+  inside `/flow:auto` it reuses the Step 2 analysis.
+
+## Rejected / out of scope
+
+- Generating a `~/.claude/skills/flow-eli5/SKILL.md` artifact (see C1):
+  un-sourced and untracked by drift tooling; deferred to whatever revived
+  generator a future change introduces.
+- Adding a programmatic test that cross-checks command files against the doc
+  tables: useful but a separate concern (no such test exists today for any flow
+  command); out of scope for this issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **`/flow:eli5` command + `/flow:auto` approval gate** (issue #398) - new
+  `.claude/commands/flow/eli5.md` runs after Analyze and before Implement and
+  emits a reviewer-facing report: a plain-language (ELI5) restatement of the
+  issue's intent, a necessity/staleness verdict (Still needed / Partially
+  addressed / No longer needed / Needs reframing) backed by evidence from
+  commits and PRs landed since the issue was filed, and the proposed changes
+  pending approval. `/flow:auto` inserts it as Step 3 (lifecycle renumbered
+  8 -> 9) and treats it as a gate: it pauses for plan approval by default
+  (`--yes` / `--auto-approve`, or an `eli5: auto-approve` trailer, for
+  unattended runs), and a `No longer needed` verdict routes to a close-issue
+  recommendation instead of implementing. Registered in `flow/help.md`,
+  `CLAUDE.md`, and `README.md`.
 - **Skill drift/orphan detection in `/cpp:update`** (issue #395) - new Step 7.5
   detects retired and orphaned generated skills in `~/.claude/skills/` and offers
   guided, per-family, user-confirmed removal, mirroring the existing MCP/systemd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,11 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 
 ### Workflow
 - `/flow:start` - Create worktree for an issue
+- `/flow:eli5 <issue>` - Plain-language intent + necessity/staleness verdict + plan approval gate (runs after analyze, before implement)
 - `/flow:check` - Run lint + test + security scan (no commit)
 - `/flow:finish` - Quality gates, commit, push, create PR
 - `/flow:deploy [target]` - Run make deploy + health/smoke checks
-- `/flow:auto` - Full issue lifecycle in one shot
+- `/flow:auto` - Full issue lifecycle in one shot (ELI5 plan/necessity approval gate between analyze and implement; `--yes` to skip the pause)
 - `/flow:merge` - Merge PR, clean up worktree
 - `/flow:sync` - Push WIP to remote for cross-machine pickup
 - `/flow:cleanup` - Prune stale worktrees and branches

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What It Does
 
-- **Workflow commands** (`/flow:auto`, `/flow:start`, `/flow:finish`) - Issue-driven development with worktrees, quality gates, automated PR lifecycle, and CI verification
+- **Workflow commands** (`/flow:auto`, `/flow:start`, `/flow:eli5`, `/flow:finish`) - Issue-driven development with worktrees, a pre-implementation ELI5 plan/necessity approval gate, quality gates, automated PR lifecycle, and CI verification
 - **MCP servers** - Three containerized servers extending Claude Code's capabilities:
   - **Second Opinion** (port 8080) - Multi-model code review via external LLMs (Gemini, OpenAI, Anthropic)
   - **Playwright Persistent** (port 8081) - Browser automation with 29 tools
@@ -80,6 +80,7 @@ claude-power-pack/
 |----------|---------|-------------|
 | Workflow | `/flow:auto 42` | Full issue lifecycle in one shot |
 | Workflow | `/flow:start 42` | Create worktree for an issue |
+| Workflow | `/flow:eli5 42` | Plain-language intent + necessity verdict + plan approval gate |
 | Workflow | `/flow:finish` | Lint, test, commit, push, create PR |
 | Project | `/project:init myapp` | Scaffold a new project |
 | Security | `/security:scan` | Full vulnerability scan |


### PR DESCRIPTION
## Summary

- New command `/flow:eli5 <ISSUE>` (`.claude/commands/flow/eli5.md`): the post-analysis, pre-implementation communication and approval gate. It produces a reviewer-facing report with three sections - an ELI5 restatement of the issue's intent, a necessity/staleness verdict, and the proposed changes pending approval.
- The necessity analysis anchors to the issue's `createdAt` and inspects history landed *after* filing (`git log --since`, `gh pr list --search "merged:>=..."`, duplicate/superseding `gh issue list` scan), emitting one verdict with evidence: **Still needed / Partially addressed / No longer needed / Needs reframing**.
- `/flow:auto` now invokes it as **Step 3** between Analyze and Implement (lifecycle renumbered 8 -> 9 throughout: intro, step headers, report lines, error-handling/resume map, failure scenarios, final summary, notes).
- It is a real gate: pauses for plan approval by default; `--yes` / `--auto-approve` (or an `eli5: auto-approve` trailer) bypasses the pause for unattended runs; a `No longer needed` verdict never auto-implements and routes to a close-issue recommendation.
- Registered in `flow/help.md` (table + golden path), `CLAUDE.md` (Workflow reference), and `README.md` (key commands + feature line); `CHANGELOG` `[Unreleased]` entry added.

## Acceptance criteria

- [x] `/flow:eli5 <ISSUE>` exists and is invocable standalone (gathers its own context when not run inside `/flow:auto`)
- [x] Output contains all three sections (ELI5 intent, necessity/staleness with explicit verdict + evidence, proposed changes pending approval)
- [x] Necessity analysis inspects code/history pushed *after* the issue was filed (anchored to `createdAt`)
- [x] `/flow:auto` invokes it after Analyze, before Implement, as an approval gate
- [x] `/flow:auto` step list and numbering updated in `.claude/commands/flow/auto.md`
- [x] `No longer needed` verdict routes to a close-issue recommendation rather than implementation
- [x] `/flow:help` and command registry of record (help.md / CLAUDE.md / README.md) list `flow-eli5`
- [x] Docs updated (CLAUDE.md, README.md, CHANGELOG.md)

## Design notes

- "Skill registry": CPP has no positive registry file and the manifest-driven skill generator was retired, so the registries of record are the documented command lists (`flow/help.md`, `CLAUDE.md`, `README.md`). A slash command's source of truth is its `.claude/commands/flow/*.md` file, which `/cpp:init` symlinks into projects - so `eli5.md` makes `/flow:eli5` invocable with no further wiring. No hand-authored `~/.claude/skills/flow-eli5/SKILL.md` was generated (it would be an un-sourced artifact the drift tooling cannot reconcile).
- Default = require approval (per the issue), with explicit bypasses so unattended `/flow:auto` runs are not broken.

## Test plan

- [x] `make verify` green: ruff clean, 742 passed / 1 skipped, mypy success (markdown-only change; no Python touched)
- [x] No em/en dashes in changed files (CLAUDE.md core directive)
- [x] `auto.md` renumbering verified: 9 ordered step headers, 9 consistent report lines, no stale `N/8` references
- [ ] Reviewer: confirm the ELI5 gate wording reads well as a human checkpoint

Grill-yourself transcript: `.specify/grills/2026-06-28-issue-398.md`.

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)