### PR TITLE
fix(drift): derive systemd unit presence from LoadState, not is-active

### DIFF
--- a/scripts/drift-detect.sh
+++ b/scripts/drift-detect.sh
@@ -87,6 +87,29 @@ systemd_unit_path() {
     fi
 }
 
+# Authoritative presence check. `systemctl is-active` reports "inactive" with a
+# zero exit even for units that were never installed, so presence must come from
+# systemd's LoadState (or an on-disk unit file) - never from is-active. Checks
+# the user manager first, then the system manager.
+systemd_unit_exists() {
+    local unit="$1"
+    local load_state
+
+    if command -v systemctl &>/dev/null; then
+        load_state=$(systemctl --user show -p LoadState --value "$unit" 2>/dev/null || true)
+        case "$load_state" in
+            loaded|masked) return 0 ;;
+        esac
+
+        load_state=$(systemctl show -p LoadState --value "$unit" 2>/dev/null || true)
+        case "$load_state" in
+            loaded|masked) return 0 ;;
+        esac
+    fi
+
+    [[ -n "$(systemd_unit_path "$unit")" ]]
+}
+
 systemd_unit_state() {
     local unit="$1"
     local state=""
@@ -94,7 +117,7 @@ systemd_unit_state() {
     if command -v systemctl &>/dev/null; then
         state=$(systemctl --user is-active "$unit" 2>/dev/null || true)
         case "$state" in
-            active|activating|deactivating|failed|inactive)
+            active|activating|deactivating|failed)
                 echo "$state"
                 return
                 ;;
@@ -102,25 +125,24 @@ systemd_unit_state() {
 
         state=$(systemctl is-active "$unit" 2>/dev/null || true)
         case "$state" in
-            active|activating|deactivating|failed|inactive)
+            active|activating|deactivating|failed)
                 echo "$state"
                 return
                 ;;
         esac
     fi
 
-    if [[ -n "$(systemd_unit_path "$unit")" ]]; then
-        echo "installed"
+    # is-active returns "inactive" (exit 0) even for never-installed units, so it
+    # cannot prove presence. Confirm via LoadState / on-disk unit file instead.
+    if systemd_unit_exists "$unit"; then
+        echo "inactive"
     else
         echo "not-found"
     fi
 }
 
 is_systemd_unit_present() {
-    local unit="$1"
-    local state
-    state=$(systemd_unit_state "$unit")
-    [[ "$state" != "not-found" ]]
+    systemd_unit_exists "$1"
 }
 
 repo_ships_systemd_unit() {

--- a/tests/test_drift_detect.py
+++ b/tests/test_drift_detect.py
@@ -147,3 +147,92 @@ def test_drift_detect_flags_docker_systemd_conflicts_and_orphans(tmp_path: Path)
     assert "port binding conflict - port 8081" in output
     assert "Default convergence is Docker" in output
     assert "claude mcp remove second-opinion" in output
+
+
+def test_drift_detect_no_false_conflict_when_units_absent(tmp_path: Path) -> None:
+    """`systemctl is-active <unit>` returns "inactive" (exit 0) even for units that
+    were never installed. Presence must be derived from LoadState / on-disk unit
+    files, not is-active - otherwise every Docker-only MCP server is wrongly flagged
+    as a Docker/systemd deployment-model conflict."""
+    home = tmp_path / "home"
+    (home / ".config" / "systemd" / "user").mkdir(parents=True)  # deliberately empty
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "uv", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(
+        bin_dir / "docker",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "--version" ]]; then
+          echo "Docker version 26.0.0"; exit 0
+        fi
+        if [[ "$1" == "compose" && "$2" == "version" ]]; then
+          echo "Docker Compose version v2.27.0"; exit 0
+        fi
+        if [[ "$1" == "compose" && "$*" == *" ps "* ]]; then
+          echo "mcp-second-opinion:Up (healthy)"
+          echo "mcp-playwright-persistent:Up (healthy)"
+          exit 0
+        fi
+        if [[ "$1" == "ps" ]]; then
+          echo "mcp-second-opinion:Up 2 hours (healthy)"
+          echo "mcp-playwright-persistent:Up 2 hours (healthy)"
+          exit 0
+        fi
+        exit 0
+        """,
+    )
+    # No unit files on disk and systemd knows nothing about these units:
+    # is-active answers "inactive" (the real-world trap), LoadState answers "not-found".
+    _write_executable(
+        bin_dir / "systemctl",
+        """
+        #!/usr/bin/env bash
+        args="$*"
+        if [[ "$args" == *"show -p LoadState"* ]]; then
+          echo "not-found"; exit 0
+        fi
+        if [[ "$args" == *"is-active"* ]]; then
+          echo "inactive"; exit 0
+        fi
+        if [[ "$args" == *"list-unit"* ]]; then
+          exit 0
+        fi
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "ss",
+        "#!/usr/bin/env bash\necho 'State Recv-Q Send-Q Local Address:Port Peer Address:Port Process'\n",
+    )
+    _write_executable(
+        bin_dir / "sysctl",
+        """
+        #!/usr/bin/env bash
+        case "$2" in
+          vm.swappiness) echo 10 ;;
+          vm.vfs_cache_pressure) echo 50 ;;
+          fs.inotify.max_user_watches) echo 524288 ;;
+          fs.inotify.max_user_instances) echo 512 ;;
+          *) echo unknown ;;
+        esac
+        """,
+    )
+
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "PATH": f"{bin_dir}:{env['PATH']}", "USER": "tester"})
+
+    result = subprocess.run(
+        ["bash", str(DRIFT_SCRIPT), "--fix"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    output = result.stdout
+    assert "deployment model conflict" not in output
+    assert "no Docker/systemd conflicts or failed units" in output


### PR DESCRIPTION
## Problem

`make drift-check` / `scripts/drift-detect.sh` reported false **deployment model conflict** drift on a Docker-only host — flagging every running MCP server (`mcp-second-opinion`, `mcp-nano-banana`, `mcp-playwright-persistent`) as having a conflicting systemd unit, and exiting non-zero, even though **no MCP systemd units exist** on the host.

Surfaced during a routine `/cpp:update` on a host with zero MCP systemd units.

## Root cause

`systemctl is-active <unit>` returns `inactive` with **exit 0** even for units that were never installed. `systemd_unit_state()` matched `inactive` in its early-return `case`, so `is_systemd_unit_present()` (which only checked `state != "not-found"`) treated never-installed units as present. Any MCP server with a running Docker container then tripped the Docker+systemd conflict branch.

The script's own "Systemd Units" / "orphaned units" sections (which key off on-disk unit files) correctly reported none — the two disagreed.

## Fix

- New `systemd_unit_exists()` helper derives presence **authoritatively from `LoadState`** (`loaded`/`masked`), falling back to on-disk unit files. Never uses `is-active` for presence.
- `is_systemd_unit_present()` now calls it directly.
- `systemd_unit_state()` only early-returns on unambiguous states (`active`/`activating`/`deactivating`/`failed`); the `inactive`/not-found decision goes through `systemd_unit_exists()`.

## Tests

- New regression test `test_drift_detect_no_false_conflict_when_units_absent` reproduces the trap (running container + `is-active`→`inactive` + `LoadState`→`not-found`) and asserts no conflict is reported.
- Existing conflict/orphan/failed-unit test still passes.
- Verified against the real host: `MCP Deployment Models` now reports `no Docker/systemd conflicts`, exit 0 (was 3 conflicts / exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)