### PR TITLE
feat(codex): add /codex:ask - read-only question delegation to Codex (Closes #393)

### DIFF
--- a/.claude/commands/codex/ask.md
+++ b/.claude/commands/codex/ask.md
@@ -1,0 +1,149 @@
+---
+description: Delegate a read-only question to Codex (gpt-5.5) and relay its answer - read-only by default, network opt-in on explicit request
+allowed-tools: Bash(codex:*), Bash(mktemp:*), Bash(cat:*), Bash(rm:*), Bash(test:*), Bash(command -v codex), Read
+---
+
+# Codex Ask: Delegate a Read-Only Question to Codex
+
+Send a question (or read-only analysis task) to OpenAI Codex (`gpt-5.5`) through the
+`codex` CLI and relay its answer back, clearly attributed. Codex runs **read-only**:
+it may read files in the current directory to answer questions about the codebase,
+but it cannot modify anything.
+
+This is the question / second-opinion counterpart to the code-mutating Codex commands:
+
+- **`/codex:ask`** (this) - ask Codex a question, get an answer. Read-only, no changes.
+- **`/codex:exec`** - hand Codex a coding task in the current dir (writes files, `danger-full-access`).
+- **`/codex:auto`** - full issue lifecycle delegated to Codex (worktree, PR, quality gates).
+- **`/second-opinion:start`** - code review via *other* external LLMs through the MCP server.
+
+## Arguments
+
+- `QUESTION` (required): What to ask Codex. Take it from the slash-command arguments,
+  or from whatever question the user phrased when they asked you to delegate to Codex.
+
+## Instructions
+
+When the user invokes `/codex:ask <QUESTION>` (or asks you to delegate/ask Codex):
+
+### Step 1: Preflight
+
+```bash
+if ! command -v codex >/dev/null 2>&1; then
+    echo "ERROR: Codex CLI not found. Install: npm install -g @openai/codex; then: codex login"
+    exit 1
+fi
+codex --version
+```
+
+If the question is empty, ask the user what they want to delegate before running anything.
+For a fuller readiness check (login, config, MCP registrations), run `/codex:status`.
+
+### Step 2: Ask Codex
+
+Capture Codex's final answer to a temp file with `--output-last-message`, run read-only,
+and disable color for clean text. By default Codex runs in the current working directory
+so it can read the project to answer codebase questions.
+
+```bash
+ANSWER=$(mktemp /tmp/codex-ask.XXXXXX.txt)
+
+codex exec \
+    --sandbox read-only \
+    --color never \
+    --skip-git-repo-check \
+    --output-last-message "$ANSWER" \
+    "$QUESTION"
+
+CODEX_EXIT=$?
+```
+
+Notes on the flags:
+- `--sandbox read-only` - Codex can read files / run read-only commands, never writes. This is
+  the guardrail that makes "delegate a question" safe even inside a live repo.
+- `--output-last-message "$ANSWER"` - writes ONLY Codex's final answer to the file (the stdout
+  stream also includes its reasoning / tool steps; the file is the clean answer to relay).
+- `--skip-git-repo-check` - lets it run anywhere, not just inside a git repo.
+- `--color never` - avoids ANSI codes in captured text.
+
+While it runs, the stdout stream shows Codex's progress - surface anything notable
+(plan, files it read, errors) to the user.
+
+### Step 3: Relay the answer
+
+```bash
+echo "===== Codex (gpt-5.5) answer ====="
+cat "$ANSWER"
+rm -f "$ANSWER"
+```
+
+Then present Codex's answer to the user, **attributed to Codex** - do not silently pass it
+off as your own. Keep Codex's answer and any take of your own clearly separated. If the
+user asked you to compare or sanity-check it, add your own assessment in a labeled section
+after relaying Codex's answer verbatim.
+
+If `CODEX_EXIT` is non-zero, report the failure and the tail of the stream; do not fabricate
+an answer.
+
+## Options
+
+Adjust the Step 2 command when the user asks for any of these:
+
+- **Different model / reasoning effort:** add `-m <model>` (e.g. `-m gpt-5.5`) or
+  `-c model_reasoning_effort=high`. Defaults come from `~/.codex/config.toml`
+  (currently `gpt-5.5`, `xhigh`).
+- **Ask about a different directory:** add `-C <DIR>` (alias `--cd`) so Codex reads that
+  project instead of the current one.
+- **Attach a file or piped context:** pipe it on stdin - it is appended as a `<stdin>` block:
+  `cat notes.md | codex exec --sandbox read-only --color never -o "$ANSWER" "Summarize this:"`.
+  Attach images with `-i <FILE>`.
+- **Attach repo context inline:** include the relevant snippet / path in the QUESTION text;
+  the read-only sandbox also lets Codex open files itself.
+- **Follow-up on the same thread:** continue the previous session with
+  `codex exec resume --last --sandbox read-only --color never -o "$ANSWER" "<follow-up>"`.
+- **Let Codex reach the network (fetch repos, browse, curl):** read-only blocks network for
+  the commands Codex runs. To allow it, escalate the sandbox - network access is bundled with
+  write access in Codex, so there are two opt-in levels. **Only do this when the user explicitly
+  asks**, and tell them what you are granting:
+  - Network + scratch writes (preferred): `--sandbox workspace-write -c sandbox_workspace_write.network_access=true`
+    Codex can `git clone` / `curl` and write under the working dir + `/tmp`, but not elsewhere.
+    Point `-C` at a throwaway dir (e.g. `mktemp -d`) so it does not litter a real project.
+  - Full access: `--sandbox danger-full-access` - network + writes anywhere. Maximum risk; avoid
+    unless the user insists.
+  - Safety: with network on, a model-generated command can fetch and run arbitrary code, exfiltrate
+    files it can read, or act on a prompt-injection embedded in a file or page. Never enable it
+    silently, and prefer the workspace-write level scoped to a scratch dir.
+  - Note: Codex always reaches OpenAI to run the model itself; the sandbox only governs the
+    network access of the *shell commands* it executes. "No network" means it cannot fetch
+    external sources, not that the model is offline.
+- **Let Codex actually DO something (write files in your repo):** that is no longer "delegate a
+  question" - use `/codex:exec` (one-shot) or `/codex:auto` (full lifecycle) instead, which run
+  with write access and JSONL monitoring.
+
+## Long-running delegations
+
+Deep questions at `xhigh` over a real repo can take many minutes and will blow past a normal
+foreground command timeout. For anything non-trivial:
+
+- **Run it in the background** so it is not bound by the tool timeout, and stream to a log
+  instead of buffering with `tail` (which hides progress until the end):
+  ```bash
+  ANSWER=$(mktemp /tmp/codex-ask.XXXXXX.txt)
+  LOG=$(mktemp /tmp/codex-ask.XXXXXX.log)
+  codex exec --sandbox read-only --color never --skip-git-repo-check \
+      --output-last-message "$ANSWER" "$QUESTION" > "$LOG" 2>&1   # launch in background
+  ```
+  Poll `tail -n 20 "$LOG"` for progress; read `$ANSWER` once it exits.
+- To keep latency tractable instead, lower effort with `-c model_reasoning_effort=high` (or
+  `medium`) - faster, slightly less thorough than the `xhigh` default.
+- Scope tightly: target the smallest relevant dir with `-C`, and name the key files / paths in
+  the question so Codex does not crawl an entire monorepo.
+
+## Notes
+
+- Uses the user's **Codex account** (real quota / billing on each call). Keep delegated
+  questions purposeful; do not loop unattended.
+- Read-only by design: safe to run inside any project without risking edits. Network and write
+  access are explicit opt-ins (see Options) - never escalate without the user asking.
+- The temp answer file lives in `/tmp` and is removed after relaying.
+- For code CHANGES, use `/codex:exec` (one-shot) or `/codex:auto` (full issue lifecycle) instead.

--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -419,3 +419,4 @@ Key failure scenarios:
 - Cross-model review catches issues that same-model review might miss
 - Fix loop re-prompts Codex with error context, max 2 retries before stopping
 - Worktree cleanup follows the same safe pattern as flow:auto (cd out before removing)
+- To ask Codex a read-only question instead of delegating an implementation, use `/codex:ask`

--- a/.claude/commands/codex/exec.md
+++ b/.claude/commands/codex/exec.md
@@ -98,3 +98,4 @@ or git checkout -- . to discard.
 - JSONL output is saved to /tmp for later inspection
 - No automatic commit - user reviews and commits manually
 - For full issue lifecycle with review and quality gates, use `/codex:auto`
+- For a read-only question (no file changes), use `/codex:ask`

--- a/.claude/commands/codex/help.md
+++ b/.claude/commands/codex/help.md
@@ -13,6 +13,7 @@ Cross-model implementation and review - Claude manages the workflow, Codex write
 |---------|-------------|
 | `/codex:auto <ISSUE>` | Full issue lifecycle delegated to Codex - worktree, implement, review, quality gates, PR |
 | `/codex:exec <PROMPT>` | One-shot Codex execution in current directory with JSONL monitoring |
+| `/codex:ask <QUESTION>` | Delegate a read-only question to Codex and relay its answer (network opt-in on request) |
 | `/codex:status` | Check Codex CLI installation, config, and readiness |
 | `/codex:help` | This help overview |
 
@@ -38,6 +39,9 @@ Claude Code (supervisor)            Codex CLI (implementer)
 
 # Run a quick one-shot task
 /codex:exec "Add input validation to the login form"
+
+# Ask Codex a read-only question (no file changes)
+/codex:ask "What does lib/cicd/config.py validate, and where are its tests?"
 
 # Full issue lifecycle
 /codex:auto 42

--- a/.claude/commands/codex/status.md
+++ b/.claude/commands/codex/status.md
@@ -120,6 +120,7 @@ if [ "$READY" = "true" ]; then
     echo "Commands available:"
     echo "  /codex:auto <ISSUE>  - Full issue lifecycle via Codex"
     echo "  /codex:exec <PROMPT> - One-shot Codex execution"
+    echo "  /codex:ask <QUESTION> - Read-only question, relayed answer"
 else
     echo "Status: NOT READY"
     echo ""

--- a/.claude/commands/cpp/help.md
+++ b/.claude/commands/cpp/help.md
@@ -65,6 +65,7 @@ CPP uses a tiered installation model:
 ### Tier 5 - Codex
 - **Codex Auto** (`/codex:auto`): Full issue lifecycle delegated to Codex CLI
 - **Codex Exec** (`/codex:exec`): One-shot Codex execution with JSONL monitoring
+- **Codex Ask** (`/codex:ask`): Delegate a read-only question to Codex and relay its answer
 - **Cross-model review**: Claude reviews Codex's implementation
 - **Fix loop**: Automatic re-prompt on quality gate failure (max 2 retries)
 
@@ -86,6 +87,7 @@ CPP uses a tiered installation model:
 |---------|---------|
 | `/codex:auto <ISSUE>` | Full issue lifecycle delegated to Codex CLI |
 | `/codex:exec <PROMPT>` | One-shot Codex execution with JSONL monitoring |
+| `/codex:ask <QUESTION>` | Delegate a read-only question to Codex and relay its answer |
 | `/codex:status` | Check Codex CLI installation and readiness |
 | `/codex:help` | Codex commands overview |
 

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -375,7 +375,7 @@ This will make the following changes:
   [Tier 5 - Codex CLI]
     - Requires: Codex CLI (npm install -g @openai/codex)
     - Requires: OpenAI API key (codex login)
-    - Installs: /codex:auto, /codex:exec, /codex:status, /codex:help commands
+    - Installs: /codex:auto, /codex:exec, /codex:ask, /codex:status, /codex:help commands
     - Optional: Register CPP MCP servers with Codex
 
   Disk usage: ~0 MB (commands via symlink)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`/codex:ask` command** (issue #393) - new `.claude/commands/codex/ask.md`
+  delegates a **read-only** question to Codex (`gpt-5.5`) via `codex exec
+  --sandbox read-only` and relays the answer attributed to Codex - the
+  question / second-opinion counterpart to the code-mutating `/codex:exec`
+  and `/codex:auto`. Documents network opt-in (`--sandbox workspace-write -c
+  sandbox_workspace_write.network_access=true`, scoped to a scratch dir, with
+  prompt-injection / exfiltration caveats; only on explicit request) and
+  background / long-running guidance. Promotes the personal `delegate`
+  prototype skill into a first-class, shipped command listed in `/codex:help`,
+  `/cpp:help`, `/cpp:init` (Tier 5), and the CLAUDE.md Codex Orchestration
+  section.
+
 ## [7.2.0] - 2026-06-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 ### Codex Orchestration
 - `/codex:auto <ISSUE>` - Full issue lifecycle delegated to Codex CLI (worktree, implement, review, quality gates, PR)
 - `/codex:exec <PROMPT>` - One-shot Codex execution in current directory with JSONL monitoring
+- `/codex:ask <QUESTION>` - Delegate a read-only question to Codex and relay its answer (read-only by default; network opt-in on explicit request)
 - `/codex:status` - Check Codex CLI installation, config, and readiness
 - `/codex:help` - Codex commands overview
 


### PR DESCRIPTION
## Summary
- Adds **`/codex:ask`** (`.claude/commands/codex/ask.md`) - delegate a **read-only** question to Codex (`gpt-5.5`) via `codex exec --sandbox read-only --color never --skip-git-repo-check --output-last-message` and relay the answer **attributed to Codex**. The question / second-opinion counterpart to the code-mutating `/codex:exec` and `/codex:auto`.
- Documents **network opt-in** (`--sandbox workspace-write -c sandbox_workspace_write.network_access=true`, scoped to a scratch dir, explicit request only, with prompt-injection / exfiltration caveats; `danger-full-access` as last resort) and **background / long-running** guidance.
- Promotes the personal `delegate` prototype skill (`~/.claude/skills/delegate/SKILL.md`) into a first-class shipped command, matching the codex command family style (`description` + `allowed-tools` frontmatter).
- Wires it into every doc surface: `/codex:help` (table + quick start), `/codex:status` summary, `/cpp:help` (Tier 5 bullets + table), `/cpp:init` (Tier 5 installs), `CLAUDE.md` Codex Orchestration, sibling cross-refs in `codex/exec.md` + `codex/auto.md`, and a `CHANGELOG.md` Unreleased entry.

## ELI5 / necessity verdict
**Still needed.** The command did not exist (`.claude/commands/codex/` had only auto/exec/help/status); no PR merged since the issue was filed (2026-06-21) added `/codex:ask` or `/delegate`; no superseding issue. The prototype still lived only on the author's machine.

## Acceptance criteria
- [x] `/codex:ask "<question>"` returns Codex's answer, attributed, read-only by default.
- [x] Documented network opt-in + background guidance.
- [x] Listed in `/codex:help` and the CLAUDE.md Codex Orchestration section.

## Gates
- `make verify` (ruff + pytest + mypy): **743 passed, 1 skipped**, mypy clean. Change is markdown-only; no test enumerates the codex command set.
- No em/en dashes (CPP style rule) - scanned clean.

## Test plan
- [ ] Run `/codex:ask "What does lib/cicd/config.py validate, and where are its tests?"` in a repo with Codex CLI installed; confirm a read-only answer is relayed and no files change.
- [ ] Confirm `/codex:help`, `/cpp:help`, `/codex:status` list the new command.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)