### PR TITLE
fix(codex): redirect stdin from /dev/null so codex exec never hangs in non-TTY (Closes #408)

### DIFF
--- a/.claude/commands/codex/ask.md
+++ b/.claude/commands/codex/ask.md
@@ -53,7 +53,7 @@ codex exec \
     --color never \
     --skip-git-repo-check \
     --output-last-message "$ANSWER" \
-    "$QUESTION"
+    "$QUESTION" < /dev/null   # non-TTY: EOF stdin so codex answers instead of blocking on `Reading additional input from stdin...`
 
 CODEX_EXIT=$?
 ```
@@ -100,7 +100,7 @@ Adjust the Step 2 command when the user asks for any of these:
 - **Attach repo context inline:** include the relevant snippet / path in the QUESTION text;
   the read-only sandbox also lets Codex open files itself.
 - **Follow-up on the same thread:** continue the previous session with
-  `codex exec resume --last --sandbox read-only --color never -o "$ANSWER" "<follow-up>"`.
+  `codex exec resume --last --sandbox read-only --color never -o "$ANSWER" "<follow-up>" < /dev/null`.
 - **Let Codex reach the network (fetch repos, browse, curl):** read-only blocks network for
   the commands Codex runs. To allow it, escalate the sandbox - network access is bundled with
   write access in Codex, so there are two opt-in levels. **Only do this when the user explicitly
@@ -131,7 +131,7 @@ foreground command timeout. For anything non-trivial:
   ANSWER=$(mktemp /tmp/codex-ask.XXXXXX.txt)
   LOG=$(mktemp /tmp/codex-ask.XXXXXX.log)
   codex exec --sandbox read-only --color never --skip-git-repo-check \
-      --output-last-message "$ANSWER" "$QUESTION" > "$LOG" 2>&1   # launch in background
+      --output-last-message "$ANSWER" "$QUESTION" < /dev/null > "$LOG" 2>&1   # launch in background (stdin EOF'd so it never blocks on stdin read)
   ```
   Poll `tail -n 20 "$LOG"` for progress; read `$ANSWER` once it exits.
 - To keep latency tractable instead, lower effort with `-c model_reasoning_effort=high` (or

--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -159,7 +159,7 @@ codex exec \
     --json \
     -C "$WORKTREE_PATH" \
     --sandbox danger-full-access \
-    "$CODEX_PROMPT" 2>&1 | tee /tmp/codex-output-${ISSUE_NUM}.jsonl
+    "$CODEX_PROMPT" < /dev/null 2>&1 | tee /tmp/codex-output-${ISSUE_NUM}.jsonl   # </dev/null: non-TTY EOF so codex never blocks reading stdin
 ```
 
 **Monitor the JSONL stream** - parse and report:
@@ -276,7 +276,7 @@ If quality gates fail:
        --json \
        -C "$WORKTREE_PATH" \
        --sandbox danger-full-access \
-       "$FIX_PROMPT" 2>&1 | tee /tmp/codex-fix-${ISSUE_NUM}-${RETRY}.jsonl
+       "$FIX_PROMPT" < /dev/null 2>&1 | tee /tmp/codex-fix-${ISSUE_NUM}-${RETRY}.jsonl   # </dev/null: non-TTY EOF so codex never blocks reading stdin
    ```
 4. **Re-run quality gates.**
 5. If still failing after 2 retries, STOP and report.

--- a/.claude/commands/codex/exec.md
+++ b/.claude/commands/codex/exec.md
@@ -42,7 +42,7 @@ OUTPUT_FILE="/tmp/codex-exec-${TIMESTAMP}.jsonl"
 codex exec \
     --json \
     --sandbox danger-full-access \
-    "$PROMPT" 2>&1 | tee "$OUTPUT_FILE"
+    "$PROMPT" < /dev/null 2>&1 | tee "$OUTPUT_FILE"   # </dev/null: non-TTY EOF so codex never blocks reading stdin
 
 CODEX_EXIT=$?
 ```


### PR DESCRIPTION
## Summary
- `codex exec` reads stdin whenever it is **not a TTY** and appends it as a `<stdin>` block, so when launched from a non-interactive parent (Claude Code Bash tool, cron, CI) it blocks forever on `Reading additional input from stdin...` and never answers.
- This made `/codex:ask`, `/codex:exec`, `/codex:auto`, and the `delegate` skill hang until killed (issue #408).
- Fix: add `< /dev/null` to **every** non-interactive `codex exec` invocation so it gets an immediate EOF and proceeds straight to answering.

## Scope (approved: thorough)
Fixed all 5 in-repo `codex exec` sites, not just the 2 the issue names:

| File | What |
|------|------|
| `.claude/commands/codex/ask.md` | primary (L51), background variant (L133), `resume` example (L103) |
| `.claude/commands/codex/exec.md` | `/codex:exec` (L42) |
| `.claude/commands/codex/auto.md` | `/codex:auto` execute (L158) + retry (L275) |

The intentional `cat notes.md | codex exec …` stdin-pipe example is **left untouched**.

> Note: the global `~/.claude/skills/delegate/SKILL.md` (the file the issue's line-refs point at) has the same defect and was **patched locally**, but it lives outside this repo so it is not part of this PR.

## ELI5 / necessity verdict
**Still needed.** No commits touched `.claude/commands/codex/` since #408 was filed (2026-07-01); the `< /dev/null` fix was absent everywhere. Not stale.

## Second-opinion review
Skipped — 6-line doc-only change with conclusive runtime A/B proof (below); a multi-model review adds no signal.

## Test plan
- [x] `make verify` — 743 passed, 1 skipped; ruff clean; mypy success (incl. `test_skill_drift.py`, `test_codex_skill_gen.py`).
- [x] **A/B repro in the non-TTY Bash environment:**
  - Broken (no redirect): **exit 124** (hung, killed by timeout), log shows `Reading additional input from stdin...`, no answer file.
  - Fixed (`< /dev/null`): **exit 0**, answer file contains the correct `CODEX_OK` reply.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)