### PR TITLE
feat(cpp): detect and tear down orphaned Docker MCP infra on server removal (Closes #405)

### DIFF
--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -422,6 +422,25 @@ done
 if [ "$LEGACY_SYSTEMD_FOUND" -eq 0 ]; then
   echo "  none (ok)"
 fi
+
+# Check orphaned Docker MCP servers (removed from compose but still present as a
+# container, mcp-<name>:* image, or claude/codex registration). Driven by the
+# curated .claude/deprecated-mcps.yaml list of record (issue #405). This closes
+# the blind spot where a removed Docker server kept running unreported.
+echo ""
+echo "Orphaned Docker MCP (teardown available via /cpp:update):"
+if command -v docker &>/dev/null && [ -f "$CPP_DIR/scripts/mcp-drift.py" ]; then
+  ORPHAN_MCPS="$(python3 "$CPP_DIR/scripts/mcp-drift.py" --list-orphans 2>/dev/null || true)"
+  if [ -n "$ORPHAN_MCPS" ]; then
+    while IFS= read -r m; do
+      [ -n "$m" ] && echo "  [!] $m: removed from docker-compose.yml but still present - run /cpp:update to tear down"
+    done <<< "$ORPHAN_MCPS"
+  else
+    echo "  none (ok)"
+  fi
+else
+  echo "  skipped (docker or mcp-drift.py unavailable)"
+fi
 ```
 
 ## Step 5: Check Tier 4 (CI/CD)

--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -485,6 +485,9 @@ Status classifications:
 - **LEGACY SYSTEMD** - systemd unit remains for a current Docker server; teardown only
 - **LEGACY DEPRECATED** - deprecated server has a systemd unit; teardown only
 - **ORPHANED LEGACY** - installed/running legacy unit is no longer a repo Docker server
+- **ORPHANED DOCKER MCP** - a curated retired server (`.claude/deprecated-mcps.yaml`)
+  that is no longer in `docker-compose.yml` but is still present locally as a
+  container, an `mcp-<name>:*` image, or a `claude`/`codex mcp` registration
 - **PORT CONFLICT** - multiple listener processes are bound to the same MCP port
 - **NEW - NOT INSTALLED** - repo ships it but it is not installed
 - **NOT RUNNING** - installed but service/container is not active
@@ -499,6 +502,37 @@ Use `scripts/drift-detect.sh --fix` as raw inventory for:
 When presenting the final drift table, reclassify any systemd finding from that
 script as `LEGACY SYSTEMD`, `LEGACY DEPRECATED`, or `ORPHANED LEGACY`. Do not
 report systemd as `CONFLICT`, `FAILED SYSTEMD`, or `STALE SERVICE`.
+
+### 6c: Detect Orphaned Docker MCP Servers
+
+Systemd orphans are only half the picture: when a server is removed from
+`docker-compose.yml`, a machine that ran it keeps the old container, the old
+`mcp-<name>:*` images, and a live `claude`/`codex mcp` registration on a
+now-unmanaged port. `scripts/mcp-drift.py` detects those, driven by the curated
+`.claude/deprecated-mcps.yaml` list of record (never a blanket "every
+registration not in compose" sweep, which would tear down a user's own custom
+MCP servers).
+
+```bash
+cd "$CPP_DIR"
+
+MCP_DOCKER_DRIFT_STATUS="clean"
+python3 scripts/mcp-drift.py --check
+MCP_DOCKER_DRIFT_RC=$?
+```
+
+A server is classified **ORPHANED DOCKER MCP** only when it is listed in
+`deprecated-mcps.yaml` **and** no longer a service in
+`docker compose config --services` (across every profile) **and** still present
+locally. A server that is still a compose service is `OK`; a listed server with
+nothing present is `ABSENT`; if the current service set cannot be read the
+server is `UNKNOWN` (never torn down). Registrations CPP never shipped are never
+listed, so they are never flagged.
+
+Limitation to surface if asked: like skill drift, detection is curated-list
+driven. A server removed from compose without a `deprecated-mcps.yaml` entry
+reads as `ABSENT`/untracked; the fix is to add it to that file, not to broaden
+the teardown.
 
 ---
 
@@ -525,6 +559,65 @@ Options:
 
 If they choose teardown, use the same scope-aware removal commands from Step
 4.5 and re-run drift detection to verify no legacy units remain.
+
+### For ORPHANED DOCKER MCP findings
+
+**Only if `MCP_DOCKER_DRIFT_RC` is 1** (Step 6c found orphans). Pull the
+structured findings and drive a per-server, user-confirmed teardown. Teardown is
+reversible-where-possible: images keep a newest-tag restore point unless the user
+chooses prune-all, and `mcp-drift.py` hard-refuses to touch anything not
+classified `ORPHANED DOCKER MCP`.
+
+```bash
+cd "$CPP_DIR"
+python3 scripts/mcp-drift.py --json > /tmp/mcp-drift.json
+```
+
+For each orphaned server, show the user what is present (container, image tags,
+`claude`/`codex` registrations) plus its `reason` and `replacement`, and ask once
+per server with AskUserQuestion:
+
+```
+mcp-nano-banana was removed from docker-compose.yml but is still on this machine
+({reason}).
+Replacement: {replacement}
+Present: {container} container, {N} image tag(s), claude:{regs}, codex:{regs}
+Port to reclaim: {port}
+```
+
+Options:
+- **Tear down (keep a restore image)** - stop + remove the container, prune old
+  `mcp-<name>:*` image tags but keep the newest as a restore point, unregister
+  from `claude`/`codex mcp`. Runs:
+  ```bash
+  python3 scripts/mcp-drift.py --teardown <name>
+  ```
+- **Tear down (prune all images)** - same, but remove every `mcp-<name>:*` image:
+  ```bash
+  python3 scripts/mcp-drift.py --teardown <name> --prune-all-images
+  ```
+- **Keep** - leave it in place (re-runs of /cpp:update will keep flagging it).
+
+The teardown stops and removes the container (`docker stop` / `docker rm -f`),
+prunes images, removes the `claude mcp` registration at its detected scope
+(`claude mcp remove <name> -s <scope>`), removes any `codex mcp` registration,
+and reports the freed port and image tags. After all confirmed teardowns, re-scan
+and record the outcome for the summary:
+
+```bash
+cd "$CPP_DIR"
+python3 scripts/mcp-drift.py --check
+if [ $? -eq 0 ]; then
+  MCP_DOCKER_DRIFT_STATUS="torn down (newest image kept as restore point unless prune-all)"
+else
+  MCP_DOCKER_DRIFT_STATUS="drift remaining (user kept some servers)"
+fi
+```
+
+Never tear down a server the user chose to keep, and never tear down without an
+explicit per-server confirmation. `mcp-drift.py` refuses any server still in
+compose (`OK`), any with nothing present (`ABSENT`), and any name not on the
+curated list - so a user's own custom MCP registration is never removed.
 
 ### For NEW servers (in repo, not installed):
 
@@ -769,6 +862,10 @@ MCP Drift:
   {drift summary - e.g. "1 new server refreshed via Docker, 1 legacy unit removed"
    or "No drift detected - all servers in sync"}
 
+Docker MCP Drift:
+  {MCP_DOCKER_DRIFT_STATUS - e.g. "clean", "torn down (newest image kept as restore
+   point unless prune-all)", or "drift remaining (user kept some servers)"}
+
 Skill Drift:
   {SKILL_DRIFT_STATUS - e.g. "clean", "pruned (backup under ~/.claude/.backup/skills/)",
    or "drift remaining (user kept some skills)"}
@@ -789,6 +886,12 @@ Run /cpp:status for full installation details.
 - Legacy systemd units are detected before Docker refresh and are removed only after user confirmation
 - MCP drift detection compares repo state against Docker containers, legacy systemd remnants, claude mcp registrations, and listening ports
 - Orphaned legacy systemd units such as `mcp-coordination` are flagged for teardown
+- Orphaned Docker MCP infra (Step 6c/7) - a container, `mcp-<name>:*` image, or
+  `claude`/`codex mcp` registration left behind after a server is removed from
+  `docker-compose.yml` - is detected via the curated `.claude/deprecated-mcps.yaml`
+  list and torn down per-server with confirmation, keeping a newest-image restore
+  point unless prune-all is chosen. Driven by `scripts/mcp-drift.py`; a user's own
+  custom MCP registration is never flagged or removed
 - New servers are offered only through the Docker refresh path
 - mcp-evaluate is recognized as deprecated and flagged for legacy teardown if installed
 - Skill drift (Step 7.5) prunes retired generated skills using the curated

--- a/.claude/deprecated-mcps.yaml
+++ b/.claude/deprecated-mcps.yaml
@@ -1,0 +1,88 @@
+# Deprecated Docker MCP servers retired from Claude Power Pack.
+#
+# Companion to .claude/deprecated-skills.yaml (which does the same job for
+# generated skills). This file is the deprecation list of record for MCP
+# *servers*. scripts/mcp-drift.py consumes it to detect ORPHANED DOCKER MCP
+# infrastructure - a container, an mcp-<name>:* image, or a claude/codex mcp
+# registration that is still present on a machine after the server was removed
+# from docker-compose.yml - and to offer a guided, user-confirmed teardown via
+# /cpp:update (Step 7).
+#
+# SAFETY - two conditions must BOTH hold before anything is classified
+# ORPHANED DOCKER MCP (and therefore offered for teardown):
+#
+#   1. the server is listed here, AND
+#   2. it is no longer a service in docker-compose.yml
+#      (docker compose config --services, across all profiles).
+#
+# So a name can be seeded here ahead of its removal PR with zero risk: while the
+# service is still in compose it is classified OK and never touched. Only once
+# the removal lands (and a stale copy lingers on a host) does it become an
+# orphan. Equally important: a registration CPP never shipped (a user's own
+# custom MCP server) is simply not in this file, so it is never flagged and
+# never removed. Adding an entry here does NOT delete anything on its own -
+# teardown is always per-server and user-confirmed.
+#
+# Per-entry fields:
+#   name         (required) - canonical server / compose service name.
+#   reason       (required) - why it was retired (keep it colon-free).
+#   replacement  (optional) - the supported successor, if any.
+#   port         (optional) - the CPP port it used (8080-8089), for reporting.
+#   image_prefix (optional, default = name) - docker image repository; matching
+#                             images are `<image_prefix>:*`.
+#   containers   (optional, default = [name]) - container names to stop/remove
+#                             (matched against the docker-compose container_name,
+#                             with or without CPP_CONTAINER_PREFIX).
+#   claude_registrations (optional) - names as they appear in `claude mcp list`.
+#   codex_registrations  (optional) - names as they appear in `codex mcp list`.
+
+version: 1
+
+deprecated:
+  - name: mcp-nano-banana
+    reason: >-
+      The nano-banana diagram and PPTX MCP server is retired; PowerPoint
+      generation moves to the native Anthropic pptx skill (issue #401).
+    replacement: /documentation:pptx (native pptx skill)
+    port: 8084
+    image_prefix: mcp-nano-banana
+    containers:
+      - mcp-nano-banana
+    claude_registrations:
+      - nano-banana
+      - mcp-nano-banana
+    codex_registrations:
+      - nano-banana
+
+  - name: mcp-woodpecker-ci
+    reason: >-
+      The woodpecker-ci MCP server is unused; /flow:auto talks to the Woodpecker
+      API directly (issue #404).
+    replacement: Woodpecker API via /flow:auto
+    port: 8085
+    image_prefix: mcp-woodpecker-ci
+    containers:
+      - mcp-woodpecker-ci
+    claude_registrations:
+      - woodpecker-ci
+      - mcp-woodpecker-ci
+
+  - name: mcp-coordination
+    reason: >-
+      The Redis-backed coordination MCP server was retired when solo-dev
+      worktrees replaced distributed session locking; it was demoted to extras
+      and then removed (issues #91 and #405).
+    replacement: git worktrees via /flow:start and /flow:auto
+    port: 8082
+    image_prefix: mcp-coordination
+    containers:
+      - mcp-coordination
+      - mcp-coordinator
+    claude_registrations:
+      - coordination
+      - mcp-coordination
+      - coordinator
+      - mcp-coordinator
+    codex_registrations:
+      - coordination
+      - mcp-coordination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,30 @@
   prototype skill into a first-class, shipped command listed in `/codex:help`,
   `/cpp:help`, `/cpp:init` (Tier 5), and the CLAUDE.md Codex Orchestration
   section.
+- **Orphaned Docker MCP teardown in `/cpp:update`** (issue #405) - `/cpp:update`
+  now detects and offers guided teardown of stale Docker MCP infrastructure left
+  behind when a server is removed from `docker-compose.yml`: the old container,
+  its `mcp-<name>:*` images, and any `claude`/`codex mcp` registration. Step 6c
+  detects, Step 7 tears down per-server with confirmation (keeping the newest
+  image tag as a restore point unless prune-all is chosen), mirroring the skill
+  drift design (#395). `/cpp:status` surfaces orphaned Docker MCPs too, closing
+  the blind spot where a removed server kept running unreported.
+- `scripts/mcp-drift.py` - classifies deprecated MCP servers against the curated
+  `.claude/deprecated-mcps.yaml` as ORPHANED DOCKER MCP / OK / ABSENT / UNKNOWN,
+  with `--check`, `--json`, `--list-orphans`, `--plan`, and a guarded
+  `--teardown` (`--prune-all-images` to drop the restore point). A server is
+  orphaned only when it is on the list **and** gone from
+  `docker compose config --services` (all profiles) **and** still present locally;
+  teardown hard-refuses anything still shipped, absent, or not on the list - so a
+  user's own custom MCP registration is never removed. Detection is curated-list
+  driven, not a blanket "not in compose" sweep.
+- `.claude/deprecated-mcps.yaml` - curated retired-MCP list of record (companion
+  to `.claude/deprecated-skills.yaml`), seeded with `mcp-nano-banana` (#401),
+  `mcp-woodpecker-ci` (#404), and the retired `mcp-coordination` server.
+- `scripts/drift-detect.sh` - derives the current service set dynamically from
+  `docker compose config --services` and flags orphaned Docker MCPs via
+  `mcp-drift.py`, so a removed server is torn down instead of silently forgotten
+  by the hardcoded server arrays.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Core components and their locations:
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
 - `lib/spec_bridge/` - Spec-to-GitHub-issue sync
-- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift)
+- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift)
 - `templates/` - Makefile, workflow, container templates
 - `docker-compose.yml` - MCP server orchestration (profiles: `core`, `browser`, `cicd`)
 - `.woodpecker.yml` - Woodpecker CI pipeline (lint, test, typecheck, image security gates, runtime smoke)
@@ -66,7 +66,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - **Runtime smoke:** CI uses a `cpp-smoke-$CI_PIPELINE_NUMBER` compose project with random host ports (driven by `scripts/runtime-smoke.sh`), validates service health, asserts the agent is reachable cross-container at `http://aws-secrets-agent:2773` (proving the `0.0.0.0` bind), exercises the client's real fetch/parse/export path via a hermetic fake agent (`scripts/fake-secrets-agent.py` + `docker-compose.smoke.yml`) with a non-empty `AWS_SECRET_NAME`, and drives a secret through the **REAL** `aws-secrets-agent` binary against a LocalStack Secrets Manager (real AWS SDK `GetSecretValue` via `AWS_ENDPOINT_URL`, no production credentials) so a consumer actually receives a genuinely-fetched secret (issue #377). In-container readiness probes are retried (up to 10x, 3s apart) so a transient post-`--wait` connection refusal does not fail the build; on genuine exhaustion the step dumps `docker compose ps` and the failing service's recent logs (issue #375). It runs `docker compose down -v` before exiting. CI must not deploy persistent containers or prune host images.
 - **Image security gates:** CI runs hadolint over every Dockerfile, validates `docker compose config --quiet`, blocks rendered `:latest`, `default-token`, and host-published agent port regressions, then scans built images for fixed HIGH/CRITICAL CVEs and writes SPDX/CycloneDX SBOMs to `artifacts/sbom/`.
 - **Bootstrap checks:** `make bootstrap-check` verifies admin-only prerequisites (IAM roles, secrets provisioning) before deploy. Configure in `.claude/bootstrap.yaml`. Runs as the first step in the deploy pipeline - blocks with remediation if unsatisfied.
-- **Drift detection:** `make drift-check` compares host-installed artifacts against repo templates and treats remaining systemd MCP units as legacy migration findings. Run it manually when reconciling workstation-managed artifacts. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
+- **Drift detection:** `make drift-check` compares host-installed artifacts against repo templates and treats remaining systemd MCP units as legacy migration findings. It also flags **orphaned Docker MCP servers** - a container, `mcp-<name>:*` image, or `claude`/`codex mcp` registration left behind after a server is removed from `docker-compose.yml` - by deriving the current service set from `docker compose config --services` and matching against the curated `.claude/deprecated-mcps.yaml` list of record (via `scripts/mcp-drift.py`). Detection is curated-list driven so a user's own custom MCP registration is never flagged; teardown is offered per-server, user-confirmed, and keeps a newest-image restore point unless prune-all is chosen (run `/cpp:update`, or `python3 scripts/mcp-drift.py --teardown <name>`). Run it manually when reconciling workstation-managed artifacts. See `docs/HOST_MANAGED_ARTIFACTS.md` for full inventory.
 - **Reproducible builds:** Every base image and build tool (python, rust, debian, `uv`, gitleaks, woodpecker server/agent) is pinned by version tag plus `@sha256:` digest in the Dockerfiles, `.woodpecker.yml`, and infra compose files - never `:latest`. Deployable images are tagged with `CPP_IMAGE_TAG` (the short git SHA, set by the Makefile) instead of `:latest`, so each image traces to a commit and rollbacks have provenance. `renovate.json` rotates the pinned digests on a weekly schedule so pinning never freezes security updates.
 
 ## Commands Reference
@@ -168,7 +168,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/dockers` - Docker container status, health, project linkages
 - `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD, Codex)
 - `/cpp:status` - Check installation state
-- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, then prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed)
+- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, tear down orphaned Docker MCP infra via the curated `.claude/deprecated-mcps.yaml` (Step 6c/7, user-confirmed), then prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed)
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
 - `/happy-check` - Check happy-cli version (optional)
 

--- a/scripts/drift-detect.sh
+++ b/scripts/drift-detect.sh
@@ -263,7 +263,8 @@ Categories checked:
   3. Go binary        - ~/go/bin/woodpecker-mcp version currency
   4. Docker containers - running container health status
   5. Shared scripts   - cross-container script consistency (fetch-secrets.sh, bash-prep.sh)
-  6. MCP deployment models - Docker/systemd conflicts, failed/orphaned units, port bindings
+  6. MCP deployment models - Docker/systemd conflicts, failed/orphaned units,
+                             orphaned Docker MCP servers (via mcp-drift.py), port bindings
 
 Exit codes:
   0 - No drift (or no artifacts installed to check)
@@ -535,6 +536,45 @@ check_orphaned_systemd_units() {
     fi
 }
 
+# --- Orphaned Docker MCP servers ---
+# Delegates to scripts/mcp-drift.py, which derives the current service set
+# dynamically from `docker compose config --services` (across every profile) and
+# flags a server that is on the curated `.claude/deprecated-mcps.yaml` list but no
+# longer in compose while still present locally (container / image / registration).
+# This is what makes a *removed* Docker MCP get torn down instead of silently
+# forgotten - the hardcoded MCP_* arrays above only ever describe current servers.
+check_orphaned_docker_mcps() {
+    local helper="$SCRIPT_DIR/mcp-drift.py"
+
+    if ! command -v docker &>/dev/null; then
+        skip "orphaned Docker MCPs - docker not installed"
+        return
+    fi
+    if [[ ! -f "$helper" ]] || ! command -v python3 &>/dev/null; then
+        skip "orphaned Docker MCPs - mcp-drift.py or python3 unavailable"
+        return
+    fi
+
+    local orphans
+    orphans=$(python3 "$helper" --list-orphans 2>/dev/null || true)
+    if [[ -z "$orphans" ]]; then
+        ok "orphaned Docker MCPs - none detected"
+        return
+    fi
+
+    local name cmd
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        drift "orphaned Docker MCP $name - removed from docker-compose.yml but still present locally"
+        if $FIX_MODE; then
+            while IFS= read -r cmd; do
+                [[ -n "$cmd" ]] && fix "$cmd"
+            done < <(python3 "$helper" --plan "$name" 2>/dev/null || true)
+        fi
+    done <<< "$orphans"
+    fix "Guided teardown: run /cpp:update (Step 7), or: python3 scripts/mcp-drift.py --teardown <name>"
+}
+
 check_mcp_port_bindings() {
     if ! command -v ss &>/dev/null; then
         skip "ports - ss not available"
@@ -703,6 +743,7 @@ main() {
     echo "------------------------------------------------"
     check_mcp_deployment_models
     check_orphaned_systemd_units
+    check_orphaned_docker_mcps
     check_mcp_port_bindings
     echo ""
 

--- a/scripts/mcp-drift.py
+++ b/scripts/mcp-drift.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""mcp-drift.py - Detect and tear down orphaned Docker MCP infrastructure.
+
+Part of Claude Power Pack (CPP). Companion to scripts/skill-drift.py (which does
+the same job for generated skills) and scripts/drift-detect.sh (systemd/host
+drift). This script owns *Docker MCP server* drift.
+
+The hazard: when a server is removed from docker-compose.yml, a machine that ran
+it keeps the old container, the old `mcp-<name>:*` images, and a live
+`claude`/`codex mcp` registration pointing at a now-unmanaged port. /cpp:update
+tore down orphaned systemd units but had no Docker equivalent, so that stale
+infra just lingered and kept running (issue #405).
+
+Detection is CURATED-LIST DRIVEN via `.claude/deprecated-mcps.yaml` - never a
+blanket "every registration not in compose" sweep, which would tear down a
+user's own custom MCP servers. A server is classified ORPHANED DOCKER MCP only
+when BOTH hold:
+
+  1. it is listed in deprecated-mcps.yaml, AND
+  2. it is no longer a service in docker-compose.yml
+     (docker compose config --services, across every profile), AND
+  3. it is still locally present (container, mcp-<name>:* image, or registration).
+
+Statuses:
+  ORPHANED DOCKER MCP - listed, gone from compose, still present  -> offer teardown
+  OK                  - listed but still a compose service        -> never touched
+  ABSENT              - listed, gone from compose, nothing present -> nothing to do
+  UNKNOWN             - current service set could not be determined
+                        (no docker / compose parse failed)        -> never touched
+
+Usage:
+  mcp-drift.py                          # report table; exit 1 if orphans found
+  mcp-drift.py --check                  # same as no args (explicit)
+  mcp-drift.py --json                   # machine-readable findings (array)
+  mcp-drift.py --list-orphans           # orphan server names, one per line (exit 0)
+  mcp-drift.py --plan NAME [NAME..]     # print teardown commands (no execution)
+  mcp-drift.py --teardown NAME [NAME..] # execute guarded teardown
+
+Teardown options:
+  --prune-all-images   Remove every mcp-<name>:* image (default: keep the newest
+                       tag as a restore point).
+
+Options:
+  --deprecated-file FILE  Deprecation list (default: <repo>/.claude/deprecated-mcps.yaml)
+  --compose-file FILE     Compose file (default: <repo>/docker-compose.yml)
+  --verbose               Also list OK / ABSENT servers in the report
+
+Exit codes:
+  0 - No orphans (--check), plan printed, or teardown succeeded
+  1 - Orphans detected (--check/--json), or teardown refused/failed
+  2 - Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Status constants
+ORPHANED = "ORPHANED DOCKER MCP"
+OK = "OK"
+ABSENT = "ABSENT"
+UNKNOWN = "UNKNOWN"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# --------------------------------------------------------------------------- #
+# Deprecation-list parsing (mirrors skill-drift.py; fallback drops folded text)
+# --------------------------------------------------------------------------- #
+def _load_yaml(text: str) -> dict:
+    """Load YAML, preferring PyYAML; fall back to a minimal parser if absent."""
+    try:
+        import yaml  # type: ignore
+
+        return yaml.safe_load(text) or {}
+    except ImportError:
+        return _fallback_parse(text)
+
+
+def _strip_comment(value: str) -> str:
+    in_single = in_double = False
+    for i, ch in enumerate(value):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            if i == 0 or value[i - 1] in " \t":
+                return value[:i]
+    return value
+
+
+def _scalar(value: str) -> object:
+    value = _strip_comment(value).strip()
+    if not value or value in (">-", ">", "|", "|-", "[]"):
+        return "" if value != "[]" else []
+    if (value[0] == value[-1]) and value[0] in ("'", '"') and len(value) >= 2:
+        return value[1:-1]
+    low = value.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    if re.fullmatch(r"-?\d+", value):
+        return int(value)
+    return value
+
+
+_LIST_FIELDS = ("containers", "claude_registrations", "codex_registrations")
+
+
+def _fallback_parse(text: str) -> dict:
+    """Minimal YAML parser for the deprecated-mcps.yaml schema only.
+
+    Handles a top-level `version` scalar and a `deprecated:` block list of
+    mappings, each with scalar fields plus the block-list fields in _LIST_FIELDS.
+    Folded scalars (reason/replacement `>-` blocks) are intentionally dropped -
+    exactly like skill-drift.py - so the parity test compares structured fields
+    only. Keep folded reason text colon-free so a continuation line is never
+    mistaken for a field.
+    """
+    result: dict = {}
+    entries: list[dict] = []
+    current: dict | None = None
+    list_key: str | None = None
+    list_indent = -1
+
+    for raw in text.splitlines():
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        body = line.lstrip(" ")
+
+        # Continuation of a block list: "- item" more indented than its key.
+        if list_key is not None and body.startswith("- ") and indent > list_indent:
+            current.setdefault(list_key, []).append(_scalar(body[2:]))  # type: ignore[union-attr]
+            continue
+        list_key = None  # any other line ends the current block list
+
+        # Top-level scalar (e.g. "version: 1") or the "deprecated:" header.
+        if indent == 0 and not body.startswith("- ") and ":" in body:
+            key, _, val = body.partition(":")
+            key = key.strip()
+            if key == "deprecated":
+                result["deprecated"] = entries
+            else:
+                result[key] = _scalar(val)
+            continue
+
+        # New entry: "- name: X"
+        if body.startswith("- ") and "name:" in body:
+            current = {}
+            entries.append(current)
+            after = body[2:]
+            key, _, val = after.partition(":")
+            current[key.strip()] = _scalar(val)
+            continue
+
+        if current is None:
+            continue
+
+        # A field on the current entry mapping.
+        if ":" in body and not body.startswith("- "):
+            key, _, val = body.partition(":")
+            key = key.strip()
+            sval = _scalar(val)
+            if key in _LIST_FIELDS and sval == "":
+                current[key] = []
+                list_key = key
+                list_indent = indent
+            else:
+                current[key] = sval
+
+    if "deprecated" not in result:
+        result["deprecated"] = entries
+    return result
+
+
+def load_deprecated_mcps(deprecated_file: Path) -> list[dict]:
+    """Return the normalized list of deprecated MCP server entries."""
+    if not deprecated_file.is_file():
+        return []
+    data = _load_yaml(deprecated_file.read_text(encoding="utf-8"))
+    out: list[dict] = []
+    for entry in data.get("deprecated") or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            continue
+        image_prefix = str(entry.get("image_prefix") or name).strip()
+        containers = [str(c) for c in (entry.get("containers") or [name])]
+        out.append(
+            {
+                "name": name,
+                "reason": (str(entry.get("reason") or "")).strip(),
+                "replacement": (str(entry.get("replacement") or "")).strip(),
+                "port": str(entry.get("port") or "").strip(),
+                "image_prefix": image_prefix,
+                "containers": containers,
+                "claude_registrations": [str(r) for r in (entry.get("claude_registrations") or [])],
+                "codex_registrations": [str(r) for r in (entry.get("codex_registrations") or [])],
+            }
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Host state - live inventory of what is actually present on the machine
+# --------------------------------------------------------------------------- #
+class HostState:
+    """Present Docker/registration state. Built from the host by collect_host_state,
+    or constructed directly in tests to keep classification hermetic."""
+
+    def __init__(
+        self,
+        current_services: set[str] | None = None,
+        services_known: bool = True,
+        containers: dict[str, str] | None = None,
+        images: dict[str, list[dict]] | None = None,
+        claude_regs: set[str] | None = None,
+        codex_regs: set[str] | None = None,
+    ) -> None:
+        self.current_services = current_services or set()
+        self.services_known = services_known
+        self.containers = containers or {}  # container name -> state (running/exited/...)
+        self.images = images or {}          # image repository -> [{tag,id,size,created}]
+        self.claude_regs = claude_regs or set()
+        self.codex_regs = codex_regs or set()
+
+
+def _run(cmd: list[str], timeout: int = 20) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, check=False, timeout=timeout
+        )
+        return proc.returncode, proc.stdout
+    except (OSError, subprocess.SubprocessError):
+        return 127, ""
+
+
+def _has(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def collect_current_services(compose_file: Path) -> tuple[set[str], bool]:
+    """Return (services, known). `known` is False when the current service set
+    could not be determined - in which case NOTHING is classified orphaned."""
+    if not _has("docker") or not compose_file.is_file():
+        return set(), False
+
+    base = ["docker", "compose", "-f", str(compose_file)]
+    rc, out = _run(base + ["config", "--profiles"])
+    profile_args: list[str] = []
+    if rc == 0:
+        for p in out.splitlines():
+            p = p.strip()
+            if p:
+                profile_args += ["--profile", p]
+
+    rc, out = _run(base + profile_args + ["config", "--services"])
+    services = {line.strip() for line in out.splitlines() if line.strip()}
+    # An empty result almost always means the parse did not really work (broken
+    # docker, malformed compose). Treat it as UNKNOWN rather than "zero services",
+    # otherwise every present server would be wrongly flagged orphaned. A real CPP
+    # compose always yields at least one service.
+    if rc != 0 or not services:
+        return set(), False
+    return services, True
+
+
+def collect_containers() -> dict[str, str]:
+    if not _has("docker"):
+        return {}
+    rc, out = _run(["docker", "ps", "-a", "--format", "{{.Names}}\t{{.State}}"])
+    if rc != 0:
+        return {}
+    result: dict[str, str] = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if not parts or not parts[0].strip():
+            continue
+        result[parts[0].strip()] = (parts[1].strip() if len(parts) > 1 else "").lower()
+    return result
+
+
+def collect_images() -> dict[str, list[dict]]:
+    if not _has("docker"):
+        return {}
+    rc, out = _run(
+        [
+            "docker",
+            "images",
+            "--format",
+            "{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}\t{{.CreatedAt}}",
+        ]
+    )
+    if rc != 0:
+        return {}
+    result: dict[str, list[dict]] = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3 or not parts[0].strip():
+            continue
+        repo = parts[0].strip()
+        if parts[1].strip() == "<none>":
+            continue
+        result.setdefault(repo, []).append(
+            {
+                "tag": parts[1].strip(),
+                "id": parts[2].strip(),
+                "size": parts[3].strip() if len(parts) > 3 else "",
+                "created": parts[4].strip() if len(parts) > 4 else "",
+            }
+        )
+    return result
+
+
+def _collect_registrations(cmd: str) -> set[str]:
+    if not _has(cmd):
+        return set()
+    rc, out = _run([cmd, "mcp", "list"])
+    if rc != 0:
+        return set()
+    names: set[str] = set()
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or line.lower().startswith(("no mcp", "checking", "mcp server")):
+            continue
+        # Accept "name: url ...", "name  url", or a bare "name".
+        token = re.split(r"[:\s]", line, maxsplit=1)[0].strip()
+        if token and not token.startswith(("-", "#", "=")):
+            names.add(token)
+    return names
+
+
+def collect_host_state(compose_file: Path) -> HostState:
+    services, known = collect_current_services(compose_file)
+    return HostState(
+        current_services=services,
+        services_known=known,
+        containers=collect_containers(),
+        images=collect_images(),
+        claude_regs=_collect_registrations("claude"),
+        codex_regs=_collect_registrations("codex"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+def _matching_containers(entry: dict, host: HostState) -> list[dict]:
+    """Present containers for this entry, respecting an optional CPP_CONTAINER_PREFIX."""
+    found: list[dict] = []
+    for want in entry["containers"]:
+        for name, state in host.containers.items():
+            if name == want or name.endswith(want):
+                found.append({"name": name, "state": state})
+    return found
+
+
+def classify(deprecated: list[dict], host: HostState) -> list[dict]:
+    findings: list[dict] = []
+    for entry in deprecated:
+        name = entry["name"]
+        in_compose = name in host.current_services
+
+        containers = _matching_containers(entry, host)
+        images = host.images.get(entry["image_prefix"], [])
+        claude = [r for r in entry["claude_registrations"] if r in host.claude_regs]
+        codex = [r for r in entry["codex_registrations"] if r in host.codex_regs]
+        present = bool(containers or images or claude or codex)
+
+        if not host.services_known:
+            status = UNKNOWN
+        elif in_compose:
+            status = OK
+        elif present:
+            status = ORPHANED
+        else:
+            status = ABSENT
+
+        findings.append(
+            {
+                "server": name,
+                "status": status,
+                "reason": entry["reason"],
+                "replacement": entry["replacement"],
+                "port": entry["port"],
+                "image_prefix": entry["image_prefix"],
+                "in_compose": in_compose,
+                "containers": containers,
+                "images": images,
+                "claude_registrations": claude,
+                "codex_registrations": codex,
+            }
+        )
+    return findings
+
+
+def removable(findings: list[dict]) -> list[dict]:
+    return [f for f in findings if f["status"] == ORPHANED]
+
+
+# --------------------------------------------------------------------------- #
+# Teardown planning + execution
+# --------------------------------------------------------------------------- #
+def images_to_remove(images: list[dict], prune_all: bool) -> list[dict]:
+    """Which image tags to remove. keep-one (default) keeps the newest tag as a
+    restore point; prune-all removes them all. Newest = last in docker's default
+    (most-recent-first) ordering, so we keep index 0 and remove the rest."""
+    if not images:
+        return []
+    if prune_all:
+        return list(images)
+    # docker images lists most-recently-created first; keep that one.
+    return list(images[1:])
+
+
+def plan_teardown(finding: dict, prune_all_images: bool) -> list[str]:
+    """Return the ordered shell commands a teardown WOULD run. Pure - no side effects."""
+    cmds: list[str] = []
+    for c in finding["containers"]:
+        if c["state"] not in ("exited", "created", "dead", ""):
+            cmds.append(f"docker stop {c['name']}")
+        cmds.append(f"docker rm -f {c['name']}")
+
+    to_remove = images_to_remove(finding["images"], prune_all_images)
+    for img in to_remove:
+        cmds.append(f"docker rmi {finding['image_prefix']}:{img['tag']}")
+    kept = [i for i in finding["images"] if i not in to_remove]
+    if kept and not prune_all_images:
+        cmds.append(f"# kept restore point: {finding['image_prefix']}:{kept[0]['tag']}")
+
+    for reg in finding["claude_registrations"]:
+        scope = detect_claude_scope(reg, execute=False)
+        cmds.append(f"claude mcp remove {reg} -s {scope}")
+    for reg in finding["codex_registrations"]:
+        cmds.append(f"codex mcp remove {reg}")
+    return cmds
+
+
+def detect_claude_scope(name: str, execute: bool = True) -> str:
+    """Best-effort scope detection for `claude mcp remove -s <scope>`.
+
+    Parses `claude mcp get <name>` for a local/project/user scope; defaults to
+    `local` (where these servers were registered). In plan mode we skip the probe
+    and just report the default so `--plan` stays side-effect free."""
+    default = "local"
+    if not execute or not _has("claude"):
+        return default
+    rc, out = _run(["claude", "mcp", "get", name])
+    if rc != 0:
+        return default
+    low = out.lower()
+    for scope in ("local", "project", "user"):
+        if re.search(rf"scope[^\n]*\b{scope}\b", low):
+            return scope
+    return default
+
+
+def teardown(
+    names: list[str],
+    findings: list[dict],
+    prune_all_images: bool = False,
+    execute: bool = True,
+) -> int:
+    """Guarded teardown of ORPHANED DOCKER MCP servers.
+
+    Hard-refuses any name that is not classified ORPHANED (unlisted, still in
+    compose/OK, ABSENT, or UNKNOWN) BEFORE running anything - this is what keeps
+    a user's own custom MCP registration from ever being removed. Each teardown
+    step is best-effort so one failure does not strand the rest."""
+    by_name = {f["server"]: f for f in findings}
+    refused = 0
+    torn = 0
+
+    for name in names:
+        finding = by_name.get(name)
+        if finding is None:
+            print(f"REFUSED {name}: not in the deprecated-mcps.yaml list of record", file=sys.stderr)
+            refused += 1
+            continue
+        if finding["status"] != ORPHANED:
+            print(
+                f"REFUSED {name}: classified {finding['status']}; only "
+                "ORPHANED DOCKER MCP servers may be torn down",
+                file=sys.stderr,
+            )
+            refused += 1
+            continue
+
+        cmds = plan_teardown(finding, prune_all_images)
+        if not execute:
+            for c in cmds:
+                print(c)
+            torn += 1
+            continue
+
+        print(f"Tearing down {name} (port {finding['port'] or 'n/a'})...")
+        for c in cmds:
+            if c.startswith("#"):
+                print(f"  {c}")
+                continue
+            rc, out = _run(c.split())
+            marker = "ok" if rc == 0 else f"warn (rc={rc})"
+            print(f"  [{marker}] {c}")
+        removed_imgs = images_to_remove(finding["images"], prune_all_images)
+        disk = ", ".join(f"{i['tag']} ({i['size']})" for i in removed_imgs if i.get("size"))
+        freed_port = finding["port"] or "n/a"
+        print(
+            f"  freed port {freed_port}; removed {len(finding['containers'])} container(s), "
+            f"{len(removed_imgs)} image tag(s)" + (f" - reclaimed {disk}" if disk else "")
+        )
+        torn += 1
+
+    if refused:
+        print(f"\n{torn} torn down, {refused} refused.", file=sys.stderr)
+        return 1
+    print(f"\n{torn} orphaned Docker MCP server(s) torn down.")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def render_table(findings: list[dict], verbose: bool) -> str:
+    lines = ["Docker MCP Drift Report", "=======================", ""]
+    shown = [f for f in findings if verbose or f["status"] == ORPHANED]
+    if shown:
+        lines.append(f"{'Server':<24} {'Port':<6} {'In-compose':<11} {'Status'}")
+        lines.append(f"{'-' * 24} {'-' * 6} {'-' * 11} {'-' * 20}")
+        for f in shown:
+            lines.append(
+                f"{f['server']:<24} {f['port'] or '-':<6} "
+                f"{'yes' if f['in_compose'] else 'no':<11} {f['status']}"
+            )
+        lines.append("")
+
+    orphans = removable(findings)
+    for f in orphans:
+        present = []
+        if f["containers"]:
+            present.append(f"{len(f['containers'])} container(s)")
+        if f["images"]:
+            present.append(f"{len(f['images'])} image tag(s)")
+        if f["claude_registrations"]:
+            present.append(f"claude:{','.join(f['claude_registrations'])}")
+        if f["codex_registrations"]:
+            present.append(f"codex:{','.join(f['codex_registrations'])}")
+        lines.append(f"  {f['server']} - present: {', '.join(present) or 'unknown'}")
+        if f["replacement"]:
+            lines.append(f"    replacement: {f['replacement']}")
+
+    if any(f["status"] == UNKNOWN for f in findings):
+        lines.append(
+            "Note: current service set could not be determined (docker/compose "
+            "unavailable); nothing classified as orphaned."
+        )
+    if not orphans:
+        lines.append("No orphaned Docker MCP servers detected.")
+    else:
+        lines.append(
+            f"{len(orphans)} orphaned Docker MCP server(s) flagged. Teardown is "
+            "offered with confirmation by /cpp:update; a keep-one image restore "
+            "point is retained unless you choose prune-all."
+        )
+    lines.append(
+        "Note: detection is curated-list driven (.claude/deprecated-mcps.yaml). "
+        "A server removed from compose without a list entry is not auto-detected, "
+        "and a user's own custom MCP registration is never flagged."
+    )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--check", action="store_true", help="Report drift table (default)")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON array")
+    parser.add_argument("--list-orphans", action="store_true",
+                        help="Print orphaned server names, one per line (exit 0)")
+    parser.add_argument("--plan", nargs="+", metavar="NAME",
+                        help="Print teardown commands for named servers (no execution)")
+    parser.add_argument("--teardown", nargs="+", metavar="NAME",
+                        help="Execute guarded teardown of named ORPHANED servers")
+    parser.add_argument("--prune-all-images", action="store_true",
+                        help="Remove every mcp-<name>:* image (default: keep newest)")
+    parser.add_argument("--verbose", action="store_true", help="List OK/ABSENT too")
+    parser.add_argument("--deprecated-file", default=None)
+    parser.add_argument("--compose-file", default=None)
+    args = parser.parse_args(argv)
+
+    deprecated_file = (
+        Path(args.deprecated_file) if args.deprecated_file
+        else REPO_ROOT / ".claude" / "deprecated-mcps.yaml"
+    )
+    compose_file = (
+        Path(args.compose_file) if args.compose_file
+        else REPO_ROOT / "docker-compose.yml"
+    )
+
+    deprecated = load_deprecated_mcps(deprecated_file)
+    host = collect_host_state(compose_file)
+    findings = classify(deprecated, host)
+
+    if args.plan:
+        return teardown(args.plan, findings, args.prune_all_images, execute=False)
+
+    if args.teardown:
+        return teardown(args.teardown, findings, args.prune_all_images, execute=True)
+
+    if args.list_orphans:
+        for f in removable(findings):
+            print(f["server"])
+        return 0
+
+    if args.json:
+        print(json.dumps(findings, indent=2))
+        return 1 if removable(findings) else 0
+
+    # default / --check
+    print(render_table(findings, verbose=args.verbose))
+    return 1 if removable(findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_drift_detect.py
+++ b/tests/test_drift_detect.py
@@ -236,3 +236,91 @@ def test_drift_detect_no_false_conflict_when_units_absent(tmp_path: Path) -> Non
     output = result.stdout
     assert "deployment model conflict" not in output
     assert "no Docker/systemd conflicts or failed units" in output
+
+
+def test_drift_detect_flags_orphaned_docker_mcp(tmp_path: Path) -> None:
+    """A curated server (nano-banana) that is gone from `docker compose config
+    --services` but still present as a container must be surfaced as an orphaned
+    Docker MCP, with a teardown plan under --fix. Exercises the mcp-drift.py
+    delegation added for issue #405."""
+    home = tmp_path / "home"
+    (home / ".config" / "systemd" / "user").mkdir(parents=True)  # no systemd units
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "uv", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(
+        bin_dir / "docker",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "--version" ]]; then echo "Docker version 26.0.0"; exit 0; fi
+        if [[ "$1" == "compose" && "$2" == "version" ]]; then echo "Docker Compose version v2.27.0"; exit 0; fi
+        if [[ "$1" == "compose" && "$*" == *"config --profiles"* ]]; then
+          echo core; echo browser; echo cicd; exit 0
+        fi
+        if [[ "$1" == "compose" && "$*" == *"config --services"* ]]; then
+          # nano-banana deliberately ABSENT from the current service set
+          echo mcp-second-opinion; echo mcp-playwright-persistent
+          echo mcp-woodpecker-ci; echo aws-secrets-agent; exit 0
+        fi
+        if [[ "$1" == "compose" && "$*" == *" ps "* ]]; then
+          echo "mcp-nano-banana:Up (healthy)"; exit 0
+        fi
+        if [[ "$1" == "ps" && "$2" == "-a" ]]; then
+          printf 'mcp-nano-banana\\trunning\\n'; exit 0   # still present locally
+        fi
+        if [[ "$1" == "ps" ]]; then echo "mcp-nano-banana:Up 2 hours (healthy)"; exit 0; fi
+        if [[ "$1" == "images" ]]; then exit 0; fi
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "systemctl",
+        """
+        #!/usr/bin/env bash
+        args="$*"
+        if [[ "$args" == *"show -p LoadState"* ]]; then echo "not-found"; exit 0; fi
+        if [[ "$args" == *"is-active"* ]]; then echo "inactive"; exit 0; fi
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "claude",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "mcp" && "$2" == "list" ]]; then echo "nano-banana"; exit 0; fi
+        if [[ "$1" == "mcp" && "$2" == "get" ]]; then echo "Scope: local"; exit 0; fi
+        exit 0
+        """,
+    )
+    _write_executable(bin_dir / "codex", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(bin_dir / "ss",
+        "#!/usr/bin/env bash\necho 'State Recv-Q Send-Q Local Address:Port Peer Address:Port Process'\n")
+    _write_executable(
+        bin_dir / "sysctl",
+        """
+        #!/usr/bin/env bash
+        case "$2" in
+          vm.swappiness) echo 10 ;;
+          vm.vfs_cache_pressure) echo 50 ;;
+          fs.inotify.max_user_watches) echo 524288 ;;
+          fs.inotify.max_user_instances) echo 512 ;;
+          *) echo unknown ;;
+        esac
+        """,
+    )
+
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "PATH": f"{bin_dir}:{env['PATH']}", "USER": "tester"})
+
+    result = subprocess.run(
+        ["bash", str(DRIFT_SCRIPT), "--fix"],
+        cwd=ROOT, env=env, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+    )
+
+    output = result.stdout
+    assert result.returncode == 1
+    assert "orphaned Docker MCP mcp-nano-banana" in output
+    assert "docker rm -f mcp-nano-banana" in output          # teardown plan under --fix
+    assert "claude mcp remove nano-banana" in output

--- a/tests/test_mcp_drift.py
+++ b/tests/test_mcp_drift.py
@@ -1,0 +1,346 @@
+"""Regression tests for Docker MCP drift/orphan detection + teardown (issue #405).
+
+The core hazard: when a server is removed from docker-compose.yml, a machine that
+ran it keeps the old container, mcp-<name>:* images, and a live claude/codex mcp
+registration. Detection must fire for exactly those - and NEVER for a server that
+is still shipped, nor for a user's own custom (non-CPP) MCP registration. These
+tests pin the curated-list-only classifier and the teardown guardrails.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "mcp-drift.py"
+
+_spec = importlib.util.spec_from_file_location("mcp_drift", SCRIPT)
+assert _spec and _spec.loader
+md = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(md)
+
+
+DEPRECATION = """\
+    version: 1
+    deprecated:
+      - name: mcp-nano-banana
+        reason: retired diagram server
+        replacement: pptx skill
+        port: 8084
+        image_prefix: mcp-nano-banana
+        containers:
+          - mcp-nano-banana
+        claude_registrations:
+          - nano-banana
+          - mcp-nano-banana
+        codex_registrations:
+          - nano-banana
+      - name: mcp-woodpecker-ci
+        reason: unused
+        port: 8085
+        containers:
+          - mcp-woodpecker-ci
+        claude_registrations:
+          - woodpecker-ci
+"""
+
+
+def _depfile(tmp_path: Path, body: str = DEPRECATION) -> Path:
+    f = tmp_path / "deprecated-mcps.yaml"
+    f.write_text(textwrap.dedent(body), encoding="utf-8")
+    return f
+
+
+def _dep(tmp_path: Path) -> list[dict]:
+    return md.load_deprecated_mcps(_depfile(tmp_path))
+
+
+def _status(findings: list[dict], server: str) -> str:
+    return next(f["status"] for f in findings if f["server"] == server)
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+def test_orphan_when_removed_from_compose_but_present(tmp_path: Path) -> None:
+    """nano-banana gone from compose but still present -> ORPHANED;
+    woodpecker still a compose service -> OK (never flagged)."""
+    host = md.HostState(
+        current_services={"mcp-woodpecker-ci", "mcp-second-opinion"},
+        services_known=True,
+        containers={"mcp-nano-banana": "running"},
+        images={"mcp-nano-banana": [{"tag": "abc", "id": "1", "size": "1GB", "created": "2026-06-30"}]},
+        claude_regs={"nano-banana"},
+    )
+    findings = md.classify(_dep(tmp_path), host)
+    assert _status(findings, "mcp-nano-banana") == md.ORPHANED
+    assert _status(findings, "mcp-woodpecker-ci") == md.OK
+    assert [f["server"] for f in md.removable(findings)] == ["mcp-nano-banana"]
+
+
+def test_absent_when_nothing_present(tmp_path: Path) -> None:
+    host = md.HostState(current_services={"mcp-second-opinion"}, services_known=True)
+    findings = md.classify(_dep(tmp_path), host)
+    assert _status(findings, "mcp-nano-banana") == md.ABSENT
+    assert md.removable(findings) == []
+
+
+def test_unknown_when_services_undeterminable(tmp_path: Path) -> None:
+    """If the current service set can't be read (no docker / compose parse fail),
+    nothing is torn down - present servers are UNKNOWN, never ORPHANED."""
+    host = md.HostState(
+        services_known=False,
+        containers={"mcp-nano-banana": "running"},
+        claude_regs={"nano-banana"},
+    )
+    findings = md.classify(_dep(tmp_path), host)
+    assert _status(findings, "mcp-nano-banana") == md.UNKNOWN
+    assert md.removable(findings) == []
+
+
+def test_container_prefix_is_matched(tmp_path: Path) -> None:
+    """A CPP_CONTAINER_PREFIX'd container (e.g. `ci-mcp-nano-banana`) still matches."""
+    host = md.HostState(
+        current_services={"mcp-second-opinion"},
+        services_known=True,
+        containers={"ci-mcp-nano-banana": "exited"},
+    )
+    findings = md.classify(_dep(tmp_path), host)
+    nano = next(f for f in findings if f["server"] == "mcp-nano-banana")
+    assert nano["status"] == md.ORPHANED
+    assert nano["containers"] == [{"name": "ci-mcp-nano-banana", "state": "exited"}]
+
+
+def test_user_custom_registration_never_flagged(tmp_path: Path) -> None:
+    """A registration CPP never shipped is not in the list -> never a finding,
+    never removable, and teardown of it is refused."""
+    host = md.HostState(
+        current_services={"mcp-second-opinion"},
+        services_known=True,
+        claude_regs={"my-personal-tool", "some-other-mcp"},
+    )
+    findings = md.classify(_dep(tmp_path), host)
+    assert md.removable(findings) == []
+    assert "my-personal-tool" not in {f["server"] for f in findings}
+    rc = md.teardown(["my-personal-tool"], findings, execute=True)
+    assert rc == 1  # refused: not on the list of record
+
+
+def test_no_deprecation_file_finds_nothing(tmp_path: Path) -> None:
+    host = md.HostState(current_services={"mcp-second-opinion"}, services_known=True,
+                        claude_regs={"nano-banana"})
+    findings = md.classify(md.load_deprecated_mcps(tmp_path / "missing.yaml"), host)
+    assert findings == []
+
+
+# --------------------------------------------------------------------------- #
+# Teardown guardrails
+# --------------------------------------------------------------------------- #
+def _findings(tmp_path: Path, host: md.HostState) -> list[dict]:
+    return md.classify(_dep(tmp_path), host)
+
+
+def test_teardown_refuses_ok_server(tmp_path: Path) -> None:
+    host = md.HostState(current_services={"mcp-woodpecker-ci"}, services_known=True,
+                        claude_regs={"woodpecker-ci"})
+    rc = md.teardown(["mcp-woodpecker-ci"], _findings(tmp_path, host), execute=True)
+    assert rc == 1  # OK (still shipped) -> never torn down
+
+
+def test_teardown_refuses_absent_and_unknown(tmp_path: Path) -> None:
+    absent = md.HostState(current_services={"mcp-second-opinion"}, services_known=True)
+    assert md.teardown(["mcp-nano-banana"], _findings(tmp_path, absent), execute=True) == 1
+    unknown = md.HostState(services_known=False, containers={"mcp-nano-banana": "running"})
+    assert md.teardown(["mcp-nano-banana"], _findings(tmp_path, unknown), execute=True) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Image handling (keep-one restore point vs prune-all)
+# --------------------------------------------------------------------------- #
+def test_images_to_remove_keep_one_vs_prune_all() -> None:
+    images = [
+        {"tag": "new", "id": "1", "size": "", "created": "2026-06-30"},
+        {"tag": "mid", "id": "2", "size": "", "created": "2026-06-20"},
+        {"tag": "old", "id": "3", "size": "", "created": "2026-06-10"},
+    ]
+    # docker lists newest-first; keep-one keeps index 0 (newest) as restore point.
+    assert [i["tag"] for i in md.images_to_remove(images, prune_all=False)] == ["mid", "old"]
+    assert [i["tag"] for i in md.images_to_remove(images, prune_all=True)] == ["new", "mid", "old"]
+    assert md.images_to_remove([], prune_all=False) == []
+
+
+def test_plan_teardown_command_sequence(tmp_path: Path) -> None:
+    host = md.HostState(
+        current_services={"mcp-second-opinion"},
+        services_known=True,
+        containers={"mcp-nano-banana": "running"},
+        images={"mcp-nano-banana": [
+            {"tag": "keep", "id": "1", "size": "1GB", "created": "2026-06-30"},
+            {"tag": "drop", "id": "2", "size": "1GB", "created": "2026-06-10"},
+        ]},
+        claude_regs={"nano-banana"},
+        codex_regs={"nano-banana"},
+    )
+    nano = next(f for f in _findings(tmp_path, host) if f["server"] == "mcp-nano-banana")
+    plan = md.plan_teardown(nano, prune_all_images=False)
+    assert "docker stop mcp-nano-banana" in plan
+    assert "docker rm -f mcp-nano-banana" in plan
+    assert "docker rmi mcp-nano-banana:drop" in plan
+    assert any("kept restore point: mcp-nano-banana:keep" in c for c in plan)
+    assert "docker rmi mcp-nano-banana:keep" not in plan  # newest kept
+    assert any(c.startswith("claude mcp remove nano-banana -s ") for c in plan)
+    assert "codex mcp remove nano-banana" in plan
+
+
+# --------------------------------------------------------------------------- #
+# Fallback YAML parser parity (structured fields; folded reason text dropped)
+# --------------------------------------------------------------------------- #
+def test_fallback_parser_matches_real_file() -> None:
+    real = (ROOT / ".claude" / "deprecated-mcps.yaml").read_text(encoding="utf-8")
+    import yaml
+
+    expected = yaml.safe_load(real)
+    got = md._fallback_parse(real)
+
+    exp = {e["name"]: e for e in expected["deprecated"]}
+    gotm = {e["name"]: e for e in got["deprecated"]}
+    assert set(exp) == set(gotm)
+    for name, ee in exp.items():
+        ge = gotm[name]
+        assert str(ge.get("port", "")) == str(ee.get("port", ""))
+        assert (ge.get("image_prefix") or "") == (ee.get("image_prefix") or "")
+        for field in ("containers", "claude_registrations", "codex_registrations"):
+            assert sorted(ge.get(field) or []) == sorted(ee.get(field) or []), field
+
+
+def test_load_defaults_container_and_image_prefix_to_name(tmp_path: Path) -> None:
+    dep = md.load_deprecated_mcps(_depfile(tmp_path, """\
+        version: 1
+        deprecated:
+          - name: mcp-foo
+            reason: gone
+    """))
+    assert dep[0]["containers"] == ["mcp-foo"]
+    assert dep[0]["image_prefix"] == "mcp-foo"
+
+
+# --------------------------------------------------------------------------- #
+# CLI contract + execution path (fake docker/claude/codex on PATH)
+# --------------------------------------------------------------------------- #
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _fake_bin(tmp_path: Path, *, services: str, containers: str = "",
+              images: str = "", claude_regs: str = "", codex_regs: str = "") -> tuple[Path, Path]:
+    """Build fake docker/claude/codex presenting a fixed host scenario. Fixture
+    data is written to files the fakes `cat` (so tabs/newlines survive intact).
+    Mutating commands (stop/rm/rmi/remove) append their argv to a shared log."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    data = tmp_path / "fixtures"
+    data.mkdir()
+    (data / "services").write_text(services, encoding="utf-8")
+    (data / "containers").write_text(containers, encoding="utf-8")
+    (data / "images").write_text(images, encoding="utf-8")
+    (data / "claude").write_text(claude_regs, encoding="utf-8")
+    (data / "codex").write_text(codex_regs, encoding="utf-8")
+    log = tmp_path / "calls.log"
+
+    _write_exec(bin_dir / "docker", f"""
+        #!/usr/bin/env bash
+        if [[ "$1" == "compose" && "$*" == *"config --profiles"* ]]; then echo "core"; exit 0; fi
+        if [[ "$1" == "compose" && "$*" == *"config --services"* ]]; then cat {str(data / "services")!r}; exit 0; fi
+        if [[ "$1" == "ps" ]]; then cat {str(data / "containers")!r}; exit 0; fi
+        if [[ "$1" == "images" ]]; then cat {str(data / "images")!r}; exit 0; fi
+        echo "docker $*" >> {str(log)!r}
+        exit 0
+    """)
+    _write_exec(bin_dir / "claude", f"""
+        #!/usr/bin/env bash
+        if [[ "$1" == "mcp" && "$2" == "list" ]]; then cat {str(data / "claude")!r}; exit 0; fi
+        if [[ "$1" == "mcp" && "$2" == "get" ]]; then echo "Scope: local"; exit 0; fi
+        echo "claude $*" >> {str(log)!r}
+        exit 0
+    """)
+    _write_exec(bin_dir / "codex", f"""
+        #!/usr/bin/env bash
+        if [[ "$1" == "mcp" && "$2" == "list" ]]; then cat {str(data / "codex")!r}; exit 0; fi
+        echo "codex $*" >> {str(log)!r}
+        exit 0
+    """)
+    return bin_dir, log
+
+
+def _run_cli(bin_dir: Path, depfile: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--deprecated-file", str(depfile),
+         "--compose-file", str(ROOT / "docker-compose.yml"), *args],
+        text=True, capture_output=True, check=False, env=env,
+    )
+
+
+def test_cli_check_and_list_orphans(tmp_path: Path) -> None:
+    dep = _depfile(tmp_path)
+    # nano-banana removed from compose, still present as a container + registration.
+    bin_dir, _ = _fake_bin(
+        tmp_path,
+        services="mcp-second-opinion\nmcp-woodpecker-ci",
+        containers="mcp-nano-banana\trunning\n",
+        claude_regs="nano-banana\nmy-tool\n",
+    )
+    check = _run_cli(bin_dir, dep, "--check")
+    assert check.returncode == 1
+    assert "ORPHANED DOCKER MCP" in check.stdout
+    assert "mcp-nano-banana" in check.stdout
+
+    orphans = _run_cli(bin_dir, dep, "--list-orphans")
+    assert orphans.returncode == 0
+    assert orphans.stdout.strip() == "mcp-nano-banana"
+
+    data = json.loads(_run_cli(bin_dir, dep, "--json").stdout)
+    rec = next(f for f in data if f["server"] == "mcp-nano-banana")
+    assert rec["status"] == md.ORPHANED
+
+
+def test_cli_teardown_executes_and_refuses(tmp_path: Path) -> None:
+    dep = _depfile(tmp_path)
+    bin_dir, log = _fake_bin(
+        tmp_path,
+        services="mcp-second-opinion\nmcp-woodpecker-ci",
+        containers="mcp-nano-banana\trunning\n",
+        # docker images lists most-recently-created first: new, then old.
+        images="mcp-nano-banana\tnew\t1\t1GB\t2026-06-30\nmcp-nano-banana\told\t2\t1GB\t2026-06-01\n",
+        claude_regs="nano-banana\nmcp-nano-banana\n",
+        codex_regs="nano-banana\n",
+    )
+    res = _run_cli(bin_dir, dep, "--teardown", "mcp-nano-banana")
+    assert res.returncode == 0, res.stderr
+    calls = log.read_text() if log.exists() else ""
+    assert "docker stop mcp-nano-banana" in calls
+    assert "docker rm -f mcp-nano-banana" in calls
+    assert "docker rmi mcp-nano-banana:old" in calls          # older tag pruned
+    assert "docker rmi mcp-nano-banana:new" not in calls      # newest kept as restore point
+    assert "claude mcp remove nano-banana -s local" in calls
+    assert "codex mcp remove nano-banana" in calls
+
+    # woodpecker is still a compose service -> teardown must be refused (no calls).
+    log.unlink(missing_ok=True)
+    refused = _run_cli(bin_dir, dep, "--teardown", "mcp-woodpecker-ci")
+    assert refused.returncode == 1
+    assert "REFUSED" in refused.stderr
+    assert not log.exists()
+
+
+def test_script_is_executable() -> None:
+    assert SCRIPT.stat().st_mode & stat.S_IXUSR

--- a/tests/test_mcp_drift.py
+++ b/tests/test_mcp_drift.py
@@ -143,7 +143,7 @@ def test_no_deprecation_file_finds_nothing(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 # Teardown guardrails
 # --------------------------------------------------------------------------- #
-def _findings(tmp_path: Path, host: md.HostState) -> list[dict]:
+def _findings(tmp_path: Path, host) -> list[dict]:
     return md.classify(_dep(tmp_path), host)
 
 


### PR DESCRIPTION
## Summary

When a server is removed from `docker-compose.yml`, a machine that ran it kept the old container, its `mcp-<name>:*` images, and a live `claude`/`codex mcp` registration on a now-unmanaged port. `/cpp:update` tore down orphaned *systemd* units but had no *Docker* equivalent, so that stale infra just lingered and kept running. This adds detection + guided teardown, mirroring the merged skill-drift design (#395).

## What changed

- **`scripts/mcp-drift.py`** (new) - curated-list-driven detector + guarded teardown (`--check`/`--json`/`--list-orphans`/`--plan`/`--teardown`). A server is **ORPHANED DOCKER MCP** only when it is on the curated list **and** no longer in `docker compose config --services` (all profiles) **and** still present locally. Teardown hard-refuses anything still shipped (`OK`), `ABSENT`, `UNKNOWN`, or not on the list. Images keep a newest-tag restore point unless `--prune-all-images`.
- **`.claude/deprecated-mcps.yaml`** (new) - curated retired-MCP list of record (companion to `deprecated-skills.yaml`), seeded with `mcp-nano-banana` (#401), `mcp-woodpecker-ci` (#404), and the retired `mcp-coordination` server.
- **`scripts/drift-detect.sh`** - derives the current service set dynamically from compose and flags orphaned Docker MCPs via `mcp-drift.py` (no per-server script edit needed when a service is removed).
- **`/cpp:update`** - Step 6c detects, Step 7 tears down per-server with confirmation (keep-one vs prune-all, reports freed port + disk reclaimed).
- **`/cpp:status`** - surfaces orphaned Docker MCPs, closing the blind spot where a removed server kept running unreported.
- Docs: `CHANGELOG.md`, `CLAUDE.md`.

## Safety

Detection is **curated-list driven**, never a blanket "every registration not in compose" sweep. A registration CPP never shipped (a user's own custom MCP) is not on the list, so it is never flagged and never removed. Seeding nano-banana/woodpecker-ci now is safe: they are still compose services (classified `OK`), so nothing is torn down until their removal PRs (#401/#404) land. If the current service set can't be read, servers are `UNKNOWN` and never torn down.

## Test plan

- `tests/test_mcp_drift.py` (new): ORPHANED/OK/ABSENT/UNKNOWN classification, container-prefix match, **user-custom registration never flagged or torn down**, teardown guardrails (refuses OK/absent/unknown/unlisted), keep-one vs prune-all image logic, teardown command sequence, fallback YAML parser parity, CLI + end-to-end teardown via fake docker/claude/codex.
- `tests/test_drift_detect.py`: added an integration test asserting `drift-detect.sh --fix` surfaces the orphan + teardown plan.
- Quality gates green: `ruff` clean, full suite **756 passed / 1 skipped**, `lib.cicd run --plan finish` (lint + test + security_scan) all SUCCESS.

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7WfCV39cfNqFn79ZcCb3j