### PR TITLE
chore(docs): prune dangling references to removed nano-banana + woodpecker-ci MCP servers

### DIFF
--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -612,10 +612,10 @@ curated list - so a user's own custom MCP registration is never removed.
 Ask the user per server:
 
 ```
-mcp-woodpecker-ci is available in the repo but not installed.
-  - Port: 8085
-  - Docker profile: cicd
-  - Purpose: Woodpecker CI pipeline management
+mcp-<name> is available in the repo but not installed.
+  - Port: <8080-8089>
+  - Docker profile: <profile>
+  - Purpose: <what the server does>
 ```
 
 Options:

--- a/.claude/commands/documentation/pptx.md
+++ b/.claude/commands/documentation/pptx.md
@@ -15,10 +15,11 @@ itself (python-pptx based). CPP no longer ships its own PowerPoint engine - the
 > (runs `npx skills add anthropics/skills@pptx`; requires Node/npx). If it cannot be
 > installed, tell the user and stop rather than falling back to a removed MCP tool.
 
-> **Diagrams are descoped.** Automated diagram generation was provided by the retired
-> `nano-banana` MCP server. Choosing a replacement rendering engine is tracked in
-> **issue #411**. Until then this command embeds only diagram images the user supplies
-> (PNG/JPG paths); it does not auto-render diagrams.
+> **Diagrams: bring pre-rendered images.** This command embeds diagram images you
+> supply (PNG/JPG paths); it does not render diagrams itself. For C4 architecture
+> diagrams, run `/documentation:c4` (renders GitHub-friendly Mermaid via
+> `scripts/c4-mermaid.py`) and export an image from its `.mmd` / `index.md` output;
+> otherwise supply any other pre-rendered image.
 
 ## Arguments
 
@@ -109,10 +110,11 @@ Report the plan and ask for confirmation.
 
 ### Step 3: Diagram Images (optional)
 
-Automated diagram generation is descoped (the `nano-banana` engine was removed in #401;
-replacement tracked in #411). If the user wants diagrams on slides:
+This command does not render diagrams itself. If the user wants diagrams on slides:
 
 - Ask for paths to **pre-rendered** image files (PNG/JPG) and note which slide each belongs on.
+- For C4 architecture diagrams, run `/documentation:c4` and export an image from its
+  Mermaid `.mmd` / `index.md` output (e.g. via mermaid.live).
 - If the user has no images, proceed without diagrams (do not attempt to generate them).
 
 ### Step 4: Build the Deck via the native pptx skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,25 @@
   mypy `exclude` (its directory was already removed). Follow-up orphan-teardown
   automation for machines that still have the old container/image is tracked in **#405**.
 
+### Fixed
+
+- **Prune dangling references to removed MCP servers** - follow-up cleanup of
+  stragglers left after #401 (`nano-banana`) and #404 (`mcp-woodpecker-ci`) that still
+  described removed tooling as current:
+  - `scripts/drift-detect.sh`: removed the `check_go_binary` category that probed the
+    deleted `~/go/bin/woodpecker-mcp` binary (it printed a phantom skip/drift line on
+    every `make drift-check`); renumbered the remaining categories and the `--help`
+    list. `tests/test_drift_detect.py`: dropped the removed `cicd` profile and
+    `mcp-woodpecker-ci` service from the mocked `docker compose` output.
+  - `docs/HOST_MANAGED_ARTIFACTS.md`: dropped the "Go Binary (Woodpecker MCP)" section
+    and its `setup-go-binary.sh` timing-table row (the script was deleted with the
+    server).
+  - `.claude/commands/documentation/pptx.md`: replaced the "diagrams descoped,
+    replacement tracked in #411" note (now shipped, PR #415) with guidance to render C4
+    diagrams via `/documentation:c4` and embed the exported image.
+  - `.claude/commands/cpp/update.md`: genericized the "new server in repo" example that
+    named the removed `mcp-woodpecker-ci`.
+
 ## [7.2.0] - 2026-06-28
 
 ### Added

--- a/docs/HOST_MANAGED_ARTIFACTS.md
+++ b/docs/HOST_MANAGED_ARTIFACTS.md
@@ -53,22 +53,7 @@ rarely change and are not deploy-critical. `bash-prep.sh` is idempotent and safe
 
 **Reconciliation:** `scripts/bash-prep.sh --apply`
 
-### 3. Go Binary (Woodpecker MCP)
-
-| Artifact | Source Script | Installed Location | Category |
-|----------|-------------|--------------------|----------|
-| `woodpecker-mcp` binary | `mcp-woodpecker-ci/scripts/setup-go-binary.sh` | `~/go/bin/woodpecker-mcp` | Provisioning-only |
-| Woodpecker config | `mcp-woodpecker-ci/scripts/setup-go-binary.sh` | `~/.config/woodpecker-mcp/config.yaml` | Provisioning-only |
-
-**Risk:** Binary installed via `go install` from upstream repo. Version drift is between
-upstream releases, not between our repo and host. Config contains credentials fetched
-from AWS Secrets Manager.
-
-**Detection:** `scripts/drift-detect.sh` verifies binary is executable and config exists.
-
-**Reconciliation:** `mcp-woodpecker-ci/scripts/setup-go-binary.sh`
-
-### 4. Woodpecker Secrets
+### 3. Woodpecker Secrets
 
 | Artifact | Source Script | Installed Location | Category |
 |----------|-------------|--------------------|----------|
@@ -95,7 +80,6 @@ These artifacts are fully managed by the repo and rebuilt on every deploy:
 |--------|---------|-----------|-------------|
 | `bash-prep.sh` | Workstation setup | Once | No (idempotent, re-runnable) |
 | `install-service.sh` (both) | Service setup | Once | No - should be re-run when templates change |
-| `setup-go-binary.sh` | MCP server setup | Once | No (manual upgrade) |
 | `bootstrap-secrets.py` | Woodpecker setup | Once | No (manual credential rotation) |
 | `make deploy` | Manual local deploy or `/flow:deploy` | Operator-controlled | Yes - rebuilds containers from repo |
 | `.woodpecker.yml` runtime-smoke | MCP stack CI validation | Relevant push/PR paths | No - validates an isolated stack, then tears it down |

--- a/scripts/drift-detect.sh
+++ b/scripts/drift-detect.sh
@@ -248,10 +248,9 @@ Usage:
 Categories checked:
   1. Systemd units    - installed .service files vs repo templates
   2. Sysctl config    - /etc/sysctl.d/99-claude-code.conf vs bash-prep.sh targets
-  3. Go binary        - ~/go/bin/woodpecker-mcp version currency
-  4. Docker containers - running container health status
-  5. Shared scripts   - cross-container script consistency (fetch-secrets.sh, bash-prep.sh)
-  6. MCP deployment models - Docker/systemd conflicts, failed/orphaned units,
+  3. Docker containers - running container health status
+  4. Shared scripts   - cross-container script consistency (fetch-secrets.sh, bash-prep.sh)
+  5. MCP deployment models - Docker/systemd conflicts, failed/orphaned units,
                              orphaned Docker MCP servers (via mcp-drift.py), port bindings
 
 Exit codes:
@@ -378,38 +377,6 @@ check_sysctl() {
         ok "sysctl - all parameters match bash-prep.sh targets"
     else
         fix "Re-run: $REPO_ROOT/scripts/bash-prep.sh --apply"
-    fi
-}
-
-# --- Go binary drift ---
-check_go_binary() {
-    local binary="$HOME/go/bin/woodpecker-mcp"
-
-    if [[ ! -x "$binary" ]]; then
-        skip "woodpecker-mcp - Go binary not installed"
-        return
-    fi
-
-    # Check if binary exists and can execute
-    if "$binary" --version &>/dev/null 2>&1 || "$binary" version &>/dev/null 2>&1; then
-        ok "woodpecker-mcp - binary present and executable"
-    else
-        # Binary exists but might be stale - just verify it runs
-        if "$binary" --help &>/dev/null 2>&1; then
-            ok "woodpecker-mcp - binary present and executable"
-        else
-            drift "woodpecker-mcp - binary exists but fails to execute"
-        fi
-    fi
-
-    # Check config exists
-    local config="$HOME/.config/woodpecker-mcp/config.yaml"
-    if [[ -f "$config" ]]; then
-        ok "woodpecker-mcp - config present at $config"
-    else
-        if [[ -x "$binary" ]]; then
-            drift "woodpecker-mcp - binary installed but config missing"
-        fi
     fi
 }
 
@@ -706,25 +673,19 @@ main() {
     check_sysctl
     echo ""
 
-    # Category 3: Go binary
-    echo -e "${BOLD}Go Binaries${NC}"
-    echo "------------------------------------------------"
-    check_go_binary
-    echo ""
-
-    # Category 4: Docker containers
+    # Category 3: Docker containers
     echo -e "${BOLD}Docker Containers${NC}"
     echo "------------------------------------------------"
     check_docker_compose
     echo ""
 
-    # Category 5: Shared script contracts
+    # Category 4: Shared script contracts
     echo -e "${BOLD}Shared Script Contracts${NC}"
     echo "------------------------------------------------"
     check_shared_scripts
     echo ""
 
-    # Category 6: MCP deployment model consistency
+    # Category 5: MCP deployment model consistency
     echo -e "${BOLD}MCP Deployment Models${NC}"
     echo "------------------------------------------------"
     check_mcp_deployment_models

--- a/tests/test_drift_detect.py
+++ b/tests/test_drift_detect.py
@@ -256,12 +256,12 @@ def test_drift_detect_flags_orphaned_docker_mcp(tmp_path: Path) -> None:
         if [[ "$1" == "--version" ]]; then echo "Docker version 26.0.0"; exit 0; fi
         if [[ "$1" == "compose" && "$2" == "version" ]]; then echo "Docker Compose version v2.27.0"; exit 0; fi
         if [[ "$1" == "compose" && "$*" == *"config --profiles"* ]]; then
-          echo core; echo browser; echo cicd; exit 0
+          echo core; echo browser; exit 0
         fi
         if [[ "$1" == "compose" && "$*" == *"config --services"* ]]; then
           # nano-banana deliberately ABSENT from the current service set
           echo mcp-second-opinion; echo mcp-playwright-persistent
-          echo mcp-woodpecker-ci; echo aws-secrets-agent; exit 0
+          echo aws-secrets-agent; exit 0
         fi
         if [[ "$1" == "compose" && "$*" == *" ps "* ]]; then
           echo "mcp-nano-banana:Up (healthy)"; exit 0


### PR DESCRIPTION
## Summary
Follow-up straggler cleanup after **#401** (nano-banana removal) and **#404** (mcp-woodpecker-ci removal) — references that still described removed tooling as current. Surfaced while cleaning the nano-banana PPTX docs; the sweep found the woodpecker-ci leftovers that #404's PR missed.

| File | Straggler removed | Source |
|---|---|---|
| `scripts/drift-detect.sh` | `check_go_binary` category probing the deleted `~/go/bin/woodpecker-mcp` binary (phantom line on every `make drift-check`); categories + `--help` renumbered | #404 |
| `tests/test_drift_detect.py` | removed `cicd` profile + `mcp-woodpecker-ci` from the mocked `docker compose` output | #404 |
| `docs/HOST_MANAGED_ARTIFACTS.md` | "Go Binary (Woodpecker MCP)" section + `setup-go-binary.sh` timing-table row (script deleted with the server) | #404 |
| `documentation/pptx.md` | "diagrams descoped, replacement tracked in #411" note → now points to the shipped `/documentation:c4` Mermaid engine (PR #415) | #401 |
| `cpp/update.md` | genericized the "new server in repo" example that named removed `mcp-woodpecker-ci` | #404 |

**Coordination MCP** was explicitly checked and is already clean — every remaining reference is the canonical `deprecated-mcps.yaml` registry, legacy-teardown tooling (intentionally naming it to detect/remove it), or history.

## What was intentionally left
- `CHANGELOG.md` and README release-history blocks (accurate history).
- `.claude/deprecated-mcps.yaml` (the canonical teardown registry — *should* list them).
- Teardown tooling / test fixtures that name removed servers to detect them.

## Test plan
- [x] `make verify` green (lint + 636 tests + mypy)
- [x] `bash -n scripts/drift-detect.sh` passes
- [x] Post-edit grep: no `check_go_binary` / `woodpecker-mcp` binary / `setup-go-binary` refs remain outside CHANGELOG history

🤖 Generated with [Claude Code](https://claude.com/claude-code)