### PR TITLE
feat(flow): distribute the flow read-only permission allowlist (Closes #427)

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -474,6 +474,50 @@ fi
 
 - **Custom**: Build JSON from selected categories
 
+**User-Level Flow Allowlist (Optional)**
+
+The project profiles above govern ONE repo. The `/flow:*` commands also run
+read-only git/gh plumbing (issue reads, worktree creation, the branch-slug
+text pipeline) in EVERY repo, which prompts on every run unless the rules
+exist at user level. Offer to merge the CPP allowlist template into
+`~/.claude/settings.json`:
+
+```
+=== Optional: User-Level Flow Allowlist ===
+
+/flow commands run read-only git/gh plumbing (gh issue view, git fetch,
+git worktree, slug pipelines) that triggers a permission prompt on every
+run, in every repo, unless allowed at user level.
+
+Merge the CPP read-only allowlist into ~/.claude/settings.json?
+(Additive and idempotent - existing settings and rules are preserved.
+Rationale and caveats: templates/claude-settings-permissions.md)  [y/N]
+```
+
+If yes:
+
+```bash
+TEMPLATE="$CPP_DIR/templates/claude-settings-permissions.json"
+TARGET="$HOME/.claude/settings.json"
+mkdir -p "$HOME/.claude"
+[ -f "$TARGET" ] || echo '{}' > "$TARGET"
+
+BEFORE=$(jq '(.permissions.allow // []) | length' "$TARGET")
+jq -s '.[0].permissions.allow = (((.[0].permissions.allow // []) + .[1].permissions.allow) | unique) | .[0]' \
+  "$TARGET" "$TEMPLATE" > "$TARGET.tmp" && mv "$TARGET.tmp" "$TARGET"
+AFTER=$(jq '.permissions.allow | length' "$TARGET")
+
+echo "✓ Flow allowlist merged into ~/.claude/settings.json ($((AFTER - BEFORE)) new rules, $AFTER total)"
+echo "  Note: sed is allowed for the flow slug pipeline; see the template doc for the sed -i caveat."
+```
+
+If no:
+
+```bash
+echo "→ Flow allowlist skipped"
+echo "  Merge later via /cpp:update, or read templates/claude-settings-permissions.md"
+```
+
 **Shell Prompt Integration (Optional)**
 
 Ask the user if they want shell prompt integration:

--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -763,6 +763,58 @@ per-family confirmation.
 
 ---
 
+## Step 7.6: User-Level Flow Allowlist Refresh
+
+The git pull may have updated `templates/claude-settings-permissions.json`
+(the user-level read-only allowlist that keeps `/flow:*` from prompting for
+its git/gh plumbing - see `templates/claude-settings-permissions.md`). Check
+whether `~/.claude/settings.json` is missing any template rules and offer to
+merge the difference.
+
+```bash
+cd "$CPP_DIR"
+TEMPLATE="$CPP_DIR/templates/claude-settings-permissions.json"
+TARGET="$HOME/.claude/settings.json"
+
+if [ -f "$TEMPLATE" ]; then
+  if [ -f "$TARGET" ]; then
+    MISSING=$(jq -s '(.[1].permissions.allow - (.[0].permissions.allow // [])) | length' "$TARGET" "$TEMPLATE")
+    jq -rs '(.[1].permissions.allow - (.[0].permissions.allow // []))[] | "  + \(.)"' "$TARGET" "$TEMPLATE"
+  else
+    MISSING=$(jq '.permissions.allow | length' "$TEMPLATE")
+    jq -r '.permissions.allow[] | "  + \(.)"' "$TEMPLATE"
+  fi
+
+  if [ "$MISSING" -eq 0 ]; then
+    echo "✓ Flow allowlist up to date"
+  else
+    echo "Flow allowlist: $MISSING rule(s) from the template are not in ~/.claude/settings.json"
+  fi
+fi
+```
+
+If rules are missing, ask the user:
+
+```
+Merge the missing flow allowlist rules into ~/.claude/settings.json?
+(Additive and idempotent - existing settings and rules are preserved.
+Rationale and caveats: templates/claude-settings-permissions.md)  [y/N]
+```
+
+If yes, run the same merge as `/cpp:init`:
+
+```bash
+mkdir -p "$HOME/.claude"
+[ -f "$TARGET" ] || echo '{}' > "$TARGET"
+jq -s '.[0].permissions.allow = (((.[0].permissions.allow // []) + .[1].permissions.allow) | unique) | .[0]' \
+  "$TARGET" "$TEMPLATE" > "$TARGET.tmp" && mv "$TARGET.tmp" "$TARGET"
+echo "✓ Flow allowlist merged ($(jq '.permissions.allow | length' "$TARGET") total allow rules)"
+```
+
+If no: report `→ Flow allowlist refresh skipped` and continue.
+
+---
+
 ## Step 8: Detect Current Installation Tier
 
 Determine the user's current tier level so we can offer upgrades:

--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -112,6 +112,32 @@ for script in prompt-context.sh worktree-remove.sh hook-mask-output.sh hook-vali
 done
 ```
 
+### Step 5b: User-Level Flow Allowlist
+
+Check whether the flow read-only permission allowlist
+(`templates/claude-settings-permissions.json`) is merged into
+`~/.claude/settings.json`. Without it, every `/flow:*` run prompts for its
+read-only git/gh plumbing (issue reads, worktree creation, slug pipeline).
+
+```bash
+TEMPLATE="$CPP_DIR/templates/claude-settings-permissions.json"
+TARGET="$HOME/.claude/settings.json"
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "SKIP flow allowlist (template not found - CPP checkout incomplete?)"
+elif [ ! -f "$TARGET" ]; then
+  echo "FAIL flow allowlist (~/.claude/settings.json missing - all $(jq '.permissions.allow | length' "$TEMPLATE") rules absent)"
+else
+  TOTAL=$(jq '.permissions.allow | length' "$TEMPLATE")
+  MISSING=$(jq -s '(.[1].permissions.allow - (.[0].permissions.allow // [])) | length' "$TARGET" "$TEMPLATE")
+  if [ "$MISSING" -eq 0 ]; then
+    echo "PASS flow allowlist ($TOTAL/$TOTAL rules present)"
+  else
+    echo "WARN flow allowlist ($((TOTAL - MISSING))/$TOTAL rules present, $MISSING missing)"
+  fi
+fi
+```
+
 ### Step 6: Active Worktrees
 
 ```bash
@@ -240,6 +266,7 @@ Output a single diagnostic report in this format:
 | prompt-context.sh | ✅/❌ | Shell prompt context |
 | worktree-remove.sh | ✅/❌ | Safe worktree removal |
 | secrets-mask.sh | ✅/❌ | Output masking filter |
+| Flow allowlist | ✅/⚠️/❌ | 32/32 rules in ~/.claude/settings.json / N missing / settings.json missing |
 
 ### MCP Server Connectivity
 
@@ -292,6 +319,7 @@ Output a single diagnostic report in this format:
    - Rust: `cp ~/Projects/claude-power-pack/templates/makefiles/rust.mk Makefile`
    - Monorepo: `cp ~/Projects/claude-power-pack/templates/makefiles/multi.mk Makefile`
 2. ❌ **worktree-remove.sh not found** - Run: `ln -sf ~/Projects/claude-power-pack/scripts/worktree-remove.sh ~/.claude/scripts/`
+2b. ⚠️ **Flow allowlist missing/incomplete** - `/flow:*` will prompt for read-only git/gh plumbing on every run. Merge via `/cpp:update` (Step 7.6) or `/cpp:init`; rationale and caveats in `templates/claude-settings-permissions.md`
 3. ⚠️ **uv not installed** - Install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 4. ❌ **cicd.yml missing** - Run `/cicd:init` to auto-detect framework and generate configuration
 5. ⚠️ **Makefile gaps** - Run `/cicd:check` for details or `/cicd:init` to add missing targets

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ desktop.ini
 !tsconfig.json
 !.claude/hooks.json
 !renovate.json
+!templates/claude-settings-permissions.json
 node_modules/
 .claude/settings*.json
 .claude/plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Added
 
+- **Flow read-only permission allowlist template** (issue #427) - new
+  `templates/claude-settings-permissions.json` (+ rationale doc
+  `templates/claude-settings-permissions.md`) codifies the 32 user-level
+  permission rules that stop `/flow:*` from prompting for its read-only
+  git/gh plumbing (issue reads, worktree creation, the branch-slug pipeline)
+  on every run in every repo. `/cpp:init` gains an optional user-confirmed
+  step that jq union-merges the template into `~/.claude/settings.json`
+  (additive, idempotent - existing settings and rules preserved);
+  `/cpp:update` Step 7.6 detects and offers to merge rules the template
+  gained since the last update; `/flow:doctor` reports installed/missing
+  rule counts with remediation. Shipping actions (`git push`, `gh pr
+  create`) and `cat` stay deliberately excluded so the gate policy and
+  secret-read prompts remain intact; the `sed -i` caveat is documented with
+  a one-line opt-out. First codified-learning artifact for the grill-me
+  cycle (#426).
 - **C4 diagram rendering engine** (issue #411) - new zero-dependency Python
   renderer `scripts/c4-mermaid.py` replaces the removed `nano-banana` MCP server
   (#401) as the engine behind `/documentation:c4`. It consumes a JSON C4 model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/dockers` - Docker container status, health, project linkages
 - `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD, Codex)
 - `/cpp:status` - Check installation state
-- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, tear down orphaned Docker MCP infra via the curated `.claude/deprecated-mcps.yaml` (Step 6c/7, user-confirmed), then prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed)
+- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, tear down orphaned Docker MCP infra via the curated `.claude/deprecated-mcps.yaml` (Step 6c/7, user-confirmed), prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed), then offer to merge new flow allowlist rules from `templates/claude-settings-permissions.json` into `~/.claude/settings.json` (Step 7.6, user-confirmed)
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
 - `/happy-check` - Check happy-cli version (optional)
 
@@ -190,6 +190,7 @@ Flow commands use Makefile targets as the canonical build interface:
 - `/flow:finish` and `/flow:deploy` run security quick scan as quality gates
 - CRITICAL findings block gates; HIGH findings produce warnings
 - Configure gating in `.claude/security.yml` (optional, created by `/security:scan` when needed)
+- **User-level flow allowlist** (`templates/claude-settings-permissions.json`) auto-approves the read-only git/gh plumbing that `/flow:*` runs; shipping actions (`git push`, `gh pr create`) and `cat` are deliberately excluded so gates and secret-read prompts stay intact. Merged via `/cpp:init` or `/cpp:update` Step 7.6; checked by `/flow:doctor`. Rationale: `templates/claude-settings-permissions.md`
 
 ## On-Demand Documentation
 

--- a/templates/claude-settings-permissions.json
+++ b/templates/claude-settings-permissions.json
@@ -1,0 +1,38 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git worktree:*)",
+      "Bash(git config --get:*)",
+      "Bash(git remote -v)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(echo:*)",
+      "Bash(tr:*)",
+      "Bash(cut:*)",
+      "Bash(sed:*)",
+      "Bash(basename:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(cd:*)",
+      "Bash(pwd)"
+    ]
+  }
+}

--- a/templates/claude-settings-permissions.md
+++ b/templates/claude-settings-permissions.md
@@ -1,0 +1,62 @@
+# Flow Read-Only Permission Allowlist
+
+`claude-settings-permissions.json` is a user-level Claude Code permission
+allowlist covering the read-only and worktree-plumbing Bash commands that
+`/flow:auto` (and the other `/flow:*` commands) run before any code is
+written - issue reads, worktree creation, staleness checks, and the
+branch-slug text pipeline. Without it, every flow run in every repo triggers
+a permission prompt per command.
+
+It is merged into `~/.claude/settings.json` (user scope, applies across all
+repos on the machine) by `/cpp:init` and refreshed by `/cpp:update`. The merge
+is additive and idempotent: existing settings and rules are preserved, the
+union is deduplicated, and re-running adds nothing. `/flow:doctor` reports
+whether the allowlist is installed.
+
+## What is included, and why
+
+| Group | Rules | Used by |
+|-------|-------|---------|
+| GitHub reads | `gh issue view/list`, `gh pr view/list/checks`, `gh run view/list`, `gh repo view` | issue fetch (flow Step 1), ELI5 staleness check, CI verification |
+| Git reads | `git status/log/diff/show/branch/rev-parse`, `git config --get`, `git remote -v` | analysis, ELI5 anchored history check, verification gates |
+| Git plumbing | `git fetch`, `git worktree` | worktree create/list/remove (flow Steps 1 and 7) |
+| Text pipeline | `echo/tr/cut/sed/basename` | the branch-slug sanitization pipeline in flow Step 1 |
+| Filesystem reads | `grep/rg/ls/find/head/tail/wc`, `cd`, `pwd` | codebase exploration, directory verification gates |
+
+## What is deliberately excluded
+
+- **`git commit`, `git push`, `git merge`, `gh pr create`, `gh pr merge`** -
+  CPP's gate policy: shipping actions stay behind explicit approval (or the
+  deterministic `/flow:finish` path the user invokes on purpose).
+- **`cat`** - reads file contents into terminal output. In CPP repos the
+  PostToolUse masking hook redacts secrets, but this allowlist is user-level
+  and applies in repos WITHOUT that hook; excluding `cat` keeps secret-file
+  reads behind a prompt. (Claude's Read tool is governed separately.)
+- **`git remote` (bare)** - `git remote add/remove` writes `.git/config`;
+  only the exact read form `git remote -v` is allowed.
+
+## Known caveat: `sed`
+
+`Bash(sed:*)` is included because the flow Step 1 slug pipeline pipes through
+`sed` twice, and a compound command only auto-approves when every segment is
+allowed. The trade-off: `sed -i` (in-place file editing) is also covered by
+the prefix rule, so sed-based file edits will not prompt. If that bothers
+you, remove the `"Bash(sed:*)"` line from `~/.claude/settings.json` and
+accept one prompt per flow run.
+
+## Relationship to the /cpp:init permission profiles (Step 3b)
+
+`/cpp:init` Step 3b writes per-PROJECT profiles (Cautious/Standard/Trusted)
+to `.claude/settings.local.json`. Those govern one repo, are written only
+when the file is absent, and predate the flow-plumbing needs (`git worktree`,
+`git rev-parse`, the slug pipeline, `gh run` are not in the Standard
+profile). This template is the USER-level floor that makes `/flow:*` quiet
+everywhere; project profiles layer additional, repo-specific trust on top.
+Claude Code merges permission rules across scopes, so the two compose.
+
+## Origin
+
+Codified 2026-07-03 from a friction retrospective: months of tolerated
+`/flow:auto` pre-ELI5 permission prompts (issue #427). This template is also
+the reference artifact for the grill-me cycle (#426) - its first acceptance
+case is emitting exactly this list from a flow transcript.


### PR DESCRIPTION
## Summary

Turns the 2026-07-03 one-off fix (hand-written user-level allowlist that stopped months of /flow:auto pre-ELI5 permission prompts) into a CPP deliverable:

- **templates/claude-settings-permissions.json** - the 32-rule user-level allowlist: gh issue/pr/run reads, git reads + fetch + worktree plumbing, and the branch-slug text pipeline (echo/tr/sed/cut/basename). Plus a .gitignore negation: the repo's blanket `*.json` rule was silently ignoring the new template (same trap class as the dockerignore `*.md` incident).
- **templates/claude-settings-permissions.md** - rationale doc: what is included and why, deliberate exclusions (git push / gh pr create / gh pr merge keep the gate policy; cat keeps secret-file reads prompted in repos without the masking hook), the sed -i caveat with a one-line opt-out, and how this user-level floor composes with the /cpp:init Step 3b project profiles.
- **/cpp:init** - optional user-confirmed step: jq union-merge of the template into ~/.claude/settings.json (creates if absent, dedupes, never replaces; verified idempotent).
- **/cpp:update Step 7.6** - detects rules the template gained since last update and offers the same merge.
- **/flow:doctor** - Step 5b check (PASS/WARN/FAIL with installed/missing rule counts), a Workflow Readiness report row, and an Actions Needed remediation line.
- **CHANGELOG.md + CLAUDE.md** updated (cpp:update step list, Security section).

Cross-link: this template is the reference artifact for the grill-me cycle (#426) - its first acceptance case is emitting exactly this list from a flow transcript.

## Test plan

- [x] `make lint` - all checks passed
- [x] `make test` - 636 passed
- [x] `make secret-scan` - no leaks
- [x] jq merge pipe-tested: empty target (32 rules), populated target (other keys/deny/custom rules preserved, overlap deduped), re-run adds nothing (idempotent)
- [x] doctor/update detect expression pipe-tested: 30 missing on partial file, 0 after merge
- [x] Template JSON validates; no em/en dashes introduced

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)