### PR TITLE
feat(cpp): install the spec-kit CLI as part of CPP setup (Closes #434)

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -609,6 +609,49 @@ If no:
 echo "→ Happy CLI installation skipped"
 ```
 
+**Spec-Kit CLI Installation (Optional)**
+
+Ask the user if they want to install the official spec-kit CLI (`specify`). This is the
+authoring engine behind `/spec:adopt`; installing it now means `/spec:adopt` and the
+`/speckit-*` skills work in any project without a first-run install step. This installs
+only the CLI - it does NOT scaffold `.specify/` into any project (that stays on-demand
+via `/spec:adopt`).
+
+```
+=== Optional: Spec-Kit CLI ===
+
+Spec-Kit is GitHub's spec-driven-development toolkit. CPP's /spec:adopt delegates to
+its `specify` CLI (constitution -> specify -> clarify -> plan -> tasks).
+https://github.com/github/spec-kit
+
+Install the spec-kit CLI? [y/N]
+```
+
+If yes:
+```bash
+# Check if already installed
+if command -v specify &>/dev/null; then
+  echo "→ spec-kit CLI already installed (skipped)"
+  specify version 2>/dev/null | head -1 || true
+else
+  echo "Installing spec-kit CLI (uv tool)..."
+  uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+  if command -v specify &>/dev/null; then
+    echo "✓ spec-kit CLI installed"
+    echo "  Run /spec:adopt in a project to scaffold spec-kit into it"
+  else
+    echo "⚠ Installation failed - ensure 'uv' is installed and ~/.local/bin is on PATH"
+    echo "  Try: uv tool install specify-cli --from git+https://github.com/github/spec-kit.git"
+  fi
+fi
+echo "✓ /spec:adopt command available (per-project spec-kit scaffold)"
+```
+
+If no:
+```bash
+echo "→ Spec-Kit CLI installation skipped (/spec:adopt installs it on first use)"
+```
+
 ### Tier 3 Execution
 
 #### 3a. Docker Prerequisites and Legacy Systemd Warning

--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -124,6 +124,31 @@ done
 
 ---
 
+## Step 4.6: Refresh Spec-Kit CLI (Optional)
+
+If the official spec-kit CLI (`specify`) is installed, upgrade it so `/spec:adopt`
+delegates to the current upstream. If it is absent, offer to install it (never forced -
+`/spec:adopt` also installs it on first use). This only touches the CLI; it does not
+scaffold `.specify/` into any project.
+
+```bash
+if command -v specify &>/dev/null; then
+  echo ""
+  echo "Upgrading spec-kit CLI..."
+  uv tool upgrade specify-cli 2>/dev/null && echo "Done: spec-kit CLI up to date" \
+    || echo "Note: could not upgrade specify-cli (not a uv tool install?) - skipping"
+else
+  echo ""
+  echo "spec-kit CLI (specify) is not installed."
+  echo "  Install now with: uv tool install specify-cli --from git+https://github.com/github/spec-kit.git"
+  echo "  (or just run /spec:adopt in a project - it installs the CLI on first use)"
+  # If the user agrees, run:
+  #   uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+fi
+```
+
+---
+
 ## Step 4.5: Legacy Systemd Teardown
 
 Before refreshing Docker, detect legacy MCP systemd units in both system and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/project-lite` - Quick project reference (~500-800 tokens)
 
 ### Spec-Driven Development
-- `/spec:adopt` - **(supported)** Install the official GitHub spec-kit CLI and scaffold it into the project (`specify init --here --ai claude`); then author with the `/speckit-*` skills and ship with `/flow:auto`. Turn `tasks.md` into GitHub issues with `scripts/speckit-tasks-to-issues.sh` (gh-CLI, no github-mcp-server). Per-project, always latest upstream.
+- `/spec:adopt` - **(supported)** Install the official GitHub spec-kit CLI and scaffold it into the project (`specify init --here --ai claude`); then author with the `/speckit-*` skills and ship with `/flow:auto`. Turn `tasks.md` into GitHub issues with `scripts/speckit-tasks-to-issues.sh` (gh-CLI, no github-mcp-server). Per-project, always latest upstream. The `specify` CLI installs on first `/spec:adopt` use, or up front via `/cpp:init` / `/cpp:update`.
 - `/spec:init` - *(legacy, pending retirement)* Initialize CPP's own `.specify/` structure
 - `/spec:create NAME` - *(legacy, pending retirement)* Create new feature specification
 - `/spec:sync [NAME]` - *(legacy, pending retirement)* Sync tasks.md to GitHub issues
@@ -167,9 +167,9 @@ The `/spec:*` family and `lib/spec_bridge` are being retired in favor of the off
 
 ### Other
 - `/dockers` - Docker container status, health, project linkages
-- `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD, Codex)
+- `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD, Codex); optionally installs the spec-kit CLI (`specify`, the engine behind `/spec:adopt`)
 - `/cpp:status` - Check installation state
-- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, tear down orphaned Docker MCP infra via the curated `.claude/deprecated-mcps.yaml` (Step 6c/7, user-confirmed), prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed), then offer to merge new flow allowlist rules from `templates/claude-settings-permissions.json` into `~/.claude/settings.json` (Step 7.6, user-confirmed)
+- `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, tear down orphaned Docker MCP infra via the curated `.claude/deprecated-mcps.yaml` (Step 6c/7, user-confirmed), prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed), then offer to merge new flow allowlist rules from `templates/claude-settings-permissions.json` into `~/.claude/settings.json` (Step 7.6, user-confirmed); also refreshes the optional spec-kit CLI (`specify`) if installed (Step 4.6)
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
 - `/happy-check` - Check happy-cli version (optional)
 


### PR DESCRIPTION
## Summary

Wires the official `specify` CLI (the engine behind `/spec:adopt`, shipped in #428) into CPP's own setup, so spec-kit is ready without a manual step - mirroring how **Tier 5 already installs the Codex CLI**.

CLI only. The per-project `specify init` scaffold (writes `.specify/`) stays on-demand in `/spec:adopt`; nothing is scaffolded at install time.

## Changes

- **`/cpp:init`**: optional "Spec-Kit CLI" install block (`command -v specify` -> else `uv tool install specify-cli --from git+github/spec-kit` -> report), modelled exactly on the existing Happy CLI optional-tool block. Prompted, never forced.
- **`/cpp:update`**: new Step 4.6 - `uv tool upgrade specify-cli` if present; offers install if absent.
- **`/spec:adopt`**: unchanged - already self-installs the CLI on first run (cross-referenced in docs).
- **Docs**: CLAUDE.md notes the `/cpp:init` + `/cpp:update` behaviour.

## Design decision (from the #434 ELI5 gate)

`bootstrap.yaml` is intentionally **not** touched. It is a *deploy* preflight (jq / aws-credentials / docker) whose schema has no `optional` field - every dep blocks the deploy gate. `specify` is a dev-workflow tool, not a deploy prerequisite, so adding it there (even after extending the schema) would muddy bootstrap's purpose. The self-heal in `/spec:adopt` + `/cpp:init` + `/cpp:update` covers install cleanly.

## Test plan

- `make verify` green: ruff + 636 pytest + mypy.
- Changes are markdown-only (`/cpp:init`, `/cpp:update`, CLAUDE.md); the install block mirrors the verified Happy CLI / Codex CLI idioms already in the wizard.

## Non-goals (tracked under #417 Phase A)

- Retiring `lib/spec_bridge` + `/spec:create|sync|status`.

Closes #434.