### PR TITLE
feat(browser): named concurrent sessions via lease-desk pool (Closes #421)

### DIFF
--- a/.claude/commands/browser/help.md
+++ b/.claude/commands/browser/help.md
@@ -1,0 +1,75 @@
+---
+description: Overview of browser session commands (named concurrent playwright-mcp sessions)
+allowed-tools: Bash(python3:*), Read
+---
+
+# Browser Commands Help
+
+Named **concurrent** browser sessions over upstream `@playwright/mcp`, using a
+static "lease-desk" pool (issue #421). Upstream gives one browser per connection;
+this wrapper multiplexes any number of named, independently-authenticated
+sessions across a small fixed pool of pre-registered instances - the one feature
+upstream lacks (microsoft/playwright-mcp#1530), recovered without a fork.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/browser:session create <name> [url]` | Lease a free desk for a new named session |
+| `/browser:session resume <name> [url]` | Re-open a session (restores its saved login) |
+| `/browser:session save <name>` | Persist the session's cookies/localStorage to a state file |
+| `/browser:session close <name> [--discard]` | Free the desk (keep state, or `--discard` to forget) |
+| `/browser:session list` | Show sessions, status, and desk occupancy |
+| `/browser:session cleanup [--idle-seconds N]` | Release desks of idle sessions (keeps state) |
+| `/browser:session pool` | Show pool configuration and occupancy |
+| `/browser:help` | This help page |
+
+## The model in one paragraph
+
+A fixed **pool of desks** (`playwright-desk-1..N`, pre-registered at Claude Code startup)
+is leased by user-named **sessions**. A session's identity lives in a portable
+storage-state file (`.claude/playwright-state/<name>.json`), so **sessions outlive desks**:
+`close` frees a desk but keeps the file, `resume` re-leases any free desk and restores the
+file into it. N desks multiplex unlimited named sessions.
+
+## Setup (one time)
+
+1. Register the desk pool: `/cpp:init` -> Full tier -> **browser pool** step (writes
+   `.claude/playwright-pool.json` from `templates/playwright-pool.example.json` and runs
+   `claude mcp add playwright-desk-N ... -- npx -y @playwright/mcp@<ver> --isolated ...`).
+2. **Restart Claude Code** so the `playwright-desk-*` MCP servers load at startup
+   (mid-session registration does not take effect - see the spike doc).
+3. Verify: `/browser:session pool` and confirm `mcp__playwright-desk-1__*` tools exist.
+
+## Configuration: `.claude/playwright-pool.json`
+
+```json
+{
+  "version": 1,
+  "desks": ["playwright-desk-1", "playwright-desk-2", "playwright-desk-3"],
+  "idle_timeout_seconds": 1800,
+  "state_dir": ".claude/playwright-state"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `desks` | MCP server names of the pre-registered pool (one browser each). Add more to widen concurrency (then register + restart). |
+| `idle_timeout_seconds` | `cleanup` releases sessions idle beyond this (replaces the old server's `SESSION_TIMEOUT`). |
+| `state_dir` | Where per-session storage-state files live (gitignored). |
+
+The live ledger `.claude/playwright-sessions.json` is managed by the wrapper - do not edit.
+
+## Requirements
+
+- Node/`npx` on PATH (upstream `@playwright/mcp` runs via `npx`; no custom image).
+- Desk pool registered **before** the session started (see Setup).
+
+## When NOT to use this
+
+Single-session automation (`/qa:test`, a one-off screenshot) needs only plain upstream
+`playwright-mcp`. Reach for the desk pool only when you need several **named, concurrent**
+sessions - e.g. driving two logged-in accounts side by side.
+
+See `docs/skills/browser-session-wrapper.md` for the full guide and
+`docs/reviews/2026-07-03-playwright-spike-419.md` for the design rationale.

--- a/.claude/commands/browser/session.md
+++ b/.claude/commands/browser/session.md
@@ -1,0 +1,173 @@
+---
+description: Named concurrent browser sessions over upstream playwright-mcp via a lease-desk pool
+allowed-tools: Bash, Read, Write, AskUserQuestion, mcp__playwright-desk-1__*, mcp__playwright-desk-2__*, mcp__playwright-desk-3__*
+---
+
+# Browser Session - Named Concurrent Sessions (Lease-Desk)
+
+Run several **named**, independently-authenticated browser sessions at once over
+upstream `@playwright/mcp`, which by itself gives only one browser context per
+connection. This is the one capability upstream lacks
+(microsoft/playwright-mcp#1530); CPP recovers it as a thin wrapper - no fork
+(issue #421, design from `docs/reviews/2026-07-03-playwright-spike-419.md`).
+
+**Arguments:** `$ARGUMENTS`
+- Format: `<verb> [name] [url]`
+- Verbs: `create`, `resume`, `save`, `close`, `list`, `cleanup`, `pool`
+- Examples:
+  - `/browser:session create gmail https://mail.google.com` - start a named session
+  - `/browser:session resume gmail` - re-open it later (restores saved login)
+  - `/browser:session save gmail` - persist its cookies/localStorage
+  - `/browser:session close gmail` - free its desk, keep its state
+  - `/browser:session list` - show sessions and desk occupancy
+
+---
+
+## The lease-desk model (read once)
+
+- A fixed **pool of desks** (pre-registered upstream instances: `playwright-desk-1`,
+  `playwright-desk-2`, ...) is registered at Claude Code **startup**. Mid-session MCP
+  registration is impossible in Claude Code, so the pool must pre-exist - see the spike.
+- A **session** is a user-named identity (`gmail`, `staging-checkout`). Starting one
+  **leases a free desk**; each desk runs `--isolated`, so its context is blank and the
+  session's identity lives entirely in a portable **storage-state file**
+  (`.claude/playwright-state/<name>.json`).
+- **Sessions outlive desks.** `close` frees the desk but keeps the state file; `resume`
+  leases whatever desk is free and restores the state into it. N desks therefore
+  multiplex any number of named sessions, and a session survives restarts as a file.
+- The wrapper never touches the browser. The helper `scripts/playwright-desk.py` owns
+  the **ledger** (which desk each session holds) and tells you which `browser_*` tool
+  namespace to drive and where the state file lives. You drive the browser and read/write
+  the state file.
+
+**Desk N's tools are `mcp__playwright-desk-N__browser_*`.** The helper reports the exact
+`mcp_prefix` for each session so you never guess.
+
+---
+
+## Step 0: Resolve the helper and check the pool
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then CPP_DIR="$dir"; break; fi
+done
+DESK="python3 ${CPP_DIR:-.}/scripts/playwright-desk.py"
+
+# Show pool config + occupancy (creates nothing).
+$DESK pool
+```
+
+**If no `mcp__playwright-desk-*` tools are available in this session**, the desk pool was
+not registered before startup. STOP and tell the user:
+
+> The desk pool is not registered. Run `/cpp:init` (Full tier -> "browser pool"), then
+> **restart Claude Code** so the `playwright-desk-*` MCP servers load at startup.
+> (`/qa:test` and single-session work do not need the pool - they use plain upstream
+> `playwright-mcp`.)
+
+Do not attempt dynamic `claude mcp add` mid-session - it will not take effect until restart.
+
+---
+
+## Step 1: Parse the verb
+
+Extract `<verb>`, and where relevant `<name>` and an optional `<url>` from `$ARGUMENTS`.
+For `list`, `cleanup`, and `pool` no name is needed.
+
+---
+
+## Step 2: Run the ledger verb
+
+Always call the helper with `--json` and act on the returned object (`desk`, `mcp_prefix`,
+`state_file`, `restore`, `free_desks_remaining`, `message`). On a non-zero exit the object
+has `"ok": false` and an `error` slug - relay `message` to the user and stop.
+
+### `create <name> [url]`
+```bash
+$DESK create <name> --json
+```
+- Leases a free desk (exit code 3 / `no_free_desk` if the pool is full - offer `close` or
+  `cleanup`; exit code 2 / `session_exists` if the name is taken - suggest `resume`).
+- The desk is blank (fresh `--isolated` context). If a `url` was given, navigate:
+  `mcp__<desk>__browser_navigate(url=...)`.
+- Do the work (log in, fill forms, ...). When the identity is worth keeping, run `save`.
+
+### `resume <name> [url]`
+```bash
+$DESK resume <name> --json
+```
+- Leases a free desk for an existing session (idempotent if already seated).
+- **If `restore` is true:** the session has a saved state file. RESTORE it before anything
+  else:
+  1. `Read` the reported `state_file`.
+  2. Call `mcp__<desk>__browser_set_storage_state` with those contents (this re-injects
+     cookies + origin localStorage into the blank desk).
+  3. Then navigate (to `url` if given, else the app's origin) - the session is logged in.
+- **If `restore` is false:** no state saved yet; treat like a fresh `create`.
+
+### `save <name>`
+```bash
+$DESK save <name> --json
+```
+- The helper only records the intent and returns the target `state_file`. YOU persist:
+  1. Call `mcp__<desk>__browser_storage_state` for the seated desk -> returns the storage
+     state JSON (cookies + origin storage).
+  2. `Write` that JSON verbatim to the reported `state_file`.
+- Now the session survives `close`, desk restarts, and Claude Code restarts.
+
+### `close <name>` (add `--discard` to also delete the saved state)
+```bash
+$DESK close <name> --json          # frees the desk, keeps the state file
+$DESK close <name> --discard --json # frees the desk and forgets the session entirely
+```
+- After a plain `close`, optionally free the browser context too:
+  `mcp__<desk>__browser_close` (or navigate to `about:blank`) so the desk is clean for the
+  next lease. The `--isolated` desk discards its context on the next `browser_navigate`
+  regardless, so this is best-effort hygiene.
+
+### `list` / `pool`
+```bash
+$DESK list --json   # sessions + status (active/detached) + desk + idle age
+$DESK pool --json   # desks, which are free, idle timeout, state dir
+```
+Render a short human-readable summary for the user.
+
+### `cleanup [--idle-seconds N]`
+```bash
+$DESK cleanup --json                 # release desks idle beyond the pool's timeout
+$DESK cleanup --idle-seconds 600 --json
+```
+Releases (detaches) idle sessions so their desks return to the pool. **State files are kept**
+- this is the idle-timeout story that replaced the old server's `SESSION_TIMEOUT`.
+
+---
+
+## Step 3: Report
+
+Summarize what happened for the user - e.g. which desk a session is on, how many desks are
+free, and the next verb they'll likely want:
+
+```markdown
+## Browser Session: gmail
+
+Seated at: playwright-desk-1  (mcp__playwright-desk-1__browser_*)
+State:     .claude/playwright-state/gmail.json (restored)
+Pool:      1/3 desks free
+
+Next: `/browser:session save gmail` to persist, or `/browser:session close gmail` when done.
+```
+
+---
+
+## Notes
+
+- **Isolation:** each desk runs `--isolated` (blank context per lease); cross-session
+  bleed-through is prevented by starting blank and restoring only the named session's state.
+  Enlarge the pool by adding desks in `.claude/playwright-pool.json` and registering the
+  matching `playwright-desk-N` MCP servers via `/cpp:init` (then restart).
+- **Never** hand-edit `.claude/playwright-sessions.json`; it is the lease ledger the helper
+  owns. The pool config `.claude/playwright-pool.json` is yours to edit (desk count, idle
+  timeout).
+- **Not needed for single-session work.** `/qa:test` uses one plain upstream session; only
+  reach for the pool when you genuinely need several named sessions concurrently.

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -298,6 +298,11 @@ This will make the following changes:
     • mcp-second-opinion         - host port 8080
     • mcp-playwright-persistent  - host port 8081
 
+  [Tier 3 - Browser desk pool] (optional, off by default)
+    • /browser:session named concurrent sessions over upstream @playwright/mcp
+    • Registers playwright-desk-1..N (npx, no custom image) - requires a restart
+    • Skip unless you need several logged-in browser sessions at once
+
   [Tier 3 - Configuration Files]
     • .env (AWS credentials + AWS_TOKEN for sidecar, or direct API keys)
 
@@ -310,6 +315,8 @@ This will make the following changes:
     cd {CPP_DIR} && make docker-down
     claude mcp remove second-opinion
     claude mcp remove playwright-persistent
+    # If the browser desk pool was enabled:
+    for d in $(python3 -c "import json;print(' '.join(json.load(open('.claude/playwright-pool.json'))['desks']))" 2>/dev/null); do claude mcp remove "$d"; done
 
 Proceed? [y/N]
 ```
@@ -863,6 +870,49 @@ if ! echo "$MCP_LIST" | grep -q "playwright-persistent"; then
 else
   echo "→ playwright-persistent MCP already registered (skipped)"
 fi
+```
+
+#### 3e. Register the browser desk pool (optional, off by default)
+
+The **lease-desk pool** powers `/browser:session` - named **concurrent** browser
+sessions over upstream `@playwright/mcp` (issue #421). It is opt-in: it registers
+N always-present upstream instances ("desks"), each adding a `browser_*` tool
+surface to every session's startup context. Single-session work (`/qa:test`, a
+one-off screenshot) does **not** need it.
+
+Ask the user with AskUserQuestion: **"Enable the browser desk pool (named concurrent
+sessions)? Adds N upstream playwright-mcp instances via npx."** Default: **No**.
+
+If the user opts in, seed the pool config into the project and register the desks as
+stdio MCP servers (upstream via `npx`, no custom image, pinned version):
+
+```bash
+# Seed the project's pool config (edit desk count / idle timeout there later).
+mkdir -p .claude
+if [ ! -f .claude/playwright-pool.json ]; then
+  cp "$CPP_DIR/templates/playwright-pool.example.json" .claude/playwright-pool.json
+  echo "✓ Seeded .claude/playwright-pool.json"
+fi
+
+# Register one MCP server per desk listed in the pool config. Each runs upstream
+# @playwright/mcp with --isolated (blank context per lease; session identity lives
+# in the portable state file, not the desk).
+PW_MCP_VERSION="0.0.77"
+DESKS=$(python3 -c "import json; print('\n'.join(json.load(open('.claude/playwright-pool.json'))['desks']))")
+MCP_LIST=$(claude mcp list 2>/dev/null || echo "")
+for desk in $DESKS; do
+  if echo "$MCP_LIST" | grep -q "$desk"; then
+    echo "→ $desk already registered (skipped)"
+  else
+    claude mcp add "$desk" --scope user -- npx -y "@playwright/mcp@${PW_MCP_VERSION}" --isolated
+    echo "✓ $desk registered (npx @playwright/mcp@${PW_MCP_VERSION} --isolated)"
+  fi
+done
+
+echo ""
+echo "IMPORTANT: restart Claude Code so the playwright-desk-* servers load at startup"
+echo "(MCP config is read only at startup; mid-session registration does not take effect)."
+echo "Then verify with: /browser:session pool"
 ```
 
 ### Tier 4 Execution (CI/CD)

--- a/.gitignore
+++ b/.gitignore
@@ -57,10 +57,18 @@ desktop.ini
 !.claude/hooks.json
 !renovate.json
 !templates/claude-settings-permissions.json
+!templates/playwright-pool.example.json
 node_modules/
 .claude/settings*.json
 .claude/plans/
 .claude/security.yml
+
+# Lease-desk browser sessions (issue #421) - live ledger, pool config, and
+# per-session storage-state files are per-workstation state, never tracked.
+# (Already covered by *.json above; listed explicitly for intent.)
+.claude/playwright-sessions.json
+.claude/playwright-pool.json
+.claude/playwright-state/
 
 # Logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### Added
 
+- **Browser session wrapper - named concurrent sessions (lease-desk)** (issue #421) -
+  new `/browser:session` + `/browser:help` commands recover named **concurrent**
+  browser sessions over upstream `@playwright/mcp` (the one feature upstream lacks,
+  microsoft/playwright-mcp#1530) as a thin wrapper - no fork, no custom image. A fixed
+  pool of pre-registered upstream instances ("desks", `playwright-desk-1..N`, run via
+  `npx --isolated`) is leased by user-named sessions; each session's identity lives in a
+  portable storage-state file (`.claude/playwright-state/<name>.json`), so sessions
+  outlive desks - N desks multiplex unlimited named sessions, surviving restarts.
+  The deterministic ledger `scripts/playwright-desk.py` (zero-dep stdlib) owns lease /
+  release / idle-cleanup (`create`/`resume`/`save`/`close`/`list`/`cleanup`/`pool`,
+  `--json` contract, 14 tests); the model drives each desk's `browser_*` MCP tools and
+  the state files. `/cpp:init` gains an **opt-in** "browser pool" step (Full tier) that
+  seeds `.claude/playwright-pool.json` from `templates/playwright-pool.example.json` and
+  registers the desks. Design A (static pool) per the #419 spike - mid-session MCP
+  registration is infeasible in Claude Code, so desks are pre-registered at startup;
+  ratified by the #422 closure (owner chose the local wrapper over waiting on upstream).
+  Guide: `docs/skills/browser-session-wrapper.md`.
+
 - **Flow read-only permission allowlist template** (issue #427) - new
   `templates/claude-settings-permissions.json` (+ rationale doc
   `templates/claude-settings-permissions.md`) codifies the 32 user-level

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Core components and their locations:
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
 - `lib/spec_bridge/` - Spec-to-GitHub-issue sync (legacy, pending retirement; superseded by official spec-kit via `/spec:adopt` + `scripts/speckit-tasks-to-issues.sh`)
-- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift)
+- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift, playwright-desk lease-desk ledger)
 - `templates/` - Makefile, workflow, container templates
 - `docker-compose.yml` - MCP server orchestration (profiles: `core`, `browser`)
 - `.woodpecker.yml` - Woodpecker CI pipeline (lint, test, typecheck, image security gates, runtime smoke)
@@ -152,7 +152,11 @@ The `/spec:*` family and `lib/spec_bridge` are being retired in favor of the off
 - `/second-opinion:models` - Interactive model/depth selection
 
 ### QA
-- `/qa:test` - Automated web testing via Playwright
+- `/qa:test` - Automated web testing via Playwright (single upstream session)
+
+### Browser Sessions
+- `/browser:session <verb> [name]` - Named **concurrent** browser sessions over upstream `@playwright/mcp` via a static "lease-desk" pool (create/resume/save/close/list/cleanup/pool). Recovers the one feature upstream lacks (microsoft/playwright-mcp#1530) with no fork. Opt-in pool registered via `/cpp:init` (Full tier -> browser pool); ledger in `scripts/playwright-desk.py`. See `docs/skills/browser-session-wrapper.md`.
+- `/browser:help` - Browser session commands overview
 
 ### CLAUDE.md Management
 - `/claude-md:lint` - Lint CLAUDE.md for missing CI/CD, Docker, and troubleshooting directives

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ claude-power-pack/
 | Secrets | `/secrets:list` | List managed credentials |
 | CI/CD | `/cicd:init` | Detect framework, generate Makefile |
 | Docs | `/documentation:c4` | Generate C4 architecture diagrams |
+| Browser | `/browser:session create gmail` | Named concurrent browser sessions (lease-desk pool) |
 | Review | `/second-opinion:start` | Get code review from external LLMs |
 
 ## Docker Deployment

--- a/docs/skills/browser-session-wrapper.md
+++ b/docs/skills/browser-session-wrapper.md
@@ -1,0 +1,107 @@
+---
+name: Browser Session Wrapper
+description: Named concurrent browser sessions over upstream playwright-mcp via a lease-desk pool
+trigger: browser session, playwright, named session, concurrent browser, lease desk, storage state
+---
+
+# Browser Session Wrapper (Lease-Desk)
+
+Recover **named concurrent** browser sessions on top of upstream
+`@playwright/mcp` - the one capability upstream lacks
+(microsoft/playwright-mcp#1530) - as a thin CPP wrapper, with no fork and no
+custom 1.27 GB image. Surface: `/browser:session` and `/browser:help`
+(issue #421). Design rationale: `docs/reviews/2026-07-03-playwright-spike-419.md`.
+
+## Why a pool (the constraint)
+
+Upstream playwright-mcp provides **one browser context per client connection**.
+So "several named sessions at once" requires **several server instances**. And
+Claude Code reads MCP config **only at startup** - a server added mid-session
+(`claude mcp add` + `/mcp reconnect`) is not exposed until a restart. That rules
+out spawn-per-session (Design B) and leaves exactly one viable shape: a **static,
+pre-registered pool** (Design A).
+
+## The lease-desk model
+
+- **Desk** = one pre-registered upstream instance (`playwright-desk-1`, ...),
+  each launched with `--isolated` (blank, in-memory context). Registered as an
+  MCP server at startup, so its tools appear as `mcp__playwright-desk-N__browser_*`.
+- **Session** = a user-named identity (`gmail`, `staging-checkout`). Its cookies +
+  origin localStorage are a **portable storage-state JSON** at
+  `.claude/playwright-state/<name>.json`.
+- **Lease** = binding a session to a free desk. `create`/`resume` acquire; `close`/
+  `cleanup` release. The binding lives in the ledger `.claude/playwright-sessions.json`.
+- **Sessions outlive desks.** Because identity is a file, a session can be closed,
+  the desk reused by another session, the container restarted - and the session
+  resumes on any free desk by re-injecting its state file. N desks multiplex an
+  unbounded number of named sessions.
+
+```
+sessions (unbounded)          desks (fixed pool = concurrency limit)
+  gmail ........ leases ---->  playwright-desk-1  (mcp__playwright-desk-1__*)
+  staging ...... leases ---->  playwright-desk-2  (mcp__playwright-desk-2__*)
+  reporting .... detached      playwright-desk-3  (free)
+     ^ state on file, no desk
+```
+
+## Components
+
+| Piece | Role |
+|-------|------|
+| `scripts/playwright-desk.py` | Deterministic ledger + state-file bookkeeping (lease/release/idle-cleanup). Zero-dependency stdlib. Emits `--json` for the skill, human text for you. Never touches the browser. |
+| `.claude/commands/browser/session.md` | The `/browser:session` verbs; drives each desk's `browser_*` tools and reads/writes state files. |
+| `.claude/playwright-pool.json` | Pool config: desk names, idle timeout, state dir. Seed from `templates/playwright-pool.example.json`. Gitignored. |
+| `.claude/playwright-sessions.json` | Live lease ledger (wrapper-owned; do not edit). Gitignored. |
+| `.claude/playwright-state/<name>.json` | Per-session storage state. Gitignored. |
+
+## Division of labour (important)
+
+The helper is **deterministic and browser-blind**. It answers "which desk does this
+session hold, and where is its state file?" and enforces the pool limit. Everything
+that touches a browser - navigate, `browser_set_storage_state` (restore),
+`browser_storage_state` (capture) - is done by the model via the desk's MCP tools.
+`save` is therefore two moves: the helper records intent + returns the path; the
+model captures the storage state and writes it to that path.
+
+## Lifecycle
+
+```
+create gmail ┐
+             ├─ lease desk-1 (blank) ─ navigate ─ log in ─ save gmail ─┐
+resume gmail ┘   (restore state-file first if it exists)               │
+                                                                       ▼
+             close gmail ── desk-1 freed, .claude/playwright-state/gmail.json kept
+                                                                       │
+             resume gmail ── lease any free desk ── restore file ── logged in again
+```
+
+- `create <name> [url]` - new session on a free desk (error `no_free_desk` when the
+  pool is full; `session_exists` if the name is taken).
+- `resume <name> [url]` - re-seat an existing session; when the helper reports
+  `restore: true`, read the state file and call `browser_set_storage_state` before
+  navigating.
+- `save <name>` - capture `browser_storage_state` -> write to the reported file.
+- `close <name> [--discard]` - free the desk; keep the state file unless `--discard`.
+- `list` / `pool` - inspect sessions and occupancy.
+- `cleanup [--idle-seconds N]` - release desks of idle sessions (keeps state). This is
+  the idle-timeout replacement for the retired server's `SESSION_TIMEOUT`.
+
+## Setup
+
+1. `/cpp:init` -> Full tier -> **browser pool** step: seeds `.claude/playwright-pool.json`
+   and registers `playwright-desk-1..N` as stdio MCP servers:
+   ```bash
+   claude mcp add playwright-desk-1 --scope user -- npx -y @playwright/mcp@0.0.77 --isolated
+   ```
+2. **Restart Claude Code** (startup-only MCP config load).
+3. `/browser:session pool` - confirm the pool and that `mcp__playwright-desk-1__*` tools exist.
+
+## Trade-offs and boundaries
+
+- **Concurrency = pool size.** Widen it by adding desks to the config and registering the
+  matching servers (then restart). Each desk adds its `browser_*` tool surface to every
+  session's startup context, so keep the default small (3).
+- **Not for single-session work.** `/qa:test` and one-off screenshots use plain upstream
+  `playwright-mcp`; the pool is only for genuinely concurrent named sessions.
+- **Endgame.** If named multi-session lands upstream (microsoft/playwright-mcp#1530), this
+  wrapper thins to naming discipline over native support - see issue #422's closing note.

--- a/scripts/playwright-desk.py
+++ b/scripts/playwright-desk.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""playwright-desk.py - Lease-desk ledger for named concurrent browser sessions.
+
+Part of Claude Power Pack (CPP). This is the deterministic core behind the
+``/browser:session`` skill (issue #421). It implements the "lease-desk" model
+that recovers named concurrent sessions - the one feature upstream
+``@playwright/mcp`` lacks (microsoft/playwright-mcp#1530) - WITHOUT carrying a
+custom fork.
+
+Model
+-----
+Upstream playwright-mcp gives one browser context per server connection, so a
+fixed POOL of pre-registered upstream instances ("desks", e.g.
+``playwright-desk-1``) is registered at Claude Code startup (see
+``/cpp:init`` -> browser pool). Any number of user-named SESSIONS come and go;
+at any instant only ``len(desks)`` can be seated. Starting a session LEASES a
+free desk; closing it RELEASES the desk but keeps the session's cookies /
+localStorage filed away as a portable storage-state JSON. Resuming re-leases
+whatever desk is free and restores the state into it. So N desks multiplex
+unlimited named sessions, and a session survives desk / container restarts as a
+state file.
+
+This script owns ONLY the ledger and the state-file bookkeeping - the acquire /
+release / idle-cleanup logic. Driving the browser (navigate, restore, save
+storage state) is done by the model through each desk's ``browser_*`` MCP tools;
+this script tells it which desk to use and where its state file lives.
+
+Design A is the only viable wrapper design: mid-session MCP registration is not
+possible in Claude Code (config is read at startup only), so desks must be
+pre-registered. See ``docs/reviews/2026-07-03-playwright-spike-419.md``.
+
+Usage
+-----
+    playwright-desk.py create <name> [--json]
+    playwright-desk.py resume <name> [--json]
+    playwright-desk.py save   <name> [--json]
+    playwright-desk.py close  <name> [--discard] [--json]
+    playwright-desk.py list   [--json]
+    playwright-desk.py cleanup [--idle-seconds N] [--json]
+    playwright-desk.py pool   [--json]
+
+Common flags: ``--root DIR`` (project root; default CWD), ``--pool-config PATH``,
+``--ledger PATH``, ``--state-dir PATH``. Environment overrides:
+``CPP_PLAYWRIGHT_ROOT``, ``CPP_PLAYWRIGHT_POOL_CONFIG``,
+``CPP_PLAYWRIGHT_LEDGER``, ``CPP_PLAYWRIGHT_STATE_DIR``.
+
+Exit codes
+----------
+    0  success
+    1  configuration / unexpected error
+    2  usage error (unknown session, name collision, wrong state)
+    3  no free desk (pool exhausted)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+# Built-in default pool used when no .claude/playwright-pool.json exists yet, so
+# the skill works immediately and tests need no fixture. /cpp:init seeds a real
+# config from templates/playwright-pool.example.json.
+DEFAULT_DESKS = ["playwright-desk-1", "playwright-desk-2", "playwright-desk-3"]
+DEFAULT_IDLE_TIMEOUT = 1800  # seconds (30 min); replaces the old SESSION_TIMEOUT
+DEFAULT_STATE_DIR = ".claude/playwright-state"
+LEDGER_VERSION = 1
+
+# Session status values.
+ACTIVE = "active"  # currently seated at a desk
+DETACHED = "detached"  # no desk held; identity persists as a state file
+
+# Exit codes.
+EXIT_OK = 0
+EXIT_CONFIG = 1
+EXIT_USAGE = 2
+EXIT_NO_DESK = 3
+
+
+class DeskError(Exception):
+    """Raised for expected, user-facing failures. Carries an exit code + slug."""
+
+    def __init__(self, code: int, error: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.error = error
+        self.message = message
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        raise DeskError(EXIT_CONFIG, "bad_json", f"Cannot read {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DeskError(EXIT_CONFIG, "bad_json", f"{path} is not a JSON object")
+    return data
+
+
+def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except OSError as exc:  # pragma: no cover - filesystem failure
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise DeskError(EXIT_CONFIG, "write_failed", f"Cannot write {path}: {exc}") from exc
+
+
+class Ledger:
+    """The lease ledger plus its pool config, bound to one project root."""
+
+    def __init__(self, args: argparse.Namespace) -> None:
+        env = os.environ.get
+        root = args.root or env("CPP_PLAYWRIGHT_ROOT") or os.getcwd()
+        self.root = Path(root).resolve()
+
+        pool_cfg = args.pool_config or env("CPP_PLAYWRIGHT_POOL_CONFIG")
+        self.pool_config_path = Path(pool_cfg) if pool_cfg else self.root / ".claude" / "playwright-pool.json"
+        ledger = args.ledger or env("CPP_PLAYWRIGHT_LEDGER")
+        self.ledger_path = Path(ledger) if ledger else self.root / ".claude" / "playwright-sessions.json"
+
+        cfg = _read_json(self.pool_config_path)
+        desks = cfg.get("desks")
+        self.desks: list[str] = list(desks) if isinstance(desks, list) and desks else list(DEFAULT_DESKS)
+        idle = cfg.get("idle_timeout_seconds")
+        self.idle_timeout: int = int(idle) if isinstance(idle, int) and idle > 0 else DEFAULT_IDLE_TIMEOUT
+
+        state_dir = args.state_dir or env("CPP_PLAYWRIGHT_STATE_DIR") or cfg.get("state_dir") or DEFAULT_STATE_DIR
+        sd = Path(state_dir)
+        self.state_dir = sd if sd.is_absolute() else self.root / sd
+
+        data = _read_json(self.ledger_path)
+        sessions = data.get("sessions")
+        self.sessions: dict[str, dict[str, Any]] = sessions if isinstance(sessions, dict) else {}
+
+    # -- persistence ----------------------------------------------------------
+
+    def save(self) -> None:
+        _write_json_atomic(
+            self.ledger_path,
+            {"version": LEDGER_VERSION, "updated_at": _now(), "sessions": self.sessions},
+        )
+
+    # -- pool state -----------------------------------------------------------
+
+    def leased_desks(self) -> dict[str, str]:
+        """Map desk -> session name for every currently-seated session."""
+        out: dict[str, str] = {}
+        for name, rec in self.sessions.items():
+            if rec.get("status") == ACTIVE and rec.get("desk"):
+                out[rec["desk"]] = name
+        return out
+
+    def free_desks(self) -> list[str]:
+        taken = self.leased_desks()
+        return [d for d in self.desks if d not in taken]
+
+    def _lease_free_desk(self, name: str) -> str:
+        free = self.free_desks()
+        if not free:
+            leased = self.leased_desks()
+            held = ", ".join(f"{d} -> {leased[d]}" for d in self.desks if d in leased)
+            raise DeskError(
+                EXIT_NO_DESK,
+                "no_free_desk",
+                f"No free desk: all {len(self.desks)} leased ({held}). "
+                f"Close or 'cleanup' a session, or enlarge the pool via /cpp:init.",
+            )
+        return free[0]
+
+    # -- relative path helper for stable, portable ledger output --------------
+
+    def _rel(self, path: Path) -> str:
+        try:
+            return str(path.relative_to(self.root))
+        except ValueError:
+            return str(path)
+
+    def state_file(self, name: str) -> Path:
+        return self.state_dir / f"{name}.json"
+
+    def _desk_result(self, name: str, action: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+        rec = self.sessions[name]
+        desk = rec.get("desk")
+        sf = self.state_file(name)
+        result: dict[str, Any] = {
+            "ok": True,
+            "action": action,
+            "session": name,
+            "desk": desk,
+            "mcp_prefix": f"mcp__{desk}__" if desk else None,
+            "state_file": self._rel(sf),
+            "state_exists": sf.exists(),
+            "status": rec.get("status"),
+            "free_desks_remaining": len(self.free_desks()),
+        }
+        if extra:
+            result.update(extra)
+        return result
+
+    # -- verbs ----------------------------------------------------------------
+
+    def create(self, name: str) -> dict[str, Any]:
+        if name in self.sessions:
+            raise DeskError(
+                EXIT_USAGE,
+                "session_exists",
+                f"Session '{name}' already exists - use 'resume {name}' to re-seat it, "
+                f"or 'close {name} --discard' first.",
+            )
+        desk = self._lease_free_desk(name)
+        now = _now()
+        self.sessions[name] = {
+            "desk": desk,
+            "status": ACTIVE,
+            "created_at": now,
+            "last_used_at": now,
+        }
+        self.save()
+        res = self._desk_result(name, "create")
+        # A brand-new session has no papers to restore yet.
+        res["restore"] = False
+        res["message"] = (
+            f"Leased {desk} for new session '{name}'. Drive it with {res['mcp_prefix']}browser_* tools. "
+            f"Call 'save {name}' to persist login/cookies to {res['state_file']}."
+        )
+        return res
+
+    def resume(self, name: str) -> dict[str, Any]:
+        rec = self.sessions.get(name)
+        if rec is None:
+            raise DeskError(
+                EXIT_USAGE,
+                "unknown_session",
+                f"No session '{name}'. Use 'create {name}' to start one, or 'list' to see sessions.",
+            )
+        now = _now()
+        if rec.get("status") == ACTIVE and rec.get("desk") in self.desks:
+            # Already seated - idempotent.
+            rec["last_used_at"] = now
+            self.save()
+            res = self._desk_result(name, "resume")
+            res["restore"] = res["state_exists"]
+            res["message"] = f"Session '{name}' already seated at {rec['desk']} (idempotent)."
+            return res
+        desk = self._lease_free_desk(name)
+        rec["desk"] = desk
+        rec["status"] = ACTIVE
+        rec["last_used_at"] = now
+        self.save()
+        res = self._desk_result(name, "resume")
+        res["restore"] = res["state_exists"]
+        if res["restore"]:
+            res["message"] = (
+                f"Leased {desk} for '{name}'. RESTORE first: read {res['state_file']} and call "
+                f"{res['mcp_prefix']}browser_set_storage_state with its contents, then navigate."
+            )
+        else:
+            res["message"] = f"Leased {desk} for '{name}'. No saved state file yet - start fresh, then 'save {name}'."
+        return res
+
+    def save_session(self, name: str) -> dict[str, Any]:
+        rec = self.sessions.get(name)
+        if rec is None:
+            raise DeskError(EXIT_USAGE, "unknown_session", f"No session '{name}'.")
+        if rec.get("status") != ACTIVE or not rec.get("desk"):
+            raise DeskError(
+                EXIT_USAGE,
+                "not_seated",
+                f"Session '{name}' is not seated at a desk - 'resume {name}' before saving.",
+            )
+        rec["last_used_at"] = _now()
+        self.save()
+        res = self._desk_result(name, "save")
+        res["message"] = (
+            f"Persist state now: call {res['mcp_prefix']}browser_storage_state and write the returned "
+            f"JSON to {res['state_file']} (the wrapper does not touch the browser itself)."
+        )
+        return res
+
+    def close(self, name: str, discard: bool = False) -> dict[str, Any]:
+        rec = self.sessions.get(name)
+        if rec is None:
+            raise DeskError(EXIT_USAGE, "unknown_session", f"No session '{name}'.")
+        freed = rec.get("desk")
+        sf = self.state_file(name)
+        if discard:
+            del self.sessions[name]
+            removed_state = False
+            if sf.exists():
+                try:
+                    sf.unlink()
+                    removed_state = True
+                except OSError as exc:  # pragma: no cover
+                    raise DeskError(EXIT_CONFIG, "unlink_failed", f"Cannot remove {sf}: {exc}") from exc
+            self.save()
+            return {
+                "ok": True,
+                "action": "close",
+                "session": name,
+                "freed_desk": freed,
+                "discarded": True,
+                "state_retained": False,
+                "state_removed": removed_state,
+                "free_desks_remaining": len(self.free_desks()),
+                "message": f"Closed and DISCARDED '{name}' (desk {freed} freed, state file removed).",
+            }
+        rec["status"] = DETACHED
+        rec["desk"] = None
+        rec["last_used_at"] = _now()
+        self.save()
+        return {
+            "ok": True,
+            "action": "close",
+            "session": name,
+            "freed_desk": freed,
+            "discarded": False,
+            "state_retained": sf.exists(),
+            "state_file": self._rel(sf),
+            "free_desks_remaining": len(self.free_desks()),
+            "message": (
+                f"Detached '{name}' (desk {freed} freed). "
+                f"State {'kept at ' + self._rel(sf) if sf.exists() else 'not yet saved'}; "
+                f"'resume {name}' to re-seat."
+            ),
+        }
+
+    def list_sessions(self) -> dict[str, Any]:
+        now = _now()
+        rows = []
+        for name in sorted(self.sessions):
+            rec = self.sessions[name]
+            sf = self.state_file(name)
+            last = rec.get("last_used_at", rec.get("created_at", now))
+            rows.append(
+                {
+                    "session": name,
+                    "desk": rec.get("desk"),
+                    "status": rec.get("status"),
+                    "state_exists": sf.exists(),
+                    "state_file": self._rel(sf),
+                    "idle_seconds": max(0, now - int(last)),
+                }
+            )
+        return {
+            "ok": True,
+            "action": "list",
+            "pool": {
+                "desks": self.desks,
+                "free": self.free_desks(),
+                "leased": self.leased_desks(),
+                "idle_timeout_seconds": self.idle_timeout,
+            },
+            "sessions": rows,
+        }
+
+    def cleanup(self, idle_seconds: int | None = None) -> dict[str, Any]:
+        threshold = self.idle_timeout if idle_seconds is None else idle_seconds
+        now = _now()
+        released = []
+        for name, rec in self.sessions.items():
+            if rec.get("status") != ACTIVE:
+                continue
+            last = int(rec.get("last_used_at", rec.get("created_at", now)))
+            if now - last >= threshold:
+                released.append({"session": name, "desk": rec.get("desk"), "idle_seconds": now - last})
+                rec["status"] = DETACHED
+                rec["desk"] = None
+        if released:
+            self.save()
+        return {
+            "ok": True,
+            "action": "cleanup",
+            "idle_timeout_seconds": threshold,
+            "released": released,
+            "free_desks_remaining": len(self.free_desks()),
+            "message": (
+                f"Released {len(released)} idle session(s) (>= {threshold}s); state files kept."
+                if released
+                else f"Nothing idle beyond {threshold}s."
+            ),
+        }
+
+    def pool(self) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "action": "pool",
+            "desks": self.desks,
+            "free": self.free_desks(),
+            "leased": self.leased_desks(),
+            "idle_timeout_seconds": self.idle_timeout,
+            "state_dir": self._rel(self.state_dir),
+            "pool_config": self._rel(self.pool_config_path),
+            "pool_config_exists": self.pool_config_path.exists(),
+            "ledger": self._rel(self.ledger_path),
+        }
+
+
+# -- human-readable rendering (default; --json emits the raw object) -----------
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    action = result.get("action")
+    if action == "list":
+        pool = result["pool"]
+        lines = [
+            f"Pool: {len(pool['free'])}/{len(pool['desks'])} desks free (idle timeout {pool['idle_timeout_seconds']}s)",
+        ]
+        if not result["sessions"]:
+            lines.append("  (no sessions)")
+        for row in result["sessions"]:
+            desk = row["desk"] or "-"
+            state = "state" if row["state_exists"] else "no-state"
+            lines.append(
+                f"  {row['session']:<24} {row['status']:<9} desk={desk:<18} {state:<8} idle={row['idle_seconds']}s"
+            )
+        return "\n".join(lines)
+    if action == "pool":
+        return (
+            f"Desks: {', '.join(result['desks'])}\n"
+            f"Free: {', '.join(result['free']) or '(none)'}\n"
+            f"Leased: {result['leased'] or '(none)'}\n"
+            f"Idle timeout: {result['idle_timeout_seconds']}s\n"
+            f"State dir: {result['state_dir']}\n"
+            f"Pool config: {result['pool_config']} "
+            f"({'present' if result['pool_config_exists'] else 'using built-in defaults'})"
+        )
+    if action == "cleanup":
+        return result["message"]
+    return result.get("message", json.dumps(result))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="playwright-desk.py",
+        description="Lease-desk ledger for named concurrent playwright-mcp sessions (issue #421).",
+    )
+    parser.add_argument("--root", help="Project root (default: $CPP_PLAYWRIGHT_ROOT or CWD)")
+    parser.add_argument("--pool-config", help="Path to playwright-pool.json")
+    parser.add_argument("--ledger", help="Path to the lease ledger JSON")
+    parser.add_argument("--state-dir", help="Directory for per-session storage-state files")
+    parser.add_argument("--json", action="store_true", help="Emit the raw JSON result object")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    for verb, help_text in (
+        ("create", "Lease a free desk for a new named session"),
+        ("resume", "Re-seat an existing session at a free desk"),
+        ("save", "Mark a session for state persistence and report its state file"),
+        ("list", "List sessions and pool occupancy"),
+        ("pool", "Show pool configuration and occupancy"),
+    ):
+        sp = sub.add_parser(verb, help=help_text)
+        if verb in ("create", "resume", "save"):
+            sp.add_argument("name", help="Session name")
+
+    sp_close = sub.add_parser("close", help="Release a session's desk (keep state unless --discard)")
+    sp_close.add_argument("name", help="Session name")
+    sp_close.add_argument("--discard", action="store_true", help="Also delete the state file and forget the session")
+
+    sp_cleanup = sub.add_parser("cleanup", help="Release desks of sessions idle beyond the timeout")
+    sp_cleanup.add_argument("--idle-seconds", type=int, default=None, help="Override idle threshold (seconds)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        ledger = Ledger(args)
+        if args.command == "create":
+            result = ledger.create(args.name)
+        elif args.command == "resume":
+            result = ledger.resume(args.name)
+        elif args.command == "save":
+            result = ledger.save_session(args.name)
+        elif args.command == "close":
+            result = ledger.close(args.name, discard=args.discard)
+        elif args.command == "list":
+            result = ledger.list_sessions()
+        elif args.command == "cleanup":
+            result = ledger.cleanup(idle_seconds=args.idle_seconds)
+        elif args.command == "pool":
+            result = ledger.pool()
+        else:  # pragma: no cover - argparse enforces the choices
+            parser.error(f"unknown command {args.command}")
+            return EXIT_USAGE
+    except DeskError as exc:
+        payload = {"ok": False, "error": exc.error, "message": exc.message}
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"error: {exc.message}", file=sys.stderr)
+        return exc.code
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/playwright-pool.example.json
+++ b/templates/playwright-pool.example.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "desks": [
+    "playwright-desk-1",
+    "playwright-desk-2",
+    "playwright-desk-3"
+  ],
+  "idle_timeout_seconds": 1800,
+  "state_dir": ".claude/playwright-state"
+}

--- a/tests/test_playwright_desk.py
+++ b/tests/test_playwright_desk.py
@@ -1,0 +1,174 @@
+"""Tests for scripts/playwright-desk.py - the lease-desk ledger (issue #421).
+
+The script is a hyphenated CLI helper (not an importable module), so these tests
+drive its real ``--json`` contract via subprocess, the same way
+``tests/test_drift_detect.py`` exercises its script.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "playwright-desk.py"
+
+
+def run(
+    *args: str,
+    root: Path,
+    pool_config: Path | None = None,
+    expect: int = 0,
+) -> dict[str, Any]:
+    """Invoke the helper with --json and return the parsed object."""
+    cmd = [sys.executable, str(SCRIPT), "--root", str(root), "--json"]
+    if pool_config is not None:
+        cmd += ["--pool-config", str(pool_config)]
+    cmd += list(args)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode == expect, (
+        f"exit {proc.returncode} != {expect}\ncmd={cmd}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    return json.loads(proc.stdout)
+
+
+def write_pool(path: Path, desks: list[str], idle: int = 1800) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": 1, "desks": desks, "idle_timeout_seconds": idle}),
+        encoding="utf-8",
+    )
+
+
+def test_default_pool_when_no_config(tmp_path: Path) -> None:
+    res = run("pool", root=tmp_path)
+    assert res["ok"] is True
+    assert res["desks"] == ["playwright-desk-1", "playwright-desk-2", "playwright-desk-3"]
+    assert res["pool_config_exists"] is False
+    assert res["idle_timeout_seconds"] == 1800
+
+
+def test_create_leases_a_free_desk(tmp_path: Path) -> None:
+    res = run("create", "gmail", root=tmp_path)
+    assert res["ok"] is True
+    assert res["session"] == "gmail"
+    assert res["desk"] == "playwright-desk-1"
+    assert res["mcp_prefix"] == "mcp__playwright-desk-1__"
+    assert res["restore"] is False  # fresh session, nothing to restore
+    assert res["free_desks_remaining"] == 2
+    # Ledger persisted.
+    ledger = json.loads((tmp_path / ".claude" / "playwright-sessions.json").read_text())
+    assert ledger["sessions"]["gmail"]["status"] == "active"
+
+
+def test_create_duplicate_name_is_usage_error(tmp_path: Path) -> None:
+    run("create", "gmail", root=tmp_path)
+    res = run("create", "gmail", root=tmp_path, expect=2)
+    assert res["ok"] is False
+    assert res["error"] == "session_exists"
+
+
+def test_distinct_sessions_get_distinct_desks(tmp_path: Path) -> None:
+    a = run("create", "a", root=tmp_path)
+    b = run("create", "b", root=tmp_path)
+    assert a["desk"] != b["desk"]
+    assert {a["desk"], b["desk"]} == {"playwright-desk-1", "playwright-desk-2"}
+
+
+def test_pool_exhaustion_returns_no_desk(tmp_path: Path) -> None:
+    pool = tmp_path / ".claude" / "playwright-pool.json"
+    write_pool(pool, ["only-desk"])
+    run("create", "first", root=tmp_path, pool_config=pool)
+    res = run("create", "second", root=tmp_path, pool_config=pool, expect=3)
+    assert res["ok"] is False
+    assert res["error"] == "no_free_desk"
+
+
+def test_close_frees_desk_but_keeps_session(tmp_path: Path) -> None:
+    pool = tmp_path / ".claude" / "playwright-pool.json"
+    write_pool(pool, ["only-desk"])
+    run("create", "s1", root=tmp_path, pool_config=pool)
+    closed = run("close", "s1", root=tmp_path, pool_config=pool)
+    assert closed["freed_desk"] == "only-desk"
+    assert closed["discarded"] is False
+    # Desk is now free again for a different named session.
+    reused = run("create", "s2", root=tmp_path, pool_config=pool)
+    assert reused["desk"] == "only-desk"
+    # s1 still exists, now detached.
+    listing = run("list", root=tmp_path, pool_config=pool)
+    names = {row["session"]: row for row in listing["sessions"]}
+    assert names["s1"]["status"] == "detached"
+    assert names["s1"]["desk"] is None
+
+
+def test_resume_restores_when_state_file_exists(tmp_path: Path) -> None:
+    create = run("create", "login", root=tmp_path)
+    run("close", "login", root=tmp_path)
+    # Simulate the model having saved storage state to the reported path.
+    state_file = tmp_path / create["state_file"]
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps({"cookies": []}), encoding="utf-8")
+
+    resumed = run("resume", "login", root=tmp_path)
+    assert resumed["status"] == "active"
+    assert resumed["restore"] is True
+    assert resumed["state_exists"] is True
+
+
+def test_resume_unknown_session_is_usage_error(tmp_path: Path) -> None:
+    res = run("resume", "ghost", root=tmp_path, expect=2)
+    assert res["error"] == "unknown_session"
+
+
+def test_resume_without_state_does_not_ask_to_restore(tmp_path: Path) -> None:
+    run("create", "fresh", root=tmp_path)
+    run("close", "fresh", root=tmp_path)
+    resumed = run("resume", "fresh", root=tmp_path)
+    assert resumed["restore"] is False
+
+
+def test_save_requires_seated_session(tmp_path: Path) -> None:
+    run("create", "s", root=tmp_path)
+    run("close", "s", root=tmp_path)
+    res = run("save", "s", root=tmp_path, expect=2)
+    assert res["error"] == "not_seated"
+
+
+def test_close_discard_removes_session_and_state(tmp_path: Path) -> None:
+    create = run("create", "temp", root=tmp_path)
+    state_file = tmp_path / create["state_file"]
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text("{}", encoding="utf-8")
+
+    res = run("close", "temp", "--discard", root=tmp_path)
+    assert res["discarded"] is True
+    assert res["state_removed"] is True
+    assert not state_file.exists()
+    listing = run("list", root=tmp_path)
+    assert listing["sessions"] == []
+
+
+def test_cleanup_releases_idle_sessions(tmp_path: Path) -> None:
+    run("create", "old", root=tmp_path)
+    # idle-seconds=0 forces every active session past the threshold immediately.
+    res = run("cleanup", "--idle-seconds", "0", root=tmp_path)
+    assert len(res["released"]) == 1
+    assert res["released"][0]["session"] == "old"
+    listing = run("list", root=tmp_path)
+    assert listing["sessions"][0]["status"] == "detached"
+
+
+def test_cleanup_keeps_fresh_sessions(tmp_path: Path) -> None:
+    run("create", "busy", root=tmp_path)
+    res = run("cleanup", "--idle-seconds", "3600", root=tmp_path)
+    assert res["released"] == []
+
+
+def test_resume_is_idempotent_when_already_seated(tmp_path: Path) -> None:
+    first = run("create", "x", root=tmp_path)
+    again = run("resume", "x", root=tmp_path)
+    assert again["desk"] == first["desk"]
+    assert again["status"] == "active"


### PR DESCRIPTION
## Summary

Recovers **named concurrent** browser sessions over upstream `@playwright/mcp` - the one feature upstream lacks (microsoft/playwright-mcp#1530) - as a thin CPP wrapper, with **no fork and no custom 1.27 GB image**. New surface: `/browser:session` + `/browser:help`.

**Design A (static pre-registered pool)** is the only viable design per the #419 spike (mid-session MCP registration is infeasible in Claude Code - config is read at startup only). This was ratified by the **#422 closure**: *"owner has chosen the local wrapper skill (#421, Design A static slot pool) ... shipping on our own timeline rather than waiting on an uncertain upstream merge."* Substrate chosen this session: **npx/stdio desks** (not compose containers) - matches the spike's own npx finding and the epic's shed-maintenance thesis; zero compose/Trivy/Dockerfile footprint.

### The lease-desk model
A fixed **pool of desks** (`playwright-desk-1..N`, upstream instances run via `npx --isolated`, pre-registered at Claude Code startup) is **leased** by user-named **sessions**. Each session's identity lives in a portable storage-state file (`.claude/playwright-state/<name>.json`), so **sessions outlive desks**: `close` frees a desk but keeps the file; `resume` re-leases any free desk and restores the file into it. N desks multiplex an unbounded number of named sessions, surviving desk/container/Claude restarts.

## Changes
| File | What |
|------|------|
| `scripts/playwright-desk.py` | Zero-dep stdlib ledger + state-file bookkeeping. Verbs `create`/`resume`/`save`/`close`/`list`/`cleanup`/`pool`; `--json` contract; atomic writes; idle-timeout cleanup (replaces the retired server's `SESSION_TIMEOUT`). |
| `tests/test_playwright_desk.py` | 14 tests: lease/release, pool exhaustion, resume-restores-state, idle cleanup, name collision, discard, idempotent resume. |
| `.claude/commands/browser/{session,help}.md` | `/browser:session` (drives each desk's `browser_*` MCP tools + reads/writes state files) and `/browser:help`. |
| `templates/playwright-pool.example.json` | Seed pool config (desks, idle timeout, state dir). Live copy + ledger + state dir are gitignored. |
| `.claude/commands/cpp/init.md` | **Opt-in** "browser pool" step (Full tier): seeds the pool config and registers `playwright-desk-N` via `claude mcp add ... -- npx -y @playwright/mcp@0.0.77 --isolated`. |
| `docs/skills/browser-session-wrapper.md`, `CLAUDE.md`, `README.md`, `CHANGELOG.md`, `.gitignore` | Guide, command reference, changelog, ignore rules. |

### Acceptance criteria (#421)
- [x] Implement the design selected by the #419 verdict - **Design A**, npx/stdio pool
- [x] Session-state files under a gitignored dir; idle-timeout/cleanup story (replaces `SESSION_TIMEOUT`) - `.claude/playwright-state/` + `cleanup`/`idle_timeout_seconds`
- [x] Docs plus `/cpp:init` integration (browser tier) - docs skill + opt-in Full-tier step

### Design notes
- **Opt-in by design.** The spike flagged this feature is currently unused by CPP's own consumers (`/qa:test` is single-session), so the pool is off by default and each desk adds a `browser_*` tool surface to startup context - kept small (default 3).
- `--isolated` desks (not `--user-data-dir`): each lease starts blank, so session identity lives entirely in the portable state file - no cross-session bleed-through. (Refinement over the `--user-data-dir` shown illustratively during planning.)
- **Endgame:** if named multi-session lands upstream (#1530), this wrapper thins to naming discipline over native support (per #422's reversible closing note).

## Test plan
- `make lint` - clean; `make typecheck` - clean (114 files); `make test` - **650 passed** (incl. 14 new + `test_manifest` validating the new command frontmatter).
- Deterministic finish plan (`lib.cicd run --plan finish`): lint + test + security_scan all SUCCESS.
- Manual smoke of the `--json` and human-readable helper flows (create/list/close/pool).

Closes #421