### PR TITLE
feat(self-improvement): grill-me cycle - friction capture + retro codify loop (Closes #426)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -30,6 +30,29 @@ Proceeding...
 
 ---
 
+### Friction Capture (always-on)
+
+Throughout this run, record friction the moment it happens - do NOT wait for the
+end. The richest friction is on runs that fail partway, so capture must fire on
+every step, success OR failure, and before any STOP. Whenever you hit one of these,
+append a record via the fail-open capture helper (it never blocks the flow):
+
+- a **permission prompt** the user had to approve for a Bash/tool call
+- a **quality-gate failure or retry** (lint/test/build/deploy)
+- **red output** you narrated past or worked around instead of resolving
+- a **manual intervention / correction** the user had to make
+
+```bash
+scripts/friction-log.sh --class <permission-prompt|gate-failure|red-output|manual-intervention> \
+  --signal "<what happened>" --fix "<proposed fix, if obvious>" \
+  --scope <local|portable> --run "flow:auto #$ISSUE_NUM" --step "<N/9 Name>" --outcome "<approved|retried|worked-around|corrected>"
+```
+
+Records go to `.claude/friction.jsonl` (a queue drained by `/self-improvement:retro`).
+This is capture only - proposing and applying fixes happens in the retro, not here.
+
+---
+
 ### Step 1: Start - Create Worktree
 
 **CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master. This step is NOT optional - if worktree creation fails, STOP immediately.**
@@ -499,8 +522,25 @@ Flow Auto Complete
   Worktree: ../my-project-issue-42 (removed)
   CI:       Woodpecker pipeline #5 passed | GitHub Actions run #123 passed | skipped
   Deploy:   make deploy (success) | skipped
+  Friction: 4 signals captured (.claude/friction.jsonl)
   Location: /home/user/Projects/my-project (main)
 ```
+
+---
+
+### Post-run: Friction Retro (optional, non-blocking)
+
+After the summary, if `.claude/friction.jsonl` recorded any signals this run, offer
+the codify step - do not block or auto-run it:
+
+```
+Friction retro: this run recorded N friction signal(s). Run /self-improvement:retro
+to turn them into confirmed fixes (permission allowlist, Make targets, hooks,
+CLAUDE.md, portable learnings)? [y/N]
+```
+
+Declining is free - capture already persisted the signals for a later retro. This
+offer also appears at the end of `/flow:merge`.
 
 ---
 
@@ -551,3 +591,4 @@ Key failure scenarios:
 - The deploy step is always optional - it only runs if a deploy target exists
 - After completion, the user is in the main repo on the main branch
 - For step-by-step control, use individual commands: `/flow:start`, `/flow:eli5`, `/flow:finish`, `/flow:merge`, `/flow:deploy`
+- Friction capture runs throughout (always-on, fail-open, `scripts/friction-log.sh` -> `.claude/friction.jsonl`) and the run offers `/self-improvement:retro` at the end to codify fixes - the grill-me cycle (issue #426)

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -147,6 +147,25 @@ Cleanup:
 Current directory: /home/user/Projects/my-project (main)
 ```
 
+### Step 9: Post-run Friction Retro (optional, non-blocking)
+
+Capture is always-on during a flow: whenever a step in this merge triggers a
+permission prompt, a gate failure/retry, red output you worked around, or a manual
+correction, record it immediately via the fail-open helper (it never blocks):
+
+```bash
+scripts/friction-log.sh --class <permission-prompt|gate-failure|red-output|manual-intervention> \
+  --signal "<what happened>" --run "flow:merge" --step "<N/9 Name>" --outcome "<...>"
+```
+
+Then, if `.claude/friction.jsonl` recorded any signals, offer the codify step (do
+not auto-run):
+
+```
+Friction retro: this run recorded N friction signal(s). Run /self-improvement:retro
+to codify fixes? [y/N]
+```
+
 ## Error Handling
 
 - **PR not found:** Direct user to `/flow:finish`
@@ -163,3 +182,4 @@ Current directory: /home/user/Projects/my-project (main)
 - After merge, the user ends up in the main repo on the `main` branch
 - Automatically prunes stale worktree references, merged branches, and remote tracking branches
 - For a standalone cleanup (without merging), use `/flow:cleanup`
+- Friction capture is always-on and this command offers `/self-improvement:retro` at the end to codify fixes (the grill-me cycle, issue #426)

--- a/.claude/commands/self-improvement/help.md
+++ b/.claude/commands/self-improvement/help.md
@@ -10,6 +10,7 @@ Retrospective analysis commands that examine recent failures and suggest improve
 
 | Command | Purpose |
 |---------|---------|
+| `/self-improvement:retro` | Post-run friction retro (the grill-me cycle): capture -> classify -> dedup -> propose -> confirm -> codify durable fixes |
 | `/self-improvement:deployment` | Analyze deployment errors and propose Makefile improvements |
 | `/self-improvement:help` | This help page |
 
@@ -25,6 +26,13 @@ Self-improvement commands:
 
 ## When to Use
 
+Run `/self-improvement:retro` after (or during) any flow run:
+- After a `/flow:auto` or `/flow:merge` run - both offer it automatically once
+  friction was captured
+- After a session with repeated permission prompts, gate retries, red output, or
+  manual course-corrections
+- On demand against a recorded transcript: `/self-improvement:retro <transcript>`
+
 Run `/self-improvement:deployment` after:
 - A failed `make deploy` or `make test`
 - Repeated build failures in a session
@@ -34,15 +42,20 @@ Run `/self-improvement:deployment` after:
 ## Feedback Loop
 
 ```
+/flow:auto -> friction captured -> /self-improvement:retro -> codify fixes (settings/Make/hooks/CLAUDE.md/learnings) -> next run is smoother
 /flow:deploy -> fails -> /self-improvement:deployment -> fix Makefile -> /flow:deploy -> succeeds
 ```
+
+Capture (thin, always-on, woven into the flow) and codify (the retro) are
+decoupled, so friction on runs that fail partway is not lost.
 
 ## Future Commands
 
 The self-improvement category may grow to include:
-- **test** - Analyze test failure patterns, suggest test infrastructure improvements
+- **memory** - Codify portable knowledge / infra traps to the cross-VM common
+  memory store (issue #433); `/self-improvement:retro` delegates its portable
+  findings here when installed
 - **review** - Analyze PR review feedback patterns, suggest code quality improvements
-- **session** - Analyze session patterns, suggest CLAUDE.md improvements
 
 ## See Also
 

--- a/.claude/commands/self-improvement/retro.md
+++ b/.claude/commands/self-improvement/retro.md
@@ -1,0 +1,247 @@
+# Self-Improvement: Retro - Post-Run Friction Retro + Codify Loop
+
+The "grill-me cycle": grill a just-finished session for friction, then propose and
+(user-confirmed) codify durable fixes so the same friction never recurs. This is
+the assess-and-codify member of the grill family (`/grill:me`, `/grill:yourself`,
+`/second-opinion:grill-plan`) and the general sibling of
+`/self-improvement:deployment` - it looks at ALL friction, not just deploys.
+
+Steal the compound-engineering loop: plan -> work -> assess -> **codify**, with
+learnings persisted and consulted so a fix is never re-litigated.
+
+## How capture and codify are decoupled (read this first)
+
+`/flow:auto` stops on the first failure, but the richest friction (permission
+prompts, gate retries, red output) clusters on the runs that fail partway. A
+terminal "final step retro" would be blind to exactly those. So:
+
+- **Capture** is thin, always-on instrumentation woven into `/flow:auto` and
+  `/flow:merge` that records every friction signal on every step, success OR
+  failure, via `scripts/friction-log.sh` -> `.claude/friction.jsonl`. It survives
+  failed runs. (This command consumes that buffer; it does not replace it.)
+- **Codify (local)** is THIS command: classify -> dedup -> propose -> confirm ->
+  apply -> log, for fixes that stay on this machine (settings, Makefile, hooks,
+  CLAUDE.md, quality gates). Local learnings persist in `.claude/learnings.md`.
+- **Codify (shared/portable)** is issue #433's job: portable CPP knowledge and
+  infra traps go to the cross-VM common-memory store via `/self-improvement:memory`
+  (Claude) or the `cpp-memory` CLI. This command **delegates** to that routine when
+  it is installed and degrades gracefully when it is not. It NEVER reimplements the
+  shared store, and NEVER pushes per-machine `permissions.allow` fixes to it (wrong
+  trust boundary across workstation / executor-host / hardened VMs).
+
+## Arguments
+
+- `TRANSCRIPT` (optional): path to a recorded session transcript to grill instead
+  of the live conversation (used for replay and for the acceptance case below).
+- `--dry-run` (optional): analyze and propose, but do not apply or log.
+- `--on-demand` (optional, informational): marks a manual run outside a flow.
+
+None are required. With no arguments, the command grills the current conversation
+plus `.claude/friction.jsonl`.
+
+## Instructions
+
+When the user invokes `/self-improvement:retro`, perform these steps.
+
+### Step 1: Gather friction signals
+
+Collect signals from all available sources (union, then de-duplicate):
+
+1. **Capture buffer** - if `.claude/friction.jsonl` exists, read it. Each line is a
+   JSON record: `{ts, run, step, class, signal, fix, scope, outcome}`.
+   ```bash
+   [ -f .claude/friction.jsonl ] && cat .claude/friction.jsonl || echo "NO_BUFFER"
+   ```
+2. **This conversation** - scan the session for friction the buffer may have
+   missed, across four classes:
+   - **permission-prompt** - each Bash/tool approval the user had to click
+     (`gh issue view`, `git fetch`, `git worktree`, shell pipelines, etc.).
+   - **gate-failure** - lint/test/build/deploy failures and the retries that
+     followed.
+   - **red-output** - error/red output that was narrated past or worked around
+     instead of resolved (see the "account for red output" discipline).
+   - **manual-intervention** - places where the user corrected course, re-ran a
+     command by hand, or supplied a value the flow should have known.
+3. **Replay mode** - if `TRANSCRIPT` was given, parse that file for the same four
+   classes instead of the live conversation.
+
+If nothing is found:
+```
+No friction signals found for this session.
+
+To use this command effectively:
+  1. Run it after a /flow:auto or /flow:merge run (capture is automatic), or
+  2. Grill a recorded run:  /self-improvement:retro path/to/transcript.md
+```
+
+### Step 2: Consult the ledger (dedup / rejection - do NOT re-propose)
+
+Before proposing anything, load what is already known so a fix that was applied or
+deliberately rejected is never raised again.
+
+1. **Local ledger** - read `.claude/learnings.md` if present (seed format:
+   `templates/learnings.md.example`). Note every entry's `Fingerprint`, `Status`
+   (proposed | applied | rejected | superseded) and `Scope`.
+2. **Shared store (#433), if installed** - if `/self-improvement:memory` or a
+   `cpp-memory` CLI is available, consult it for portable-knowledge dedup:
+   ```bash
+   command -v cpp-memory >/dev/null 2>&1 && echo "SHARED_MEMORY_AVAILABLE" || echo "SHARED_MEMORY_ABSENT"
+   ```
+   When present, treat its rejection ledger as authoritative for portable fixes.
+   When absent, proceed local-only (fail-open) and note the shared path is pending
+   #433.
+3. Compute each candidate fix's **fingerprint** deterministically so it matches the
+   ledger: `fingerprint = short-hash( class + "|" + normalized-fix-text )`. Drop
+   any candidate whose fingerprint is already `applied` or `rejected`.
+
+### Step 3: Classify signals and map each to a codified fix
+
+For each surviving signal, map its class to a concrete, durable fix and a scope:
+
+| Friction class | Codified fix | Scope |
+|----------------|--------------|-------|
+| permission-prompt | `.claude/settings.json` `permissions.allow` entry (or `/fewer-permission-prompts`) | **local** (per-machine, never shared) |
+| gate-failure | Makefile target / dependency / new quality gate; or CLAUDE.md directive | local if repo-specific; portable if an infra trap |
+| red-output | the underlying fix + a CLAUDE.md directive; the lesson may be a portable infra trap | local + (maybe) portable |
+| manual-intervention | a hook, Makefile target, or CLAUDE.md directive that removes the manual step | local |
+
+**Scope routing is a hard rule:**
+- **local** fixes (all `permissions.allow` changes, repo-specific Makefile/hook
+  edits) are applied on this machine only and logged to `.claude/learnings.md`.
+  They are NEVER pushed to the #433 shared store.
+- **portable** knowledge (reusable infra traps, e.g. "codex exec hangs in non-TTY
+  without `< /dev/null`") is handed to `/self-improvement:memory` (#433) for the
+  shared store, after the same propose -> confirm gate. If #433 is not installed,
+  record it locally and flag it as "pending shared codify (#433)".
+
+### Step 4: Emit the permission allowlist from permission-prompt signals
+
+This is the motivating case and the primary acceptance path. When
+permission-prompt signals are present:
+
+1. For each distinct prompted command, derive the narrowest safe allow rule of the
+   form `Bash(<command prefix>:*)` (e.g. `gh issue view` -> `Bash(gh issue view:*)`,
+   `git fetch` -> `Bash(git fetch:*)`, `git worktree add ...` -> `Bash(git worktree:*)`,
+   the branch-slug pipeline `tr` / `sed` / `cut` -> `Bash(tr:*)`, `Bash(sed:*)`,
+   `Bash(cut:*)`). Bare commands with no subcommand use the exact form CPP ships
+   (e.g. `pwd` -> `Bash(pwd)`, `git remote -v` -> `Bash(git remote -v)`).
+2. **Deliberately EXCLUDE shipping/mutating actions** so gates and secret-read
+   prompts stay intact: never propose allow rules for `git push`, `gh pr create`,
+   `gh pr merge`, or `cat` (which would defeat output masking).
+3. Recognize that CPP already ships this exact set as
+   `templates/claude-settings-permissions.json`. If your derived rules are a subset
+   of that template, recommend the supported merge path instead of hand-editing:
+   ```
+   The friction you hit is the read-only /flow:* plumbing CPP already codifies.
+   Merge the shipped allowlist into ~/.claude/settings.json:
+     - run /cpp:update  (Step 7.6 union-merges new rules), or
+     - run /fewer-permission-prompts  (native, transcript-derived)
+   ```
+4. Present the derived rules as a ready-to-merge `permissions.allow` block so the
+   user can confirm.
+
+### Step 5: Propose -> confirm -> apply
+
+Present all proposals in one report (see Output Format), then, for each one the
+user approves:
+
+- **settings.json allow rules**: union-merge into `~/.claude/settings.json`
+  (additive, idempotent - never drop existing rules). Prefer `/cpp:update` /
+  `/fewer-permission-prompts` when the rules match the shipped template.
+- **Makefile / hook / CLAUDE.md / gate** edits: apply with the Edit tool.
+- **portable knowledge**: hand to `/self-improvement:memory` (#433) when available.
+
+Never auto-apply without confirmation. `permissions.allow` changes in particular
+are always human-confirmed on the machine they affect (trust boundary). `--dry-run`
+stops after the report.
+
+### Step 6: Codify to the ledger (persist the decision)
+
+Append one entry per decision to `.claude/learnings.md` (create it from
+`templates/learnings.md.example` on first run), recording BOTH applied AND rejected
+outcomes so nothing is re-proposed next run:
+
+```
+## <short title>
+- Fingerprint: <hash>
+- Date: <YYYY-MM-DD>
+- Source: <run label, e.g. flow:auto #426>
+- Class: <permission-prompt | gate-failure | red-output | manual-intervention>
+- Scope: <local | portable>
+- Status: <applied | rejected | superseded>
+- Fix: <the concrete change or rule>
+- Rationale: <why applied/rejected>
+```
+
+Then truncate or archive the drained `.claude/friction.jsonl` records so the next
+retro starts clean (the buffer is a queue, the ledger is the record).
+
+## Auto-offer at end of a flow run
+
+`/flow:auto` and `/flow:merge` offer this command after their final summary
+(non-blocking):
+```
+Friction retro: this run recorded N friction signal(s). Run /self-improvement:retro
+to codify fixes? [y/N]
+```
+Decline is free; capture already persisted the signals for a later run.
+
+## Acceptance demonstration (acceptance criterion 1)
+
+Run the cycle against the recorded pre-2026-07-03 transcript fixture and confirm it
+emits the shipped allowlist unaided:
+```
+/self-improvement:retro tests/fixtures/retro/flow-auto-pre-eli5.md
+```
+Expected: the Step 4 output is the 32-rule `permissions.allow` block equal to
+`templates/claude-settings-permissions.json`, derived from the permission-prompt
+signals alone, with the `/cpp:update` merge recommendation.
+
+## Output Format
+
+```
+Self-Improvement: Friction Retro
+================================
+
+Session:          <run label>
+Signals captured: N  (permission-prompt: a, gate-failure: b, red-output: c, manual: d)
+Ledger:           local .claude/learnings.md (M entries) | shared #433: available|absent
+Skipped (known):  K  (already applied/rejected)
+
+Proposed fixes: P
+
+  1. [local]    settings.json allowlist (32 rules)   -> merge via /cpp:update
+  2. [local]    Makefile: deploy depends on test lint
+  3. [portable] infra trap: <...>                     -> /self-improvement:memory (#433)
+
+Apply which? [all / 1,2 / none]
+```
+
+## Error handling
+
+- **No friction found**: report it; suggest running after a flow or on a transcript.
+- **No capture buffer AND no conversation context** (fresh session): read from the
+  `TRANSCRIPT` argument, or explain there is nothing to grill.
+- **Shared store (#433) unreachable/absent**: fail-open - proceed local-only, tag
+  portable items "pending shared codify (#433)", never block.
+- **settings.json write blocked**: output the merge block as a diff and point to
+  `/cpp:update` / `/fewer-permission-prompts`.
+- **Ledger unreadable**: warn, treat as empty, do not block.
+
+## Notes
+
+- This is the **mechanism** that should have produced the pre-ELI5 permission
+  allowlist months ago instead of it being hand-authored once (issue #426 vs the
+  artifact shipped in #427).
+- Capture is fail-open and always-on; codify is deliberate and confirmed.
+- Standalone-extraction candidate (Phase C, alongside `flow-eli5`): the command,
+  `scripts/friction-log.sh`, and `templates/learnings.md.example` are self-contained.
+- No em/en dashes - ASCII hyphens only (CLAUDE.md core directive).
+
+## See also
+
+- `/self-improvement:deployment` - the deploy-only retrospective this generalizes
+- `/self-improvement:memory` (#433) - portable/shared codify to common memory
+- `/fewer-permission-prompts` - native allowlist derivation (the permission slice)
+- `/grill:me`, `/grill:yourself`, `/second-opinion:grill-plan` - the grill family
+- `/flow:doctor` - reports installed vs missing flow allowlist rules

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,12 @@ node_modules/
 .claude/playwright-pool.json
 .claude/playwright-state/
 
+# Grill-me cycle runtime state (issue #426): capture buffer + local learnings
+# ledger. Templates/fixtures are tracked; the live per-project files are not.
+.claude/friction.jsonl
+.claude/friction/
+.claude/learnings.md
+
 # Logs
 *.log
 logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@
   ratified by the #422 closure (owner chose the local wrapper over waiting on upstream).
   Guide: `docs/skills/browser-session-wrapper.md`.
 
+- **Grill-me cycle: post-run friction retro (issue #426)** - the capture + local
+  codify half of the compound-engineering loop (plan -> work -> assess -> codify).
+  New always-on **capture** helper `scripts/friction-log.sh` (fail-open JSONL
+  append to `.claude/friction.jsonl`) is woven into `/flow:auto` and `/flow:merge`
+  so friction is recorded on every step of every run - success OR failure - because
+  the richest friction (permission prompts, gate retries, red output) clusters on
+  runs that fail partway, where a terminal retro would be blind. New **retro**
+  command `/self-improvement:retro` grills the captured buffer + session, classifies
+  the four friction classes, dedups against a persistent local ledger
+  (`.claude/learnings.md`, seed `templates/learnings.md.example`) so applied/rejected
+  fixes are never re-proposed, then proposes and (user-confirmed) applies codified
+  fixes. Acceptance case demonstrated: run against the recorded pre-2026-07-03
+  `/flow:auto` transcript (`tests/fixtures/retro/flow-auto-pre-eli5.md`) it emits
+  exactly the 32-rule allowlist of `templates/claude-settings-permissions.json`
+  (#427) unaided, excluding shipping/secret actions. Scope is bounded by trust
+  boundary: per-machine `permissions.allow` fixes stay local and are never pushed to
+  a shared store; portable knowledge/infra traps delegate to `/self-improvement:memory`
+  (issue #433, common-memory substrate) when installed and degrade gracefully when
+  not. Generalizes `/self-improvement:deployment` beyond deploys; standalone-
+  extraction candidate (Phase C, alongside `flow-eli5`).
 - **Flow read-only permission allowlist template** (issue #427) - new
   `templates/claude-settings-permissions.json` (+ rationale doc
   `templates/claude-settings-permissions.md`) codifies the 32 user-level

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/cpp:init` - Interactive setup wizard (Tiers: Minimal, Standard, Full, CI/CD, Codex); optionally installs the spec-kit CLI (`specify`, the engine behind `/spec:adopt`)
 - `/cpp:status` - Check installation state
 - `/cpp:update` - Pull latest, sync deps, migrate legacy systemd units if present, refresh Docker local-build runtime, tear down orphaned Docker MCP infra via the curated `.claude/deprecated-mcps.yaml` (Step 6c/7, user-confirmed), prune retired/orphaned generated skills via the curated `.claude/deprecated-skills.yaml` (Step 7.5, user-confirmed), then offer to merge new flow allowlist rules from `templates/claude-settings-permissions.json` into `~/.claude/settings.json` (Step 7.6, user-confirmed); also refreshes the optional spec-kit CLI (`specify`) if installed (Step 4.6)
+- `/self-improvement:retro` - Post-run friction retro (the grill-me cycle): always-on capture (`scripts/friction-log.sh` -> `.claude/friction.jsonl`, woven into `/flow:auto` + `/flow:merge`) then classify -> dedup -> propose -> confirm -> codify durable fixes; local ledger `.claude/learnings.md`, portable knowledge delegates to `/self-improvement:memory` (#433)
 - `/self-improvement:deployment` - Retrospective analysis after failed deploys
 - `/happy-check` - Check happy-cli version (optional)
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ claude-power-pack/
 | Workflow | `/flow:start 42` | Create worktree for an issue |
 | Workflow | `/flow:eli5 42` | Plain-language intent + necessity verdict + plan approval gate |
 | Workflow | `/flow:finish` | Lint, test, commit, push, create PR |
+| Improve | `/self-improvement:retro` | Post-run friction retro: capture -> codify durable fixes (the grill-me cycle) |
 | Project | `/project:init myapp` | Scaffold a new project |
 | Security | `/security:scan` | Full vulnerability scan |
 | Secrets | `/secrets:list` | List managed credentials |

--- a/scripts/friction-log.sh
+++ b/scripts/friction-log.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# friction-log.sh - Always-on friction capture for the grill-me cycle (issue #426).
+#
+# Appends one JSON object per friction event to a local, append-only buffer
+# (default: .claude/friction.jsonl). This is the "capture" half of the grill-me
+# cycle: thin instrumentation the flow commands call on every step of every run,
+# success OR failure, so the richest friction (the runs that fail partway) is not
+# lost. The buffer is drained later by /self-improvement:retro (local codify) and,
+# when installed, by #433's shared "cpp-memory record" (portable codify).
+#
+# Fail-open by design: this NEVER exits non-zero and NEVER blocks a flow run, even
+# on bad input or an unwritable path. Capture is best-effort; a flow must never
+# break because its flight recorder could not write.
+#
+# Usage:
+#   friction-log.sh --class <class> --signal <text> [options]
+#
+# Required:
+#   --class   <c>    friction class: permission-prompt | gate-failure |
+#                    red-output | manual-intervention | other
+#   --signal  <s>    short description of what happened
+#
+# Optional:
+#   --fix     <f>    proposed fix (e.g. a settings.json allow rule, a Make target)
+#   --scope   <sc>   local | portable                         (default: local)
+#   --outcome <o>    free text (approved | retried | worked-around | corrected)
+#   --run     <r>    run label (e.g. "flow:auto #426")
+#   --step    <st>   step label (e.g. "1/9 Start")
+#
+# Environment:
+#   CPP_FRICTION_LOG  override the buffer path (default: .claude/friction.jsonl)
+#
+# Example:
+#   friction-log.sh --class permission-prompt \
+#     --signal 'gh issue view 426 required approval' \
+#     --fix 'Bash(gh issue view:*)' --scope local \
+#     --run 'flow:auto #426' --step '1/9 Start' --outcome approved
+
+# Deliberately NO `set -e`: fail-open means we swallow errors and exit 0.
+set -u 2>/dev/null || true
+
+CLASS=""
+SIGNAL=""
+FIX=""
+SCOPE="local"
+OUTCOME=""
+RUN=""
+STEP=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --class)   CLASS="${2:-}"; shift 2 || shift ;;
+    --signal)  SIGNAL="${2:-}"; shift 2 || shift ;;
+    --fix)     FIX="${2:-}"; shift 2 || shift ;;
+    --scope)   SCOPE="${2:-local}"; shift 2 || shift ;;
+    --outcome) OUTCOME="${2:-}"; shift 2 || shift ;;
+    --run)     RUN="${2:-}"; shift 2 || shift ;;
+    --step)    STEP="${2:-}"; shift 2 || shift ;;
+    -h|--help)
+      sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "friction-log: ignoring unknown argument '$1'" >&2
+      shift
+      ;;
+  esac
+done
+
+# Required fields missing -> warn and exit clean; do not append a junk record.
+if [ -z "$CLASS" ] || [ -z "$SIGNAL" ]; then
+  echo "friction-log: --class and --signal are required (skipping)" >&2
+  exit 0
+fi
+
+# Escape a string for embedding in a JSON double-quoted value. Handles the two
+# structural characters (backslash, double-quote) and folds control whitespace so
+# every record stays on a single line (JSONL).
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"   # backslash first
+  s="${s//\"/\\\"}"   # then double-quote
+  s="${s//$'\r'/}"    # drop carriage returns
+  s="${s//$'\t'/ }"   # tabs -> space
+  s="${s//$'\n'/ }"   # newlines -> space
+  printf '%s' "$s"
+}
+
+LOG="${CPP_FRICTION_LOG:-.claude/friction.jsonl}"
+DIR="$(dirname "$LOG")"
+
+if ! mkdir -p "$DIR" 2>/dev/null; then
+  echo "friction-log: cannot create '$DIR' (skipping)" >&2
+  exit 0
+fi
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf '')"
+
+LINE="$(printf '{"ts":"%s","run":"%s","step":"%s","class":"%s","signal":"%s","fix":"%s","scope":"%s","outcome":"%s"}' \
+  "$(json_escape "$TS")" \
+  "$(json_escape "$RUN")" \
+  "$(json_escape "$STEP")" \
+  "$(json_escape "$CLASS")" \
+  "$(json_escape "$SIGNAL")" \
+  "$(json_escape "$FIX")" \
+  "$(json_escape "$SCOPE")" \
+  "$(json_escape "$OUTCOME")")"
+
+if ! printf '%s\n' "$LINE" >>"$LOG" 2>/dev/null; then
+  echo "friction-log: cannot write '$LOG' (skipping)" >&2
+  exit 0
+fi
+
+exit 0

--- a/templates/learnings.md.example
+++ b/templates/learnings.md.example
@@ -1,0 +1,58 @@
+# Learnings Ledger (local, fail-open)
+
+Persistent record of friction fixes proposed by the grill-me cycle
+(`/self-improvement:retro`). Its purpose is dedup: the retro reads this file first
+and never re-proposes a fix already `applied` or `rejected` here.
+
+- **Scope of this file:** LOCAL, per-machine fixes only - `permissions.allow`
+  changes, repo-specific Makefile/hook/CLAUDE.md edits. Per-machine permission
+  fixes deliberately stay here and are never pushed to a shared store (wrong trust
+  boundary across workstation / executor-host / hardened VMs).
+- **Portable knowledge** (reusable infra traps) is codified to the cross-VM common
+  memory via `/self-improvement:memory` (issue #433), not here. When #433 is not
+  installed, portable items are parked here tagged "pending shared codify (#433)".
+- This file is the local fail-open tier that #433's client degrades to when the
+  shared store is unreachable. #433 owns the canonical schema; keep entries in the
+  simple block form below until then.
+
+This file is git-ignored in consuming projects (runtime state). Copy this template
+to `.claude/learnings.md`; the retro also creates it on first run.
+
+## Entry format
+
+    ## <short title>
+    - Fingerprint: <short-hash of  class + "|" + normalized-fix-text>
+    - Date: <YYYY-MM-DD>
+    - Source: <run label, e.g. flow:auto #426>
+    - Class: <permission-prompt | gate-failure | red-output | manual-intervention>
+    - Scope: <local | portable>
+    - Status: <proposed | applied | rejected | superseded>
+    - Fix: <the concrete change or rule>
+    - Rationale: <why it was applied or rejected>
+
+---
+
+## Pre-ELI5 read-only flow allowlist
+- Fingerprint: perm-flow-readonly-allowlist
+- Date: 2026-07-03
+- Source: flow:auto (pre-2026-07-03 runs, recurring)
+- Class: permission-prompt
+- Scope: local
+- Status: applied
+- Fix: union-merged templates/claude-settings-permissions.json (32 read-only git/gh
+  + shell-plumbing rules) into ~/.claude/settings.json via /cpp:update Step 7.6.
+- Rationale: /flow:* re-prompted for the same read-only issue reads, worktree
+  creation, and branch-slug pipeline on every run in every repo. Shipping actions
+  (git push, gh pr create) and cat stay excluded so gates and secret-read prompts
+  remain intact. This is the artifact #426's cycle should emit unaided (see #427).
+
+## Example rejected fix (do not re-propose)
+- Fingerprint: allow-git-push-blanket
+- Date: 2026-07-03
+- Source: flow:auto (example)
+- Class: permission-prompt
+- Scope: local
+- Status: rejected
+- Fix: Bash(git push:*) added to permissions.allow
+- Rationale: shipping/mutating actions are intentionally gated; auto-approving push
+  would defeat the review/PR boundary. Rejected permanently; never re-propose.

--- a/tests/fixtures/retro/flow-auto-pre-eli5.md
+++ b/tests/fixtures/retro/flow-auto-pre-eli5.md
@@ -1,0 +1,71 @@
+# Recorded transcript: /flow:auto (pre-2026-07-03), pre-ELI5 stages
+
+Acceptance fixture for issue #426 (grill-me cycle). This is a lightly redacted
+recording of a `/flow:auto <issue>` run from BEFORE the read-only flow allowlist
+existed (`templates/claude-settings-permissions.json`, shipped in #427 on
+2026-07-03). Every read-only command in Steps 1-2 triggered a manual permission
+prompt.
+
+Running `/self-improvement:retro tests/fixtures/retro/flow-auto-pre-eli5.md` must
+emit the 32-rule `permissions.allow` block equal to that template, derived from the
+permission-prompt signals below and nothing else.
+
+Each line marked `[permission prompt -> approved]` is a friction signal of class
+`permission-prompt`.
+
+---
+
+## Step 1/9: Start - Create Worktree
+
+    $ gh issue view 512 --json number,title,state,body      [permission prompt -> approved]
+    $ gh repo view --json nameWithOwner                     [permission prompt -> approved]
+    $ git rev-parse --show-toplevel                         [permission prompt -> approved]
+    $ git branch --show-current                             [permission prompt -> approved]
+    $ git fetch origin                                      [permission prompt -> approved]
+    $ git branch -r                                         [permission prompt -> approved]  (already approved: git branch)
+    $ git remote -v                                         [permission prompt -> approved]
+    $ git config --get remote.origin.url                    [permission prompt -> approved]
+    $ git worktree list                                     [permission prompt -> approved]
+    $ echo "Fix login redirect loop" | tr '[:upper:]' '[:lower:]'   [permission prompt -> approved] (echo)
+    $ ... | tr '[:upper:]' '[:lower:]'                      [permission prompt -> approved] (tr)
+    $ ... | sed 's/[^a-z0-9]/-/g'                           [permission prompt -> approved] (sed)
+    $ ... | cut -c1-50                                      [permission prompt -> approved] (cut)
+    $ basename "$(git rev-parse --show-toplevel)"           [permission prompt -> approved] (basename)
+    $ git worktree add -b issue-512-... ../repo-issue-512 origin/main   [permission prompt -> approved] (git worktree)
+    $ cd ../repo-issue-512                                  [permission prompt -> approved] (cd)
+    $ pwd                                                   [permission prompt -> approved] (pwd)
+    $ ls -1                                                 [permission prompt -> approved] (ls)
+
+## Step 2/9: Analyze - Understand the Issue
+
+    $ gh issue list --search "login redirect" --state all  [permission prompt -> approved]
+    $ git log --since=2026-06-01 --oneline                  [permission prompt -> approved]
+    $ git status                                            [permission prompt -> approved]
+    $ git diff --stat origin/main                           [permission prompt -> approved]
+    $ git show HEAD:src/auth/login.py                       [permission prompt -> approved]
+    $ grep -rn "redirect" src/                              [permission prompt -> approved] (grep)
+    $ rg "handle_login" src/                                [permission prompt -> approved] (rg)
+    $ find . -name "*.py" -path "*auth*"                    [permission prompt -> approved] (find)
+    $ head -40 src/auth/login.py                            [permission prompt -> approved] (head)
+    $ tail -20 tests/test_auth.py                           [permission prompt -> approved] (tail)
+    $ wc -l src/auth/login.py                               [permission prompt -> approved] (wc)
+
+## Step 8/9: Verify CI (later in the same run)
+
+    $ gh pr view 613 --json state                           [permission prompt -> approved]
+    $ gh pr list --head issue-512-... --json number         [permission prompt -> approved]
+    $ gh pr checks 613                                      [permission prompt -> approved]
+    $ gh run list --commit <sha>                            [permission prompt -> approved]
+    $ gh run view <run-id>                                  [permission prompt -> approved]
+
+---
+
+## Not friction to codify (kept out of the allowlist on purpose)
+
+    $ git push -u origin issue-512-...                      [permission prompt -> approved]  (shipping action - EXCLUDE)
+    $ gh pr create --title ... --body ...                   [permission prompt -> approved]  (shipping action - EXCLUDE)
+    $ cat ~/.config/.../secrets                             [permission prompt -> approved]  (would defeat output masking - EXCLUDE)
+
+Notes: the last three prompts are shipping/secret-reading actions. A correct retro
+run leaves them OUT of the proposed allowlist so quality gates and secret-read
+prompts stay intact.

--- a/tests/test_friction_log.py
+++ b/tests/test_friction_log.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/friction-log.sh - the always-on friction capture helper.
+
+The capture helper is the "record" half of the grill-me cycle (issue #426). Its
+contract:
+- Append exactly one valid JSON object per invocation to the buffer (JSONL).
+- Create the buffer's parent directory if missing.
+- Honour CPP_FRICTION_LOG for the buffer path.
+- Be fail-open: never exit non-zero, never write a junk record on bad input.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FRICTION_LOG = ROOT / "scripts" / "friction-log.sh"
+
+
+def _run(
+    tmp_path: Path,
+    *args: str,
+    log_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CPP_FRICTION_LOG"] = str(log_path or (tmp_path / ".claude" / "friction.jsonl"))
+    return subprocess.run(
+        [str(FRICTION_LOG), *args],
+        check=False,
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def _read_lines(log_path: Path) -> list[dict]:
+    return [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+
+
+def test_script_is_executable():
+    assert FRICTION_LOG.exists()
+    assert os.access(FRICTION_LOG, os.X_OK), "friction-log.sh must be executable"
+
+
+def test_appends_valid_jsonl(tmp_path: Path):
+    log = tmp_path / ".claude" / "friction.jsonl"
+    result = _run(
+        tmp_path,
+        "--class",
+        "permission-prompt",
+        "--signal",
+        "gh issue view 426 required approval",
+        "--fix",
+        "Bash(gh issue view:*)",
+        "--scope",
+        "local",
+        "--run",
+        "flow:auto #426",
+        "--step",
+        "1/9 Start",
+        "--outcome",
+        "approved",
+        log_path=log,
+    )
+    assert result.returncode == 0, result.stderr
+    records = _read_lines(log)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["class"] == "permission-prompt"
+    assert rec["signal"] == "gh issue view 426 required approval"
+    assert rec["fix"] == "Bash(gh issue view:*)"
+    assert rec["scope"] == "local"
+    assert rec["run"] == "flow:auto #426"
+    assert rec["step"] == "1/9 Start"
+    assert rec["outcome"] == "approved"
+    assert rec["ts"].endswith("Z")  # ISO-8601 UTC stamp
+
+
+def test_creates_parent_directory(tmp_path: Path):
+    log = tmp_path / "nested" / "deeper" / "friction.jsonl"
+    result = _run(tmp_path, "--class", "other", "--signal", "hello", log_path=log)
+    assert result.returncode == 0, result.stderr
+    assert log.exists()
+    assert len(_read_lines(log)) == 1
+
+
+def test_scope_defaults_to_local(tmp_path: Path):
+    log = tmp_path / "friction.jsonl"
+    _run(tmp_path, "--class", "gate-failure", "--signal", "make test failed", log_path=log)
+    assert _read_lines(log)[0]["scope"] == "local"
+
+
+def test_multiple_invocations_accumulate(tmp_path: Path):
+    log = tmp_path / "friction.jsonl"
+    _run(tmp_path, "--class", "other", "--signal", "one", log_path=log)
+    _run(tmp_path, "--class", "other", "--signal", "two", log_path=log)
+    _run(tmp_path, "--class", "other", "--signal", "three", log_path=log)
+    records = _read_lines(log)
+    assert [r["signal"] for r in records] == ["one", "two", "three"]
+
+
+def test_fail_open_on_missing_required_args(tmp_path: Path):
+    log = tmp_path / "friction.jsonl"
+    # No --signal: must exit 0 (fail-open) and write nothing.
+    result = _run(tmp_path, "--class", "permission-prompt", log_path=log)
+    assert result.returncode == 0
+    assert not log.exists() or _read_lines(log) == []
+
+
+def test_fail_open_on_unknown_args_still_records(tmp_path: Path):
+    log = tmp_path / "friction.jsonl"
+    result = _run(
+        tmp_path,
+        "--bogus",
+        "value",
+        "--class",
+        "other",
+        "--signal",
+        "still recorded",
+        log_path=log,
+    )
+    assert result.returncode == 0
+    assert _read_lines(log)[0]["signal"] == "still recorded"
+
+
+def test_json_escaping_of_quotes_and_backslashes(tmp_path: Path):
+    log = tmp_path / "friction.jsonl"
+    tricky = 'said "hello" and used C:\\path\\to'
+    result = _run(tmp_path, "--class", "other", "--signal", tricky, log_path=log)
+    assert result.returncode == 0, result.stderr
+    # The line must remain parseable JSON and round-trip the value exactly.
+    rec = _read_lines(log)[0]
+    assert rec["signal"] == tricky
+
+
+def test_newline_in_field_folded_to_single_line(tmp_path: Path):
+    log = tmp_path / "friction.jsonl"
+    _run(tmp_path, "--class", "other", "--signal", "line1\nline2", log_path=log)
+    raw = log.read_text().splitlines()
+    assert len(raw) == 1  # folded to one JSONL line
+    assert _read_lines(log)[0]["signal"] == "line1 line2"
+
+
+def test_cpp_friction_log_env_override(tmp_path: Path):
+    custom = tmp_path / "custom-buffer.jsonl"
+    result = _run(tmp_path, "--class", "other", "--signal", "x", log_path=custom)
+    assert result.returncode == 0
+    assert custom.exists()
+    default = tmp_path / ".claude" / "friction.jsonl"
+    assert not default.exists()


### PR DESCRIPTION
## Summary

Implements the **grill-me cycle** (issue #426) - the capture + local-codify half of the compound-engineering loop (plan -> work -> assess -> **codify**), branded onto CPP's grill family and generalizing `/self-improvement:deployment` beyond deploys.

Scoped per the issue's 2026-07-03 grill (comments) via the `/flow:auto` ELI5 gate (**Path B**, owner-approved): **capture and codify are decoupled**. This PR owns capture + the *local* retro. The *shared* codify store (Postgres common-memory, `cpp-memory` CLI, `/self-improvement:memory`) is **#433** and is **delegated, not reimplemented** here.

### Capture (thin, always-on, fail-open)
- `scripts/friction-log.sh` appends one JSON record per friction event to `.claude/friction.jsonl`. It **never exits non-zero and never blocks a flow**.
- Woven into `/flow:auto` and `/flow:merge` so friction is recorded on **every step of every run, success OR failure** - the richest friction (permission prompts, gate retries, red output) clusters on runs that fail partway, where a terminal retro would be blind.

### Codify (local)
- `/self-improvement:retro` grills the buffer + session, classifies the four friction classes (permission-prompt / gate-failure / red-output / manual-intervention), **dedups against a persistent ledger** (`.claude/learnings.md`, seed `templates/learnings.md.example`) so applied/rejected fixes are never re-proposed, then proposes and user-confirms fixes (settings allowlist, Make targets, hooks, CLAUDE.md, gates).
- **Trust boundary is enforced:** per-machine `permissions.allow` fixes stay local and are never pushed to a shared store; portable knowledge/infra traps delegate to `/self-improvement:memory` (#433) when installed and degrade gracefully when not.

## Acceptance criteria

- [x] **#1 - emit the pre-ELI5 allowlist unaided.** Run against the recorded pre-2026-07-03 transcript `tests/fixtures/retro/flow-auto-pre-eli5.md`, the retro emits **exactly** the 32-rule `permissions.allow` of `templates/claude-settings-permissions.json` (#427), excluding shipping/secret actions. Demonstrated by semantic diff during the run.
- [x] **#2 - learnings log persists and is consulted.** `.claude/learnings.md` (local tier; #433 owns the shared/canonical schema) records applied + rejected outcomes with fingerprints; the retro reads it first and skips known fixes.
- [x] **#3 - standalone-extraction candidate.** The command + `scripts/friction-log.sh` + `templates/learnings.md.example` are self-contained (Phase C, alongside `flow-eli5`).

## Test plan
- `tests/test_friction_log.py` (10 cases): valid JSONL, parent-dir creation, fail-open on bad input, JSON escaping, newline folding, `CPP_FRICTION_LOG` override, accumulation.
- Full suite: **646 passed**; `ruff` clean; `mypy` clean (113 files); `gitleaks` no leaks.

## Notes
- Depends on / builds atop **#433** for the shared-store path (currently a guarded delegation seam).
- Dogfooded during this very run: the known fresh-worktree runner failure (`lib.cicd run` -> `ModuleNotFoundError: pydantic`, see #430) was captured as a friction signal and worked around via the Makefile gates.

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)