### PR TITLE
fix(flow): harden runner invocation + guard silently-ignored files (Closes #430)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -245,17 +245,41 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
      fi
    done
 
-   if [ -n "$CPP_DIR" ]; then
-       PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+   RUNNER_RAN=0
+   if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+       # Invoke through uv so lib/cicd's deps (pydantic) resolve and the
+       # interpreter is pinned >= 3.11. Bare `python3 -m lib.cicd` uses the
+       # system interpreter (often 3.10, no venv) inside a fresh worktree and
+       # dies on ModuleNotFoundError - silently degrading to the fallback in
+       # exactly the environment /flow:auto always creates (issue #430).
+       # PYTHONPATH must point at CPP_DIR (the PARENT of lib/) so `-m lib.cicd`
+       # resolves for external projects too, not just when dogfooding CPP.
+       PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
        RUNNER_EXIT=$?
+       RUNNER_RAN=1
+   fi
+
+   if [ "$RUNNER_RAN" -eq 0 ]; then
+       REASON=$([ -z "$CPP_DIR" ] && echo "CPP checkout not found" || echo "uv not installed")
+       echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback." >&2
    fi
    ```
 
-   - If runner succeeds (exit 0): quality gates passed, proceed to commit.
-   - If runner fails: parse JSON output, report the failed step, **STOP**.
+   - If runner ran and **succeeds** (exit 0): quality gates passed, proceed to commit.
+   - If runner ran and **fails**: parse JSON output, report the failed step, **STOP**.
 
-   **Fallback** (only if runner unavailable): Run `make lint` and `make test` directly.
+   **Fallback** (only when the runner did not run, `RUNNER_RAN=0`): Run `make lint` and `make test` directly (these bootstrap the venv via `uv run`).
    - If either fails: **STOP**. Report the failure and exit.
+
+   **Ignored-additions guard** (issue #430, Finding 1): before committing, warn
+   if a blanket `.gitignore` rule silently swallowed a new file you meant to
+   track (`git add` no-ops with no error):
+   ```bash
+   if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/check-ignored-additions.sh" ]; then
+       "$CPP_DIR/scripts/check-ignored-additions.sh"   # advisory: warns, never blocks
+   fi
+   ```
+   If it warns, add a `!negation` to `.gitignore` for any intended file and re-stage.
 
 2. **Commit** - if there are uncommitted changes:
    - Use conventional commit format: `type(scope): Description (Closes #N)`

--- a/.claude/commands/flow/check.md
+++ b/.claude/commands/flow/check.md
@@ -100,9 +100,12 @@ fi
 
 ### Step 5: Run Makefile Completeness Check (optional)
 
+Invoke via `uv run` so `lib/cicd`'s deps resolve under a pinned >= 3.11
+interpreter; bare `python3` crashes in a fresh worktree (#430).
+
 ```bash
-if [[ "$HAS_CICD" == "true" ]] && [[ -f "Makefile" ]]; then
-    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary
+if [[ "$HAS_CICD" == "true" ]] && [[ -f "Makefile" ]] && command -v uv >/dev/null 2>&1; then
+    PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd check --summary
     CICD_EXIT=$?
     CHECKS_RUN=$((CHECKS_RUN + 1))
     if [[ $CICD_EXIT -eq 0 ]]; then
@@ -110,6 +113,22 @@ if [[ "$HAS_CICD" == "true" ]] && [[ -f "Makefile" ]]; then
     else
         CHECKS_WARN=$((CHECKS_WARN + 1))  # Non-blocking
     fi
+fi
+```
+
+### Step 5b: Guard Against Silently-Ignored New Files (advisory)
+
+A blanket `.gitignore` rule (e.g. `*.json`) can swallow a file you meant to
+commit - `git add` no-ops with no error (issue #430, Finding 1). Surface it:
+
+```bash
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/check-ignored-additions.sh" ]; then
+    "$CPP_DIR/scripts/check-ignored-additions.sh"
+    IGN_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    # Advisory only: the script exits 0 even when it warns, so this never fails
+    # the check. Any warning it prints is surfaced to the user for review.
+    CHECKS_PASS=$((CHECKS_PASS + 1))
 fi
 ```
 

--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -69,8 +69,11 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
   if [ -d "$dir/lib/cicd" ]; then CPP_DIR="$dir"; break; fi
 done
 
-if [ -n "$CPP_DIR" ] && [ ! -f "Makefile" ]; then
-  DETECTED=$(PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -c "
+# Invoke lib.cicd via uv so its deps (pydantic) resolve under a pinned >= 3.11
+# interpreter; PYTHONPATH points at CPP_DIR (parent of lib/) so `-m lib.cicd`
+# resolves from any project cwd. Bare python3 crashes in a venv-less tree (#430).
+if [ -n "$CPP_DIR" ] && [ ! -f "Makefile" ] && command -v uv >/dev/null 2>&1; then
+  DETECTED=$(PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -c "
 from lib.cicd.detector import detect_framework
 info = detect_framework('.')
 print(f'{info.framework.value}:{info.package_manager.value}')
@@ -180,11 +183,11 @@ If `CPP_DIR` is found, run these checks:
 # 1. cicd.yml config file
 [ -f ".claude/cicd.yml" ] && echo "PASS cicd.yml" || echo "MISSING cicd.yml"
 
-# 2. Framework detection
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect --quiet 2>/dev/null
+# 2. Framework detection (via uv so deps resolve; PYTHONPATH=CPP_DIR, see #430)
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd detect --quiet 2>/dev/null
 
 # 3. Makefile completeness (uses lib/cicd check)
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary 2>/dev/null
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd check --summary 2>/dev/null
 
 # 4. Health check configuration
 grep -q "endpoints:" .claude/cicd.yml 2>/dev/null && echo "PASS health endpoints" || echo "MISSING health endpoints"

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -34,15 +34,28 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
   fi
 done
 
-if [ -n "$CPP_DIR" ]; then
-    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+RUNNER_RAN=0
+if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+    # Invoke through uv so lib/cicd's deps (pydantic) resolve and the
+    # interpreter is pinned >= 3.11. Bare `python3 -m lib.cicd` uses the
+    # system interpreter (often 3.10, no venv) inside a fresh worktree and
+    # dies on ModuleNotFoundError, silently degrading to the fallback (#430).
+    # PYTHONPATH must point at CPP_DIR (the PARENT of lib/) so `-m lib.cicd`
+    # resolves for external projects too, not just when dogfooding CPP.
+    PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
     RUNNER_EXIT=$?
+    RUNNER_RAN=1
+fi
+
+if [ "$RUNNER_RAN" -eq 0 ]; then
+    REASON=$([ -z "$CPP_DIR" ] && echo "CPP checkout not found" || echo "uv not installed")
+    echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback." >&2
 fi
 ```
 
-- If runner **succeeds** (exit 0): quality gates passed, skip to Step 2d.
-- If runner **fails** (exit non-zero): parse the JSON output for the failed step, report it, and **stop**.
-- If runner is **not available** (no CPP_DIR or import error): fall back to manual execution below.
+- If runner ran and **succeeds** (exit 0): quality gates passed, skip to Step 2d.
+- If runner ran and **fails** (exit non-zero): parse the JSON output for the failed step, report it, and **stop**.
+- If the runner **did not run** (`RUNNER_RAN=0` - no CPP_DIR or no uv): fall back to manual execution below.
 
 **Fallback path** (only if runner unavailable):
 
@@ -134,11 +147,15 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
 done
 ```
 
-If `CPP_DIR` is found and a Makefile exists:
+If `CPP_DIR` is found, `uv` is available, and a Makefile exists (invoke via
+`uv run` so `lib/cicd`'s deps resolve under a pinned >= 3.11 interpreter - bare
+`python3` crashes in a fresh worktree, see #430):
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary
-CHECK_EXIT=$?
+if command -v uv >/dev/null 2>&1; then
+    PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd check --summary
+    CHECK_EXIT=$?
+fi
 ```
 
 - If check reports **missing required targets**: display as a warning but **do NOT block**.
@@ -158,6 +175,20 @@ CHECK_EXIT=$?
 # Check for uncommitted changes
 git status --porcelain
 ```
+
+**Guard against silently-ignored new files** (issue #430, Finding 1). A
+blanket `.gitignore` rule (e.g. `*.json`) can swallow a file you meant to
+commit - `git add` no-ops with no error. Surface it before committing:
+
+```bash
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/check-ignored-additions.sh" ]; then
+    "$CPP_DIR/scripts/check-ignored-additions.sh"   # advisory: warns, never blocks
+fi
+```
+
+- If it warns, confirm each listed file is genuinely scratch. If any is an
+  intended addition, add a `!negation` to `.gitignore` (or narrow the blanket
+  rule) and re-stage before committing.
 
 - If there are uncommitted changes, help the user commit them using standard git commit workflow.
 - Use conventional commit format: `type(scope): Description (Closes #N)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Core components and their locations:
 - `lib/creds/` - Secrets management (dotenv/AWS SM, FastAPI UI, audit logging)
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
-- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift, speckit-tasks-to-issues, playwright-desk lease-desk ledger)
+- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
 - `templates/` - Makefile, workflow, container templates
 - `docker-compose.yml` - MCP server orchestration (profiles: `core`, `browser`)
 - `.woodpecker.yml` - Woodpecker CI pipeline (lint, test, typecheck, image security gates, runtime smoke)

--- a/scripts/check-ignored-additions.sh
+++ b/scripts/check-ignored-additions.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# check-ignored-additions.sh - Warn when a working-tree file is git-ignored
+# but looks like an intentional source addition (the blanket-ignore trap).
+#
+# Motivation: .gitignore uses blanket rules with hand-maintained negation
+# allow-lists (e.g. `*.json` + `!package.json` + `!renovate.json`, or the
+# `.dockerignore *.md` incident in agentic-asst #452). When you author a new
+# file the repo *should* track, `git add` silently no-ops - nothing fails
+# until someone notices the file never got committed. This guard makes that
+# loud instead of silent.
+#
+# Strategy: `git status --ignored=matching` lists every ignored file
+# individually (it does NOT collapse whole ignored directories the way the
+# default mode does, so a file in a brand-new all-ignored directory is still
+# seen). We then drop the usual scratch/build noise by scanning each path
+# component against a known set of cache/venv/build dir names, plus a few
+# scratch file patterns. What remains is an ignored file sitting in a tracked
+# source area - the trap - which we warn about. Near-zero false positives
+# against normal venv/cache noise.
+#
+# Usage:
+#   check-ignored-additions.sh [--strict]
+#
+# Options:
+#   --strict   Exit non-zero (3) when suspicious ignored files are found.
+#              Default is advisory: always exit 0, just print the warning.
+#
+# Output:
+#   Prints a "[flow] WARNING" block listing suspicious ignored files with a
+#   remediation hint. Prints nothing (exit 0) when clean.
+
+set -euo pipefail
+
+STRICT=0
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=1 ;;
+    *) echo "check-ignored-additions.sh: unknown option '$arg'" >&2; exit 2 ;;
+  esac
+done
+
+# Not a git repo -> nothing to check.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Path components that mark a scratch/build/cache tree (matched at any depth).
+_SCRATCH_DIRS=".git .venv venv env __pycache__ node_modules .pytest_cache \
+.ruff_cache .mypy_cache .tox .nox .cache .eggs dist build htmlcov coverage \
+.next .turbo .parcel-cache site-packages artifacts"
+
+is_scratch() {
+  # Scratch by file pattern.
+  case "$1" in
+    *.pyc|*.pyo|*.log|*.swp|*~|*.DS_Store|.coverage) return 0 ;;
+  esac
+  # Scratch by any path component (dir name or *.egg-info).
+  local comp
+  local IFS='/'
+  for comp in $1; do
+    case " $_SCRATCH_DIRS " in *" $comp "*) return 0 ;; esac
+    case "$comp" in *.egg-info) return 0 ;; esac
+  done
+  return 1
+}
+
+suspicious=()
+while IFS= read -r -d '' entry; do
+  # porcelain -z format: 2-char status, a space, then the path.
+  status="${entry:0:2}"
+  path="${entry:3}"
+  [ "$status" = "!!" ] || continue
+  case "$path" in */) continue ;; esac   # defensive: skip any dir entry
+  is_scratch "$path" && continue
+  suspicious+=("$path")
+done < <(git status --ignored=matching --porcelain -z 2>/dev/null)
+
+if [ "${#suspicious[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+echo "[flow] WARNING: ${#suspicious[@]} file(s) are git-ignored and will NOT be committed:" >&2
+for p in "${suspicious[@]}"; do
+  reason="$(git check-ignore -v "$p" 2>/dev/null || echo "(ignored)")"
+  echo "  - $p    <- $reason" >&2
+done
+echo "" >&2
+echo "  If these are intentional additions, add a negation to .gitignore" >&2
+echo "  (e.g. '!$( [ "${#suspicious[@]}" -ge 1 ] && echo "${suspicious[0]}" )') or narrow the blanket rule." >&2
+echo "  If they are scratch files, ignore this warning." >&2
+
+if [ "$STRICT" -eq 1 ]; then
+  exit 3
+fi
+exit 0

--- a/tests/test_check_ignored_additions.py
+++ b/tests/test_check_ignored_additions.py
@@ -1,0 +1,93 @@
+"""Regression tests for the silently-ignored-file guard (issue #430, Finding 1).
+
+The `.gitignore` blanket-ignore + negation-allowlist pattern silently drops
+new files the repo should track. `scripts/check-ignored-additions.sh` makes
+that loud. These tests pin its behaviour: warn on an individual ignored file
+in a tracked source dir, stay silent on the usual venv/cache noise.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "scripts" / "check-ignored-additions.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _init_repo(repo: Path, gitignore: str) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / ".gitignore").write_text(gitignore, encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-q", "-m", "init")
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(GUARD), *args], cwd=repo, capture_output=True, text=True
+    )
+
+
+def test_clean_repo_is_silent(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, "*.json\n!package.json\n")
+    result = _run(repo)
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_warns_on_ignored_source_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, "*.json\n!package.json\n")
+    (repo / "templates").mkdir()
+    (repo / "templates" / "new-config.json").write_text("{}", encoding="utf-8")
+
+    result = _run(repo)
+    assert result.returncode == 0  # advisory by default
+    assert "WARNING" in result.stderr
+    assert "templates/new-config.json" in result.stderr
+
+
+def test_strict_exits_nonzero_on_finding(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, "*.json\n")
+    (repo / "data.json").write_text("{}", encoding="utf-8")
+
+    result = _run(repo, "--strict")
+    assert result.returncode == 3
+    assert "data.json" in result.stderr
+
+
+def test_ignores_venv_and_cache_noise(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, ".venv/\n__pycache__/\n*.pyc\n")
+    # The usual scratch noise: a whole ignored dir + a stray pyc.
+    venv = repo / ".venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+    pycache = repo / "pkg" / "__pycache__"
+    pycache.mkdir(parents=True)
+    (pycache / "mod.cpython-311.pyc").write_text("x", encoding="utf-8")
+
+    result = _run(repo)
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_negated_file_is_not_flagged(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, "*.json\n!renovate.json\n")
+    # renovate.json is negated -> tracked, so it must NOT be reported.
+    (repo / "renovate.json").write_text("{}", encoding="utf-8")
+
+    result = _run(repo)
+    assert result.returncode == 0
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary

Fixes the three retro findings from `/flow:auto #427` (issue #430). All three were reproduced live before fixing.

### Finding 1 - `.gitignore *.json` blanket silently drops new repo files
`git add templates/foo.json` no-ops with no error when a blanket rule swallows it.
- **New:** `scripts/check-ignored-additions.sh` - lists `git status --ignored=matching` files, filters venv/cache/build noise by path component, warns on any remaining ignored file in a tracked source area (the trap). Advisory (exit 0), `--strict` opt-in.
- Wired as a non-blocking guard into `/flow:finish` (Step 3), `/flow:check` (Step 5b), `/flow:auto` (Step 6).
- **Kept the blanket rule** - narrowing to root-only is unsafe: it also protects generated SBOM/coverage JSON in subdirs (only 3 JSON files are tracked repo-wide).

### Finding 2 - deterministic runner died in fresh worktrees
`python3 -m lib.cicd` used system 3.10 (no venv) → `ModuleNotFoundError: pydantic` → silent degrade to Makefile fallback, in exactly the environment `/flow:auto` always creates.
- Now invoked via `uv run --project "$CPP_DIR"` (resolves pydantic, pins interpreter >= 3.11).
- **Also fixed a latent path bug:** `PYTHONPATH` must point at `$CPP_DIR` (parent of `lib/`), not `$CPP_DIR/lib`, so `-m lib.cicd` resolves for external projects - the old form only worked via cwd shadowing when dogfooding CPP itself.
- Added an honest `runner unavailable, using Makefile fallback` note instead of degrading silently.
- Applied across `auto.md`, `finish.md`, `check.md`, `doctor.md`.

### Finding 3 - stale global `flow-doctor` mirror
Regenerated `~/.claude/skills/flow-doctor/SKILL.md` (a hand-maintained file **outside this repo**, so not in this diff) from the canonical `doctor.md`. It had described the abandoned agent-power-pack architecture (AGENTS.md canonicalization, manifest validator, `claude-power-pack` CLI on PATH, six MCP servers on dual stdio+SSE incl. plane/wikijs/nano-banana/woodpecker, spec-kit constitution) - all retired.
- **Audit delivered** (mirror staleness across all 11 flow-* mirrors): `flow-doctor` (38 markers), `flow-auto` (35), `flow-finish` (20) are on the abandoned architecture; the rest are mostly incidental.
- **Deferred to epic #417 Phase B** (dual-surface elimination / marketplace packaging): full `flow-auto`/`flow-finish` mirror regeneration - regenerating them now risks throwaway work if Phase B removes the global-skills surface entirely.

## Test plan
- [x] `scripts/check-ignored-additions.sh` unit tests (`tests/test_check_ignored_additions.py`, 5 cases: clean / warns-on-source-file / --strict / venv-cache-noise-ignored / negated-file-not-flagged)
- [x] Reproduced Finding 2 crash on system py3.10; verified `uv run` fix (exit 0, 3/3 gates)
- [x] Verified corrected `PYTHONPATH=$CPP_DIR` form resolves `lib.cicd` from a non-CPP cwd
- [x] `lib.cicd run --plan finish` green (lint + test + security_scan)
- [x] `mypy` clean on the new test module
- [x] Regenerated mirror verified free of stale-architecture markers

Closes #430