### PR TITLE
fix(tests): skip git-dependent guard tests where git is unavailable (Closes #430)

### DIFF
--- a/tests/test_check_ignored_additions.py
+++ b/tests/test_check_ignored_additions.py
@@ -8,11 +8,23 @@ in a tracked source dir, stay silent on the usual venv/cache noise.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 GUARD = ROOT / "scripts" / "check-ignored-additions.sh"
+
+# These tests drive real `git` and `bash` subprocesses. The Woodpecker
+# `validate` step runs in `uv:python3.11-bookworm-slim`, which ships bash but
+# NOT git, so without this guard the module errors (FileNotFoundError) and
+# fails CI. Skip cleanly where git/bash are unavailable (issue #430).
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="requires git and bash on PATH",
+)
 
 
 def _git(repo: Path, *args: str) -> None:


### PR DESCRIPTION
## Summary

Fix-forward for the CI regression introduced by #449. `tests/test_check_ignored_additions.py` shells out to real `git` and `bash` via subprocess. The Woodpecker `validate` step runs in `ghcr.io/astral-sh/uv:python3.11-bookworm-slim`, which ships **bash but not git**, so the module raised `FileNotFoundError` and failed CI.

**Evidence:** pipelines #496, #502, #504 all failed at `validate` (exit 1); every other recent main pipeline was green - the regression was isolated to these new tests. No existing test uses a real `git` subprocess (they all mock it via a fake bin dir).

## Fix

Module-level `pytest.mark.skipif(shutil.which("git") is None or shutil.which("bash") is None)` - the suite skips cleanly in the git-less validate container while still running (and passing) everywhere git is present (local dev, where the guard actually runs).

## Test plan (verified)
- [x] **git present (local):** `5 passed`
- [x] **git absent (exact `uv:python3.11-bookworm-slim` image via docker):** `git ABSENT (as in CI)` -> `5 skipped`, pytest exit 0
- [x] `ruff check` + `mypy` clean on the changed file

Closes #430