### PR TITLE
docs(security): defer semantic scan to native /security-review, keep gitleaks/git-history/pip-audit orchestration (Closes #438)

### DIFF
--- a/.claude/commands/security/deep.md
+++ b/.claude/commands/security/deep.md
@@ -7,6 +7,12 @@ allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Read(*.py), Read(*.yml)
 
 Thorough security scan including git history analysis. Runs all native and external scanners.
 
+> **Semantic code review?** For code-logic vulnerabilities (SQL injection, XSS,
+> authorization, insecure credential handling), use Claude Code's native
+> **`/security-review`**. This command is the *deterministic* complement - its
+> distinctive value is **git-history secret scanning**, which native review
+> does not perform.
+
 ## Arguments
 
 - `--json` - Output as JSON

--- a/.claude/commands/security/explain.md
+++ b/.claude/commands/security/explain.md
@@ -38,3 +38,8 @@ Get a detailed explanation of a specific security finding type.
 ```bash
 PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security explain "$@"
 ```
+
+> These finding IDs cover CPP's *deterministic* checks (secrets, dependencies,
+> config). For semantic code-vulnerability review - SQL injection, XSS,
+> authorization, insecure credential handling - use Claude Code's native
+> **`/security-review`**.

--- a/.claude/commands/security/help.md
+++ b/.claude/commands/security/help.md
@@ -2,6 +2,25 @@
 
 Novice-friendly security scanning for Claude Code projects.
 
+## Scope: the deterministic half
+
+Claude Code ships a native **`/security-review`** command (plus an official
+GitHub Action) that performs **semantic** code-vulnerability review - reasoning
+about SQL injection, XSS, broken authorization, and insecure credential
+handling by reading your code. For that class of review, use `/security-review`.
+
+CPP's `/security:*` commands own the **deterministic** complement that native
+review does not provide:
+
+- **Secret scanning** - gitleaks plus zero-dependency native patterns
+- **Git-history scanning** - secrets committed and later removed (`/security:deep`)
+- **Dependency CVE audits** - `pip-audit`, `npm audit`
+- **The blocking gate** - CRITICAL findings block `/flow:finish` and `/flow:deploy`
+  (see [Severity Levels](#severity-levels))
+
+The two halves are complementary: run `/security-review` for code-logic flaws,
+and `/security:*` for secrets, dependencies, and the flow gate.
+
 ## Commands
 
 | Command | Purpose |

--- a/.claude/commands/security/quick.md
+++ b/.claude/commands/security/quick.md
@@ -7,6 +7,11 @@ allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Read(*.py), Read(*.yml)
 
 Fast security scan using only built-in native scanners. No external tools required.
 
+> **Semantic code review?** For SQL injection, XSS, authorization, and insecure
+> credential handling, use Claude Code's native **`/security-review`**. This
+> command covers the *deterministic* complement - fast secret and config checks
+> with zero dependencies.
+
 ## Arguments
 
 - `--json` - Output as JSON

--- a/.claude/commands/security/scan.md
+++ b/.claude/commands/security/scan.md
@@ -7,6 +7,12 @@ allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Read(*.py), Read(*.yml)
 
 Run a full security scan using native checks plus any available external tools.
 
+> **Semantic code review?** For code-logic vulnerabilities - SQL injection, XSS,
+> broken authorization, insecure credential handling - use Claude Code's native
+> **`/security-review`** (and its GitHub Action). This command is the
+> *deterministic* complement: secret scanning (gitleaks + patterns) and
+> dependency CVE audits (`pip-audit`, `npm audit`). Run both for full coverage.
+
 ## Arguments
 
 - `--json` - Output as JSON (machine-readable)

--- a/.specify/grills/2026-07-03-issue-438.md
+++ b/.specify/grills/2026-07-03-issue-438.md
@@ -1,0 +1,37 @@
+# Grill-yourself - Issue #438 (security split)
+
+Date: 2026-07-03
+Trigger: file-count > 5 (7 repo files + 4 global skills). Change is docs/positioning only.
+Verdict: **yes-with-caveats**
+
+## Interrogation
+
+**Q1. Does CPP /security:* actually perform semantic scanning (SQLi/XSS/authz) that must be removed?**
+No. `grep -rinE "sqli|xss|authz|owasp|injection"` over `.claude/commands` + `lib/security` finds
+nothing. CPP does *deterministic* scanning only (gitleaks, git-history, pip-audit, npm audit, native
+secret/gitignore/permission/env/debug checks). "Defer semantic to native /security-review" is therefore a
+**boundary-clarification**, not a code removal. No scanner deleted.
+
+**Q2. Is CLAUDE.md generated from AGENTS.md? Would the linter revert my edits?**
+No. CLAUDE.md has no GENERATED marker; there is no AGENTS.md in the repo. CLAUDE.md is hand-maintained
+canonical. Direct edit of its Security section is correct. Step-6 agents-md:lint is N/A (no AGENTS.md).
+
+**Q3. Does the change break the CRITICAL-blocks gate?**
+No. Gate logic lives in `lib/security/orchestrator.py:check_gate` + `lib/cicd/steps.py` StepDefs +
+`flow/finish.md` Step 2b / `flow/deploy.md` Step 4b. All left byte-for-byte unchanged. Task 3 = "preserve".
+
+**Q4. Risk in adding lib/security/README.md + editing 5 command docs + CLAUDE.md?**
+Inert markdown. `make verify` (lint+tests) unaffected - no Python touched. Confirm with make verify at Step 7.
+
+**Q5. Global ~/.claude/skills/security-* are GENERATED-marked orphans referencing a retired manifests/ path.
+Editing them by hand contradicts the marker.**
+User explicitly approved fixing them; the generator is retired (single source = repo commands now). Hand-edit
+is a deliberate, user-approved exception. They are OUTSIDE the git tree -> not in the PR/CI (local-only).
+
+## Caveats carried into implementation
+- C1: Wording MUST NOT imply CPP stopped detecting secrets. Only *semantic code-logic* review defers to
+  native /security-review; deterministic secret/dep/history scanning is KEPT.
+- C2: CLAUDE.md safe to edit directly (not generated).
+- C3: Step-6 agents-md:lint N/A (no AGENTS.md); make verify is the real gate.
+- C4: Global skills = user-approved hand-edit of generated orphans; local-only, not in PR.
+- C5: No churn to lib/security/*.py, flow finish/deploy, lib/cicd/steps.py.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,12 +188,21 @@ Flow commands use Makefile targets as the canonical build interface:
 
 ## Security
 
+Security is split into two complementary halves. **Semantic** code-vulnerability
+review - SQL injection, XSS, broken authorization, insecure credential handling -
+is handled by Claude Code's native **`/security-review`** command and its GitHub
+Action; CPP defers to it and does not duplicate it. CPP's `/security:*` commands
+and `lib/security` own the **deterministic** complement: secret scanning
+(gitleaks + native patterns), git-history secret scanning, dependency CVE audits
+(`pip-audit`, `npm audit`), and the blocking gate. See `lib/security/README.md`.
+
 - **Destructive commands** (force push to main, `rm -rf /`, disk formatting, etc.) are blocked by Claude Code's native destructive-git auto-blocking and OS sandbox - the custom PreToolUse dangerous-command hook was retired (issue #439) as redundant.
 - **PostToolUse hook** masks secrets in Bash/Read output (connection strings, API keys, env vars). Retained because native tooling blocks credential *reads* but does not *mask* secrets that surface in output.
 - **Hooks configured in** `.claude/hooks.json` (SessionStart + PostToolUse)
-- `/flow:finish` and `/flow:deploy` run security quick scan as quality gates
+- `/flow:finish` and `/flow:deploy` run the deterministic security scan (`lib/security`) as a quality gate
 - CRITICAL findings block gates; HIGH findings produce warnings
 - Configure gating in `.claude/security.yml` (optional, created by `/security:scan` when needed)
+- For **semantic** code review (SQLi/XSS/authz/insecure handling), run native `/security-review` - not a CPP command
 - **User-level flow allowlist** (`templates/claude-settings-permissions.json`) auto-approves the read-only git/gh plumbing that `/flow:*` runs; shipping actions (`git push`, `gh pr create`) and `cat` are deliberately excluded so gates and secret-read prompts stay intact. Merged via `/cpp:init` or `/cpp:update` Step 7.6; checked by `/flow:doctor`. Rationale: `templates/claude-settings-permissions.md`
 
 ## On-Demand Documentation

--- a/lib/security/README.md
+++ b/lib/security/README.md
@@ -1,0 +1,100 @@
+# `lib/security` - deterministic security orchestration
+
+This module is the **deterministic half** of Claude Power Pack's security
+surface. It backs the `/security:quick`, `/security:scan`, `/security:deep`,
+and `/security:explain` commands and the CRITICAL-blocks gate used by
+`/flow:finish` and `/flow:deploy`.
+
+## The split: semantic vs. deterministic
+
+Claude Code ships a native **`/security-review`** command (and an official
+GitHub Action) that performs **semantic** code-vulnerability review - reasoning
+about SQL injection, XSS, broken authorization, and insecure credential
+handling by reading the code. CPP **defers to it** for that class of review and
+does not duplicate it.
+
+`lib/security` owns the **deterministic** complement that native review does not
+provide:
+
+| Concern | Owner |
+|---------|-------|
+| SQLi / XSS / authz / insecure-handling (semantic code logic) | native `/security-review` |
+| Secret scanning (patterns + gitleaks) | `lib/security` |
+| Git-history secret scanning | `lib/security` (`/security:deep`) |
+| Dependency CVE audits (`pip-audit`, `npm audit`) | `lib/security` |
+| `.gitignore` / file-permission / `.env`-tracked / debug-flag checks | `lib/security` |
+| The blocking gate for `/flow:finish` and `/flow:deploy` | `lib/security` |
+
+The two halves are complementary - run `/security-review` for code-logic flaws
+and `lib/security` (`/security:*`) for secrets, dependencies, and the flow gate.
+
+## Entry points
+
+```bash
+# All commands honor --path <dir> (default: current project) and --json.
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security quick
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security scan
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security deep
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security explain HARDCODED_PASSWORD
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate flow_finish
+```
+
+## Scan modes
+
+| Mode | Scanners | Speed |
+|------|----------|-------|
+| `quick` | native only: secrets, `.gitignore`, permissions, `.env`-tracked, debug flags | ~1 s |
+| `scan` | `quick` + **gitleaks** (working tree) + **pip-audit** + **npm audit** (auto-detected) | ~5 s |
+| `deep` | `scan` + **gitleaks `--include_history`** (secrets committed then removed) | ~30 s |
+
+External tools (`gitleaks`, `pip-audit`, `npm audit`) are auto-detected via
+`shutil.which(...)` and skipped cleanly when absent - the native checks always
+run, so the module has no hard external dependency.
+
+## Modules (`lib/security/modules/`)
+
+| Module | Kind | Detects |
+|--------|------|---------|
+| `secrets.py` | native | AWS / OpenAI / Anthropic / GitHub / GitLab / Google / Slack keys; hardcoded passwords & secrets |
+| `gitignore.py` | native | sensitive patterns (`.env`, `*.key`, `*.pem`, `secrets/`) missing from `.gitignore` |
+| `permissions.py` | native | world-readable secret/key files |
+| `env_files.py` | native | `.env` files tracked by git |
+| `debug_flags.py` | native | debug mode enabled in production config |
+| `gitleaks.py` | external | secrets in working tree (and git history with `include_history=True`) |
+| `pip_audit.py` | external | Python dependency CVEs |
+| `npm_audit.py` | external | Node dependency CVEs |
+
+## The gate
+
+`python -m lib.security gate <gate_name>` runs the **quick native** scan, then
+`orchestrator.check_gate` compares findings against the named gate's policy and
+returns `(passed, messages)`. `/flow:finish` and `/flow:deploy` invoke this via
+`lib/cicd` StepDefs; a blocked gate stops the flow (no PR / no deploy).
+
+Default policies (`config.py`) - configurable in `.claude/security.yml`:
+
+| Gate | Blocks on | Warns on |
+|------|-----------|----------|
+| `flow_finish` | CRITICAL | HIGH |
+| `flow_deploy` | CRITICAL, HIGH | MEDIUM |
+
+Severities not listed pass silently. To tune gates or suppress a known false
+positive, create `.claude/security.yml`:
+
+```yaml
+gates:
+  flow_finish:
+    block_on: [critical]
+    warn_on: [high]
+  flow_deploy:
+    block_on: [critical, high]
+    warn_on: [medium]
+
+suppressions:
+  - id: HARDCODED_SECRET
+    path: tests/fixtures/.*
+    reason: "Test fixtures with fake credentials"
+```
+
+See `/security:explain <ID>` for details on any finding type, and
+`.claude/commands/security/help.md` for the command-surface overview.


### PR DESCRIPTION
## Summary
- Draw an explicit **semantic vs. deterministic** split across the `/security:*` surface.
- **Semantic** code-vulnerability review (SQL injection, XSS, broken authz, insecure credential handling) → point users to Claude Code's **native `/security-review`** (+ its GitHub Action).
- **Deterministic** half (secret scanning via gitleaks + native patterns, git-history secret scanning, `pip-audit`/`npm audit` dependency CVEs, and the blocking gate) → **retained and documented** in CPP.
- New `lib/security/README.md` documents the retained orchestration: entry points, scan modes, modules, and gate policy.
- `CLAUDE.md` Security section restated with the split.

## ELI5 / necessity verdict
**Still needed.** Issue filed 2026-07-03; no commit/PR since touches the security surface; distinct live sibling in epic #417 Phase A (alongside #439/#440/#441). Key finding during analysis: CPP's `/security:*` **never actually did semantic scanning** (no SQLi/XSS/authz code anywhere) — so "defer semantic to native" is a **boundary-clarification / positioning + documentation** change, not a code removal. **No scanner deleted; the CRITICAL-blocks gate is untouched.**

## Acceptance criteria
- [x] Repoint `/security:*` to defer semantic scanning to native `/security-review` (`quick`/`scan`/`deep`/`explain`/`help`)
- [x] Keep **and document** the deterministic gitleaks + git-history + pip-audit orchestration (`lib/security/README.md`)
- [x] Preserve CRITICAL-blocks-gate behavior in `/flow:finish` and `/flow:deploy` (gate code byte-for-byte unchanged)
- [x] Update `CLAUDE.md` Security section

## Lint result
`agents-md:lint` is **N/A** — CPP has no `AGENTS.md`; `CLAUDE.md` is hand-maintained canonical (no GENERATED marker), so direct edits are correct.

## Grill-yourself transcript
`.specify/grills/2026-07-03-issue-438.md` (fired on >5-file threshold; verdict **yes-with-caveats** — chiefly: wording must not imply CPP stopped detecting secrets; only *semantic code-logic* review defers).

## Second-opinion review
Skipped for this docs-only positioning change — verified directly against source instead (the flow **gate** runs `scan_quick` native-only; module list and gate defaults confirmed in `lib/security/config.py`).

## Notes
- The stale global `~/.claude/skills/security-*` skills (which referenced a retired `manifests/` generator path and still claimed SAST/OWASP/injection) were repositioned **locally** to match — outside the git tree, so not part of this PR/CI.

## Test plan
- [x] `make verify` green — 650 tests passed, mypy clean (114 files)
- [x] Diff is docs-only — no `.py` touched; gate invocation in `flow/finish.md` + `lib/cicd/steps.py` intact

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)