### PR TITLE
refactor(flow): rebase /flow worktrees onto native EnterWorktree/ExitWorktree (Closes #440)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -57,11 +57,13 @@ This is capture only - proposing and applying fixes happens in the retro, not he
 
 **CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master. This step is NOT optional - if worktree creation fails, STOP immediately.**
 
-Create a worktree and branch for the issue. If one already exists, `cd` into it.
+Worktree mechanics ride Claude Code's **native worktrees**: the `EnterWorktree`
+tool creates a checkout under `.claude/worktrees/<name>` on a new branch and
+switches the session into it. CPP keeps and enforces the issue-anchored
+`issue-<N>-<slug>` branch name (the gate policy the native tool does not absorb).
 
 ```bash
 ISSUE_NUM="$1"
-REPO=$(basename "$(git rev-parse --show-toplevel)")
 
 # Fetch issue details
 gh issue view "$ISSUE_NUM" --json number,title,state,body
@@ -71,53 +73,68 @@ gh issue view "$ISSUE_NUM" --json number,title,state,body
 - Extract the title for branch naming.
 
 ```bash
-# Sanitize title for branch name
+# Sanitize title for branch name (cut keeps within EnterWorktree's 64-char limit)
 SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
-WORKTREE_DIR="../${REPO}-issue-${ISSUE_NUM}"
 ```
 
-**Check for existing work:**
+**Check for existing work, then pick exactly one path:**
 
 ```bash
 # Check if already on the issue's branch
 CURRENT_BRANCH=$(git branch --show-current)
-if [[ "$CURRENT_BRANCH" =~ issue-${ISSUE_NUM}- ]]; then
-    # Already in the right worktree - skip creation
-fi
 
-# Check if worktree already exists
+# Check if a worktree already exists for this issue
 git worktree list | grep "issue-${ISSUE_NUM}"
 
-# Check if remote branch exists
+# Check if a remote branch exists (cross-machine pickup)
 git fetch origin
 git branch -r | grep "issue-${ISSUE_NUM}-"
 ```
 
-- **Already on issue branch:** Verify you are NOT on main/master. Use current directory.
-- **Worktree exists:** `cd` into the existing worktree directory.
-- **Remote branch exists:** Create worktree tracking the remote branch, then `cd` into it:
+- **Already on issue branch** (`$CURRENT_BRANCH` matches `issue-${ISSUE_NUM}-`):
+  verify you are NOT on main/master and use the current directory. This is a
+  resumed run - remember it so Step 7 uses the git cleanup fallback, not
+  `ExitWorktree`.
+- **Worktree exists** (prior session): switch into it with
+  `EnterWorktree(path="<path from git worktree list>")`. Resumed run - Step 7 uses
+  the git cleanup fallback.
+- **Remote branch exists, no local worktree** (cross-machine pickup): the native
+  tool cannot check out an existing remote branch, so add it with git, then switch
+  in:
   ```bash
-  git worktree add -b "$LOCAL_BRANCH" "$WORKTREE_DIR" "$REMOTE_BRANCH"
-  cd "$WORKTREE_DIR"
+  REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
+  LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
+  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
   ```
-- **Neither exists:** Create fresh from `origin/main`, then `cd` into it:
-  ```bash
-  git fetch origin main
-  git worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main
-  cd "$WORKTREE_DIR"
-  ```
+  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`. Step 7 uses
+  the git cleanup fallback (a `path`-entered worktree is not removed by
+  `ExitWorktree`).
+- **Neither exists** (fresh start): create and enter natively by calling the
+  `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
+  `origin/<default-branch>` (default `worktree.baseRef: fresh`) and switches the
+  session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to `git worktree
+  add` for the fresh path. This is a session-created worktree - Step 7 removes it
+  with `ExitWorktree`.
 
 #### Verification Gate (MANDATORY - do NOT skip)
 
-Before proceeding to Step 2, verify you are in the correct working directory:
+Before proceeding to Step 2, verify you are in the worktree and enforce the
+issue-anchored branch name (the moat every later step relies on):
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
-    echo "ERROR: Still on main/master after Step 1. Worktree creation failed or cd was skipped."
+    echo "ERROR: Still on main/master after Step 1. EnterWorktree did not switch the session."
     echo "STOP: Cannot proceed. You MUST be on an issue branch, not main."
     exit 1
+fi
+
+# Native worktree creation derives the branch from the worktree name; normalize
+# to the issue-anchored convention so downstream steps can parse the issue number.
+if [[ "$CURRENT_BRANCH" != "$BRANCH" && ! "$CURRENT_BRANCH" =~ ^issue-${ISSUE_NUM}- ]]; then
+    git branch -m "$BRANCH"
+    CURRENT_BRANCH="$BRANCH"
 fi
 echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
 ```
@@ -334,49 +351,70 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    ```
    - If merge fails (conflicts, checks): **STOP**. Report and exit.
 
-2. **Update local main:**
+2. **Capture the worktree and main repo paths (before leaving the worktree):**
    ```bash
    if [[ -f ".git" ]]; then
+       WORKTREE_PATH=$(pwd)
        MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
    else
+       WORKTREE_PATH=""   # not in a worktree - on a feature branch in the main repo
        MAIN_REPO=$(pwd)
    fi
-   git -C "$MAIN_REPO" checkout main 2>/dev/null || true
-   git -C "$MAIN_REPO" pull origin main
    ```
 
 3. **Clean up worktree and branch:**
 
-   **CRITICAL: You MUST `cd` to the main repo BEFORE removing the worktree. NEVER remove a worktree while your working directory is inside it - this kills all subsequent bash commands. Execute these as SEPARATE Bash calls, not in a single script.**
+   **If Step 1 created the worktree this session via `EnterWorktree(name=...)`**
+   (the fresh-start path), remove it natively - a single tool call that deletes the
+   worktree and its branch and restores the session to the main repo, with no
+   manual `cd`-before-remove dance:
 
-   **Step 7a - Exit the worktree (separate Bash call):**
+   `ExitWorktree(action="remove", discard_changes=true)`
+
+   `discard_changes=true` is required because the squash-merge leaves the local
+   branch with commits not on `main`; discarding the now-merged local branch is
+   correct. After this the session cwd is back in the main repo.
+
+   **Otherwise** (Step 1 resumed an existing worktree, entered via
+   `EnterWorktree(path=...)`, or you are on a feature branch in the main repo)
+   `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
+   the main repo BEFORE removing the worktree - never remove a worktree while your
+   cwd is inside it. Execute as SEPARATE Bash calls.**
+
+   **Step 7a - Return to the main repo (separate Bash call):**
    ```bash
    cd "$MAIN_REPO"
-   pwd  # Verify you are in the main repo
+   pwd  # Verify you are in the main repo, NOT the worktree
    ```
 
    **Step 7b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
    ```bash
-   if [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
-       ~/.claude/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
+   if [[ -n "$WORKTREE_PATH" && "$WORKTREE_PATH" != "$MAIN_REPO" ]]; then
+       if [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
+           ~/.claude/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
+       else
+           git worktree remove "$WORKTREE_PATH" --force
+           git branch -D "$BRANCH" 2>/dev/null || true
+       fi
    else
-       git worktree remove "$WORKTREE_PATH" --force
+       # On a feature branch in the main repo (no worktree) - just delete the branch
        git branch -D "$BRANCH" 2>/dev/null || true
    fi
    ```
 
-   **Step 7c - Verify working directory is valid:**
+4. **Update local main:**
+   ```bash
+   git -C "$MAIN_REPO" checkout main 2>/dev/null || true
+   git -C "$MAIN_REPO" pull origin main
+   ```
+
+   **Verify working directory is valid:**
    ```bash
    pwd  # MUST show main repo path, NOT the deleted worktree
    git status  # MUST succeed - if this fails, your CWD was deleted
    ```
 
-   If you are NOT in a worktree (just on a feature branch in main repo):
-   ```bash
-   git branch -D "$BRANCH" 2>/dev/null || true
-   ```
-
-4. **Close issue** (if still open):
+5. **Close issue** (if still open):
    ```bash
    if [[ -n "$ISSUE_NUM" ]]; then
        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
@@ -543,7 +581,7 @@ Flow Auto Complete
   Changes:  Modified 3 files (src/auth/login.py, tests/test_auth.py, config/routes.py)
   PR:       #78 (squash-merged)
   Branch:   issue-42-fix-login (deleted)
-  Worktree: ../my-project-issue-42 (removed)
+  Worktree: .claude/worktrees/issue-42-fix-login (removed)
   CI:       Woodpecker pipeline #5 passed | GitHub Actions run #123 passed | skipped
   Deploy:   make deploy (success) | skipped
   Friction: 4 signals captured (.claude/friction.jsonl)
@@ -604,7 +642,7 @@ Key failure scenarios:
 - **CI pipeline fails:** Stop at step 8, link to pipeline/run for investigation
 - **CI not detected:** Non-blocking at step 8, warn and continue to deploy
 - **Deploy fails:** Report but don't roll back (deploy is best-effort)
-- **Inside worktree being removed:** `worktree-remove.sh` handles this safely
+- **Inside worktree being removed:** `ExitWorktree(action="remove")` restores the session cwd for session-created worktrees; the git fallback path uses `worktree-remove.sh`, which also handles removing from inside safely
 
 ## Notes
 
@@ -612,6 +650,7 @@ Key failure scenarios:
 - The analyze step ensures Claude understands the issue before writing code
 - The ELI5 step (Step 3) is a human checkpoint: it restates intent in plain language, verifies the issue is still worth doing, and gates implementation on plan approval. Use `--yes` (or an `eli5: auto-approve` trailer) for fully unattended runs; a `No longer needed` verdict never auto-implements
 - Each step builds on the previous one; there's no skipping
+- Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - The deploy step is always optional - it only runs if a deploy target exists
 - After completion, the user is in the main repo on the main branch
 - For step-by-step control, use individual commands: `/flow:start`, `/flow:eli5`, `/flow:finish`, `/flow:merge`, `/flow:deploy`

--- a/.claude/commands/flow/cleanup.md
+++ b/.claude/commands/flow/cleanup.md
@@ -7,6 +7,12 @@ allowed-tools: Bash(git:*), Bash(grep:*), Bash(wc:*), Bash(echo:*), Read
 
 Remove orphaned worktree references, delete local branches already merged to main, and prune stale remote tracking branches.
 
+Native worktrees live under `.claude/worktrees/`. `git worktree list`,
+`git worktree prune`, and `git worktree remove` operate on them exactly as they do
+on any worktree, so this command is the correct cross-session cleanup path -
+native `ExitWorktree` only removes worktrees created by `EnterWorktree` in the
+current session and cannot prune stale or prior-session ones.
+
 ## Arguments
 
 - No arguments required. Run from the main repo or any worktree.

--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -106,7 +106,7 @@ destructive-git blocking + OS sandboxing cover it.
 Check that core scripts exist in `~/.claude/scripts/`:
 
 ```bash
-for script in prompt-context.sh worktree-remove.sh hook-mask-output.sh secrets-mask.sh; do
+for script in prompt-context.sh hook-mask-output.sh secrets-mask.sh; do
   if [ -x "$HOME/.claude/scripts/$script" ]; then
     echo "PASS $script"
   elif [ -f "$HOME/.claude/scripts/$script" ]; then
@@ -115,6 +115,18 @@ for script in prompt-context.sh worktree-remove.sh hook-mask-output.sh secrets-m
     echo "FAIL $script"
   fi
 done
+
+# worktree-remove.sh is now a FALLBACK, not a hard requirement: `/flow` creates
+# and removes worktrees with the native EnterWorktree/ExitWorktree tools; the
+# script is only used for cross-session / cross-machine worktree cleanup. Missing
+# is a WARN, not a FAIL.
+if [ -x "$HOME/.claude/scripts/worktree-remove.sh" ]; then
+  echo "PASS worktree-remove.sh (optional fallback)"
+elif [ -f "$HOME/.claude/scripts/worktree-remove.sh" ]; then
+  echo "WARN worktree-remove.sh (not executable)"
+else
+  echo "WARN worktree-remove.sh (optional fallback not installed; native ExitWorktree covers same-session cleanup)"
+fi
 ```
 
 ### Step 5b: User-Level Flow Allowlist
@@ -268,7 +280,7 @@ Output a single diagnostic report in this format:
 | hooks.json | ✅/❌ | 2 hooks configured / Not found |
 | mask-output hook | ✅/❌ | ~/.claude/scripts/hook-mask-output.sh |
 | prompt-context.sh | ✅/❌ | Shell prompt context |
-| worktree-remove.sh | ✅/❌ | Safe worktree removal |
+| worktree-remove.sh | ✅/⚠️ | Optional fallback (native ExitWorktree is primary) |
 | secrets-mask.sh | ✅/❌ | Output masking filter |
 | Flow allowlist | ✅/⚠️/❌ | 32/32 rules in ~/.claude/settings.json / N missing / settings.json missing |
 
@@ -322,7 +334,7 @@ Output a single diagnostic report in this format:
    - Go: `cp ~/Projects/claude-power-pack/templates/makefiles/go.mk Makefile`
    - Rust: `cp ~/Projects/claude-power-pack/templates/makefiles/rust.mk Makefile`
    - Monorepo: `cp ~/Projects/claude-power-pack/templates/makefiles/multi.mk Makefile`
-2. ❌ **worktree-remove.sh not found** - Run: `ln -sf ~/Projects/claude-power-pack/scripts/worktree-remove.sh ~/.claude/scripts/`
+2. ⚠️ **worktree-remove.sh not found (optional)** - `/flow` uses the native `EnterWorktree`/`ExitWorktree` tools for same-session worktrees; the script is only a fallback for cross-session / cross-machine cleanup. Install if you want it: `ln -sf ~/Projects/claude-power-pack/scripts/worktree-remove.sh ~/.claude/scripts/`
 2b. ⚠️ **Flow allowlist missing/incomplete** - `/flow:*` will prompt for read-only git/gh plumbing on every run. Merge via `/cpp:update` (Step 7.6) or `/cpp:init`; rationale and caveats in `templates/claude-settings-permissions.md`
 3. ⚠️ **uv not installed** - Install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 4. ❌ **cicd.yml missing** - Run `/cicd:init` to auto-detect framework and generate configuration

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -2,6 +2,15 @@
 
 Merge the current branch's PR, then clean up the worktree and branch.
 
+Worktrees are Claude Code's **native worktrees** (checkouts under
+`.claude/worktrees/<name>`). `/flow:merge` is usually invoked standalone, in a
+fresh session from inside the worktree - so the worktree was NOT created by
+`EnterWorktree` in this session and `ExitWorktree` would be a no-op. The safe
+cross-session cleanup therefore stays on `git worktree remove` /
+`worktree-remove.sh`. If (and only if) you created this worktree earlier in the
+same session with `EnterWorktree(name=...)`, prefer the native
+`ExitWorktree(action="remove", discard_changes=true)` instead of Steps 5a-5c.
+
 ## Instructions
 
 When the user invokes `/flow:merge`, perform these steps:
@@ -137,7 +146,7 @@ PR #78 merged (squash) ✅
 
 Cleanup:
   ✅ Remote branch deleted: issue-42-fix-login
-  ✅ Worktree removed: ../my-project-issue-42
+  ✅ Worktree removed: .claude/worktrees/issue-42-fix-login
   ✅ Local branch deleted: issue-42-fix-login
   ✅ Issue #42 closed
   ✅ Pruned stale worktree references
@@ -178,7 +187,7 @@ to codify fixes? [y/N]
 
 - Squash merge is the default - produces clean single-commit history
 - The remote branch is deleted by `gh pr merge --delete-branch`
-- The worktree removal uses the safe `worktree-remove.sh` script when available
+- Worktrees are native (`.claude/worktrees/`); cross-session cleanup uses `git worktree remove` / the safe `worktree-remove.sh` script (native `ExitWorktree` only removes worktrees created by `EnterWorktree` in the current session)
 - After merge, the user ends up in the main repo on the `main` branch
 - Automatically prunes stale worktree references, merged branches, and remote tracking branches
 - For a standalone cleanup (without merging), use `/flow:cleanup`

--- a/.claude/commands/flow/start.md
+++ b/.claude/commands/flow/start.md
@@ -2,6 +2,13 @@
 
 Create a worktree and branch for a GitHub issue. Stateless - all context from git and GitHub.
 
+Worktree mechanics ride Claude Code's **native worktrees**: the `EnterWorktree`
+tool creates a checkout under `.claude/worktrees/<name>` on a new branch (base
+governed by the `worktree.baseRef` setting - `fresh`, the default, branches from
+`origin/<default-branch>`, matching the old `origin/main` behavior) and switches
+the session into it. The issue-anchored `issue-<N>-<slug>` branch name is the
+policy CPP keeps and enforces; it is not absorbed by the native tool.
+
 ## Arguments
 
 - `ISSUE` (required): GitHub issue number (e.g., `42`)
@@ -33,50 +40,75 @@ gh issue view "$ISSUE_NUM" --json number,title,state,body
 ### Step 3: Derive Branch and Worktree Names
 
 ```bash
-REPO=$(basename "$(git rev-parse --show-toplevel)")
-
-# Sanitize title: lowercase, replace non-alphanum with hyphens, truncate
+# Sanitize title: lowercase, replace non-alphanum with hyphens, truncate.
+# The cut -c1-64 keeps the name within the EnterWorktree 64-char limit.
 SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
 
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
-WORKTREE_DIR="../${REPO}-issue-${ISSUE_NUM}"
 ```
+
+The native worktree lives under `.claude/worktrees/${BRANCH}` - you do not choose
+a sibling directory; pass `${BRANCH}` as the worktree `name` and the tool places
+and names it.
 
 ### Step 4: Check for Existing Work
 
 ```bash
-# Check if worktree already exists
+# Check if already on the issue's branch (do NOT re-create in that case)
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Check if a worktree already exists for this issue
 git worktree list | grep "issue-${ISSUE_NUM}"
 
-# Check if remote branch exists (cross-machine pickup)
+# Check if a remote branch exists (cross-machine pickup)
 git fetch origin
 git branch -r | grep "issue-${ISSUE_NUM}-"
 ```
 
-- **If worktree exists:** Inform user of the path. Do not recreate. `cd` into the existing worktree.
-- **If remote branch exists (no local worktree):** Create worktree tracking the remote branch, then `cd` into it:
+Pick exactly one path:
+
+- **Already on the issue branch** (`$CURRENT_BRANCH` matches `issue-${ISSUE_NUM}-`):
+  verify you are NOT on main/master and use the current directory. Do nothing else.
+- **Worktree already exists** (from a prior session): enter it with the
+  `EnterWorktree` tool using its existing path (do NOT create a new one):
+  `EnterWorktree(path="<path from git worktree list>")`.
+- **Remote branch exists, no local worktree** (cross-machine pickup): the native
+  tool cannot check out an existing remote branch, so add the worktree with git,
+  then switch into it with `EnterWorktree`:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" "$WORKTREE_DIR" "$REMOTE_BRANCH"
-  cd "$WORKTREE_DIR"
+  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
   ```
-- **If neither exists:** Create fresh, then `cd` into it:
-  ```bash
-  git fetch origin main
-  git worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main
-  cd "$WORKTREE_DIR"
-  ```
+  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`.
+- **Neither exists** (fresh start): create and enter the worktree natively by
+  calling the `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
+  `origin/<default-branch>` (under the default `worktree.baseRef: fresh`) and
+  switches the session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to
+  `git worktree add` for the fresh path. If your `worktree.baseRef` is set to
+  `head`, sync `main` first so the branch does not start from a stale local HEAD.
 
-### Step 5: Verify and Output
+### Step 5: Verify, Normalize Branch, Output
 
 **CRITICAL: Verify you are in the worktree, not on main/master.**
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
-    echo "ERROR: Still on main/master. Worktree creation or cd failed."
+    echo "ERROR: Still on main/master. EnterWorktree did not switch the session."
     exit 1
+fi
+```
+
+**Enforce the issue-anchored branch name (the moat).** Native worktree creation
+derives the branch from the worktree name; if the resulting branch is not exactly
+`issue-${ISSUE_NUM}-${SLUG}`, rename it so every downstream step (`/flow:merge`,
+`/flow:status`, `/flow:cleanup`) can extract the issue number from the branch:
+
+```bash
+if [[ "$CURRENT_BRANCH" != "$BRANCH" ]]; then
+    git branch -m "$BRANCH"
+    CURRENT_BRANCH="$BRANCH"
 fi
 echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
 ```
@@ -86,7 +118,7 @@ Report to the user:
 ```
 Created worktree for issue #42: "Fix login bug"
 
-  Directory: ../my-project-issue-42
+  Directory: .claude/worktrees/issue-42-fix-login-bug
   Branch:    issue-42-fix-login-bug
   Verified:  Working directory is now the worktree (not main)
 ```

--- a/.claude/commands/flow/status.md
+++ b/.claude/commands/flow/status.md
@@ -55,8 +55,8 @@ ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null 
 
 | Worktree | Issue | Branch | Status | PR |
 |----------|-------|--------|--------|----|
-| ../{repo}-issue-42 | #42 Fix login bug | issue-42-fix-login | 3 dirty files, 2 unpushed | - |
-| ../{repo}-issue-55 | #55 Add tests | issue-55-add-tests | Clean | PR #78 (OPEN) |
+| .claude/worktrees/issue-42-fix-login | #42 Fix login bug | issue-42-fix-login | 3 dirty files, 2 unpushed | - |
+| .claude/worktrees/issue-55-add-tests | #55 Add tests | issue-55-add-tests | Clean | PR #78 (OPEN) |
 
 ### Suggestions
 - **#42**: Has uncommitted work - commit or stash before switching

--- a/.claude/commands/flow/sync.md
+++ b/.claude/commands/flow/sync.md
@@ -72,6 +72,7 @@ Synced branch to remote.
 ## Notes
 
 - This command is intentionally simple - just commit WIP + push.
-- `/flow:start` already handles the receiving end (detects remote branches and creates worktrees tracking them).
+- Cross-machine sync operates on the `issue-<N>-<slug>` **branch**, not on worktree paths, so the native `.claude/worktrees/` location (which is per-workstation and gitignored) does not affect it.
+- `/flow:start` already handles the receiving end: it detects the remote branch and, because the native `EnterWorktree` tool cannot check out an existing remote branch, adds a worktree tracking it with `git worktree add` and then switches in with `EnterWorktree(path=...)`.
 - WIP commits are harmless because `/flow:merge` uses squash-merge, collapsing all commits into one clean commit.
 - No configuration required - works with any git remote.

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,11 @@ node_modules/
 .claude/friction/
 .claude/learnings.md
 
+# Native Claude Code worktrees (issue #440) - the EnterWorktree tool creates
+# full checkouts under .claude/worktrees/<name>; these are per-workstation and
+# must never be committed to the parent repo.
+.claude/worktrees/
+
 # Logs
 *.log
 logs/

--- a/.specify/grills/2026-07-03-issue-440.md
+++ b/.specify/grills/2026-07-03-issue-440.md
@@ -1,0 +1,108 @@
+# Grill-yourself: Issue #440 - Rebase /flow onto native worktrees
+
+- Date: 2026-07-03
+- Mode: inline (second-opinion MCP unreachable on :8080)
+- Scope estimate: ~11 files (wider doc scope approved), ~350 lines
+- Verdict: **yes-with-caveats**
+
+## Q1. Does `EnterWorktree(name=X)` create a branch named exactly `X`?
+
+Unverified from the tool schema (it says "on a new branch" but does not pin the
+branch name to the worktree name). This is the single biggest risk because the
+whole moat rides on the `issue-<N>-<slug>` branch name (every downstream step
+extracts the issue via `grep -oP 'issue-\K[0-9]+'`).
+
+**Mitigation (in design):** after `EnterWorktree`, verify `git branch
+--show-current`; if it is not `issue-<N>-<slug>`, run `git branch -m
+issue-<N>-<slug>` to normalize. The moat is then robust regardless of how native
+derives the branch name. The verification gate (must-not-be-on-main) stays.
+
+## Q2. Does the Bash tool cwd follow the EnterWorktree session-cwd switch?
+
+Yes - the tool description states it "switches the session's working directory,"
+and the Bash tool shares the session cwd. Defensively, the post-enter
+verification gate re-runs `git branch --show-current`; if the switch somehow did
+not happen, the gate is still on main -> STOP. No silent wrong-dir writes.
+
+## Q3. `worktree.baseRef` edge - what if a user set `head` instead of `fresh`?
+
+Default is `fresh` (branches from origin/default-branch), which matches today's
+`origin/main` behavior. A user who set `head` branches from local HEAD, which
+could be stale. **Mitigation:** document the dependency in the instructions
+(fresh is assumed; if you use `head`, sync main first). Low severity.
+
+## Q4. Post-merge, will `ExitWorktree(remove)` refuse?
+
+Yes - after a squash-merge the local branch has commits not on the original
+branch, so `ExitWorktree(remove)` refuses unless `discard_changes: true`. Since
+the PR is already merged, discarding the local worktree+branch is correct.
+**Design:** instruct `ExitWorktree(action: remove, discard_changes: true)` in the
+post-merge cleanup.
+
+## Q5. Can native fully replace `git worktree remove`?
+
+No - and this is the honest boundary. `ExitWorktree` only removes worktrees that
+`EnterWorktree` created **in the same session**; it is a no-op for
+prior-session/cross-machine worktrees and refuses to remove `path`-entered ones.
+`/flow:merge` and `/flow:cleanup` frequently run in a fresh session, so they
+**must keep** `git worktree remove` / `worktree-remove.sh`. Design: use native
+where it genuinely applies (same-session create+enter+exit in `/flow:auto`,
+`/flow:start`); keep git-remove as the documented fallback. Not a regression - an
+accurate boundary. Surface it in the PR body and CLAUDE.md.
+
+## Q6. `.claude/worktrees/` and gitignore
+
+`.claude/` is only partially tracked (commands are in git), so a nested
+`.claude/worktrees/<name>` checkout would show as untracked and could be
+accidentally staged. **Fix:** add `.claude/worktrees/` to `.gitignore`. Verified
+today's `.gitignore` does NOT ignore it - a real latent bug this issue fixes.
+
+## Q7. `.claude/worktrees/` nested-location math in merge/cleanup
+
+The `.git` file of a nested worktree reads `gitdir: <repo>/.git/worktrees/<name>`;
+the existing `sed 's|/.git/worktrees/.*||'` still yields `<repo>`. Works for the
+nested location. The one weak spot is `worktree-remove.sh`'s "dir already gone"
+prune branch, which scans siblings of the worktree path for a main repo - for
+`.claude/worktrees/foo` the siblings are other worktrees, not the main repo.
+**Mitigation:** harden that branch to also walk up parents for a `.git`
+directory. Fallback-of-a-fallback, low severity.
+
+## Q8. `/flow:auto` Step 1 idempotency (resume / re-run)
+
+Three states must be handled without double-creating: (a) already on the issue
+branch -> no-op; (b) worktree exists (prior session) -> `EnterWorktree(path=...)`,
+NOT `name`; (c) remote branch exists -> `git worktree add -b ... origin/<branch>`
++ `EnterWorktree(path=...)`. Only the truly-fresh case calls
+`EnterWorktree(name=...)`. Cleanup for (b)/(c) uses the git fallback because
+`ExitWorktree` will not remove `path`-entered worktrees.
+
+## Q9. EnterWorktree authorization requirement
+
+The tool must only be used when the user or project instructions direct worktree
+use. `/flow:*` are project instructions and CLAUDE.md documents `/flow` as a
+worktree workflow; invoking `/flow:start` is an explicit worktree request. Adding
+a CLAUDE.md note that `/flow` uses native worktrees makes this airtight (also why
+the issue lists CLAUDE.md).
+
+## Q10. Two flow surfaces (repo vs global hand-maintained mirror)
+
+Per project memory there are two `/flow` surfaces: the repo `.claude/commands/flow/*`
+(shipped, this PR) and a global `~/.claude/skills/flow-*` hand-maintained mirror.
+The mirror is out of repo/PR scope; note it as a post-merge local sync in the PR
+body. Do not block CI on it.
+
+## Q11. Test brittleness
+
+The new regression test asserts native tool references
+(`EnterWorktree`/`ExitWorktree`) are present in the migrated commands, the moat
+keywords remain (eli5 gate, quality gates, `issue-` naming), and
+`.claude/worktrees/` is gitignored. It avoids asserting exact prose so ordinary
+copy edits do not break it. Must pass ruff + mypy (Python-only lint).
+
+## Caveats carried into implementation
+
+- (a) branch==name unverified -> verify+rename normalize.
+- (b) `worktree.baseRef=head` edge -> documented.
+- (c) full git-remove replacement impossible (session-scoped ExitWorktree) ->
+  keep documented fallback; not a regression.
+- (d) global `flow-*` mirror out of PR scope -> post-merge local sync.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,19 @@ MCP containers fetch API keys at startup from AWS Secrets Manager via an `aws-se
 - `/flow:status` - Show active worktrees
 - `/flow:doctor` - Diagnose workflow environment
 
+**Native worktrees (issue #440):** `/flow` rides Claude Code's built-in
+worktrees. `/flow:start` and `/flow:auto` create and enter a worktree with the
+`EnterWorktree` tool (checkout under `.claude/worktrees/<name>`, branched from
+`origin/<default-branch>` under the default `worktree.baseRef: fresh`) instead of
+shelling out to `git worktree add`; same-session cleanup uses `ExitWorktree`.
+`.claude/worktrees/` is gitignored. CPP layers its issue-anchored gate policy on
+top of these mechanics and does not delegate it: the `issue-<N>-<slug>` branch
+name (enforced after `EnterWorktree`), the `/flow:eli5` necessity gate, the
+quality gates, and merge/cleanup discipline are unchanged. Because native
+`ExitWorktree` only removes worktrees created in the current session, cross-session
+and cross-machine cleanup (`/flow:merge`, `/flow:cleanup`) keep `git worktree
+remove` / `scripts/worktree-remove.sh` as the fallback.
+
 ### Project
 - `/project:init <name>` - Full project scaffolding (zero to GitHub repo)
 - `/project-next` - Full issue analysis and prioritization (~15-30K tokens)

--- a/ISSUE_DRIVEN_DEVELOPMENT.md
+++ b/ISSUE_DRIVEN_DEVELOPMENT.md
@@ -225,15 +225,26 @@ Git worktrees allow multiple branches to be checked out simultaneously in differ
 | Entity | Pattern | Example |
 |--------|---------|---------|
 | Branch | `issue-{number}-{short-description}` | `issue-123-player-landing` |
-| Worktree | `{repo}-issue-{number}` | `nhl-api-issue-123` |
+| Worktree | `.claude/worktrees/issue-{number}-{short-description}` | `.claude/worktrees/issue-123-player-landing` |
 
 ### Worktree Commands
 
-**Create worktree for an issue:**
+The `/flow` commands ride Claude Code's **native worktrees**. Prefer the tools
+below; the raw `git worktree` commands are the underlying mechanic and remain
+available for manual use.
+
+**Create worktree for an issue (recommended):** call the `EnterWorktree` tool with
+`name=issue-{N}-{description}`. It creates a checkout under
+`.claude/worktrees/issue-{N}-{description}`, branches from
+`origin/<default-branch>` (default `worktree.baseRef: fresh`), and switches your
+session into it. Enforce the `issue-{N}-{description}` branch name afterward
+(`git branch -m` if native derived a different name).
+
+**Create worktree manually (fallback / cross-machine remote branch):**
 ```bash
 cd /path/to/main-repo
-git worktree add -b issue-{N}-{description} ../repo-issue-{N}
-cd ../repo-issue-{N}
+git worktree add -b issue-{N}-{description} .claude/worktrees/issue-{N}-{description}
+# then switch in with EnterWorktree(path=".claude/worktrees/issue-{N}-{description}")
 ```
 
 **List all worktrees:**
@@ -241,15 +252,20 @@ cd ../repo-issue-{N}
 git worktree list
 ```
 
-**Remove after merge:**
+**Remove after merge (recommended, same session):** call `ExitWorktree` with
+`action="remove"` (add `discard_changes=true` after a squash-merge). This deletes
+the worktree and branch and restores your session to the main repo. Native
+`ExitWorktree` only removes worktrees it created in the current session.
+
+**Remove manually (cross-session / cross-machine fallback):**
 ```bash
 # IMPORTANT: cd to main repo FIRST to avoid breaking the shell
 cd /path/to/main-repo
-git worktree remove ../repo-issue-{N}
+git worktree remove .claude/worktrees/issue-{N}-{description}
 git branch -d issue-{N}-{description}
 ```
 
-> ⚠️ **Shell CWD Warning:** Always `cd` to the main repo before removing a worktree. If your shell's current working directory is inside the worktree being removed, the shell will break and no further commands will work. Using `git -C /path/to/main-repo worktree remove` does NOT protect against this-only changing the shell's cwd does.
+> ⚠️ **Shell CWD Warning:** Always `cd` to the main repo before manually removing a worktree. If your shell's current working directory is inside the worktree being removed, the shell will break and no further commands will work. Using `git -C /path/to/main-repo worktree remove` does NOT protect against this-only changing the shell's cwd does. (The native `ExitWorktree` tool restores your cwd for you.)
 
 **Prune stale worktrees:**
 ```bash
@@ -579,11 +595,15 @@ Runs `make deploy` if the target exists.
 <details>
 <summary>Click to expand manual workflow</summary>
 
+The `/flow` commands use the native `EnterWorktree`/`ExitWorktree` tools; the raw
+git commands below are the equivalent manual path (worktrees now live under
+`.claude/worktrees/`).
+
 ```bash
 # Create worktree
 cd /home/user/Projects/my-api
-git worktree add -b issue-123-player-landing ../my-api-issue-123
-cd ../my-api-issue-123
+git worktree add -b issue-123-player-landing .claude/worktrees/issue-123-player-landing
+cd .claude/worktrees/issue-123-player-landing
 
 # Implement and commit
 git commit -m "feat(downloader): Add player landing persistence (Closes #123)"
@@ -594,7 +614,7 @@ gh pr create --title "feat(downloader): Player landing persistence" --body "Clos
 
 # Cleanup (CRITICAL: cd to main repo FIRST)
 cd /home/user/Projects/my-api
-git worktree remove ../my-api-issue-123
+git worktree remove .claude/worktrees/issue-123-player-landing
 git branch -d issue-123-player-landing
 git pull
 ```
@@ -662,10 +682,10 @@ git pull
 /flow:auto 42                                      # Full lifecycle in one shot
 /flow:help                                         # Show all flow commands
 
-# Manual Worktree Management
-git worktree add -b issue-N-desc ../repo-issue-N   # Create
+# Manual Worktree Management (native path: EnterWorktree / ExitWorktree tools)
+git worktree add -b issue-N-desc .claude/worktrees/issue-N-desc   # Create
 git worktree list                                   # List all
-cd /path/to/main-repo && git worktree remove ../repo-issue-N  # Remove (cd first!)
+cd /path/to/main-repo && git worktree remove .claude/worktrees/issue-N-desc  # Remove (cd first!)
 git worktree prune                                 # Clean stale
 
 # Shell Prompt Context (automatic - no commands needed)

--- a/docs/skills/idd-workflow.md
+++ b/docs/skills/idd-workflow.md
@@ -59,15 +59,21 @@ export PS1='$(~/.claude/scripts/prompt-context.sh)\w $ '
 
 ## Worktree Commands
 
+`/flow` rides Claude Code's native worktrees. Recommended: create/enter with the
+`EnterWorktree` tool (`name=issue-42-auth`, checkout under `.claude/worktrees/`,
+branched from `origin/<default-branch>`) and remove same-session worktrees with
+`ExitWorktree(action="remove")`. The raw git commands below are the manual
+equivalent and the cross-session fallback.
+
 ```bash
-# Create worktree for issue
-git worktree add -b issue-42-auth ../project-issue-42
+# Create worktree for issue (manual / cross-machine fallback)
+git worktree add -b issue-42-auth .claude/worktrees/issue-42-auth
 
 # List worktrees
 git worktree list
 
-# Remove worktree (use script for safety)
-~/.claude/scripts/worktree-remove.sh ../project-issue-42 --delete-branch
+# Remove worktree cross-session (use script for safety)
+~/.claude/scripts/worktree-remove.sh .claude/worktrees/issue-42-auth --delete-branch
 ```
 
 ## Getting Started

--- a/scripts/worktree-remove.sh
+++ b/scripts/worktree-remove.sh
@@ -98,15 +98,35 @@ if [[ ! -d "$WORKTREE_PATH" ]]; then
     echo -e "${YELLOW}Warning: Worktree directory does not exist: ${WORKTREE_PATH}${NC}"
     echo "It may have already been removed. Running 'git worktree prune'..."
 
-    # Find the main repo by looking for a non-worktree .git directory
-    # Try common parent patterns
+    # Find the main repo (a directory whose .git is a real directory, not a
+    # worktree's .git file). Two layouts to cover:
+    #   1. Legacy sibling worktrees:  ../repo-issue-N  (main repo is a sibling)
+    #   2. Native worktrees:          .claude/worktrees/<name>  (main repo is an ancestor)
+    PRUNE_REPO=""
+    # (1) Scan siblings of the worktree path.
     for parent in "$(dirname "$WORKTREE_PATH")"/*; do
-        if [[ -d "$parent/.git" && ! -f "$parent/.git" ]]; then
-            git -C "$parent" worktree prune
-            echo -e "${GREEN}Pruned stale worktree references.${NC}"
+        if [[ -d "$parent/.git" ]]; then
+            PRUNE_REPO="$parent"
             break
         fi
     done
+    # (2) Walk up ancestors (covers .claude/worktrees/<name> nested under the repo).
+    if [[ -z "$PRUNE_REPO" ]]; then
+        ancestor="$(dirname "$WORKTREE_PATH")"
+        while [[ "$ancestor" != "/" && -n "$ancestor" ]]; do
+            if [[ -d "$ancestor/.git" ]]; then
+                PRUNE_REPO="$ancestor"
+                break
+            fi
+            ancestor="$(dirname "$ancestor")"
+        done
+    fi
+    if [[ -n "$PRUNE_REPO" ]]; then
+        git -C "$PRUNE_REPO" worktree prune
+        echo -e "${GREEN}Pruned stale worktree references.${NC}"
+    else
+        echo -e "${YELLOW}Could not locate the main repository to prune; run 'git worktree prune' from it manually.${NC}"
+    fi
     exit 0
 fi
 

--- a/tests/test_flow_worktree_native.py
+++ b/tests/test_flow_worktree_native.py
@@ -1,0 +1,73 @@
+"""Regression tests for issue #440: /flow rides native worktrees.
+
+These pin the migration from bespoke ``git worktree add/remove`` plumbing to
+Claude Code's native ``EnterWorktree``/``ExitWorktree`` tools, while proving the
+issue-anchored gate policy (the moat) stays layered on top: the eli5 necessity
+gate, quality gates, the ``issue-<N>-<slug>`` branch name, squash-merge
+discipline, and the cross-session ``git worktree`` cleanup fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_start_uses_native_enter_worktree() -> None:
+    text = _read(".claude/commands/flow/start.md")
+    assert "EnterWorktree" in text
+    # Fresh path creates the worktree by name (native), not a sibling dir.
+    assert 'name="${BRANCH}"' in text
+
+
+def test_auto_uses_native_enter_and_exit_worktree() -> None:
+    text = _read(".claude/commands/flow/auto.md")
+    assert "EnterWorktree" in text  # Step 1 create/enter
+    assert "ExitWorktree" in text  # Step 7 same-session cleanup
+
+
+def test_fresh_path_drops_sibling_worktree_dir() -> None:
+    # The old plumbing created ../<repo>-issue-<N> and branched it with git; the
+    # native fresh path must not reintroduce that create mechanic. The
+    # cross-machine path (which git-adds "$LOCAL_BRANCH") is intentionally kept.
+    for rel in (".claude/commands/flow/start.md", ".claude/commands/flow/auto.md"):
+        text = _read(rel)
+        assert 'WORKTREE_DIR="../' not in text, f"{rel} still creates a sibling worktree dir"
+        assert 'git worktree add -b "$BRANCH"' not in text, f"{rel} still git-adds the fresh path"
+
+
+def test_native_worktrees_are_gitignored() -> None:
+    assert ".claude/worktrees/" in _read(".gitignore")
+
+
+def test_moat_preserved_in_auto() -> None:
+    text = _read(".claude/commands/flow/auto.md")
+    # eli5 necessity gate still runs before implementation.
+    assert "eli5" in text.lower()
+    # Issue-anchored branch name is enforced after native creation.
+    assert 'BRANCH="issue-${ISSUE_NUM}-${SLUG}"' in text
+    assert "git branch -m" in text
+    # Squash-merge discipline is unchanged.
+    assert "--squash" in text
+    # Quality gates are unchanged.
+    assert "lib.cicd run --plan finish" in text or "make verify" in text or "make lint" in text
+
+
+def test_cross_session_cleanup_keeps_git_fallback() -> None:
+    # /flow:merge and /flow:cleanup usually run in a fresh session where
+    # ExitWorktree is a no-op, so the git-worktree removal path must remain.
+    merge = _read(".claude/commands/flow/merge.md")
+    cleanup = _read(".claude/commands/flow/cleanup.md")
+    assert "git worktree remove" in merge or "worktree-remove.sh" in merge
+    assert "git worktree" in cleanup
+
+
+def test_worktree_remove_script_retained_as_fallback() -> None:
+    assert (ROOT / "scripts" / "worktree-remove.sh").exists(), (
+        "worktree-remove.sh must remain as the cross-session cleanup fallback"
+    )


### PR DESCRIPTION
## Summary
- `/flow:start` and `/flow:auto` now create/enter worktrees with the native **`EnterWorktree`** tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>` under the default `worktree.baseRef: fresh`) instead of bespoke `git worktree add`. Same-session cleanup uses **`ExitWorktree`**.
- The **issue-anchored gate policy (the moat) is preserved and unchanged**: the `issue-<N>-<slug>` branch name (now *enforced* after native creation via `git branch -m`, robust to however native derives the branch), the `/flow:eli5` necessity gate, the quality gates, and squash-merge/cleanup discipline.
- `.gitignore` now ignores `.claude/worktrees/` (native worktrees nest inside the repo — a latent gap).
- CLAUDE.md + IDD methodology docs document the native flow and the fallback boundary.

## Design boundary (honest)
Native `ExitWorktree` only removes worktrees created by `EnterWorktree` **in the current session**. `/flow:merge` and `/flow:cleanup` usually run in a fresh session, so they **keep `git worktree remove` / `scripts/worktree-remove.sh` as the cross-session + cross-machine fallback** (a full removal of git-worktree plumbing would regress that path). `worktree-remove.sh` is hardened to prune the nested `.claude/worktrees/` layout. Cross-machine `/flow:sync` is preserved — it operates on the `issue-<N>-<slug>` **branch**, not on worktree paths.

## ELI5 / necessity verdict
**Still needed.** No commits touched `.claude/commands/flow/` or `scripts/worktree-remove.sh` since the issue was filed (2026-07-03T16:30Z); `EnterWorktree` was referenced nowhere in the flow commands. Sibling #417 Phase-A PRs that merged since (#436/#431/#435/#429/#421/#426) are unrelated to worktree plumbing. Approved plan (wider doc scope: also refresh the IDD methodology docs).

## Grill-yourself
Verdict **yes-with-caveats** (transcript: `.specify/grills/2026-07-03-issue-440.md`). Caveats resolved in the diff: (a) branch==name unverified → verify + `git branch -m` normalize; (b) `worktree.baseRef=head` edge → documented; (c) full git-remove replacement impossible → keep documented fallback; (d) global `~/.claude/skills/flow-*` mirror is out of repo scope → post-merge local sync.

## Quality gates
`make verify` green locally: ruff clean, **657 tests passed** (incl. new `tests/test_flow_worktree_native.py`, 7 tests), mypy success on 115 files.

## Test plan
- [x] New regression test pins native tool references, the moat (eli5 gate, `issue-` naming, `git branch -m`, `--squash`, quality gates), `.claude/worktrees/` gitignore, and the retained git-remove fallback.
- [ ] Smoke: run `/flow:start <n>` in a consumer repo → confirm `EnterWorktree` creates `.claude/worktrees/issue-<n>-<slug>` on the correctly-named branch.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)