### PR TITLE
feat(cicd): Deploy verification skill with baseline comparison (Closes #444)

### DIFF
--- a/.claude/commands/cicd/help.md
+++ b/.claude/commands/cicd/help.md
@@ -10,6 +10,7 @@ Build, verify, and deploy automation for Claude Code projects.
 | `/cicd:check` | Validate Makefile against CPP standards |
 | `/cicd:health` | Run health checks (endpoints + processes) |
 | `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:verify` | Verify a deployment against a pre-deploy baseline (proceed/rollback) |
 | `/cicd:pipeline` | Generate CI/CD workflows (GitHub Actions, or Woodpecker via provider) |
 | `/cicd:woodpecker` | Generate a hardened self-hosted Woodpecker pipeline + scaffold server/agent |
 | `/cicd:container` | Generate Dockerfile and docker-compose.yml |
@@ -30,6 +31,7 @@ Build, verify, and deploy automation for Claude Code projects.
                                               ↓
 /cicd:health    →  Check endpoints  →  Check processes  →  Report status
 /cicd:smoke     →  Run smoke tests  →  Check results    →  Report pass/fail
+/cicd:verify    →  Baseline (pre)   →  Re-run (post)    →  Verdict: proceed/rollback
                                               ↓
 /cicd:pipeline  →  Read Makefile targets  →  Generate .github/workflows/ci.yml (or .woodpecker.yml)
 /cicd:woodpecker→  Framework + gates      →  Generate hardened .woodpecker.yml + server/agent scaffold
@@ -103,6 +105,12 @@ health:
     - name: CLI version
       command: "python -m myapp --version"
       expected_output: "v\\d+\\.\\d+"
+  # Deploy verification (used by /cicd:verify, /flow:deploy, /flow:auto):
+  # capture the endpoints/smoke_tests above as a baseline before deploy,
+  # re-run them after, and emit a proceed/rollback verdict.
+  deploy_verification:
+    enabled: true
+    on_latency_regression: review   # review | rollback | ignore
 ```
 
 See `templates/cicd.yml.example` for full documentation.
@@ -122,9 +130,13 @@ See `templates/cicd.yml.example` for full documentation.
 # Run smoke tests
 /cicd:smoke
 
+# Capture a pre-deploy baseline, deploy, then verify (proceed/rollback)
+/cicd:verify --baseline
+/cicd:verify
+
 # Use with /flow
 /flow:finish    # Runs make lint + make test
-/flow:deploy    # Runs make deploy
+/flow:deploy    # Runs make deploy, then verifies against the baseline
 ```
 
 ## Infrastructure as Code

--- a/.claude/commands/cicd/verify.md
+++ b/.claude/commands/cicd/verify.md
@@ -1,0 +1,175 @@
+---
+description: Verify a deployment against a pre-deploy baseline (proceed/rollback)
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(curl:*), Bash(ls:*), Bash(test:*), Bash(cat:*), Read
+---
+
+# /cicd:verify - Deploy Verification
+
+Validate the *deployment*, not just the code. Capture a baseline of health
+checks and smoke tests **before** a deploy, re-run them **after**, diff the two,
+and emit one actionable verdict: **PROCEED**, **REVIEW**, or **ROLLBACK**.
+
+This is the piece `/cicd:health` and `/cicd:smoke` do not cover: they report the
+current state in isolation. `/cicd:verify` answers the deploy-confidence
+question - *did this deploy make things worse than they were 60 seconds ago?*
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: claude-power-pack not found"
+  exit 1
+fi
+```
+
+---
+
+## Step 2: Check for Configuration
+
+`/cicd:verify` reuses the same `health.endpoints`, `health.processes`, and
+`health.smoke_tests` that `/cicd:health` and `/cicd:smoke` use. If none are
+configured, verification returns **REVIEW** with "no probes configured" - it
+cannot honestly claim a deploy is healthy with nothing to probe.
+
+```bash
+if [ ! -f ".claude/cicd.yml" ]; then
+  echo "No .claude/cicd.yml found in $(pwd)"
+  echo ""
+  echo "Configure the probes /cicd:verify compares, e.g.:"
+  echo ""
+  echo "  health:"
+  echo "    endpoints:"
+  echo "      - url: http://localhost:8000/health"
+  echo "        name: API Server"
+  echo "    smoke_tests:"
+  echo "      - name: API responds"
+  echo "        command: \"curl -sf http://localhost:8000/health\""
+  echo "    deploy_verification:"
+  echo "      enabled: true"
+  exit 1
+fi
+```
+
+---
+
+## Step 3: Capture the Pre-Deploy Baseline
+
+**Before deploying**, snapshot the currently-running system:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline
+```
+
+This runs every health check and smoke test once and writes the result to
+`.claude/deploy-baseline.json` (per-workstation runtime state, git-ignored). The
+baseline is the "before" picture the post-deploy run is compared against.
+
+`/flow:deploy` and `/flow:auto` capture this automatically when
+`health.deploy_verification.enabled` is set - see "Integration" below.
+
+---
+
+## Step 4: Verify After Deploy
+
+**After `make deploy`**, re-run the probes and diff against the baseline:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+```
+
+Add `--summary` for a one-line verdict, or `--json` for machine-readable output.
+
+---
+
+## Step 5: Present the Verdict
+
+The CLI prints a diff table and a verdict. Present it to the user as-is and act
+on the verdict.
+
+### Verdict meanings
+
+| Verdict | Exit | Meaning | Action |
+|---------|------|---------|--------|
+| `PROCEED` | 0 | All probes pass; no regression vs baseline | Keep the deployment |
+| `REVIEW` | 0 | Soft signal only (latency regression, or a probe that was already failing before deploy) | Look, but not clearly broken |
+| `ROLLBACK` | 1 | A probe that passed in the baseline fails now (regression), or a probe is failing with no known-good baseline | Roll back or investigate |
+
+### Probe classifications (the `Change` column)
+
+| Classification | Meaning |
+|----------------|---------|
+| `regression` | Passed in baseline, fails now (deploy made it worse) |
+| `new_failure` | Failing now, no baseline entry to compare |
+| `latency_regression` | Still passing but markedly slower than baseline |
+| `preexisting_failure` | Failing before and after (not caused by this deploy) |
+| `recovered` | Was failing in baseline, passes now |
+| `new_probe` / `ok` | Passing; no concern |
+
+---
+
+## Step 6: Handle ROLLBACK
+
+On `ROLLBACK`, do not silently proceed. Report the failing probes and recommend
+a concrete next step:
+
+```
+Deploy verification: ROLLBACK
+
+  regression: health:API Server (HTTP 500, expected 200)
+
+  Options:
+    1. Roll back: make deploy-rollback  (or redeploy the previous commit)
+    2. Investigate: /cicd:health  and  /cicd:smoke  for detail
+    3. Retrospective: /self-improvement:deployment
+```
+
+Verification never rolls back automatically - it reports an actionable verdict.
+The human (or the calling flow) decides.
+
+---
+
+## Configuration
+
+Under `health.deploy_verification` in `.claude/cicd.yml`:
+
+```yaml
+health:
+  deploy_verification:
+    enabled: true                     # let /flow:deploy + /flow:auto auto-capture/verify
+    baseline_file: .claude/deploy-baseline.json
+    latency_regression_pct: 50        # flag a probe > 50% slower than baseline
+    latency_floor_ms: 100             # ...but only if it is also over 100ms (noise floor)
+    on_latency_regression: review     # review | rollback | ignore
+    require_baseline: false           # true => no baseline downgrades PROCEED to REVIEW
+```
+
+---
+
+## Integration
+
+- **`/flow:deploy`** captures a baseline before `make deploy` and runs
+  verification after when `deploy_verification.enabled` is set (Step 8).
+- **`/flow:auto`** does the same in its Deploy step (Step 9), so the flagship
+  "one command to ship" path validates the deployment, not just the code.
+- Fail-open: if the baseline is missing or `lib/cicd` is unavailable,
+  verification degrades to an absolute pass/fail (or is skipped) and never
+  blocks the deploy pipeline.
+
+---
+
+## Notes
+
+- Zero new dependencies: reuses `curl` + `subprocess` (same as `/cicd:health`).
+- The baseline is per-workstation state, like `.claude/runs/` - never committed.
+- Pair with `/cicd:health` and `/cicd:smoke` for probe-level detail, and
+  `/self-improvement:deployment` for a post-failure Makefile retrospective.

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -552,22 +552,65 @@ Report: `Step 8/9: Verify CI complete - pipeline #{N} passed` or `Step 8/9: Veri
 
 ### Step 9: Deploy (optional)
 
-Only if a Makefile with a `deploy` target exists in the main repo:
+Only if a Makefile with a `deploy` target exists in the main repo. Because
+`/flow:auto` runs `make deploy` inline (it does NOT call `/flow:deploy`), the
+deploy-verification gate is wired in here too - otherwise the flagship
+"one command to ship" path would deploy without validating the deployment.
 
 ```bash
 cd "$MAIN_REPO"
+
+# Locate CPP source for lib/cicd (deploy verification)
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+VERIFY_ENABLED=0
+if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
+    VERIFY_ENABLED=1
+fi
+
 if [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+    # Pre-deploy: capture the baseline (before make deploy) so the post-deploy
+    # verify can detect regressions.
+    if [ "$VERIFY_ENABLED" -eq 1 ]; then
+        echo "Capturing pre-deploy baseline..."
+        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+    fi
+
     echo "Running: make deploy"
     make deploy
+    DEPLOY_EXIT=$?
+
+    # Post-deploy: verify against the baseline and emit a proceed/rollback verdict.
+    VERDICT="none"
+    if [ "$VERIFY_ENABLED" -eq 1 ]; then
+        echo "Running deploy verification..."
+        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+        VERIFY_EXIT=$?
+        VERDICT=$( [ "$VERIFY_EXIT" -eq 1 ] && echo "rollback" || echo "proceed/review" )
+        if [ "$VERIFY_EXIT" -eq 1 ]; then
+            echo "DEPLOY VERIFICATION: ROLLBACK - a probe that passed pre-deploy fails now."
+            echo "Recommend rolling back (redeploy previous commit) or investigating with /cicd:health + /cicd:smoke."
+        fi
+    fi
 
     mkdir -p .claude
-    echo "$(date -Iseconds) | deploy | $(git rev-parse --short HEAD) | main | $?" >> .claude/deploy.log
+    echo "$(date -Iseconds) | deploy | $(git rev-parse --short HEAD) | main | ${DEPLOY_EXIT} | verify:${VERDICT}" >> .claude/deploy.log
 else
     echo "No deploy target in Makefile - skipping deployment."
 fi
 ```
 
-Report: `Step 9/9: Deploy complete` or `Step 9/9: Deploy skipped (no Makefile target)`
+- Verification is fail-open and inert unless `health.deploy_verification.enabled`
+  is set in `.claude/cicd.yml`. A ROLLBACK verdict is surfaced to the user but
+  never rolls back automatically - it is an actionable signal, not an action.
+
+Report: `Step 9/9: Deploy complete (verify: {proceed|review|rollback|none})` or
+`Step 9/9: Deploy skipped (no Makefile target)`
 
 ---
 
@@ -584,6 +627,7 @@ Flow Auto Complete
   Worktree: .claude/worktrees/issue-42-fix-login (removed)
   CI:       Woodpecker pipeline #5 passed | GitHub Actions run #123 passed | skipped
   Deploy:   make deploy (success) | skipped
+  Verify:   PROCEED | REVIEW | ROLLBACK | not configured
   Friction: 4 signals captured (.claude/friction.jsonl)
   Location: /home/user/Projects/my-project (main)
 ```

--- a/.claude/commands/flow/deploy.md
+++ b/.claude/commands/flow/deploy.md
@@ -62,6 +62,32 @@ targets:
 - If `requires_confirmation: true`, ask the user to confirm before proceeding
 - If no deploy.yaml, proceed without extra confirmation
 
+### Step 4c: Capture Deploy-Verification Baseline (pre-deploy)
+
+Before deploying, snapshot the currently-running system so the post-deploy run
+(Step 8) can detect regressions. Only runs when
+`health.deploy_verification.enabled` is set in `.claude/cicd.yml`.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
+    echo "Capturing pre-deploy baseline..."
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+fi
+```
+
+- Captures health + smoke probes into `.claude/deploy-baseline.json`.
+- Fail-open: if `lib/cicd` is unavailable or no probes are configured, skip -
+  the deploy is never blocked by baseline capture.
+
 ### Step 4b: Run Deploy via Deterministic Runner (primary path)
 
 **Primary path:** Use the deterministic CI/CD runner for reproducible deploy with security gate:
@@ -186,18 +212,43 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
    SMOKE_EXIT=$?
    ```
 
+3b. **Run deploy verification (baseline comparison + verdict):**
+
+   When a baseline was captured in Step 4c, diff the post-deploy probes against
+   it and emit an actionable verdict. This is the deploy-confidence gate - it
+   catches a deploy that made things *worse* than before, which raw health/smoke
+   cannot.
+
+   ```bash
+   echo "Running deploy verification..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+   VERIFY_EXIT=$?
+   ```
+
+   - `VERIFY_EXIT == 0` (PROCEED or REVIEW): keep the deployment. On REVIEW,
+     surface the flagged probes to the user.
+   - `VERIFY_EXIT == 1` (ROLLBACK): a probe that passed in the baseline fails
+     now. **Report the regression prominently** and recommend rolling back
+     (redeploy the previous commit or run the rollback target) or investigating
+     with `/cicd:health` + `/cicd:smoke`. Verification does not roll back
+     automatically - the human decides.
+
 4. **Report results:**
-   - If all pass: `"Deploy verified ✅ - health checks and smoke tests passed"`
-   - If any fail: Report failures and suggest `/self-improvement:deployment`
+   - If verification PROCEEDs (or health + smoke pass with no baseline):
+     `"Deploy verified ✅ - no regression vs baseline"`
+   - If verification returns ROLLBACK: Report the regression and recommend
+     rollback + `/self-improvement:deployment`
+   - If any raw check fails: Report failures and suggest `/self-improvement:deployment`
 
 5. **Log verification results** (extends deploy.log format):
    ```bash
    HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
    SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
-   echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS}" >> .claude/deploy.log
+   VERDICT=$( PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
+   echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS} | verify:${VERDICT:-none}" >> .claude/deploy.log
    ```
 
-   Extended log format: `timestamp | target | commit | branch | deploy_exit | health:pass/fail | smoke:pass/fail`
+   Extended log format: `timestamp | target | commit | branch | deploy_exit | health:pass/fail | smoke:pass/fail | verify:proceed/review/rollback/none`
 
 **Skip conditions:**
 - No `.claude/cicd.yml` → skip silently

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,11 @@ node_modules/
 # must never be committed to the parent repo.
 .claude/worktrees/
 
+# Deploy-verification baseline (issue #444) - a per-workstation snapshot of
+# health + smoke probes captured before a deploy, compared against after.
+# Runtime state, like .claude/runs/; never tracked.
+.claude/deploy-baseline.json
+
 # Logs
 *.log
 logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@
 
 ### Added
 
+- **Deploy verification / `/cicd:verify`** (issue #444, epic #417 Phase C) - a
+  deploy-confidence skill that validates the *deployment*, not just the code.
+  Captures a baseline of `health.endpoints` / `health.smoke_tests` before a
+  deploy, re-runs them after, diffs the two, and emits one actionable verdict:
+  **PROCEED**, **REVIEW**, or **ROLLBACK** (a probe that passed pre-deploy
+  failing now). New `lib/cicd/verify.py` (baseline capture, persistence,
+  regression diff, verdict logic - zero new deps, reuses the existing
+  health/smoke runners), a `verify` CLI subcommand (`python -m lib.cicd verify
+  [--baseline] [--summary] [--json]`), and a `health.deploy_verification` config
+  block (latency-regression thresholds, `on_latency_regression`,
+  `require_baseline`). Wired into `/flow:deploy` (Step 8) and `/flow:auto`
+  (Step 9, which deploys inline and would otherwise skip verification): baseline
+  captured before `make deploy`, verdict emitted after. Fail-open and inert
+  unless `deploy_verification.enabled` is set; the baseline
+  (`.claude/deploy-baseline.json`) is per-workstation state and git-ignored.
+  A ROLLBACK verdict is surfaced but never rolls back automatically.
+
 - **Woodpecker self-hosted CI skill** (issue #445, epic #417 Phase C) - packages
   CPP's self-hosted Woodpecker CI knowledge as a distinct, reusable skill. The
   ecosystem assumes GitHub Actions; this is the uncovered ground. New

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ mirrors the `/security` #438 and hooks #439 defer-the-commodity-half moves).
 - `/cicd:check` - Validate Makefile against CPP standards
 - `/cicd:health` - Run health checks (endpoints + processes)
 - `/cicd:smoke` - Run smoke tests from cicd.yml
+- `/cicd:verify` - Verify a deployment against a pre-deploy baseline (proceed/review/rollback)
 - `/cicd:pipeline` - Generate CI/CD workflows: GitHub Actions, or self-hosted Woodpecker via `pipeline.provider` (consults cicd_tasks.yml manifest if present)
 - `/cicd:woodpecker` - Generate a hardened self-hosted Woodpecker pipeline (opt-in secret-scan + image-security + runtime-smoke stages) and scaffold the server/agent from `templates/woodpecker/`; see `docs/skills/woodpecker-ci.md`
 - `/cicd:container` - Generate Dockerfile and docker-compose.yml
@@ -136,6 +137,8 @@ mirrors the `/security` #438 and hooks #439 defer-the-commodity-half moves).
 - `python -m lib.cicd validate` - Validate .claude/cicd.yml with fix suggestions (Pydantic v2)
 - `python -m lib.cicd validate --schema` - Generate JSON Schema for IDE autocompletion
 - `python -m lib.cicd run --plan <name>` - Execute CI/CD plan deterministically (finish, check, deploy)
+- `python -m lib.cicd verify --baseline` - Capture pre-deploy health/smoke baseline
+- `python -m lib.cicd verify` - Verify post-deploy against baseline (exit 1 = ROLLBACK)
 - `python -m lib.cicd.bootstrap check` - Check admin-only bootstrap dependencies (config: `.claude/bootstrap.yaml`)
 
 ### Codex Orchestration

--- a/lib/cicd/__init__.py
+++ b/lib/cicd/__init__.py
@@ -5,6 +5,7 @@ Provides:
 - Makefile validation and generation
 - Health checks (HTTP endpoints, process ports)
 - Smoke tests (command execution with assertions)
+- Deploy verification (baseline comparison, proceed/review/rollback verdict)
 - Configuration from .claude/cicd.yml
 
 Quick Start:
@@ -75,6 +76,17 @@ from .runner import DeterministicRunner, RunResult, resume_run, run_plan
 from .smoke import run_smoke_tests
 from .state import RunState, StepRecord, StepStatus
 from .steps import DeployStep, ShellStep, StepDef, StepResult
+from .verify import (
+    DeployVerifyResult,
+    ProbeDiff,
+    ProbeResult,
+    Verdict,
+    VerificationSnapshot,
+    capture_snapshot,
+    load_baseline,
+    save_baseline,
+    verify_deployment,
+)
 
 __all__ = [
     # Config
@@ -88,6 +100,16 @@ __all__ = [
     "check_process",
     # Smoke
     "run_smoke_tests",
+    # Deploy verification
+    "verify_deployment",
+    "capture_snapshot",
+    "save_baseline",
+    "load_baseline",
+    "Verdict",
+    "VerificationSnapshot",
+    "DeployVerifyResult",
+    "ProbeResult",
+    "ProbeDiff",
     # Container
     "generate_container_files",
     "generate_dockerfile",

--- a/lib/cicd/cli.py
+++ b/lib/cicd/cli.py
@@ -5,6 +5,7 @@ Usage:
     python -m lib.cicd check [OPTIONS]
     python -m lib.cicd health [OPTIONS]
     python -m lib.cicd smoke [OPTIONS]
+    python -m lib.cicd verify [OPTIONS]
 
 Examples:
     python -m lib.cicd detect
@@ -16,6 +17,9 @@ Examples:
     python -m lib.cicd health --json
     python -m lib.cicd smoke
     python -m lib.cicd smoke --json
+    python -m lib.cicd verify --baseline    # capture pre-deploy baseline
+    python -m lib.cicd verify               # verify post-deploy (proceed/rollback)
+    python -m lib.cicd verify --summary
 """
 
 from __future__ import annotations
@@ -37,6 +41,12 @@ from .manifest import generate_manifest, load_manifest, write_manifest
 from .pipeline import generate_pipeline
 from .runner import resume_run, run_plan, show_status
 from .smoke import run_smoke_tests
+from .verify import (
+    Verdict,
+    capture_snapshot,
+    save_baseline,
+    verify_deployment,
+)
 
 
 def cmd_detect(args: argparse.Namespace) -> int:
@@ -298,6 +308,100 @@ def cmd_smoke(args: argparse.Namespace) -> int:
     print(f"Result: {result.summary_line()}")
 
     return 0 if result.all_passed else 1
+
+
+def _print_snapshot_table(snapshot, title: str) -> None:
+    """Print a health+smoke snapshot as a markdown table."""
+    print(f"## {title}")
+    print()
+    if not snapshot.probes:
+        print("No health or smoke probes configured.")
+        print()
+        print("  Add health.endpoints / health.smoke_tests to .claude/cicd.yml.")
+        return
+    print("| Probe | Kind | Status | Detail | Time |")
+    print("|-------|------|--------|--------|------|")
+    for probe in snapshot.probes:
+        status = "PASS" if probe.passed else "FAIL"
+        print(f"| {probe.name} | {probe.kind} | {status} | {probe.detail} | {probe.elapsed_ms:.0f}ms |")
+    print()
+    commit_suffix = f" @ {snapshot.commit}" if snapshot.commit else ""
+    print(f"Captured: {snapshot.passed}/{snapshot.total} probes passed{commit_suffix}")
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    """Capture a baseline, or verify a deployment against one (proceed/rollback)."""
+    config = CICDConfig.load(args.path)
+
+    # --baseline: capture the pre-deploy snapshot and persist it.
+    if args.baseline:
+        snapshot = capture_snapshot(config=config, project_root=args.path)
+        path = save_baseline(snapshot, config=config, project_root=args.path)
+
+        if args.json:
+            print(json.dumps({"action": "baseline", "path": str(path), "snapshot": snapshot.to_dict()}, indent=2))
+            return 0
+        if args.summary:
+            print(f"Baseline captured: {snapshot.passed}/{snapshot.total} probes passed -> {path}")
+            return 0
+
+        _print_snapshot_table(snapshot, "Pre-Deploy Baseline")
+        print()
+        print(f"Saved baseline: {path}")
+        if snapshot.total == 0:
+            print("(no probes configured - post-deploy verify will report REVIEW)")
+        return 0
+
+    # Default: verify post-deploy against the baseline.
+    result = verify_deployment(config=config, project_root=args.path)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+        return result.exit_code
+    if args.summary:
+        print(result.summary_line())
+        return result.exit_code
+
+    print("## Deploy Verification")
+    print()
+    if not result.snapshot.probes:
+        print("No health or smoke probes configured - cannot verify the deployment.")
+        print()
+        print("  Add health.endpoints / health.smoke_tests to .claude/cicd.yml,")
+        print("  then capture a baseline before deploy: python -m lib.cicd verify --baseline")
+        print()
+        print(f"Verdict: {result.verdict.value.upper()}")
+        return result.exit_code
+
+    if not result.has_baseline:
+        print("No baseline found - reporting absolute pass/fail only.")
+        print("  Capture one before the next deploy: python -m lib.cicd verify --baseline")
+        print()
+
+    print("| Probe | Kind | Baseline | Now | Change | Detail |")
+    print("|-------|------|----------|-----|--------|--------|")
+    for diff in result.diffs:
+        base = "-" if diff.baseline_passed is None else ("PASS" if diff.baseline_passed else "FAIL")
+        now = "PASS" if diff.current_passed else "FAIL"
+        print(f"| {diff.name} | {diff.kind} | {base} | {now} | {diff.classification} | {diff.detail} |")
+
+    print()
+    verdict_marker = {
+        Verdict.PROCEED: "PROCEED",
+        Verdict.REVIEW: "REVIEW",
+        Verdict.ROLLBACK: "ROLLBACK",
+    }[result.verdict]
+    print(f"Verdict: {verdict_marker}")
+    for reason in result.reasons:
+        print(f"  - {reason}")
+    if result.verdict is Verdict.ROLLBACK:
+        print()
+        print("  Action: roll back this deployment or investigate before proceeding.")
+    elif result.verdict is Verdict.REVIEW:
+        print()
+        print("  Action: review the flagged probes; deployment is not clearly broken.")
+
+    return result.exit_code
 
 
 def cmd_container(args: argparse.Namespace) -> int:
@@ -746,6 +850,25 @@ def create_parser() -> argparse.ArgumentParser:
         help="One-line summary for flow integration",
     )
 
+    # 'verify' subcommand
+    verify_parser = subparsers.add_parser(
+        "verify",
+        help="Verify a deployment against a pre-deploy baseline (proceed/review/rollback)",
+    )
+    _add_common_args(verify_parser)
+    verify_parser.add_argument(
+        "--baseline",
+        "-b",
+        action="store_true",
+        help="Capture and save the pre-deploy baseline instead of verifying",
+    )
+    verify_parser.add_argument(
+        "--summary",
+        "-s",
+        action="store_true",
+        help="One-line verdict for flow integration",
+    )
+
     # 'container' subcommand
     container_parser = subparsers.add_parser(
         "container",
@@ -847,6 +970,7 @@ def main(argv: list[str] | None = None) -> int:
         "check": cmd_check,
         "health": cmd_health,
         "smoke": cmd_smoke,
+        "verify": cmd_verify,
         "container": cmd_container,
         "pipeline": cmd_pipeline,
         "infra-init": cmd_infra_init,

--- a/lib/cicd/config.py
+++ b/lib/cicd/config.py
@@ -69,6 +69,31 @@ class SmokeTest(BaseModel):
     timeout: int = 10
 
 
+class DeployVerificationConfig(BaseModel):
+    """Post-deploy verification (deploy-confidence) configuration.
+
+    Controls the /cicd:verify baseline comparison: capture health + smoke
+    probes before a deploy, re-run them after, diff the two, and emit an
+    actionable verdict (proceed / review / rollback). Inert unless enabled
+    (or a baseline file already exists).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = False
+    baseline_file: str = ".claude/deploy-baseline.json"
+    # A probe slower than baseline_ms * (1 + latency_regression_pct/100) is
+    # flagged, but only when the current time also exceeds latency_floor_ms
+    # (avoids noise on fast probes where a few ms is a large percentage).
+    latency_regression_pct: float = 50.0
+    latency_floor_ms: float = 100.0
+    # What a latency regression means for the verdict: review | rollback | ignore
+    on_latency_regression: str = "review"
+    # When true and no baseline exists, downgrade PROCEED to REVIEW (we deployed
+    # blind - nothing to compare against).
+    require_baseline: bool = False
+
+
 class HealthConfig(BaseModel):
     """Health check and smoke test configuration."""
 
@@ -79,6 +104,7 @@ class HealthConfig(BaseModel):
     smoke_tests: list[SmokeTest] = Field(default_factory=list)
     post_deploy: bool = False
     startup_delay: int = 0
+    deploy_verification: DeployVerificationConfig = Field(default_factory=DeployVerificationConfig)
 
 
 class WoodpeckerConfig(BaseModel):

--- a/lib/cicd/verify.py
+++ b/lib/cicd/verify.py
@@ -1,0 +1,455 @@
+"""Deploy verification (deploy-confidence) for CI/CD & Verification.
+
+Validates the *deployment*, not just the code: capture a pre-deploy baseline
+of health checks and smoke tests, re-run them after deploy, diff the two, and
+emit one actionable verdict - PROCEED, REVIEW, or ROLLBACK.
+
+The novel piece here is the baseline comparison. Raw health/smoke runs already
+exist (lib.cicd.health, lib.cicd.smoke); this module composes them into a
+regression check so a deploy that makes things *worse* than 60 seconds ago is
+caught, not just a deploy whose code passed tests.
+
+Reuses run_health_checks / run_smoke_tests - no new dependencies (curl +
+subprocess, matching health.py). Baseline snapshots persist to
+.claude/deploy-baseline.json (per-workstation runtime state, like .claude/runs/).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+from .config import CICDConfig, DeployVerificationConfig
+from .health import run_health_checks
+from .smoke import run_smoke_tests
+
+
+class Verdict(str, Enum):
+    """Actionable deploy-confidence verdict."""
+
+    PROCEED = "proceed"
+    REVIEW = "review"
+    ROLLBACK = "rollback"
+
+
+# Probe classifications, ordered roughly by severity.
+CLASS_REGRESSION = "regression"  # passed in baseline, fails now -> ROLLBACK
+CLASS_NEW_FAILURE = "new_failure"  # failing now, no known-good baseline -> ROLLBACK
+CLASS_PREEXISTING = "preexisting_failure"  # failing before and after -> REVIEW
+CLASS_LATENCY = "latency_regression"  # passing but markedly slower -> REVIEW/ROLLBACK
+CLASS_RECOVERED = "recovered"  # was failing, passes now -> ok
+CLASS_NEW_PROBE = "new_probe"  # passing, not in baseline -> ok
+CLASS_OK = "ok"  # passing before and after -> ok
+
+
+@dataclass
+class ProbeResult:
+    """A single normalized probe (health check or smoke test) outcome."""
+
+    name: str
+    kind: str  # "health" | "smoke"
+    passed: bool
+    elapsed_ms: float = 0.0
+    detail: str = ""
+
+    @property
+    def key(self) -> str:
+        return f"{self.kind}:{self.name}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "passed": self.passed,
+            "elapsed_ms": round(self.elapsed_ms, 1),
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProbeResult:
+        return cls(
+            name=str(data["name"]),
+            kind=str(data.get("kind", "")),
+            passed=bool(data.get("passed", False)),
+            elapsed_ms=float(data.get("elapsed_ms", 0.0)),
+            detail=str(data.get("detail", "")),
+        )
+
+
+@dataclass
+class VerificationSnapshot:
+    """A point-in-time capture of all health + smoke probes."""
+
+    probes: list[ProbeResult] = field(default_factory=list)
+    commit: str = ""
+    captured_at: str = ""
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for p in self.probes if p.passed)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for p in self.probes if not p.passed)
+
+    @property
+    def total(self) -> int:
+        return len(self.probes)
+
+    @property
+    def all_passed(self) -> bool:
+        return self.total > 0 and self.failed == 0
+
+    def by_key(self) -> dict[str, ProbeResult]:
+        return {p.key: p for p in self.probes}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "probes": [p.to_dict() for p in self.probes],
+            "commit": self.commit,
+            "captured_at": self.captured_at,
+            "passed": self.passed,
+            "failed": self.failed,
+            "total": self.total,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> VerificationSnapshot:
+        return cls(
+            probes=[ProbeResult.from_dict(p) for p in data.get("probes", [])],
+            commit=str(data.get("commit", "")),
+            captured_at=str(data.get("captured_at", "")),
+        )
+
+
+@dataclass
+class ProbeDiff:
+    """The before/after comparison of a single probe."""
+
+    name: str
+    kind: str
+    classification: str
+    baseline_passed: Optional[bool]
+    current_passed: bool
+    baseline_ms: Optional[float]
+    current_ms: float
+    detail: str = ""
+
+    @property
+    def key(self) -> str:
+        return f"{self.kind}:{self.name}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "classification": self.classification,
+            "baseline_passed": self.baseline_passed,
+            "current_passed": self.current_passed,
+            "baseline_ms": None if self.baseline_ms is None else round(self.baseline_ms, 1),
+            "current_ms": round(self.current_ms, 1),
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class DeployVerifyResult:
+    """Aggregated verification outcome with an actionable verdict."""
+
+    verdict: Verdict
+    reasons: list[str]
+    diffs: list[ProbeDiff]
+    snapshot: VerificationSnapshot
+    baseline: Optional[VerificationSnapshot] = None
+
+    @property
+    def has_baseline(self) -> bool:
+        return self.baseline is not None
+
+    @property
+    def exit_code(self) -> int:
+        """1 for ROLLBACK (actionable stop), 0 for PROCEED/REVIEW (advisory)."""
+        return 1 if self.verdict is Verdict.ROLLBACK else 0
+
+    def diffs_by_class(self, classification: str) -> list[ProbeDiff]:
+        return [d for d in self.diffs if d.classification == classification]
+
+    def summary_line(self) -> str:
+        base = f"Deploy verdict: {self.verdict.value.upper()}"
+        if self.reasons:
+            return f"{base} - {self.reasons[0]}"
+        if self.snapshot.total == 0:
+            return f"{base} - no probes configured"
+        return f"{base} - {self.snapshot.passed}/{self.snapshot.total} probes passed"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict.value,
+            "exit_code": self.exit_code,
+            "has_baseline": self.has_baseline,
+            "reasons": self.reasons,
+            "diffs": [d.to_dict() for d in self.diffs],
+            "snapshot": self.snapshot.to_dict(),
+            "baseline": self.baseline.to_dict() if self.baseline else None,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Capture / persistence
+# --------------------------------------------------------------------------- #
+
+
+def capture_snapshot(
+    config: Optional[CICDConfig] = None,
+    project_root: Optional[str] = None,
+) -> VerificationSnapshot:
+    """Run all health checks and smoke tests and normalize them into a snapshot."""
+    if config is None:
+        config = CICDConfig.load(project_root)
+
+    probes: list[ProbeResult] = []
+
+    health = run_health_checks(config=config, project_root=project_root)
+    for check in health.checks:
+        probes.append(
+            ProbeResult(
+                name=check.name,
+                kind="health",
+                passed=check.passed,
+                elapsed_ms=check.elapsed_ms,
+                detail=check.detail,
+            )
+        )
+
+    smoke = run_smoke_tests(config=config, project_root=project_root)
+    for test in smoke.tests:
+        probes.append(
+            ProbeResult(
+                name=test.name,
+                kind="smoke",
+                passed=test.passed,
+                elapsed_ms=test.elapsed_ms,
+                detail=test.detail,
+            )
+        )
+
+    return VerificationSnapshot(
+        probes=probes,
+        commit=_git_commit(project_root),
+        captured_at=_now(),
+    )
+
+
+def _baseline_path(config: Optional[CICDConfig], project_root: Optional[str]) -> Path:
+    root = Path(project_root) if project_root else Path(".")
+    vconf = config.health.deploy_verification if config else DeployVerificationConfig()
+    return root / vconf.baseline_file
+
+
+def save_baseline(
+    snapshot: VerificationSnapshot,
+    config: Optional[CICDConfig] = None,
+    project_root: Optional[str] = None,
+) -> Path:
+    """Persist a snapshot as the pre-deploy baseline."""
+    path = _baseline_path(config, project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(snapshot.to_dict(), indent=2))
+    return path
+
+
+def load_baseline(
+    config: Optional[CICDConfig] = None,
+    project_root: Optional[str] = None,
+) -> Optional[VerificationSnapshot]:
+    """Load the pre-deploy baseline, or None if absent/unreadable (fail-open)."""
+    path = _baseline_path(config, project_root)
+    if not path.exists():
+        return None
+    try:
+        return VerificationSnapshot.from_dict(json.loads(path.read_text()))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError, OSError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Diff / verdict
+# --------------------------------------------------------------------------- #
+
+
+def _classify(
+    baseline: Optional[ProbeResult],
+    current: ProbeResult,
+    vconf: DeployVerificationConfig,
+) -> tuple[str, str]:
+    """Classify a single probe's before/after state. Returns (class, detail)."""
+    if baseline is None:
+        if current.passed:
+            return CLASS_NEW_PROBE, "not in baseline (passing)"
+        return CLASS_NEW_FAILURE, current.detail or "failing, no baseline to compare"
+
+    if baseline.passed and not current.passed:
+        return CLASS_REGRESSION, current.detail or "passed in baseline, fails now"
+
+    if not baseline.passed and not current.passed:
+        return CLASS_PREEXISTING, current.detail or "was already failing before deploy"
+
+    if not baseline.passed and current.passed:
+        return CLASS_RECOVERED, "was failing in baseline, passes now"
+
+    # Both passed - check for a latency regression.
+    if vconf.on_latency_regression != "ignore" and _is_latency_regression(baseline, current, vconf):
+        pct = ((current.elapsed_ms - baseline.elapsed_ms) / baseline.elapsed_ms) * 100
+        return (
+            CLASS_LATENCY,
+            f"{current.elapsed_ms:.0f}ms vs baseline {baseline.elapsed_ms:.0f}ms (+{pct:.0f}%)",
+        )
+
+    return CLASS_OK, "ok"
+
+
+def _is_latency_regression(
+    baseline: ProbeResult,
+    current: ProbeResult,
+    vconf: DeployVerificationConfig,
+) -> bool:
+    if baseline.elapsed_ms <= 0:
+        return False
+    if current.elapsed_ms < vconf.latency_floor_ms:
+        return False
+    threshold = baseline.elapsed_ms * (1 + vconf.latency_regression_pct / 100.0)
+    return current.elapsed_ms > threshold
+
+
+def verify_deployment(
+    config: Optional[CICDConfig] = None,
+    project_root: Optional[str] = None,
+    baseline: Optional[VerificationSnapshot] = None,
+) -> DeployVerifyResult:
+    """Run post-deploy probes, diff against the baseline, and compute a verdict.
+
+    Args:
+        config: CI/CD config (loaded from project_root if None).
+        project_root: Project root for config + baseline loading.
+        baseline: Explicit baseline (loaded from disk if None).
+    """
+    if config is None:
+        config = CICDConfig.load(project_root)
+    vconf = config.health.deploy_verification
+
+    current = capture_snapshot(config=config, project_root=project_root)
+    if baseline is None:
+        baseline = load_baseline(config=config, project_root=project_root)
+
+    base_by_key = baseline.by_key() if baseline else {}
+
+    diffs: list[ProbeDiff] = []
+    for probe in current.probes:
+        prior = base_by_key.get(probe.key)
+        classification, detail = _classify(prior, probe, vconf)
+        diffs.append(
+            ProbeDiff(
+                name=probe.name,
+                kind=probe.kind,
+                classification=classification,
+                baseline_passed=None if prior is None else prior.passed,
+                current_passed=probe.passed,
+                baseline_ms=None if prior is None else prior.elapsed_ms,
+                current_ms=probe.elapsed_ms,
+                detail=detail,
+            )
+        )
+
+    verdict, reasons = _decide(diffs, current, baseline, vconf)
+    return DeployVerifyResult(
+        verdict=verdict,
+        reasons=reasons,
+        diffs=diffs,
+        snapshot=current,
+        baseline=baseline,
+    )
+
+
+def _decide(
+    diffs: list[ProbeDiff],
+    current: VerificationSnapshot,
+    baseline: Optional[VerificationSnapshot],
+    vconf: DeployVerificationConfig,
+) -> tuple[Verdict, list[str]]:
+    """Aggregate probe classifications into a verdict + human-readable reasons."""
+    regressions = [d for d in diffs if d.classification == CLASS_REGRESSION]
+    new_failures = [d for d in diffs if d.classification == CLASS_NEW_FAILURE]
+    latency = [d for d in diffs if d.classification == CLASS_LATENCY]
+    preexisting = [d for d in diffs if d.classification == CLASS_PREEXISTING]
+    recovered = [d for d in diffs if d.classification == CLASS_RECOVERED]
+
+    reasons: list[str] = []
+
+    # Nothing to verify - be honest, do not claim PROCEED.
+    if current.total == 0:
+        return Verdict.REVIEW, [
+            "no health or smoke probes configured - cannot verify the deployment"
+        ]
+
+    # ROLLBACK: a real, current failure caused by (or coincident with) this deploy.
+    if regressions:
+        reasons.append(_names_reason("regression", regressions))
+    if new_failures:
+        reasons.append(_names_reason("failing (no baseline)", new_failures))
+    if vconf.on_latency_regression == "rollback" and latency:
+        reasons.append(_names_reason("latency regression", latency))
+    if reasons:
+        return Verdict.ROLLBACK, reasons
+
+    # REVIEW: soft signals worth a human look, but not a clear rollback trigger.
+    if latency:
+        reasons.append(_names_reason("latency regression", latency))
+    if preexisting:
+        reasons.append(_names_reason("still failing since before deploy", preexisting))
+    if not baseline and vconf.require_baseline:
+        reasons.append("no baseline captured - deployed without a comparison point")
+    if reasons:
+        return Verdict.REVIEW, reasons
+
+    # PROCEED: everything green (optionally after recovering from a broken baseline).
+    if recovered:
+        reasons.append(_names_reason("recovered since baseline", recovered))
+    return Verdict.PROCEED, reasons
+
+
+def _names_reason(label: str, diffs: list[ProbeDiff]) -> str:
+    names = ", ".join(d.key for d in diffs)
+    noun = "probe" if len(diffs) == 1 else "probes"
+    return f"{len(diffs)} {label} {noun}: {names}"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _git_commit(project_root: Optional[str]) -> str:
+    """Short HEAD commit, or '' if git is unavailable (fail-open)."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=project_root or None,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return ""
+
+
+def _now() -> str:
+    """ISO timestamp (local), matching state.py."""
+    return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())

--- a/templates/cicd.yml.example
+++ b/templates/cicd.yml.example
@@ -72,6 +72,23 @@ deploy:
 #       expected_body: '"ok"'
 
 # -------------------------------------------------------------------
+# Deploy Verification (used by /cicd:verify, /flow:deploy, /flow:auto)
+# -------------------------------------------------------------------
+# Capture the health.endpoints / health.smoke_tests above as a baseline
+# BEFORE a deploy, re-run them AFTER, diff the two, and emit an actionable
+# verdict: proceed / review / rollback. Catches a deploy that made things
+# worse than before - which raw health/smoke checks cannot.
+#
+# health:
+#   deploy_verification:
+#     enabled: true                     # let /flow:deploy + /flow:auto auto-capture/verify
+#     baseline_file: .claude/deploy-baseline.json
+#     latency_regression_pct: 50        # flag a probe > 50% slower than baseline...
+#     latency_floor_ms: 100             # ...but only if it is also over 100ms (noise floor)
+#     on_latency_regression: review     # review | rollback | ignore
+#     require_baseline: false           # true => no baseline downgrades PROCEED to REVIEW
+
+# -------------------------------------------------------------------
 # Pipeline Configuration (used by /cicd:pipeline)
 # -------------------------------------------------------------------
 # pipeline:

--- a/tests/test_cicd_verify.py
+++ b/tests/test_cicd_verify.py
@@ -1,0 +1,401 @@
+"""Tests for lib/cicd/verify.py - deploy verification (deploy-confidence).
+
+Covers baseline capture/persistence, probe classification, verdict
+aggregation (PROCEED / REVIEW / ROLLBACK), and the verify CLI subcommand.
+Health and smoke runners are mocked so no real curl/subprocess/network runs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from lib.cicd.config import CICDConfig, DeployVerificationConfig
+from lib.cicd.models import (
+    HealthCheckEntry,
+    HealthCheckResult,
+    SmokeTestEntry,
+    SmokeTestResult,
+)
+from lib.cicd.verify import (
+    CLASS_LATENCY,
+    CLASS_NEW_FAILURE,
+    CLASS_NEW_PROBE,
+    CLASS_OK,
+    CLASS_PREEXISTING,
+    CLASS_RECOVERED,
+    CLASS_REGRESSION,
+    DeployVerifyResult,
+    ProbeDiff,
+    ProbeResult,
+    Verdict,
+    VerificationSnapshot,
+    _classify,
+    _decide,
+    capture_snapshot,
+    load_baseline,
+    save_baseline,
+    verify_deployment,
+)
+
+
+def _probe(name: str, kind: str, passed: bool, ms: float = 10.0) -> ProbeResult:
+    return ProbeResult(name=name, kind=kind, passed=passed, elapsed_ms=ms)
+
+
+def _diff(cls: str, base: bool | None, now: bool, name: str = "API", kind: str = "health") -> ProbeDiff:
+    return ProbeDiff(
+        name=name,
+        kind=kind,
+        classification=cls,
+        baseline_passed=base,
+        current_passed=now,
+        baseline_ms=None if base is None else 10.0,
+        current_ms=10.0,
+    )
+
+
+class TestProbeResult:
+    def test_key(self) -> None:
+        assert _probe("API", "health", True).key == "health:API"
+
+    def test_roundtrip(self) -> None:
+        p = ProbeResult(name="API", kind="health", passed=True, elapsed_ms=42.5, detail="HTTP 200")
+        restored = ProbeResult.from_dict(p.to_dict())
+        assert restored == p
+
+    def test_from_dict_defaults(self) -> None:
+        p = ProbeResult.from_dict({"name": "x"})
+        assert p.kind == "" and p.passed is False and p.elapsed_ms == 0.0
+
+
+class TestVerificationSnapshot:
+    def test_counts(self) -> None:
+        snap = VerificationSnapshot(
+            probes=[_probe("a", "health", True), _probe("b", "smoke", False)]
+        )
+        assert snap.total == 2
+        assert snap.passed == 1
+        assert snap.failed == 1
+        assert not snap.all_passed
+
+    def test_all_passed_requires_probes(self) -> None:
+        assert not VerificationSnapshot().all_passed
+        assert VerificationSnapshot(probes=[_probe("a", "health", True)]).all_passed
+
+    def test_by_key(self) -> None:
+        snap = VerificationSnapshot(probes=[_probe("a", "health", True), _probe("a", "smoke", True)])
+        keys = set(snap.by_key().keys())
+        assert keys == {"health:a", "smoke:a"}
+
+    def test_roundtrip(self) -> None:
+        snap = VerificationSnapshot(
+            probes=[_probe("a", "health", True, 5.0)], commit="abc123", captured_at="2026-07-03T00:00:00"
+        )
+        restored = VerificationSnapshot.from_dict(snap.to_dict())
+        assert restored.commit == "abc123"
+        assert restored.probes[0].name == "a"
+
+
+class TestClassify:
+    def setup_method(self) -> None:
+        self.vconf = DeployVerificationConfig()
+
+    def test_regression(self) -> None:
+        cls, _ = _classify(_probe("a", "health", True), _probe("a", "health", False), self.vconf)
+        assert cls == CLASS_REGRESSION
+
+    def test_preexisting_failure(self) -> None:
+        cls, _ = _classify(_probe("a", "health", False), _probe("a", "health", False), self.vconf)
+        assert cls == CLASS_PREEXISTING
+
+    def test_recovered(self) -> None:
+        cls, _ = _classify(_probe("a", "health", False), _probe("a", "health", True), self.vconf)
+        assert cls == CLASS_RECOVERED
+
+    def test_ok(self) -> None:
+        cls, _ = _classify(_probe("a", "health", True, 10.0), _probe("a", "health", True, 11.0), self.vconf)
+        assert cls == CLASS_OK
+
+    def test_new_probe(self) -> None:
+        cls, _ = _classify(None, _probe("a", "health", True), self.vconf)
+        assert cls == CLASS_NEW_PROBE
+
+    def test_new_failure(self) -> None:
+        cls, _ = _classify(None, _probe("a", "health", False), self.vconf)
+        assert cls == CLASS_NEW_FAILURE
+
+    def test_latency_regression(self) -> None:
+        # 100ms baseline, 300ms now: +200% over the 50% threshold, above 100ms floor.
+        cls, detail = _classify(_probe("a", "health", True, 100.0), _probe("a", "health", True, 300.0), self.vconf)
+        assert cls == CLASS_LATENCY
+        assert "+200%" in detail
+
+    def test_latency_below_floor_is_ok(self) -> None:
+        # 10ms -> 40ms is +300% but under the 100ms floor, so not flagged.
+        cls, _ = _classify(_probe("a", "health", True, 10.0), _probe("a", "health", True, 40.0), self.vconf)
+        assert cls == CLASS_OK
+
+    def test_latency_ignored_when_configured(self) -> None:
+        vconf = DeployVerificationConfig(on_latency_regression="ignore")
+        cls, _ = _classify(_probe("a", "health", True, 100.0), _probe("a", "health", True, 500.0), vconf)
+        assert cls == CLASS_OK
+
+    def test_zero_baseline_ms_no_regression(self) -> None:
+        cls, _ = _classify(_probe("a", "health", True, 0.0), _probe("a", "health", True, 500.0), self.vconf)
+        assert cls == CLASS_OK
+
+
+class TestDecide:
+    def setup_method(self) -> None:
+        self.vconf = DeployVerificationConfig()
+
+    def _snap(self, *probes: ProbeResult) -> VerificationSnapshot:
+        return VerificationSnapshot(probes=list(probes))
+
+    def test_regression_rollback(self) -> None:
+        diffs = [_diff(CLASS_REGRESSION, True, False)]
+        verdict, reasons = _decide(diffs, self._snap(_probe("API", "health", False)), self._snap(), self.vconf)
+        assert verdict is Verdict.ROLLBACK
+        assert "regression" in reasons[0]
+
+    def test_new_failure_rollback(self) -> None:
+        diffs = [_diff(CLASS_NEW_FAILURE, None, False)]
+        verdict, _ = _decide(diffs, self._snap(_probe("API", "health", False)), None, self.vconf)
+        assert verdict is Verdict.ROLLBACK
+
+    def test_all_ok_proceed(self) -> None:
+        diffs = [_diff(CLASS_OK, True, True)]
+        verdict, _ = _decide(diffs, self._snap(_probe("API", "health", True)), self._snap(), self.vconf)
+        assert verdict is Verdict.PROCEED
+
+    def test_recovered_proceed(self) -> None:
+        diffs = [_diff(CLASS_RECOVERED, False, True)]
+        verdict, reasons = _decide(diffs, self._snap(_probe("API", "health", True)), self._snap(), self.vconf)
+        assert verdict is Verdict.PROCEED
+        assert reasons and "recovered" in reasons[0]
+
+    def test_latency_review_by_default(self) -> None:
+        diffs = [_diff(CLASS_LATENCY, True, True)]
+        verdict, _ = _decide(diffs, self._snap(_probe("API", "health", True)), self._snap(), self.vconf)
+        assert verdict is Verdict.REVIEW
+
+    def test_latency_rollback_when_configured(self) -> None:
+        vconf = DeployVerificationConfig(on_latency_regression="rollback")
+        diffs = [_diff(CLASS_LATENCY, True, True)]
+        verdict, _ = _decide(diffs, self._snap(_probe("API", "health", True)), self._snap(), vconf)
+        assert verdict is Verdict.ROLLBACK
+
+    def test_preexisting_failure_review(self) -> None:
+        diffs = [_diff(CLASS_PREEXISTING, False, False)]
+        verdict, _ = _decide(diffs, self._snap(_probe("API", "health", False)), self._snap(), self.vconf)
+        assert verdict is Verdict.REVIEW
+
+    def test_no_probes_review(self) -> None:
+        verdict, reasons = _decide([], self._snap(), None, self.vconf)
+        assert verdict is Verdict.REVIEW
+        assert "no health or smoke probes" in reasons[0]
+
+    def test_require_baseline_downgrades_to_review(self) -> None:
+        vconf = DeployVerificationConfig(require_baseline=True)
+        diffs = [_diff(CLASS_NEW_PROBE, None, True)]
+        verdict, reasons = _decide(diffs, self._snap(_probe("API", "health", True)), None, vconf)
+        assert verdict is Verdict.REVIEW
+        assert any("no baseline" in r for r in reasons)
+
+    def test_regression_beats_latency(self) -> None:
+        diffs = [_diff(CLASS_REGRESSION, True, False), _diff(CLASS_LATENCY, True, True, name="B")]
+        verdict, _ = _decide(diffs, self._snap(_probe("API", "health", False)), self._snap(), self.vconf)
+        assert verdict is Verdict.ROLLBACK
+
+
+class TestDeployVerifyResult:
+    def test_exit_code(self) -> None:
+        snap = VerificationSnapshot(probes=[_probe("a", "health", True)])
+        assert DeployVerifyResult(Verdict.ROLLBACK, [], [], snap).exit_code == 1
+        assert DeployVerifyResult(Verdict.REVIEW, [], [], snap).exit_code == 0
+        assert DeployVerifyResult(Verdict.PROCEED, [], [], snap).exit_code == 0
+
+    def test_has_baseline(self) -> None:
+        snap = VerificationSnapshot(probes=[_probe("a", "health", True)])
+        assert not DeployVerifyResult(Verdict.PROCEED, [], [], snap, baseline=None).has_baseline
+        assert DeployVerifyResult(Verdict.PROCEED, [], [], snap, baseline=snap).has_baseline
+
+    def test_summary_line(self) -> None:
+        snap = VerificationSnapshot(probes=[_probe("a", "health", True)])
+        r = DeployVerifyResult(Verdict.ROLLBACK, ["1 regression probe: health:a"], [], snap)
+        assert "ROLLBACK" in r.summary_line()
+        assert "regression" in r.summary_line()
+
+    def test_to_dict(self) -> None:
+        snap = VerificationSnapshot(probes=[_probe("a", "health", True)])
+        d = DeployVerifyResult(Verdict.PROCEED, [], [], snap, baseline=snap).to_dict()
+        assert d["verdict"] == "proceed"
+        assert d["exit_code"] == 0
+        assert d["has_baseline"] is True
+
+
+class TestBaselinePersistence:
+    def test_roundtrip(self, tmp_path) -> None:
+        config = CICDConfig()
+        snap = VerificationSnapshot(probes=[_probe("API", "health", True, 42.0)], commit="deadbee")
+        path = save_baseline(snap, config=config, project_root=str(tmp_path))
+        assert path.exists()
+        loaded = load_baseline(config=config, project_root=str(tmp_path))
+        assert loaded is not None
+        assert loaded.commit == "deadbee"
+        assert loaded.probes[0].name == "API"
+
+    def test_load_missing_returns_none(self, tmp_path) -> None:
+        assert load_baseline(config=CICDConfig(), project_root=str(tmp_path)) is None
+
+    def test_load_corrupt_returns_none(self, tmp_path) -> None:
+        baseline = tmp_path / ".claude" / "deploy-baseline.json"
+        baseline.parent.mkdir(parents=True)
+        baseline.write_text("{ not valid json ]")
+        assert load_baseline(config=CICDConfig(), project_root=str(tmp_path)) is None
+
+    def test_custom_baseline_file(self, tmp_path) -> None:
+        config = CICDConfig()
+        config.health.deploy_verification.baseline_file = ".claude/custom-baseline.json"
+        snap = VerificationSnapshot(probes=[_probe("a", "health", True)])
+        path = save_baseline(snap, config=config, project_root=str(tmp_path))
+        assert path.name == "custom-baseline.json"
+
+
+class TestCaptureSnapshot:
+    @patch("lib.cicd.verify._git_commit", return_value="abc123")
+    @patch("lib.cicd.verify.run_smoke_tests")
+    @patch("lib.cicd.verify.run_health_checks")
+    def test_normalizes_probes(self, mock_health, mock_smoke, _mock_git) -> None:
+        mock_health.return_value = HealthCheckResult(
+            checks=[HealthCheckEntry(name="API", kind="endpoint", passed=True, detail="HTTP 200", elapsed_ms=5.0)]
+        )
+        mock_smoke.return_value = SmokeTestResult(
+            tests=[SmokeTestEntry(name="CLI", command="x --version", passed=False, detail="exit 1", elapsed_ms=8.0)]
+        )
+        snap = capture_snapshot(config=CICDConfig())
+        assert snap.commit == "abc123"
+        assert len(snap.probes) == 2
+        health_probe = snap.by_key()["health:API"]
+        smoke_probe = snap.by_key()["smoke:CLI"]
+        assert health_probe.kind == "health" and health_probe.passed
+        assert smoke_probe.kind == "smoke" and not smoke_probe.passed
+
+
+class TestVerifyDeploymentIntegration:
+    @patch("lib.cicd.verify._git_commit", return_value="")
+    @patch("lib.cicd.verify.run_smoke_tests")
+    @patch("lib.cicd.verify.run_health_checks")
+    def test_regression_against_baseline(self, mock_health, mock_smoke, _git) -> None:
+        mock_health.return_value = HealthCheckResult(
+            checks=[HealthCheckEntry(name="API", kind="endpoint", passed=False, detail="HTTP 500", elapsed_ms=5.0)]
+        )
+        mock_smoke.return_value = SmokeTestResult()
+
+        baseline = VerificationSnapshot(probes=[_probe("API", "health", True, 5.0)])
+        result = verify_deployment(config=CICDConfig(), baseline=baseline)
+        assert result.verdict is Verdict.ROLLBACK
+        assert result.exit_code == 1
+        assert result.diffs[0].classification == CLASS_REGRESSION
+
+    @patch("lib.cicd.verify._git_commit", return_value="")
+    @patch("lib.cicd.verify.run_smoke_tests")
+    @patch("lib.cicd.verify.run_health_checks")
+    def test_proceed_against_baseline(self, mock_health, mock_smoke, _git) -> None:
+        mock_health.return_value = HealthCheckResult(
+            checks=[HealthCheckEntry(name="API", kind="endpoint", passed=True, detail="HTTP 200", elapsed_ms=5.0)]
+        )
+        mock_smoke.return_value = SmokeTestResult()
+        baseline = VerificationSnapshot(probes=[_probe("API", "health", True, 5.0)])
+        result = verify_deployment(config=CICDConfig(), baseline=baseline)
+        assert result.verdict is Verdict.PROCEED
+        assert result.exit_code == 0
+
+    @patch("lib.cicd.verify._git_commit", return_value="")
+    @patch("lib.cicd.verify.run_smoke_tests")
+    @patch("lib.cicd.verify.run_health_checks")
+    def test_no_probes_reviews(self, mock_health, mock_smoke, _git) -> None:
+        mock_health.return_value = HealthCheckResult()
+        mock_smoke.return_value = SmokeTestResult()
+        result = verify_deployment(config=CICDConfig())
+        assert result.verdict is Verdict.REVIEW
+        assert result.exit_code == 0
+
+
+class TestConfig:
+    def test_defaults(self) -> None:
+        vconf = DeployVerificationConfig()
+        assert vconf.enabled is False
+        assert vconf.baseline_file == ".claude/deploy-baseline.json"
+        assert vconf.latency_regression_pct == 50.0
+        assert vconf.on_latency_regression == "review"
+
+    def test_health_has_deploy_verification(self) -> None:
+        config = CICDConfig()
+        assert isinstance(config.health.deploy_verification, DeployVerificationConfig)
+
+    def test_loads_from_yaml(self, tmp_path) -> None:
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "cicd.yml").write_text(
+            "health:\n"
+            "  deploy_verification:\n"
+            "    enabled: true\n"
+            "    on_latency_regression: rollback\n"
+        )
+        config = CICDConfig.load(str(tmp_path))
+        assert config.health.deploy_verification.enabled is True
+        assert config.health.deploy_verification.on_latency_regression == "rollback"
+
+
+class TestVerifyCLI:
+    def test_baseline_capture_and_verify(self, tmp_path, capsys) -> None:
+        from lib.cicd.cli import main
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "cicd.yml").write_text(
+            "health:\n"
+            "  smoke_tests:\n"
+            "    - name: ok\n"
+            '      command: "true"\n'
+            "      expected_exit: 0\n"
+        )
+        # Capture baseline
+        rc = main(["verify", "--baseline", "--summary", "--path", str(tmp_path)])
+        assert rc == 0
+        assert (claude_dir / "deploy-baseline.json").exists()
+        capsys.readouterr()
+        # Verify -> PROCEED
+        rc = main(["verify", "--summary", "--path", str(tmp_path)])
+        assert rc == 0
+        assert "PROCEED" in capsys.readouterr().out
+
+    def test_verify_json_rollback_exit(self, tmp_path, capsys) -> None:
+        import json as _json
+
+        from lib.cicd.cli import main
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "cicd.yml").write_text(
+            "health:\n"
+            "  smoke_tests:\n"
+            "    - name: ok\n"
+            '      command: "true"\n'
+            "      expected_exit: 0\n"
+        )
+        main(["verify", "--baseline", "--path", str(tmp_path)])
+        capsys.readouterr()
+        # Break the probe, then verify as JSON.
+        (claude_dir / "cicd.yml").write_text(
+            "health:\n"
+            "  smoke_tests:\n"
+            "    - name: ok\n"
+            '      command: "false"\n'
+            "      expected_exit: 0\n"
+        )
+        rc = main(["verify", "--json", "--path", str(tmp_path)])
+        assert rc == 1
+        payload = _json.loads(capsys.readouterr().out)
+        assert payload["verdict"] == "rollback"
+        assert payload["exit_code"] == 1


### PR DESCRIPTION
## Summary

Implements #444 (Phase C of the ecosystem-review epic #417): a deploy-confidence skill that **validates the deployment, not just the code**.

`/cicd:verify` captures a **baseline** of health + smoke probes *before* a deploy, re-runs them *after*, diffs the two, and emits one actionable verdict:

| Verdict | Exit | Meaning |
|---------|------|---------|
| `PROCEED` | 0 | All probes pass, no regression vs baseline |
| `REVIEW` | 0 | Soft signal only (latency regression, or a pre-existing failure) |
| `ROLLBACK` | 1 | A probe that passed pre-deploy fails now, or a probe fails with no baseline |

This is the gap `/cicd:health` + `/cicd:smoke` leave open: they report current state in isolation and cannot tell you a deploy made things *worse* than 60 seconds ago.

## What changed

- **`lib/cicd/verify.py`** (new) - baseline capture, JSON persistence, regression classification, and verdict logic. Zero new dependencies; reuses the existing `run_health_checks` / `run_smoke_tests` runners (curl + subprocess).
- **`verify` CLI subcommand** - `python -m lib.cicd verify [--baseline] [--summary] [--json]`; exit 1 on ROLLBACK for pipeline branching.
- **`health.deploy_verification` config** - `enabled`, `baseline_file`, latency thresholds (`latency_regression_pct` / `latency_floor_ms`), `on_latency_regression` (review/rollback/ignore), `require_baseline`.
- **`/cicd:verify`** skill doc.
- **Wired into the deploy flow** (the issue's exit criterion):
  - `/flow:deploy` - baseline capture pre-deploy (Step 4c) + verdict-aware verification (Step 8); `deploy.log` records the verdict.
  - `/flow:auto` - **Step 9** runs `make deploy` inline (it does not call `/flow:deploy`), so verification is wired in there too; otherwise the flagship "one command to ship" path would deploy without validating. Baseline before deploy, verdict after.
- Docs: CLAUDE.md, `/cicd:help`, `templates/cicd.yml.example`, CHANGELOG.

## Design notes

- **Fail-open and inert** unless `deploy_verification.enabled` (or a baseline exists). Missing baseline or unavailable `lib/cicd` degrades to absolute pass/fail and never blocks a deploy.
- **Never auto-rolls-back** - a ROLLBACK verdict is an actionable signal surfaced to the human/flow, not an action.
- Baseline (`.claude/deploy-baseline.json`) is per-workstation runtime state, git-ignored like `.claude/runs/`.

## Test plan

- 44 new tests in `tests/test_cicd_verify.py` (classification, verdict aggregation, baseline round-trip, CLI dispatch incl. rollback exit code).
- Full suite: **675 passed**; ruff clean; mypy clean on the new module.
- Deterministic `finish` plan (lint + test + security_scan): all green.
- Live CLI check: baseline capture (exit 0) -> PROCEED (exit 0) -> break a probe -> ROLLBACK (exit 1).

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)