### PR TITLE
feat(cpp-memory): learnings -> GitHub issue bridge (Closes #463)

### DIFF
--- a/.claude/commands/self-improvement/memory.md
+++ b/.claude/commands/self-improvement/memory.md
@@ -30,6 +30,8 @@ cpp-memory record --class knowledge --scope knowledge \
     --title "<stable title>" --body "<reusable knowledge>" \
     --fix "<optional>" --confidence 0.8 --repo "$(basename "$(git rev-parse --show-toplevel)")"
 cpp-memory record --local-only --class permission --scope permission ...  # stays local
+cpp-memory record ... --emit-issue-candidate                             # + issue candidate (#463)
+cpp-memory link-issue --fingerprint <fp> --url <github-issue-url>        # record the filed issue
 cpp-memory reject --fingerprint <fp> --actor <user> --note "<why>"        # stops re-proposal
 ```
 
@@ -47,6 +49,9 @@ run `python -m lib.cpp_memory ...` from the repo root.
 5. Confirm with the user, then `cpp-memory record ...` (portable) or
    `--local-only` + propose the real fix in git/settings (non-portable).
 6. Record `apply`/`reject` when a stored learning is acted on here.
+7. If a portable learning is **actionable** (names a fix), `record ... --emit-issue-candidate`;
+   when `should_file` is true, confirm, `gh issue create` (body carries the fingerprint
+   marker), then `cpp-memory link-issue` the URL back (learnings->issue bridge, #463).
 
 ## Output Format
 

--- a/.claude/commands/self-improvement/retro.md
+++ b/.claude/commands/self-improvement/retro.md
@@ -174,7 +174,10 @@ portable AND carries a fix - and has no `issue_url` yet), offer to file it:
 
 1. **Confirm** with the user (per-learning y/N; never auto-file).
 2. **Route** to the target repo (`issue_candidate.repo`, derived from the learning's
-   source repo; confirm/override at file time; default to the current repo).
+   source repo; confirm/override at file time; default to the current repo). Route
+   by where the FIX lands, not where the friction surfaced: a fix to a CPP skill
+   goes to claude-power-pack; a fix to a skill that lives in its own standalone
+   repo (an extracted plugin, e.g. eli5-gate per #443) goes to that skill's repo.
 3. **Create** the issue with the candidate body (it embeds a
    `<!-- cpp-learning: <fp> -->` marker for marker-based dedup):
    ```bash

--- a/.claude/commands/self-improvement/retro.md
+++ b/.claude/commands/self-improvement/retro.md
@@ -149,11 +149,48 @@ user approves:
   (additive, idempotent - never drop existing rules). Prefer `/cpp:update` /
   `/fewer-permission-prompts` when the rules match the shipped template.
 - **Makefile / hook / CLAUDE.md / gate** edits: apply with the Edit tool.
-- **portable knowledge**: hand to `/self-improvement:memory` (#433) when available.
+- **portable knowledge**: hand to `/self-improvement:memory` (#433) when available;
+  if it is **actionable** (portable AND names a concrete fix), also offer to file a
+  tracked GitHub issue (Step 5b).
 
 Never auto-apply without confirmation. `permissions.allow` changes in particular
 are always human-confirmed on the machine they affect (trust boundary). `--dry-run`
 stops after the report.
+
+### Step 5b: Promote actionable learnings to GitHub issues (learnings->issue bridge, #463)
+
+A portable learning that names a concrete fix should not just sit in the store - it
+should become tracked work. After such a learning is confirmed and recorded, ask the
+shared-store CLI for an issue candidate:
+
+```bash
+cpp-memory record --class <infra_trap|knowledge> --scope knowledge \
+    --title "<stable title>" --body "<reusable knowledge>" \
+    --fix "<the concrete fix>" --repo "<repo-name>" --emit-issue-candidate
+```
+
+If the JSON `issue_candidate.should_file` is true (the learning is **actionable** -
+portable AND carries a fix - and has no `issue_url` yet), offer to file it:
+
+1. **Confirm** with the user (per-learning y/N; never auto-file).
+2. **Route** to the target repo (`issue_candidate.repo`, derived from the learning's
+   source repo; confirm/override at file time; default to the current repo).
+3. **Create** the issue with the candidate body (it embeds a
+   `<!-- cpp-learning: <fp> -->` marker for marker-based dedup):
+   ```bash
+   gh issue create --repo <repo> --title "<issue_candidate.title>" --body "<issue_candidate.body>"
+   ```
+4. **Link** the URL back onto the learning so it is never re-filed:
+   ```bash
+   cpp-memory link-issue --fingerprint <fp> --url <issue-url>
+   ```
+
+**Guards (hard rules):** only portable + actionable learnings become issues - never
+local/permission notes, never a pure "watch out for X" note with no fix. Dedup is
+belt-and-suspenders: the `issue_url` column (first-write-wins) AND the fingerprint
+marker (search open issues for the marker before creating). Fail-open: no `gh`, no
+network, or store unreachable -> skip issue creation, keep the local + shared codify,
+never block.
 
 ### Step 6: Codify to the ledger (persist the decision)
 
@@ -170,6 +207,7 @@ outcomes so nothing is re-proposed next run:
 - Scope: <local | portable>
 - Status: <applied | rejected | superseded>
 - Fix: <the concrete change or rule>
+- Issue: <github issue url filed via the bridge, or n/a>
 - Rationale: <why applied/rejected>
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@
 
 ### Added
 
+- **Learnings->issue bridge** (issue #463, epic #417 Phase C) - actionable
+  portable learnings can now be promoted from the retro/common-memory loop into
+  tracked GitHub issues, so a learning that names a concrete fix becomes work
+  instead of sitting inert in the store. `lib/cpp_memory` gains an `issue_url`
+  column (with an in-place `ALTER TABLE IF NOT EXISTS` upgrade for existing
+  stores), an `is_actionable`/`should_file_issue` decision pair (portable AND
+  non-empty `proposed_fix`; permission/local notes never qualify), an issue-body
+  renderer that embeds a `<!-- cpp-learning: <fp> -->` marker for marker-based
+  dedup, a first-write-wins `link-issue` CLI command, and
+  `record --emit-issue-candidate`. Filing is human-confirmed per learning
+  (never automatic) and routes to the repo the FIX targets - including skills
+  extracted to standalone plugin repos (#443) - not the repo where the friction
+  surfaced. Dedup is belt-and-suspenders (`issue_url` column + marker search);
+  everything fails open without `gh`, network, or the store. Wired into
+  `/self-improvement:retro` (Step 5b), `/self-improvement:memory`,
+  `docs/skills/common-memory.md`, and the Codex `/cpp-memory` prompt.
+
 - **Deploy verification / `/cicd:verify`** (issue #444, epic #417 Phase C) - a
   deploy-confidence skill that validates the *deployment*, not just the code.
   Captures a baseline of `health.endpoints` / `health.smoke_tests` before a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Core components and their locations:
 - `lib/creds/` - Secrets management (dotenv/AWS SM, FastAPI UI, audit logging)
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
-- `lib/cpp_memory/` - Common-memory client: fail-open Postgres ledger of *portable* CPP learnings/infra traps shared across the VM fleet (bucket-2-plus), plus a dedup/rejection ledger. Store provisioned by `scripts/memories-db-setup.sh`. Consult-not-push; see `/self-improvement:memory`.
+- `lib/cpp_memory/` - Common-memory client: fail-open Postgres ledger of *portable* CPP learnings/infra traps shared across the VM fleet (bucket-2-plus), plus a dedup/rejection ledger and a learnings->GitHub-issue bridge (`--emit-issue-candidate` / `link-issue`, #463). Store provisioned by `scripts/memories-db-setup.sh`. Consult-not-push; see `/self-improvement:memory`.
 - `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
 - `templates/` - Makefile, workflow, container templates
 - `docker-compose.yml` - MCP server orchestration (profile: `core`)

--- a/codex/prompts/cpp-memory.md
+++ b/codex/prompts/cpp-memory.md
@@ -32,6 +32,16 @@ Steps:
    fix in its proper home. Never send permission/repo_file learnings to the store.
 5. When I act on a stored learning here, record the outcome:
    `cpp-memory apply|reject --fingerprint <fp> --actor <me> --note "<why>"`.
+6. Promote to work (learnings->issue bridge, #463). If a portable learning is
+   actionable (names a concrete fix), record it with `--emit-issue-candidate`;
+   when `issue_candidate.should_file` is true, ask me to confirm, then
+   `gh issue create` in the repo the fix targets using `issue_candidate.body`
+   (it embeds a `<!-- cpp-learning: <fp> -->` marker), then
+   `cpp-memory link-issue --fingerprint <fp> --url <issue-url>`. A fix for a
+   skill that lives in its own standalone repo (an extracted plugin) files
+   there, not where the friction surfaced. Only portable + actionable learnings
+   become issues; never local/permission notes. Fail-open: no `gh` or no
+   network -> skip filing, keep the codify.
 
 Full routine: docs/skills/common-memory.md in the claude-power-pack repo.
 End with a short summary: signals found, recorded-to-shared, skipped-as-dup,

--- a/docs/skills/common-memory.md
+++ b/docs/skills/common-memory.md
@@ -31,6 +31,8 @@ cpp-memory record --class knowledge --scope knowledge \
     --title "<stable title>" --body "<reusable knowledge>" \
     --fix "<optional remediation>" --confidence 0.8 --repo "<repo-name>"
 cpp-memory record --local-only --class permission --scope permission ...  # stays local
+cpp-memory record ... --emit-issue-candidate                              # + issue_candidate block (#463)
+cpp-memory link-issue --fingerprint <fp> --url <github-issue-url>         # record the filed issue
 cpp-memory apply  --fingerprint <fp> --actor <user> --note "<what changed>"
 cpp-memory reject --fingerprint <fp> --actor <user> --note "<why not>"     # stops re-proposal
 ```
@@ -57,6 +59,13 @@ routine never blocks.
    fix in its proper home (git edit / per-machine `settings.json`); never share.
 6. **Bookkeeping.** When a stored learning is acted on here, `cpp-memory apply` or
    `reject` so other runs and VMs see the outcome.
+7. **Promote to work (learnings->issue bridge, #463).** If a portable learning is
+   **actionable** (names a concrete fix), record it with `--emit-issue-candidate`;
+   when `issue_candidate.should_file` is true, confirm with the user, `gh issue
+   create` in the candidate's repo using `issue_candidate.body` (it embeds a
+   `<!-- cpp-learning: <fp> -->` marker), then `cpp-memory link-issue` the URL back.
+   Only portable + actionable learnings become issues; dedup is the `issue_url`
+   column (first-write-wins) plus the marker; fail-open if `gh` is unavailable.
 
 ## DSN / federation
 

--- a/docs/skills/common-memory.md
+++ b/docs/skills/common-memory.md
@@ -64,6 +64,8 @@ routine never blocks.
    when `issue_candidate.should_file` is true, confirm with the user, `gh issue
    create` in the candidate's repo using `issue_candidate.body` (it embeds a
    `<!-- cpp-learning: <fp> -->` marker), then `cpp-memory link-issue` the URL back.
+   Route by where the FIX lands, not where the friction surfaced: a fix to a skill
+   that lives in its own standalone repo (an extracted plugin) files there.
    Only portable + actionable learnings become issues; dedup is the `issue_url`
    column (first-write-wins) plus the marker; fail-open if `gh` is unavailable.
 

--- a/lib/cpp_memory/__init__.py
+++ b/lib/cpp_memory/__init__.py
@@ -15,13 +15,26 @@ Design invariants (see issue #433):
 
 from .client import MemoryStore, append_local_learning
 from .config import resolve_dsn
-from .models import FIX_SCOPES, FRICTION_CLASSES, Learning, is_portable
+from .models import (
+    FIX_SCOPES,
+    FRICTION_CLASSES,
+    Learning,
+    is_actionable,
+    is_portable,
+    issue_body,
+    issue_marker,
+    should_file_issue,
+)
 
 __all__ = [
     "Learning",
     "FRICTION_CLASSES",
     "FIX_SCOPES",
     "is_portable",
+    "is_actionable",
+    "should_file_issue",
+    "issue_body",
+    "issue_marker",
     "MemoryStore",
     "append_local_learning",
     "resolve_dsn",

--- a/lib/cpp_memory/cli.py
+++ b/lib/cpp_memory/cli.py
@@ -6,11 +6,39 @@ import json
 import socket
 
 from .client import MemoryStore, append_local_learning
-from .models import Learning
+from .models import (
+    Learning,
+    is_actionable,
+    issue_body,
+    issue_marker,
+    should_file_issue,
+)
 
 
 def _vm() -> str:
     return socket.gethostname()
+
+
+def _issue_candidate(store: MemoryStore, learning: Learning, repo: str | None) -> dict:
+    """Everything the retro routine needs to (maybe) file a GitHub issue (#463).
+
+    ``should_file`` is the dedup-aware verdict: actionable AND not already filed.
+    ``body`` carries the fingerprint marker so the routine can also dedup via a
+    marker search when the store was unreachable at record time.
+    """
+    actionable = is_actionable(learning)
+    row = store.is_known(learning.fingerprint) if actionable else None
+    existing = row.get("issue_url") if row else None
+    return {
+        "actionable": actionable,
+        "should_file": should_file_issue(actionable, existing),
+        "existing_issue_url": existing,
+        "fingerprint": learning.fingerprint,
+        "marker": issue_marker(learning.fingerprint),
+        "title": learning.title,
+        "body": issue_body(learning, repo),
+        "repo": repo,
+    }
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -37,11 +65,19 @@ def _build_parser() -> argparse.ArgumentParser:
         "--local-only", action="store_true",
         help="append to .claude/learnings.md, skip the shared store",
     )
+    rc.add_argument(
+        "--emit-issue-candidate", action="store_true",
+        help="also emit an issue_candidate block (learnings->issue bridge, #463)",
+    )
 
     q = sub.add_parser("query", help="look up by fingerprint or list by class")
     q.add_argument("--fingerprint")
     q.add_argument("--class", dest="friction_class")
     q.add_argument("--limit", type=int, default=50)
+
+    li = sub.add_parser("link-issue", help="record the GitHub issue URL for a learning")
+    li.add_argument("--fingerprint", required=True)
+    li.add_argument("--url", required=True)
 
     for name in ("apply", "reject"):
         d = sub.add_parser(name, help=f"mark a learning {name}ed on this VM")
@@ -93,16 +129,15 @@ def main(argv=None) -> int:
             return 0
 
         lid = store.record_learning(learning, _vm(), args.repo)
+        out: dict = {"fingerprint": learning.fingerprint}
         if lid is None:
             path = append_local_learning(learning, args.repo or ".")
-            print(json.dumps({
-                "stored": "local-fallback", "reason": "store unavailable",
-                "path": str(path), "fingerprint": learning.fingerprint,
-            }))
-            return 0
-        print(json.dumps({
-            "stored": "shared", "id": lid, "fingerprint": learning.fingerprint,
-        }))
+            out.update(stored="local-fallback", reason="store unavailable", path=str(path))
+        else:
+            out.update(stored="shared", id=lid)
+        if args.emit_issue_candidate:
+            out["issue_candidate"] = _issue_candidate(store, learning, args.repo)
+        print(json.dumps(out))
         return 0
 
     if args.cmd == "query":
@@ -114,6 +149,7 @@ def main(argv=None) -> int:
                 {
                     "known": row is not None, "learning": row,
                     "rejected_here": rejected, "sightings": len(seen),
+                    "has_issue": bool(row.get("issue_url")) if row else False,
                 },
                 default=str,
             ))
@@ -126,6 +162,11 @@ def main(argv=None) -> int:
         fn = store.mark_applied if args.cmd == "apply" else store.mark_rejected
         ok = fn(args.fingerprint, _vm(), args.actor, args.note)
         print(json.dumps({args.cmd: ok, "fingerprint": args.fingerprint, "vm": _vm()}))
+        return 0 if ok else 1
+
+    if args.cmd == "link-issue":
+        ok = store.link_issue(args.fingerprint, args.url)
+        print(json.dumps({"linked": ok, "fingerprint": args.fingerprint, "url": args.url}))
         return 0 if ok else 1
 
     return 1

--- a/lib/cpp_memory/client.py
+++ b/lib/cpp_memory/client.py
@@ -26,7 +26,7 @@ except Exception:  # pragma: no cover - driver is an optional runtime dep
 
 _LEARNING_COLS = (
     "id", "fingerprint", "friction_class", "fix_scope",
-    "title", "status", "confidence",
+    "title", "status", "confidence", "issue_url",
 )
 
 
@@ -68,7 +68,7 @@ class MemoryStore:
             with self._conn() as c:
                 row = c.execute(
                     "SELECT id, fingerprint, friction_class, fix_scope, title,"
-                    " status, confidence FROM learnings WHERE fingerprint = %s",
+                    " status, confidence, issue_url FROM learnings WHERE fingerprint = %s",
                     (fingerprint,),
                 ).fetchone()
         except Exception as e:  # noqa: BLE001
@@ -181,14 +181,14 @@ class MemoryStore:
                 if friction_class:
                     rows = c.execute(
                         "SELECT id,fingerprint,friction_class,fix_scope,title,status,"
-                        "confidence,created_at FROM learnings WHERE friction_class = %s"
+                        "confidence,issue_url,created_at FROM learnings WHERE friction_class = %s"
                         " ORDER BY created_at DESC LIMIT %s",
                         (friction_class, limit),
                     ).fetchall()
                 else:
                     rows = c.execute(
                         "SELECT id,fingerprint,friction_class,fix_scope,title,status,"
-                        "confidence,created_at FROM learnings"
+                        "confidence,issue_url,created_at FROM learnings"
                         " ORDER BY created_at DESC LIMIT %s",
                         (limit,),
                     ).fetchall()
@@ -214,6 +214,28 @@ class MemoryStore:
         except Exception as e:  # noqa: BLE001
             log.warning("cpp_memory sightings failed: %s", e)
             return []
+
+    def link_issue(self, fingerprint: str, issue_url: str) -> bool:
+        """Record the GitHub issue a learning was promoted to (#463).
+
+        First write wins (``WHERE issue_url IS NULL``) so re-running the retro on
+        an already-filed learning never overwrites or duplicates. Returns True
+        only when it set the URL; False if already set, learning missing, or the
+        store is unreachable (fail-open).
+        """
+        if not self.available():
+            return False
+        try:
+            with self._conn() as c:
+                cur = c.execute(
+                    "UPDATE learnings SET issue_url = %s, updated_at = now()"
+                    " WHERE fingerprint = %s AND issue_url IS NULL",
+                    (issue_url, fingerprint),
+                )
+                return cur.rowcount > 0
+        except Exception as e:  # noqa: BLE001
+            log.warning("cpp_memory link_issue failed: %s", e)
+            return False
 
     def init_db(self, schema_path: str | None = None) -> bool:
         """Apply the schema (idempotent)."""

--- a/lib/cpp_memory/models.py
+++ b/lib/cpp_memory/models.py
@@ -51,3 +51,60 @@ class Learning:
     @property
     def portable(self) -> bool:
         return is_portable(self.friction_class, self.fix_scope)
+
+    @property
+    def actionable(self) -> bool:
+        return is_actionable(self)
+
+
+# --- learning -> GitHub issue bridge (#463) -------------------------------- #
+# Only portable AND actionable learnings (they name a concrete fix) become
+# tracked issues. The fingerprint is stamped into the issue body as an HTML
+# comment so the bridge can dedup even before the learning's issue_url column
+# is populated (search issues by marker). Never files non-portable learnings.
+MARKER_PREFIX = "cpp-learning"
+
+
+def issue_marker(fingerprint: str) -> str:
+    """HTML-comment marker embedding a learning fingerprint in an issue body."""
+    return f"<!-- {MARKER_PREFIX}: {fingerprint} -->"
+
+
+def is_actionable(learning: Learning) -> bool:
+    """True when a learning names a concrete fix worth tracking as an issue.
+
+    Actionable == portable (shareable) AND carries a non-empty ``proposed_fix``.
+    A pure "watch out for X" note with no fix is knowledge, not tracked work.
+    """
+    return learning.portable and bool((learning.proposed_fix or "").strip())
+
+
+def should_file_issue(actionable: bool, existing_issue_url: str | None) -> bool:
+    """Pure decision: file an issue only if actionable AND not already filed."""
+    return actionable and not (existing_issue_url or "").strip()
+
+
+def issue_body(learning: Learning, source_repo: str | None = None) -> str:
+    """Render a GitHub issue body for an actionable learning (with dedup marker)."""
+    lines = [
+        issue_marker(learning.fingerprint),
+        "",
+        "## Learning (auto-filed from the CPP friction retro)",
+        "",
+        (learning.body or "").strip() or learning.title.strip(),
+        "",
+        f"**Proposed fix:** {(learning.proposed_fix or '').strip()}",
+        "",
+        "## Provenance",
+        f"- class: {learning.friction_class} / scope: {learning.fix_scope}",
+        f"- confidence: {learning.confidence}",
+        f"- fingerprint: {learning.fingerprint}",
+    ]
+    if source_repo:
+        lines.append(f"- source repo: {source_repo}")
+    lines += [
+        "",
+        "Filed by /self-improvement:retro via the learnings->issue bridge "
+        "(claude-power-pack #463). See the common-memory ledger for context.",
+    ]
+    return "\n".join(lines)

--- a/lib/cpp_memory/sql/schema.sql
+++ b/lib/cpp_memory/sql/schema.sql
@@ -21,6 +21,11 @@ CREATE TABLE IF NOT EXISTS learnings (
     updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- #463 learnings->issue bridge: URL of the GitHub issue an actionable learning
+-- was promoted to (NULL until filed). ADD COLUMN IF NOT EXISTS upgrades an
+-- existing store too (CREATE TABLE IF NOT EXISTS won't add columns in place).
+ALTER TABLE learnings ADD COLUMN IF NOT EXISTS issue_url TEXT;
+
 CREATE INDEX IF NOT EXISTS learnings_class_idx  ON learnings (friction_class);
 CREATE INDEX IF NOT EXISTS learnings_status_idx ON learnings (status);
 

--- a/tests/test_cpp_memory.py
+++ b/tests/test_cpp_memory.py
@@ -16,8 +16,12 @@ from lib.cpp_memory import (
     Learning,
     MemoryStore,
     append_local_learning,
+    is_actionable,
     is_portable,
+    issue_body,
+    issue_marker,
     resolve_dsn,
+    should_file_issue,
 )
 from lib.cpp_memory import cli as cli_mod
 from lib.cpp_memory import client as client_mod
@@ -279,3 +283,108 @@ class TestCli:
         out = json.loads(capsys.readouterr().out)
         assert rc == 1
         assert out["reject"] is False
+
+
+# --------------------------------------------------------------------------- #
+# learnings -> GitHub issue bridge (#463)
+# --------------------------------------------------------------------------- #
+class TestActionable:
+    def test_portable_with_fix_is_actionable(self):
+        learning = Learning("knowledge", "knowledge", "t", "b", proposed_fix="do X")
+        assert is_actionable(learning) is True
+        assert learning.actionable is True
+
+    def test_portable_without_fix_is_not_actionable(self):
+        # A "watch out for X" note with no concrete fix is knowledge, not work.
+        assert is_actionable(Learning("knowledge", "knowledge", "t", "b")) is False
+        assert is_actionable(Learning("infra_trap", "knowledge", "t", "b", proposed_fix="   ")) is False
+
+    def test_non_portable_is_never_actionable(self):
+        # Even with a fix, a permission learning must never become a shared issue.
+        assert is_actionable(Learning("permission", "permission", "t", "b", proposed_fix="do X")) is False
+
+
+class TestShouldFileIssue:
+    def test_actionable_and_unfiled_files(self):
+        assert should_file_issue(True, None) is True
+        assert should_file_issue(True, "") is True
+        assert should_file_issue(True, "   ") is True
+
+    def test_already_filed_does_not_refile(self):
+        assert should_file_issue(True, "https://github.com/o/r/issues/1") is False
+
+    def test_non_actionable_never_files(self):
+        assert should_file_issue(False, None) is False
+        assert should_file_issue(False, "https://github.com/o/r/issues/1") is False
+
+
+class TestIssueBody:
+    def test_marker_is_html_comment_with_fingerprint(self):
+        marker = issue_marker("abc123")
+        assert marker == "<!-- cpp-learning: abc123 -->"
+
+    def test_body_carries_marker_fix_and_provenance(self):
+        learning = Learning(
+            "infra_trap", "knowledge", "gRPC :9001 is Tailscale-only",
+            "the woodpecker gRPC port is not on the LAN", proposed_fix="use the tailnet addr",
+        )
+        body = issue_body(learning, source_repo="agentic-asst")
+        assert issue_marker(learning.fingerprint) in body      # dedup marker
+        assert "use the tailnet addr" in body                  # the fix
+        assert "the woodpecker gRPC port is not on the LAN" in body
+        assert learning.fingerprint in body                    # provenance
+        assert "agentic-asst" in body                          # source repo
+
+
+class TestLinkIssueFailOpen:
+    def test_link_issue_benign_when_down(self, down_store):
+        assert down_store.link_issue("deadbeef", "https://github.com/o/r/issues/1") is False
+
+
+class TestCliBridge:
+    def test_record_emits_issue_candidate_for_actionable(self, cli_offline, capsys, tmp_path):
+        rc = cli_mod.main([
+            "record", "--class", "infra_trap", "--scope", "knowledge",
+            "--title", "gh merge from worktree fails", "--body", "main already checked out",
+            "--fix", "run from the main repo", "--repo", str(tmp_path),
+            "--emit-issue-candidate",
+        ])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        cand = out["issue_candidate"]
+        assert cand["actionable"] is True
+        assert cand["should_file"] is True          # store down -> no existing url -> file (fail-open)
+        assert cand["marker"] in cand["body"]
+        assert cand["repo"] == str(tmp_path)
+
+    def test_record_no_candidate_flag_omits_block(self, cli_offline, capsys, tmp_path):
+        rc = cli_mod.main([
+            "record", "--class", "knowledge", "--scope", "knowledge",
+            "--title", "t", "--body", "b", "--fix", "do X", "--repo", str(tmp_path),
+        ])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert "issue_candidate" not in out
+
+    def test_record_candidate_not_fileable_without_fix(self, cli_offline, capsys, tmp_path):
+        rc = cli_mod.main([
+            "record", "--class", "knowledge", "--scope", "knowledge",
+            "--title", "just a note", "--body", "b", "--repo", str(tmp_path),
+            "--emit-issue-candidate",
+        ])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["issue_candidate"]["actionable"] is False
+        assert out["issue_candidate"]["should_file"] is False
+
+    def test_link_issue_benign_when_down(self, cli_offline, capsys):
+        rc = cli_mod.main(["link-issue", "--fingerprint", "deadbeef", "--url", "https://github.com/o/r/issues/1"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert out["linked"] is False
+
+    def test_query_reports_has_issue_false_when_down(self, cli_offline, capsys):
+        rc = cli_mod.main(["query", "--fingerprint", "deadbeef"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["has_issue"] is False


### PR DESCRIPTION
## Summary

Closes the compound-engineering loop (capture -> codify -> consult -> **promote-to-code**) by promoting *actionable* portable learnings from the friction retro / common-memory store (#433) into tracked GitHub issues. A learning that names a concrete fix becomes work instead of sitting inert in the store.

Motivated by hand: /flow:auto #433's retro produced two learnings whose fixes were hand-filed as #461/#462; this makes that promotion a built-in, human-confirmed step.

## What's here

**Library (`lib/cpp_memory`, deterministic + tested):**
- `sql/schema.sql`: idempotent `issue_url` column via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` (upgrades the live store in place - `CREATE TABLE IF NOT EXISTS` can't add a column).
- `models.py`: `is_actionable` (portable **AND** non-empty `proposed_fix`), the pure `should_file_issue(actionable, existing_url)` decision, `issue_marker` (`<!-- cpp-learning: <fp> -->`), and an `issue_body` renderer that embeds the marker + provenance.
- `client.py`: `link_issue` (first-write-wins, fail-open) + `issue_url` surfaced in `is_known`/`list_learnings`.
- `cli.py`: `record --emit-issue-candidate` (emits a ready-to-file `{should_file,title,body,repo,marker}` block when actionable and un-filed), a `link-issue` subcommand, and `has_issue` in `query`.

**Routines (markdown - where gh auth + judgment live):**
- `/self-improvement:retro` (new Step 5b), `/self-improvement:memory`, `docs/skills/common-memory.md`, and the Codex `/cpp-memory` prompt document the confirm -> `gh issue create` -> `link-issue` flow.

**Guards (hard rules):** per-learning y/N (never auto-files); only portable + actionable learnings (never local/permission notes, never a fix-less "watch out" note); dedup is belt-and-suspenders (`issue_url` column first-write-wins **+** fingerprint marker); fail-open if `gh`, network, or the store is unavailable. Routing follows where the FIX lands (incl. extracted-plugin repos, #443), not where friction surfaced.

## Test plan

- `make lint` (ruff) clean; `make typecheck` (mypy, 119 files) clean.
- `make test`: **738 passed** (+16 new: pure decision fn, marker/body, fail-open `link_issue`, CLI candidate/link/query).
- **Live dedup proof against the real store** (with cleanup): `init_db` added the `issue_url` column; recorded an actionable learning (`should_file=True`) -> `link_issue` (first write True, second write False) -> re-check `should_file=False`, `issue_url` persisted -> deleted the throwaway. Store left pristine.
- No em/en dashes (CLAUDE.md policy).

## Acceptance (issue #463)

- [x] A confirmed portable+actionable learning can create an issue with the fingerprint marker + issue URL recorded on the learning.
- [x] Re-running does NOT create a duplicate (dedup proven live).
- [x] Non-actionable / local / permission learnings never create issues.
- [x] gh-absent / offline degrades gracefully.

## References

- First hand-filed examples this now automates: #461, #462
- Substrate: #433 (common-memory store), #426 (grill-me retro); epic #417 Phase C

Closes #463