### PR TITLE
fix(flow): sync origin/main + re-gate before squash-merge on stale branches (Closes #462)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -344,14 +344,58 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 
 ### Step 7: Merge - Squash-Merge and Clean Up
 
-1. **Merge the PR:**
+1. **Sync with `origin/main` and re-gate (stale-branch guard, issue #462):**
+   A branch cut earlier - common on resumed or cross-machine worktrees - can have
+   fallen behind `main` while the PR was open. Squash-merging it then fails at the
+   last step on a content conflict (the flow:auto #433 run hit a CLAUDE.md
+   collision), forcing a manual `git merge origin/main` + resolve + re-gate
+   mid-flow. Bring the branch current and re-run the gate on the **post-merge
+   tree** first, so the squash is deterministic and the gate reflects exactly what
+   lands on `main`:
+
+   ```bash
+   BRANCH=$(git branch --show-current)
+   git fetch origin main
+   if [[ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]]; then
+       echo "Branch is behind origin/main - merging main in before the squash."
+       if ! git merge --no-edit origin/main; then
+           echo "STOP: merging origin/main hit conflicts:"
+           git diff --name-only --diff-filter=U
+           echo "Resolve them, 'git add' + 'git commit', then re-run /flow:merge."
+           echo "(Do NOT 'git merge --abort' - that discards the resolution.)"
+           exit 1
+       fi
+       # Re-run the FULL quality gate on the MERGED tree (not the pre-merge branch)
+       # - same deterministic runner as Step 6, with the same Makefile fallback.
+       CPP_DIR=""
+       for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+         [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+       done
+       if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+           PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
+           REGATE_EXIT=$?
+       else
+           echo "NOTE: deterministic runner unavailable; re-gating via Makefile fallback." >&2
+           make lint && make test
+           REGATE_EXIT=$?
+       fi
+       if [ "$REGATE_EXIT" -ne 0 ]; then
+           echo "STOP: quality gate failed on the post-merge tree. Fix, commit, then re-run /flow:merge."
+           exit 1
+       fi
+       # Push the merge so the PR reflects the post-merge tree before squashing.
+       git push origin "$BRANCH"
+   fi
+   ```
+
+2. **Merge the PR:**
    ```bash
    PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
    gh pr merge "$PR_NUMBER" --squash --delete-branch
    ```
    - If merge fails (conflicts, checks): **STOP**. Report and exit.
 
-2. **Capture the worktree and main repo paths (before leaving the worktree):**
+3. **Capture the worktree and main repo paths (before leaving the worktree):**
    ```bash
    if [[ -f ".git" ]]; then
        WORKTREE_PATH=$(pwd)
@@ -362,7 +406,7 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    fi
    ```
 
-3. **Clean up worktree and branch:**
+4. **Clean up worktree and branch:**
 
    **If Step 1 created the worktree this session via `EnterWorktree(name=...)`**
    (the fresh-start path), remove it natively - a single tool call that deletes the
@@ -402,7 +446,7 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    fi
    ```
 
-4. **Update local main:**
+5. **Update local main:**
    ```bash
    git -C "$MAIN_REPO" checkout main 2>/dev/null || true
    git -C "$MAIN_REPO" pull origin main
@@ -414,7 +458,7 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    git status  # MUST succeed - if this fails, your CWD was deleted
    ```
 
-5. **Close issue** (if still open):
+6. **Close issue** (if still open):
    ```bash
    if [[ -n "$ISSUE_NUM" ]]; then
        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -42,7 +42,51 @@ PR_JSON=$(gh pr list --head "$BRANCH" --json number,state,mergeable,reviewDecisi
 - If PR is already merged: "PR is already merged. Run cleanup only? [y/N]"
 - Report PR state: checks passing, review status, mergeable
 
-### Step 3: Merge the PR
+### Step 3: Sync with main, re-gate, then merge
+
+**Stale-branch guard (issue #462):** a branch cut earlier can have fallen behind
+`main` while the PR was open; squash-merging it then fails at the last step on a
+content conflict. Bring the branch current and re-run the quality gate on the
+**post-merge tree** before merging, so the squash is deterministic and the gate
+reflects exactly what lands on `main`. (`/flow:auto` Step 7 runs the same guard;
+this covers the standalone/resume path.)
+
+```bash
+BRANCH=$(git branch --show-current)
+git fetch origin main
+if [[ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]]; then
+    echo "Branch is behind origin/main - merging main in before the squash."
+    if ! git merge --no-edit origin/main; then
+        echo "STOP: merging origin/main hit conflicts:"
+        git diff --name-only --diff-filter=U
+        echo "Resolve them, 'git add' + 'git commit', then re-run /flow:merge."
+        echo "(Do NOT 'git merge --abort' - that discards the resolution.)"
+        exit 1
+    fi
+    # Re-run the FULL quality gate on the MERGED tree (deterministic runner,
+    # Makefile fallback - same gate /flow:finish uses).
+    CPP_DIR=""
+    for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+      [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+    done
+    if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
+        REGATE_EXIT=$?
+    else
+        echo "NOTE: deterministic runner unavailable; re-gating via Makefile fallback." >&2
+        make lint && make test
+        REGATE_EXIT=$?
+    fi
+    if [ "$REGATE_EXIT" -ne 0 ]; then
+        echo "STOP: quality gate failed on the post-merge tree. Fix, commit, then re-run /flow:merge."
+        exit 1
+    fi
+    # Push the merge so the PR reflects the post-merge tree before squashing.
+    git push origin "$BRANCH"
+fi
+```
+
+Then merge the PR:
 
 ```bash
 PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')

--- a/tests/test_flow_worktree_native.py
+++ b/tests/test_flow_worktree_native.py
@@ -71,3 +71,23 @@ def test_worktree_remove_script_retained_as_fallback() -> None:
     assert (ROOT / "scripts" / "worktree-remove.sh").exists(), (
         "worktree-remove.sh must remain as the cross-session cleanup fallback"
     )
+
+
+def test_stale_branch_guard_before_squash_merge() -> None:
+    """Issue #462: bring a stale branch current + re-gate before the squash-merge.
+
+    Both the /flow:auto Step 7 merge and the standalone /flow:merge Step 3 must,
+    before ``gh pr merge --squash``, fetch ``origin/main``, merge it into a branch
+    that is behind, and re-run the quality gate on the POST-MERGE tree - so the
+    squash is deterministic and the gate reflects exactly what lands on ``main``.
+    """
+    for rel in (".claude/commands/flow/auto.md", ".claude/commands/flow/merge.md"):
+        text = _read(rel)
+        assert "git fetch origin main" in text, f"{rel} does not fetch origin/main before merge"
+        # Behind-check + merge main in (not rebase) so the squash is conflict-free.
+        assert "HEAD..origin/main" in text, f"{rel} does not test whether the branch is behind main"
+        assert "git merge --no-edit origin/main" in text, f"{rel} does not merge main in before squash"
+        # Conflicts are surfaced and stopped-on, never silently auto-resolved.
+        assert "--diff-filter=U" in text, f"{rel} does not surface merge conflicts on STOP"
+        # The re-gate runs on the merged tree via the deterministic runner.
+        assert "lib.cicd run --plan finish" in text, f"{rel} does not re-gate the post-merge tree"


### PR DESCRIPTION
## Summary
- **`flow/auto.md` Step 7**: before `gh pr merge --squash`, a new **stale-branch guard** (item 1; existing items renumbered 1-5 -> 2-6) runs `git fetch origin main`, and if the branch is behind, merges `main` in, re-runs the full quality gate on the **post-merge tree**, then pushes - so the squash is deterministic and the gate reflects exactly what lands on `main`.
- **`flow/merge.md` Step 3**: the same guard on the standalone/resume path (identical `gh pr merge --squash`, identical risk).
- **`tests/test_flow_worktree_native.py`**: regression test pinning the guard markers (`git fetch origin main`, `HEAD..origin/main`, `git merge --no-edit origin/main`, `--diff-filter=U`, `lib.cicd run --plan finish`) in **both** surfaces.

Conflicts are surfaced (`git diff --name-only --diff-filter=U`) and stopped-on with a resolve-and-re-run message; they are never silently auto-resolved or aborted. Clean catch-ups run fully automatically.

## ELI5 / necessity verdict
**Still needed.** Issue filed 2026-07-03; zero commits to `auto.md`/`merge.md` since; guard confirmed absent (no `fetch origin main` / `HEAD..origin/main` / `merge --no-edit origin/main`); no other open issue overlaps. Evidence: common-memory learning id=6, codified by `/self-improvement:retro` on the flow:auto #433 run (which hit a CLAUDE.md squash collision and required a manual mid-flow merge).

## Acceptance
- [x] A deliberately-stale branch is brought current + re-gated automatically before squash-merge.
- [x] The gate runs on the post-merge tree, not the pre-merge branch.

## Out of scope
- Global `~/.claude/skills/flow-*` mirror regeneration is owned by in-flight issue #457.

## Test plan
- [x] `make verify` (lint + test + typecheck): 725 passed, mypy clean, `test_skill_drift` unaffected.
- [x] New `test_stale_branch_guard_before_squash_merge` asserts the guard exists in both `auto.md` and `merge.md`.
- [x] Guard verified to appear before the `gh pr merge --squash` call in both files.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)