### PR TITLE
feat(flow): extract /flow:eli5 necessity gate to standalone eli5-gate plugin (Closes #443)

### DIFF
--- a/.claude/commands/flow/eli5.md
+++ b/.claude/commands/flow/eli5.md
@@ -1,28 +1,53 @@
+<!-- VENDORED CORE (issue #443): the section between the eli5-core markers below
+     is vendored verbatim from https://github.com/cooneycw/eli5-gate
+     (commands/eli5.md), the canonical standalone home of the necessity gate.
+     Edit the core UPSTREAM first, then re-vendor here; scripts/eli5-core-drift.sh
+     warns on drift. CPP-specific /flow wiring lives outside the markers. -->
 # Flow: ELI5 - Post-Analysis Plan + Necessity Gate
 
 The post-analysis, pre-implementation communication and approval gate. Restates an issue's intent in plain language, checks whether the issue is still worth doing given code merged since it was filed, and presents the proposed changes for reviewer approval before any code is written.
+
+This gate also ships standalone as **eli5-gate**
+(https://github.com/cooneycw/eli5-gate): installable by any Claude Code user via
+`/plugin marketplace add cooneycw/eli5-gate` then `/plugin install
+eli5-gate@eli5-gate`, or into ~40 other harnesses via `npx skills add
+cooneycw/eli5-gate`. That repo is canonical for the gate's core; improvement
+issues for the gate itself belong there, not in CPP.
 
 ## Arguments
 
 - `ISSUE` (required): GitHub issue number (e.g., `42`)
 - `--yes` (optional, alias `--auto-approve`): skip the interactive approval pause for unattended runs. The ELI5 report is still produced and recorded. A `No longer needed` verdict is NEVER auto-approved - it always stops for a human decision.
 
+<!-- eli5-core:begin (canonical: https://github.com/cooneycw/eli5-gate commands/eli5.md) -->
 ## What this is for
 
-`/flow:auto` jumps from analysis straight to implementation with only a terse implementer-facing plan in between. That gives a human reviewer no clear, plain-language checkpoint to approve, redirect, or reject before effort is spent. Two gaps in particular:
+Automated implement-from-issue pipelines jump from analysis straight to
+implementation with only a terse implementer-facing plan in between. That gives a
+human reviewer no clear, plain-language checkpoint to approve, redirect, or reject
+before effort is spent. Two gaps in particular:
 
-1. **No staleness / necessity check.** An issue filed weeks ago may already be solved (or made obsolete) by code merged since. The default flow assumes the issue is still valid and just implements it.
-2. **No reviewer-friendly intent summary.** The implementer-term plan is not the fastest way for a reviewer to catch a misread of intent.
+1. **No staleness / necessity check.** An issue filed weeks ago may already be
+   solved (or made obsolete) by code merged since. The default flow assumes the
+   issue is still valid and just implements it.
+2. **No reviewer-friendly intent summary.** The implementer-term plan is not the
+   fastest way for a reviewer to catch a misread of intent.
 
-`/flow:eli5` closes both gaps: it tells the reviewer, in their language, what the issue means, whether it is still worth doing, and what will change - then waits for approval.
+This gate closes both gaps: it tells the reviewer, in their language, what the
+issue means, whether it is still worth doing, and what will change - then waits
+for approval.
 
 ## Instructions
 
-When the user invokes `/flow:eli5 <ISSUE>`, perform the following. This command is read-only with respect to the codebase: it inspects and reports, it does not write implementation code.
+When the gate is invoked with an issue number, perform the following. This command
+is read-only with respect to the codebase: it inspects and reports, it does not
+write implementation code.
 
 ### Step 1: Gather context
 
-If this command is being run as a step inside `/flow:auto`, reuse the analysis already produced by the Analyze step and skip re-reading the codebase. When run standalone, gather context first:
+If this gate is being run as a step inside a larger pipeline that has already
+analyzed the issue, reuse that analysis and skip re-reading the codebase. When run
+standalone, gather context first:
 
 ```bash
 ISSUE_NUM="$1"
@@ -31,16 +56,22 @@ gh issue view "$ISSUE_NUM" --json number,title,state,body,createdAt,labels,close
 ISSUE_DATE=$(gh issue view "$ISSUE_NUM" --json createdAt --jq '.createdAt')
 ```
 
-- Parse acceptance criteria (`- [ ]` items), referenced files/components, and any task IDs or dependencies.
-- Read the files the issue references and the surrounding patterns so the proposed-changes section is concrete.
+- Parse acceptance criteria (`- [ ]` items), referenced files/components, and any
+  task IDs or dependencies.
+- Read the files the issue references and the surrounding patterns so the
+  proposed-changes section is concrete.
 
 ### Step 2: Produce the three-section report
 
 Emit all three sections every time. Do not skip a section even if it is short.
 
-**Section A - ELI5 overview of intent.** A plain-language restatement of what the issue is trying to accomplish and why, free of implementation jargon. Two to four sentences a non-author reviewer can sanity-check for a misread of intent.
+**Section A - ELI5 overview of intent.** A plain-language restatement of what the
+issue is trying to accomplish and why, free of implementation jargon. Two to four
+sentences a non-author reviewer can sanity-check for a misread of intent.
 
-**Section B - Necessity / staleness analysis.** Assess whether the issue is still necessary given the current code and anything merged *after* it was filed. Inspect post-filing history explicitly:
+**Section B - Necessity / staleness analysis.** Assess whether the issue is still
+necessary given the current code and anything merged *after* it was filed. Inspect
+post-filing history explicitly:
 
 ```bash
 # Commits landed since the issue was filed (global, then scoped to the files
@@ -57,7 +88,10 @@ gh issue list --state all --search "<key terms from the issue>" \
     --json number,title,state,closedAt
 ```
 
-Explicitly check for: (a) work already merged that closes or partially closes the issue, (b) design changes that make the original ask obsolete or misframed, (c) duplicate or superseding issues. Then output one verdict, with the evidence (commits, PRs, files, issue numbers) behind it:
+Explicitly check for: (a) work already merged that closes or partially closes the
+issue, (b) design changes that make the original ask obsolete or misframed, (c)
+duplicate or superseding issues. Then output one verdict, with the evidence
+(commits, PRs, files, issue numbers) behind it:
 
 | Verdict | Meaning |
 |---------|---------|
@@ -66,25 +100,35 @@ Explicitly check for: (a) work already merged that closes or partially closes th
 | **No longer needed** | Already solved or made obsolete; recommend closing instead of implementing |
 | **Needs reframing** | The surrounding design changed enough that the plan is wrong; restate the corrected approach |
 
-**Section C - Proposed changes (pending approval).** An overview of the changes proposed to close the issue, framed as a plan awaiting reviewer approval: files to create or modify, the gist of each change, scope estimate, and notable risks or edge cases. No code is written until this plan is approved.
+**Section C - Proposed changes (pending approval).** An overview of the changes
+proposed to close the issue, framed as a plan awaiting reviewer approval: files to
+create or modify, the gist of each change, scope estimate, and notable risks or
+edge cases. No code is written until this plan is approved.
 
 ### Step 3: The approval gate
 
 The verdict drives what happens next:
 
-- **No longer needed** -> do NOT implement, even with `--yes`. Recommend closing the issue and provide a ready-to-paste closing comment citing the evidence:
+- **No longer needed** -> do NOT implement, even with `--yes`. Recommend closing
+  the issue and provide a ready-to-paste closing comment citing the evidence:
   ```bash
   gh issue close "$ISSUE_NUM" --comment "<evidence-based reason; reference the superseding PR/issue>"
   ```
   Surface the recommendation and STOP. Closing is the reviewer's call.
-- **Still needed**, **Partially addressed**, or **Needs reframing** -> present Section C and gate on approval:
-  - **Default (interactive):** pause and ask the reviewer to approve, redirect, or reject the plan. Only proceed once approved. For `Partially addressed` / `Needs reframing`, the approved plan is the adjusted one, not the original issue body.
-  - **`--yes` / `--auto-approve`, or an `eli5: auto-approve` trailer in the issue body or HEAD commit message:** proceed without pausing, but still print the full report for the record and note that approval was auto-granted.
+- **Still needed**, **Partially addressed**, or **Needs reframing** -> present
+  Section C and gate on approval:
+  - **Default (interactive):** pause and ask the reviewer to approve, redirect,
+    or reject the plan. Only proceed once approved. For `Partially addressed` /
+    `Needs reframing`, the approved plan is the adjusted one, not the original
+    issue body.
+  - **`--yes` / `--auto-approve`, or an `eli5: auto-approve` trailer in the issue
+    body or HEAD commit message:** proceed without pausing, but still print the
+    full report for the record and note that approval was auto-granted.
 
 ## Output format
 
 ```
-Flow ELI5: Issue #398
+ELI5 Gate: Issue #398
 
 == A. What this issue actually wants (ELI5) ==
 {plain-language intent, 2-4 sentences}
@@ -106,6 +150,7 @@ Risks: {edge cases / unknowns}
 
 Approval: REQUIRED (interactive) | AUTO-GRANTED (--yes) | N/A (No longer needed -> close recommended)
 ```
+<!-- eli5-core:end -->
 
 ## When run inside /flow:auto
 
@@ -120,3 +165,4 @@ Approval: REQUIRED (interactive) | AUTO-GRANTED (--yes) | N/A (No longer needed 
 - It never writes implementation code; the only mutating action it suggests is `gh issue close` on a `No longer needed` verdict, and that is a recommendation for the reviewer to run.
 - The staleness check is only meaningful when it inspects history *after* the issue's `createdAt`; always anchor `git log --since` and the PR/issue searches to that timestamp.
 - For step-by-step control outside the full lifecycle, run `/flow:eli5 <ISSUE>` on its own before deciding whether to `/flow:start`.
+- The vendored core between the markers must stay byte-identical to the canonical https://github.com/cooneycw/eli5-gate copy; `scripts/eli5-core-drift.sh` checks this (advisory, fail-open).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@
 
 ### Added
 
+- **`/flow:eli5` extracted to the standalone `eli5-gate` plugin** (issue #443,
+  epic #417 Phase C) - the necessity gate (plain-language intent ELI5 +
+  staleness/necessity verdict + plan-approval pause) now lives in its own public
+  canonical repo, https://github.com/cooneycw/eli5-gate, packaged both as a
+  self-hosting Claude Code plugin marketplace (`/plugin marketplace add
+  cooneycw/eli5-gate`) and as an open-standard Agent Skill (`npx skills add
+  cooneycw/eli5-gate`), so any user can install the gate without cloning CPP.
+  CPP now VENDORS the gate's core: `.claude/commands/flow/eli5.md` carries the
+  canonical section between `eli5-core:begin`/`end` markers with CPP's
+  /flow:auto wiring outside them, and the new advisory
+  `scripts/eli5-core-drift.sh` (fail-open, network-tolerant) warns when the
+  vendored copy drifts from canonical. This is the first application of the
+  standalone-extraction pattern (documented in CLAUDE.md): extracted skills are
+  improved in their own repos - issues route there, incl. via the #463
+  learnings->issue bridge - and CPP consumes them.
+
 - **Learnings->issue bridge** (issue #463, epic #417 Phase C) - actionable
   portable learnings can now be promoted from the retro/common-memory loop into
   tracked GitHub issues, so a learning that names a concrete fix becomes work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,19 @@ execute from a global mirror (`~/.claude/skills/flow-*`) regenerated from the
 (`--write` to sync, `--check` to detect drift); `/flow:doctor` warns when the
 mirror falls behind (issue #457).
 
+**Standalone skill extractions (issue #443):** skills with standalone value are
+extracted to their own public plugin repos so users never have to clone CPP -
+they install via `/plugin marketplace add cooneycw/<repo>` or `npx skills add
+cooneycw/<repo>`, and improvement issues for an extracted skill are filed in
+THAT repo, not here (the learnings->issue bridge, #463, routes there too). CPP
+stays a consumer: it vendors the extracted skill's canonical core between
+marker comments and layers its /flow wiring outside them; an advisory drift
+script warns when the vendored copy falls behind. First extraction: the
+`/flow:eli5` necessity gate -> https://github.com/cooneycw/eli5-gate
+(core markers `eli5-core:begin`/`end` in `.claude/commands/flow/eli5.md`,
+checked by `scripts/eli5-core-drift.sh`; reconcile drift by editing the
+canonical repo first, then re-vendoring).
+
 ### Project
 - `/project:init <name>` - Full project scaffolding (zero to GitHub repo)
 - `/project-next` - Full issue analysis and prioritization (~15-30K tokens)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What It Does
 
-- **Workflow commands** (`/flow:auto`, `/flow:start`, `/flow:eli5`, `/flow:finish`) - Issue-driven development with worktrees, a pre-implementation ELI5 plan/necessity approval gate, quality gates, automated PR lifecycle, and CI verification
+- **Workflow commands** (`/flow:auto`, `/flow:start`, `/flow:eli5`, `/flow:finish`) - Issue-driven development with worktrees, a pre-implementation ELI5 plan/necessity approval gate, quality gates, automated PR lifecycle, and CI verification. The necessity gate also ships standalone as [eli5-gate](https://github.com/cooneycw/eli5-gate) - installable without CPP via `/plugin marketplace add cooneycw/eli5-gate` or `npx skills add cooneycw/eli5-gate`; CPP vendors its canonical core (file gate improvements there)
 - **MCP servers** extending Claude Code's capabilities:
   - **Second Opinion** (port 8080, containerized) - Multi-model code review via external LLMs (Gemini, OpenAI, Anthropic)
   - **Browser automation** - upstream `@playwright/mcp` server (npx/stdio, no container), registered by `/cpp:init`

--- a/scripts/eli5-core-drift.sh
+++ b/scripts/eli5-core-drift.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# eli5-core-drift.sh - advisory drift check for the vendored eli5 necessity gate.
+#
+# CPP's /flow:eli5 vendors its core (the section between the eli5-core:begin /
+# eli5-core:end markers) verbatim from the canonical standalone repo
+# https://github.com/cooneycw/eli5-gate (extracted in issue #443). This script
+# fetches the canonical copy and diffs the marker-delimited core against the
+# local vendored copy.
+#
+# Advisory and fail-open by design: network down or canonical unreachable ->
+# exit 0 with a note; drift found -> warn with the diff and exit 1 so a CI step
+# or /flow gate CAN choose to surface it, but nothing in the flow hard-fails on
+# it. Reconcile drift by editing the CANONICAL repo first, then re-vendoring.
+set -uo pipefail
+
+CANON_URL="${ELI5_GATE_CANON_URL:-https://raw.githubusercontent.com/cooneycw/eli5-gate/main/commands/eli5.md}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOCAL_FILE="$REPO_ROOT/.claude/commands/flow/eli5.md"
+
+if [[ ! -f "$LOCAL_FILE" ]]; then
+    echo "eli5-core-drift: $LOCAL_FILE not found (nothing to check)" >&2
+    exit 0
+fi
+
+# Anchored to comment-line starts so prose that merely MENTIONS the markers
+# (e.g. a Notes bullet) cannot re-trigger the state machine.
+extract_core() {
+    awk '/^<!-- eli5-core:begin/{f=1; next} /^<!-- eli5-core:end/{f=0} f' "$1"
+}
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+if ! curl -fsSL --max-time 15 "$CANON_URL" -o "$TMP"; then
+    echo "eli5-core-drift: canonical source unreachable ($CANON_URL) - skipping (fail-open)" >&2
+    exit 0
+fi
+
+if [[ ! -s "$TMP" ]] || ! grep -q "eli5-core:begin" "$TMP"; then
+    echo "eli5-core-drift: canonical copy has no eli5-core markers - skipping (fail-open)" >&2
+    exit 0
+fi
+
+if diff -u <(extract_core "$TMP") <(extract_core "$LOCAL_FILE"); then
+    echo "eli5-core-drift: vendored core is in sync with canonical eli5-gate"
+    exit 0
+fi
+
+echo "" >&2
+echo "WARNING: the vendored eli5 core has drifted from the canonical copy at" >&2
+echo "  $CANON_URL" >&2
+echo "Reconcile by updating the canonical cooneycw/eli5-gate repo first, then" >&2
+echo "re-vendoring the marker section into .claude/commands/flow/eli5.md" >&2
+echo "(and run scripts/flow-skill-sync.py --write to refresh the global mirror)." >&2
+exit 1


### PR DESCRIPTION
## Summary

First application of the standalone-extraction pattern (epic #417 Phase C, review section 6 opportunity #1): the ELI5 necessity gate - the "should this issue exist at all?" checkpoint nothing else in the ecosystem asks - now lives in its own public canonical repo, **https://github.com/cooneycw/eli5-gate**, and CPP consumes it.

The pattern this establishes (now documented in CLAUDE.md): a user who wants the gate never has to clone CPP. Skills with standalone value are extracted to their own plugin repos; users install via `/plugin marketplace add cooneycw/eli5-gate` (self-hosting marketplace) or `npx skills add cooneycw/eli5-gate` (open Agent Skills standard); improvement issues for the gate are filed in the eli5-gate repo, where the #463 learnings->issue bridge also routes them.

## What's in the eli5-gate repo (already published, v1.0.0)

- `commands/eli5.md` - the generalized command (de-CPP'd; same three-section report, four verdicts, `--yes` semantics; `eli5-core` markers delimit the canonical core)
- `.claude-plugin/plugin.json` + `marketplace.json` - self-hosting plugin, installable day one
- `skills/eli5-gate/SKILL.md` - agentskills.io packaging for skills.sh
- README / MIT LICENSE / CHANGELOG

## What changes in CPP

- `.claude/commands/flow/eli5.md` - rebuilt as vendor: provenance header + the canonical core vendored **byte-identical** between `eli5-core:begin`/`end` markers + CPP-only `/flow:auto` wiring outside the markers
- `scripts/eli5-core-drift.sh` (new) - advisory, fail-open drift check against the canonical raw URL (verified in-sync against the live repo); marker regexes are line-anchored so prose mentioning the markers cannot re-trigger extraction
- `CLAUDE.md` - the extraction pattern documented (install paths, issue routing, vendor + drift-check mechanics)
- `README.md` / `CHANGELOG.md` - feature bullet + unreleased entry

## Test plan

- [x] `lib.cicd run --plan finish`: lint, test (738 passed), security scan all green
- [x] `scripts/eli5-core-drift.sh` run against the LIVE canonical repo: in sync
- [x] core byte-identity verified via marker-delimited diff at build time
- [x] no em/en dashes introduced
- [ ] post-merge: `scripts/flow-skill-sync.py --write` to refresh the global flow-eli5 mirror (#457 tooling)

Closes #443