### PR TITLE
fix(flow): handle 'gh pr merge --delete-branch' failing from a linked worktree (Closes #461)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -391,9 +391,36 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 2. **Merge the PR:**
    ```bash
    PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
-   gh pr merge "$PR_NUMBER" --squash --delete-branch
+
+   # Merge robustly across worktree layouts. Run from inside a linked worktree,
+   # `gh pr merge --delete-branch` fails AFTER the remote squash succeeds - gh
+   # tries to switch this worktree off the merged branch onto the default branch,
+   # which is checked out in the primary worktree ("fatal: 'main' is already
+   # checked out"), and exits non-zero. The merge still landed; treating that exit
+   # as a failure is a false STOP (issue #461). The helper drops --delete-branch in
+   # a linked worktree, deletes the remote branch itself, and verifies the PR
+   # reached MERGED before reporting failure. Local worktree/branch cleanup is left
+   # to step 4 below, so the native ExitWorktree path is unaffected.
+   if [[ -x ~/.claude/scripts/gh-pr-merge.sh ]]; then
+       ~/.claude/scripts/gh-pr-merge.sh "$PR_NUMBER" "$BRANCH"
+       MERGE_RC=$?
+   else
+       # Inline fallback (helper not installed): same linked-worktree guard.
+       if [[ -f ".git" ]]; then
+           gh pr merge "$PR_NUMBER" --squash
+           git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+       else
+           gh pr merge "$PR_NUMBER" --squash --delete-branch
+       fi
+       # Trust PR state over the local exit code.
+       [[ "$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null)" == "MERGED" ]]
+       MERGE_RC=$?
+   fi
    ```
-   - If merge fails (conflicts, checks): **STOP**. Report and exit.
+   - If the merge genuinely failed (`MERGE_RC` non-zero - conflicts, failing
+     checks, PR not `MERGED`): **STOP**. Report and exit. A non-zero `gh` exit
+     whose PR is nonetheless `MERGED` is NOT a failure - the helper already treats
+     it as success and continues to cleanup.
 
 3. **Capture the worktree and main repo paths (before leaving the worktree):**
    ```bash

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -91,13 +91,36 @@ Then merge the PR:
 ```bash
 PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
 
-# Squash merge (default) - keeps history clean
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+# Squash merge (default) - keeps history clean. Run from inside a linked worktree,
+# `gh pr merge --delete-branch` fails AFTER the remote squash succeeds: gh tries to
+# switch this worktree off the merged branch onto the default branch, which is
+# checked out in the primary worktree ("fatal: 'main' is already checked out"), and
+# exits non-zero even though the merge landed (issue #461). The helper drops
+# --delete-branch in a linked worktree, deletes the remote branch itself, and
+# verifies the PR reached MERGED before reporting failure. Local worktree/branch
+# cleanup stays in Step 5 below.
+if [[ -x ~/.claude/scripts/gh-pr-merge.sh ]]; then
+    ~/.claude/scripts/gh-pr-merge.sh "$PR_NUMBER" "$BRANCH"
+    MERGE_RC=$?
+else
+    # Inline fallback (helper not installed): same linked-worktree guard.
+    if [[ -f ".git" ]]; then
+        gh pr merge "$PR_NUMBER" --squash
+        git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+    else
+        gh pr merge "$PR_NUMBER" --squash --delete-branch
+    fi
+    [[ "$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null)" == "MERGED" ]]
+    MERGE_RC=$?
+fi
 ```
 
 - Use `--squash` by default (clean history)
-- `--delete-branch` removes the remote branch automatically
-- If merge fails (conflicts, checks failing), report and stop
+- The remote branch is deleted by `--delete-branch` (primary repo) or by the
+  helper's explicit `git push origin --delete` (linked worktree)
+- If the merge genuinely failed (`MERGE_RC` non-zero - conflicts, checks failing,
+  PR not `MERGED`), report and stop. A non-zero `gh` exit whose PR is nonetheless
+  `MERGED` is not a failure - the helper treats it as success and cleanup proceeds
 
 ### Step 4: Update Local Main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,21 @@
 
 ### Fixed
 
+- **`/flow:auto` + `/flow:merge` no longer false-fail merging from a worktree**
+  (issue #461) - run from inside a linked worktree (native `.claude/worktrees/`
+  or a legacy sibling dir), `gh pr merge <N> --squash --delete-branch` errored
+  with `fatal: 'main' is already checked out` AFTER the remote squash had already
+  succeeded: gh tried to switch the worktree off the merged branch onto the
+  default branch, which is checked out in the primary worktree. The non-zero exit
+  read as a failed merge and stopped the flow (it cost a full re-diagnosis on
+  flow:auto #433). New `scripts/gh-pr-merge.sh` makes the merge layout-aware -
+  in a linked worktree it drops `--delete-branch` and deletes the remote branch
+  itself, in the primary repo it keeps `--delete-branch`, and either way it
+  verifies the PR reached `MERGED` before reporting failure. Both flow surfaces
+  (`/flow:auto` Step 7, `/flow:merge` Step 3) call the helper with an inline
+  fallback; local worktree/branch cleanup is unchanged, so the native
+  `ExitWorktree` path is unaffected. Complements the #462 stale-branch re-gate
+  guard (same Step 7). Covered by `tests/test_gh_pr_merge.py`.
 - **Prune dangling references to removed MCP servers** - follow-up cleanup of
   stragglers left after #401 (`nano-banana`) and #404 (`mcp-woodpecker-ci`) that still
   described removed tooling as current:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Core components and their locations:
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
 - `lib/cpp_memory/` - Common-memory client: fail-open Postgres ledger of *portable* CPP learnings/infra traps shared across the VM fleet (bucket-2-plus), plus a dedup/rejection ledger and a learnings->GitHub-issue bridge (`--emit-issue-candidate` / `link-issue`, #463). Store provisioned by `scripts/memories-db-setup.sh`. Consult-not-push; see `/self-improvement:memory`.
-- `scripts/` - Shell utilities (prompt-context, worktree-remove, hooks, drift-detect, skill-drift, mcp-drift, flow-skill-sync, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
+- `scripts/` - Shell utilities (prompt-context, worktree-remove, gh-pr-merge (layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`), hooks, drift-detect, skill-drift, mcp-drift, flow-skill-sync, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
 - `templates/` - Makefile, workflow, container templates
 - `docker-compose.yml` - MCP server orchestration (profile: `core`)
 - `.woodpecker.yml` - Woodpecker CI pipeline (lint, test, typecheck, image security gates, runtime smoke)

--- a/scripts/gh-pr-merge.sh
+++ b/scripts/gh-pr-merge.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# gh-pr-merge.sh - Squash-merge a PR robustly from any git worktree layout.
+#
+# Problem (issue #461):
+#   From inside a LINKED worktree - a native `.claude/worktrees/<name>` checkout
+#   or a legacy sibling dir - `gh pr merge <N> --squash --delete-branch` fails
+#   AFTER the remote merge has already succeeded:
+#
+#     failed to run git: fatal: 'main' is already checked out at '<main-repo>'
+#
+#   gh, having merged and deleted the remote branch, tries to switch THIS worktree
+#   off the now-gone branch onto the default branch - which is checked out in the
+#   primary worktree, so the local checkout errors and gh exits non-zero. The
+#   remote squash still landed (and `Closes #N` still fired); only gh's local
+#   post-merge step failed. Callers that trust the exit code read this as a failed
+#   merge and stop - a false negative that cost a full re-diagnosis on flow:auto
+#   #433.
+#
+# This wrapper makes the merge layout-aware:
+#   * Linked worktree (cwd's `.git` is a FILE): run `gh pr merge --squash` WITHOUT
+#     --delete-branch so gh never attempts the local branch switch, then delete the
+#     REMOTE branch ourselves (what --delete-branch would have done). Local worktree
+#     + branch removal is left to the caller (worktree-remove.sh / ExitWorktree),
+#     so the native cleanup path is unaffected.
+#   * Primary repo (cwd's `.git` is a DIRECTORY): keep --delete-branch; the local
+#     switch to the default branch is safe there.
+#   * Either way, verify the PR actually reached MERGED before returning non-zero,
+#     so a stray local post-merge error is never mistaken for a merge failure.
+#
+# Usage:  gh-pr-merge.sh <pr-number> <branch-name>
+# Exit:   0 if the PR is merged on the remote; 1 only if it genuinely did not merge.
+#
+# Env (test hooks - unset in normal use):
+#   GH_PR_MERGE_GH   override the `gh` binary (default: gh)
+#   GH_PR_MERGE_GIT  override the `git` binary (default: git)
+
+set -uo pipefail
+
+PR_NUMBER="${1:-}"
+BRANCH="${2:-}"
+
+if [[ -z "$PR_NUMBER" || -z "$BRANCH" ]]; then
+    echo "Usage: gh-pr-merge.sh <pr-number> <branch-name>" >&2
+    exit 2
+fi
+
+GH_BIN="${GH_PR_MERGE_GH:-gh}"
+GIT_BIN="${GH_PR_MERGE_GIT:-git}"
+
+# A linked worktree has a `.git` FILE (a gitdir pointer); the primary repo has a
+# `.git` DIRECTORY. This is the exact condition under which --delete-branch trips.
+in_linked_worktree() { [[ -f .git ]]; }
+
+if in_linked_worktree; then
+    "$GH_BIN" pr merge "$PR_NUMBER" --squash
+    merge_exit=$?
+    # Delete the remote branch ourselves - this is what --delete-branch would have
+    # done, minus the local branch switch that fails in a linked worktree.
+    if [[ $merge_exit -eq 0 ]]; then
+        "$GIT_BIN" push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+    fi
+else
+    "$GH_BIN" pr merge "$PR_NUMBER" --squash --delete-branch
+    merge_exit=$?
+fi
+
+# Trust the PR state over the exit code: a non-zero from a local post-merge step
+# must never mask a remote merge that actually succeeded.
+state=$("$GH_BIN" pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null)
+
+if [[ "$state" == "MERGED" ]]; then
+    if [[ $merge_exit -ne 0 ]]; then
+        echo "note: gh exited $merge_exit but PR #$PR_NUMBER is MERGED - a local" \
+             "post-merge step failed, not the merge itself. Continuing." >&2
+        # Ensure the remote branch is gone even if the failure preceded our push.
+        if in_linked_worktree; then
+            "$GIT_BIN" push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+        fi
+    fi
+    echo "merged"
+    exit 0
+fi
+
+echo "error: PR #$PR_NUMBER did not merge (state: ${state:-unknown})." >&2
+exit 1

--- a/tests/test_gh_pr_merge.py
+++ b/tests/test_gh_pr_merge.py
@@ -1,0 +1,161 @@
+"""Tests for scripts/gh-pr-merge.sh - layout-aware PR squash-merge (issue #461).
+
+Contract:
+- In a LINKED worktree (cwd's ``.git`` is a file), merge WITHOUT --delete-branch
+  and delete the remote branch ourselves, so gh never attempts the local branch
+  switch that fails with "fatal: 'main' is already checked out".
+- In the PRIMARY repo (cwd's ``.git`` is a directory), keep --delete-branch.
+- Verify the PR reached MERGED before returning failure, so a non-zero gh exit on
+  a local post-merge step never masks a successful remote merge.
+- Return non-zero only when the PR genuinely did not merge.
+
+``gh`` and ``git`` are stubbed via the GH_PR_MERGE_GH / GH_PR_MERGE_GIT env hooks;
+each stub appends its argv to a call log the tests assert against.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "gh-pr-merge.sh"
+
+
+def _write_stub(path: Path, body: str) -> None:
+    path.write_text("#!/usr/bin/env bash\n" + body)
+    path.chmod(0o755)
+
+
+def _make_stubs(tmp_path: Path, *, merge_exit: int = 0, pr_state: str = "MERGED") -> dict:
+    """Create fake gh/git that log their args and honour a scripted outcome."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "calls.log"
+
+    # gh: log argv; `pr merge` exits merge_exit; `pr view ... state` echoes pr_state.
+    _write_stub(
+        bin_dir / "gh",
+        f'echo "gh $*" >> "{call_log}"\n'
+        'if [[ "$1 $2" == "pr merge" ]]; then\n'
+        f"  exit {merge_exit}\n"
+        'elif [[ "$1 $2" == "pr view" ]]; then\n'
+        f'  echo "{pr_state}"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    # git: log argv; everything succeeds.
+    _write_stub(bin_dir / "git", f'echo "git $*" >> "{call_log}"\nexit 0\n')
+
+    return {
+        "GH_PR_MERGE_GH": str(bin_dir / "gh"),
+        "GH_PR_MERGE_GIT": str(bin_dir / "git"),
+        "_call_log": call_log,
+    }
+
+
+def _run(cwd: Path, stubs: dict, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GH_PR_MERGE_GH"] = stubs["GH_PR_MERGE_GH"]
+    env["GH_PR_MERGE_GIT"] = stubs["GH_PR_MERGE_GIT"]
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        check=False,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def _linked_worktree(tmp_path: Path) -> Path:
+    """A cwd whose .git is a FILE - what a linked/native worktree looks like."""
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt\n")
+    return wt
+
+
+def _primary_repo(tmp_path: Path) -> Path:
+    """A cwd whose .git is a DIRECTORY - the primary checkout."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    return repo
+
+
+def _calls(stubs: dict) -> list[str]:
+    log = stubs["_call_log"]
+    return log.read_text().splitlines() if log.exists() else []
+
+
+def test_script_is_executable():
+    assert SCRIPT.exists()
+    assert os.access(SCRIPT, os.X_OK), "gh-pr-merge.sh must be executable"
+
+
+def test_usage_error_without_args(tmp_path: Path):
+    stubs = _make_stubs(tmp_path)
+    result = _run(_primary_repo(tmp_path), stubs, "42")  # missing branch
+    assert result.returncode == 2
+    assert "Usage" in result.stderr
+
+
+def test_linked_worktree_omits_delete_branch_and_deletes_remote(tmp_path: Path):
+    stubs = _make_stubs(tmp_path, merge_exit=0, pr_state="MERGED")
+    result = _run(_linked_worktree(tmp_path), stubs, "42", "issue-461-fix")
+    assert result.returncode == 0, result.stderr
+    calls = _calls(stubs)
+    merge = next(c for c in calls if c.startswith("gh pr merge"))
+    assert "--delete-branch" not in merge, "linked worktree must NOT pass --delete-branch"
+    assert "--squash" in merge
+    # Remote branch deleted by us, not by gh.
+    assert any(c == "git push origin --delete issue-461-fix" for c in calls), calls
+
+
+def test_primary_repo_keeps_delete_branch(tmp_path: Path):
+    stubs = _make_stubs(tmp_path, merge_exit=0, pr_state="MERGED")
+    result = _run(_primary_repo(tmp_path), stubs, "42", "issue-461-fix")
+    assert result.returncode == 0, result.stderr
+    calls = _calls(stubs)
+    merge = next(c for c in calls if c.startswith("gh pr merge"))
+    assert "--delete-branch" in merge, "primary repo must keep --delete-branch"
+    # We must NOT issue a manual remote-branch delete in the primary repo.
+    assert not any("push origin --delete" in c for c in calls), calls
+
+
+def test_nonzero_gh_but_merged_is_success(tmp_path: Path):
+    # The exact #461 trap: gh exits non-zero on the local post-merge step, but the
+    # remote squash succeeded (PR is MERGED). Must be treated as success.
+    stubs = _make_stubs(tmp_path, merge_exit=1, pr_state="MERGED")
+    result = _run(_linked_worktree(tmp_path), stubs, "42", "issue-461-fix")
+    assert result.returncode == 0, result.stderr
+    assert "merged" in result.stdout
+
+
+def test_genuinely_unmerged_returns_failure(tmp_path: Path):
+    stubs = _make_stubs(tmp_path, merge_exit=1, pr_state="OPEN")
+    result = _run(_linked_worktree(tmp_path), stubs, "42", "issue-461-fix")
+    assert result.returncode == 1
+    assert "did not merge" in result.stderr
+
+
+def test_primary_repo_nonzero_but_merged_is_success(tmp_path: Path):
+    stubs = _make_stubs(tmp_path, merge_exit=1, pr_state="MERGED")
+    result = _run(_primary_repo(tmp_path), stubs, "42", "issue-461-fix")
+    assert result.returncode == 0, result.stderr
+    assert "merged" in result.stdout
+
+
+def test_flow_commands_wire_the_helper():
+    # Both merge surfaces must call the guard (helper preferred, inline fallback),
+    # not the raw `gh pr merge --squash --delete-branch` that trips #461.
+    for rel in (".claude/commands/flow/auto.md", ".claude/commands/flow/merge.md"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "gh-pr-merge.sh" in text, f"{rel} must reference the merge helper"
+        # The inline fallback keeps the linked-worktree guard even without the helper.
+        assert "git push origin --delete" in text, f"{rel} missing remote-branch delete fallback"
+        assert "MERGED" in text, f"{rel} must verify PR state, not just the exit code"


### PR DESCRIPTION
## Summary

`/flow:auto` Step 7 and `/flow:merge` Step 3 falsely reported a **failed merge** when run from inside a linked worktree. `gh pr merge <N> --squash --delete-branch` errors with `fatal: 'main' is already checked out` **after** the remote squash has already succeeded: gh tries to switch the worktree off the just-merged branch onto the default branch, which is checked out in the primary worktree. The non-zero exit was read as a merge failure and stopped the flow (it cost a full re-diagnosis on flow:auto #433).

Every native `.claude/worktrees/` checkout is a linked worktree, so this bit the flagship "one command to ship" path itself.

## Fix

New **`scripts/gh-pr-merge.sh`** makes the merge layout-aware:

- **Linked worktree** (`.git` is a file): run `gh pr merge --squash` **without** `--delete-branch` so gh never attempts the local branch switch, then delete the remote branch ourselves (`git push origin --delete`).
- **Primary repo** (`.git` is a dir): keep `--delete-branch` (the local switch is safe there).
- **Either way**: verify the PR reached `MERGED` before returning non-zero, so a stray local post-merge error never masks a successful remote merge.

Both flow surfaces call the helper with an inline fallback:
- `.claude/commands/flow/auto.md` Step 7 (item 2, alongside the #462 stale-branch re-gate guard added on main)
- `.claude/commands/flow/merge.md` Step 3

Local worktree/branch cleanup is untouched, so the native `ExitWorktree` path is unaffected.

## Acceptance

- [x] flow:auto/merge from a linked worktree completes cleanly (no false "merge failed" stop)
- [x] Native `.claude/worktrees/` path (ExitWorktree) is unaffected

## Test plan

New `tests/test_gh_pr_merge.py` (stubs `gh`/`git` via env hooks, asserts):
- linked worktree omits `--delete-branch` and deletes the remote branch itself
- primary repo keeps `--delete-branch` and issues no manual remote delete
- non-zero `gh` exit but `MERGED` PR state -> success (the exact #461 trap)
- genuinely unmerged (state `OPEN`) -> failure
- both command files wire the guard (helper + inline fallback + PR-state verify)

`make lint` / `make test` (full suite) / `make typecheck` (122 files) all green. The `security_scan` gate's only findings are in the gitignored, untracked `.claude/settings.local.json` (local env creds, never committed); zero secret findings in any git-tracked file.

Also: added `gh-pr-merge` to the CLAUDE.md scripts inventory, a CHANGELOG `Fixed` entry, and regenerated the global `flow-*` skill mirrors via `scripts/flow-skill-sync.py --write` (0 drift). Follow-up worth filing: the native secrets scanner should honor `.gitignore` (this false-positive recurred from #441).

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)