### PR TITLE
fix(security): honor .gitignore in native secrets scanner (Closes #470)

### DIFF
--- a/lib/security/README.md
+++ b/lib/security/README.md
@@ -64,6 +64,13 @@ run, so the module has no hard external dependency.
 | `pip_audit.py` | external | Python dependency CVEs |
 | `npm_audit.py` | external | Node dependency CVEs |
 
+`secrets.py` honors `.gitignore` inside a git work tree (via a batched
+`git check-ignore`), so gitignored, never-committed local files (e.g.
+`.claude/settings.local.json`) are not scanned - the gate flags only
+*committable* risk. It fails open: outside a git repo, or on any git error, the
+full tree is scanned as before. Tracked files are always scanned even if they
+match an ignore pattern (`check-ignore` is index-aware).
+
 ## The gate
 
 `python -m lib.security gate <gate_name>` runs the **quick native** scan, then

--- a/lib/security/modules/secrets.py
+++ b/lib/security/modules/secrets.py
@@ -12,6 +12,7 @@ Detects well-known secret patterns with low false-positive rates:
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 from ..models import Finding, ScanResult, Severity
@@ -177,7 +178,7 @@ def scan(project_root: str) -> ScanResult:
 
 
 def _find_source_files(root: Path) -> list[Path]:
-    """Find source files to scan, respecting skip lists."""
+    """Find source files to scan, respecting skip lists and .gitignore."""
     files = []
     for path in root.rglob("*"):
         if path.is_file():
@@ -189,4 +190,51 @@ def _find_source_files(root: Path) -> list[Path]:
                 continue
             if path.suffix in SCAN_EXTENSIONS or path.name in (".env.example", ".env.sample"):
                 files.append(path)
-    return files
+    return _filter_gitignored(root, files)
+
+
+def _filter_gitignored(root: Path, files: list[Path]) -> list[Path]:
+    """Drop candidate paths that git would ignore.
+
+    Gitignored, never-committed local files (e.g. `.claude/settings.local.json`)
+    hold real credentials by design but are excluded from the repo, so flagging
+    them is a false positive on a security gate. This filters them out while
+    keeping the scanner honest about *committable* risk: `git check-ignore` is
+    index-aware by default, so a *tracked* file that also matches an ignore
+    pattern is NOT reported as ignored and still gets scanned.
+
+    Fail-open: outside a git work tree, or on any git error/timeout, the input
+    list is returned unchanged so scanning never silently narrows.
+    """
+    if not files:
+        return files
+
+    try:
+        inside = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return files
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return files
+
+    # Batch every candidate through a single check-ignore call over stdin.
+    # Exit status: 0 = at least one path ignored, 1 = none ignored, >1 = error.
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "check-ignore", "--stdin"],
+            input="\n".join(str(f) for f in files),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return files
+    if proc.returncode not in (0, 1):
+        return files
+
+    ignored = {line for line in proc.stdout.splitlines() if line}
+    return [f for f in files if str(f) not in ignored]

--- a/tests/test_security_scanners.py
+++ b/tests/test_security_scanners.py
@@ -3,13 +3,28 @@
 from __future__ import annotations
 
 import os
+import shutil
 import stat
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from lib.security.config import SecurityConfig
 from lib.security.models import Finding, ScanResult, Severity, Suppression
 from lib.security.modules import debug_flags, gitignore, permissions, secrets
 from lib.security.orchestrator import _apply_suppressions, check_gate
+
+# CPP's Woodpecker `validate` step runs in a container without git, so tests
+# that drive a real git repo must skip there (issue #430 pattern).
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not available in this environment"
+)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run a git command in cwd (test helper for building fixture repos)."""
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
 
 
 class TestGitignoreScanner:
@@ -108,6 +123,43 @@ class TestSecretsScanner:
     def test_no_source_files(self, tmp_path: Path) -> None:
         result = secrets.scan(str(tmp_path))
         assert len(result.skipped) > 0
+
+    @requires_git
+    def test_skip_gitignored_file(self, tmp_path: Path) -> None:
+        # A secret in a gitignored, untracked file must NOT be flagged: it is
+        # never committable, so flagging it is a false positive on the gate
+        # (issue #470 - recurred on /flow:auto #441 and #461).
+        _git(tmp_path, "init")
+        (tmp_path / ".gitignore").write_text(".claude/settings.local.json\n")
+        settings = tmp_path / ".claude" / "settings.local.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text('{"key": "AKIAIOSFODNN7EXAMPLE"}\n')
+        result = secrets.scan(str(tmp_path))
+        assert len(result.findings) == 0
+
+    @requires_git
+    def test_tracked_secret_still_detected(self, tmp_path: Path) -> None:
+        # Regression guard: a secret in a git-tracked file still fails the gate,
+        # even when that file also matches a .gitignore pattern (check-ignore is
+        # index-aware, so tracked paths are never treated as ignored).
+        _git(tmp_path, "init")
+        (tmp_path / ".gitignore").write_text("*.local.json\n")
+        tracked = tmp_path / "config.local.json"
+        tracked.write_text('{"key": "AKIAIOSFODNN7EXAMPLE"}\n')
+        _git(tmp_path, "add", "-f", "config.local.json")
+        result = secrets.scan(str(tmp_path))
+        aws_findings = [f for f in result.findings if f.id == "AWS_ACCESS_KEY"]
+        assert len(aws_findings) == 1
+
+    def test_outside_git_repo_unchanged(self, tmp_path: Path) -> None:
+        # Fail-open: with no git repo, a gitignore file has no effect and the
+        # scanner behaves exactly as before (the secret is still flagged).
+        (tmp_path / ".gitignore").write_text("*.local.json\n")
+        src = tmp_path / "config.local.json"
+        src.write_text('{"key": "AKIAIOSFODNN7EXAMPLE"}\n')
+        result = secrets.scan(str(tmp_path))
+        aws_findings = [f for f in result.findings if f.id == "AWS_ACCESS_KEY"]
+        assert len(aws_findings) == 1
 
 
 class TestDebugFlagsScanner:


### PR DESCRIPTION
## Summary

The native secrets scanner (`lib/security/modules/secrets.py`) walked the entire
tree with `rglob("*")` and only skipped a fixed `SKIP_DIRS`/`SKIP_FILES` set. It
did **not** honor `.gitignore`, so it scanned gitignored, never-committed local
files - notably `.claude/settings.local.json` (the user's real Claude Code
settings, holding real AWS/GitHub creds by design) - and false-positive-blocked
the `flow_finish` security gate on content git already excludes. This recurred on
`/flow:auto` #441 and #461.

## Change

- `_find_source_files()` now routes candidate paths through a new
  `_filter_gitignored()` helper that batches them through a single
  `git -C <root> check-ignore --stdin` call and drops the ignored ones.
- **Fail-open:** outside a git work tree (`rev-parse --is-inside-work-tree` != `true`),
  or on any git error / timeout / exit status > 1, the full candidate list is
  returned unchanged - scanning never silently narrows.
- `check-ignore` is **index-aware** by default, so a *tracked* file that also
  matches an ignore pattern is NOT dropped and still gets scanned. Committable
  secrets still fail the gate.

## Test plan

Adds three regression tests to `TestSecretsScanner` (all acceptance criteria):

- `test_skip_gitignored_file` - a secret in a gitignored, untracked file produces zero findings.
- `test_tracked_secret_still_detected` - a secret in a git-tracked file still fails, even when it matches an ignore pattern (regression guard).
- `test_outside_git_repo_unchanged` - with no git repo, behavior is unchanged (fail-open, secret still flagged).

Git-dependent tests are guarded with `@requires_git` (skip where `git` is absent,
e.g. CPP's Woodpecker `validate` container). Full deterministic `finish` gate
(lint + full pytest + security scan) passes locally; the security-scan step
exercises the new filter.

Closes #470