### PR TITLE
feat(project): retire orphaned generated project-* skills, redesign /project-next as tuned compact report (Closes #475)

### DIFF
--- a/.claude/commands/project-lite.md
+++ b/.claude/commands/project-lite.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(~/.claude/:*), Read, Gl
 
 # Project Lite - Quick Reference
 
-Generate a context-efficient project overview. This command uses minimal tokens (~500-800) compared to `/project-next` (15-30K tokens).
+Generate a context-efficient project overview. This command uses minimal tokens (~500-800) compared to `/project-next` (~2-4K compact, ~15-30K with `--full`).
 
 **Use this when:**
 - Starting a session and want quick orientation
@@ -107,7 +107,7 @@ For issue analysis and prioritized recommendations, run `/project-next`.
 
 After output, add:
 
-> **Token usage:** ~{X} tokens (vs ~20K for /project-next)
+> **Token usage:** ~{X} tokens (vs ~2-4K for /project-next compact, ~15-30K for --full)
 
 ---
 
@@ -138,6 +138,6 @@ Example:
 | Scenario | Command | Token Cost |
 |----------|---------|------------|
 | Quick orientation | `/project-lite` | ~500-800 |
-| Full issue analysis | `/project-next` | ~15-30K |
+| Issue analysis + recommendations | `/project-next` | ~2-4K compact / ~15-30K --full |
 | View specific issue | `/github:issue-view N` | ~1-2K |
 | List open issues | `/github:issue-list` | ~2-5K |

--- a/.claude/commands/project-next.md
+++ b/.claude/commands/project-next.md
@@ -1,496 +1,229 @@
 ---
-description: Scan GitHub issues and worktree to recommend prioritized next steps (generic)
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(PYTHONPATH=:*), Bash(for :*), Bash(~/.claude/:*), Bash(sort:*), Bash(printf:*), Read, Glob, Grep
+description: Prioritized next-step report from GitHub issues and worktrees (compact default; --full deep analysis, --brief single pick)
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(for :*), Bash(sort:*), Bash(printf:*), Read, Glob, Grep
 ---
 
 # Project Next Steps Recommendation
 
-Analyze the current project's GitHub issues and worktree state to recommend prioritized next steps.
+Analyze the project's GitHub issues and worktree state, then recommend
+prioritized next steps. This command is **read-only**: it never modifies
+issues, creates branches, or writes files. Do NOT enter plan mode - this is a
+report, not a change.
 
-**IMPORTANT:** Use Plan Mode for this analysis. Enter plan mode immediately to gather information before making recommendations.
+## Arguments
+
+`$ARGUMENTS` may contain a project name and/or a mode flag, in any order:
+
+- `<project>` (optional): a directory under `~/Projects` to analyze.
+  Resolution order: positional argument -> `CLAUDE_PROJECT` env var -> the
+  current git repository.
+- (no flag, default): **compact report** - state summary, top 3 ready-to-start
+  issues, in-flight and blocked tables.
+- `--full`: **deep report** - priority tiers 1-5, spec features table,
+  worktree status table, categorized backlog.
+- `--brief`: **single top recommendation** only.
 
 ---
 
-## Step 1: Enter Plan Mode
+## Step 1: Resolve project and fetch state (one pass)
 
-Before doing anything else, enter plan mode to systematically gather context.
-
----
-
-## Step 2: Detect Project Context
-
-### 2.1 Repository Detection
-
-Detect the current repository with fallback to `CLAUDE_PROJECT` environment variable:
+### 1.1 Resolve the project directory
 
 ```bash
-# Priority 1: Check for CLAUDE_PROJECT environment variable
-if [ -n "$CLAUDE_PROJECT" ]; then
-  # If set and not already in a git repo, change to project directory
-  if ! git rev-parse --git-dir >/dev/null 2>&1; then
-    PROJECT_DIR="$HOME/Projects/$CLAUDE_PROJECT"
-    if [ -d "$PROJECT_DIR" ]; then
-      cd "$PROJECT_DIR"
-    fi
-  fi
+# Positional argument wins; then CLAUDE_PROJECT; then current repo
+TARGET="<first non-flag token of $ARGUMENTS>"
+if [ -n "$TARGET" ] && [ -d "$HOME/Projects/$TARGET" ]; then
+  cd "$HOME/Projects/$TARGET"
+elif [ -n "$CLAUDE_PROJECT" ] && ! git rev-parse --git-dir >/dev/null 2>&1; then
+  [ -d "$HOME/Projects/$CLAUDE_PROJECT" ] && cd "$HOME/Projects/$CLAUDE_PROJECT"
 fi
-
-# Priority 2: Standard git repo detection
-gh repo view --json owner,name,description,defaultBranchRef --jq '{owner: .owner.login, name: .name, desc: .description, default_branch: .defaultBranchRef.name}'
+gh repo view --json owner,name,defaultBranchRef \
+  --jq '{owner: .owner.login, name: .name, default_branch: .defaultBranchRef.name}'
 ```
 
-If this fails:
-- If `CLAUDE_PROJECT` is set but directory doesn't exist, inform user: "CLAUDE_PROJECT is set to '{value}' but ~/Projects/{value} doesn't exist"
-- If not in a git repo and `CLAUDE_PROJECT` not set, suggest: "Set CLAUDE_PROJECT environment variable or cd to a project directory"
+- Named project directory missing: STOP - "~/Projects/{name} doesn't exist".
+- Not a git repo and nothing resolved: STOP - "cd to a project or pass a name".
+- `gh` errors (no remote, rate limit): report the error (and reset time for
+  rate limits), then STOP.
 
-### 2.2 Prefix Detection
-
-Determine the terminal label prefix using this priority:
-
-1. **Check CLAUDE.md** for a "Terminal Prefix" or "Project Prefix" configuration
-2. **Derive from repo name**: Take first letter of each hyphen-separated word, uppercase
-   - `nhl-api` → `NHL`
-   - `claude-power-pack` → `CPP`
-   - `my-django-app` → `MDA`
-3. **Fallback**: First 4 characters of repo name, uppercase
-
-### 2.3 Worktree Detection
-
-Check if worktrees are in use:
+### 1.2 Fetch everything in ONE batched call
 
 ```bash
-# List all worktrees
-git worktree list
-
-# Parse to identify:
-# - Main repo path
-# - Worktree paths and branches
-# - Issue numbers from branch names (pattern: issue-{N}-*)
+# Single call - never per-issue `gh issue view` loops
+gh issue list --state open --json number,title,labels,body --limit 200
 ```
 
-If only one worktree (the main repo), note that worktrees are not in use.
+If no open issues: report "No actionable issues found." and stop (in compact
+and brief modes, still show the in-flight/worktree state if any exists).
 
-### 2.4 Spec-Driven Development Detection
-
-Check if the project uses spec-driven development (via the official spec-kit; CPP's
-home-grown `lib/spec_bridge` pipeline was retired - see epic #417 Phase A):
+### 1.3 Scan worktrees and branches
 
 ```bash
-# Check for .specify feature specs and which have a tasks.md ready for issue sync
+git worktree list --porcelain
+git branch --list 'issue-*'
+git fetch origin --quiet 2>/dev/null || true
+```
+
+For each worktree: note its branch, mapped issue number (pattern
+`issue-{N}-*`), and whether it is dirty (`git -C <path> status --short`).
+
+---
+
+## Step 2: Materialize state (MANDATORY verification gate)
+
+Build these three lists explicitly before writing any recommendation.
+Skipping this step causes misclassification - it is a strict gate.
+
+1. **IN_FLIGHT_ISSUES** - every issue with a matching `issue-{N}-*` branch or
+   worktree.
+2. **DEPENDENCY_MAP** - parse issue bodies for **explicit dependency keywords
+   only**: `Depends on #N`, `Blocked by #N`, `Requires #N`, `After #N`, or a
+   parent Wave/Phase/epic whose checklist still has unchecked items referencing
+   the issue. `Related to #N` / `See also #N` is NOT a dependency.
+3. **BLOCKED_ISSUES** - transitive closure over DEPENDENCY_MAP: an issue is
+   blocked if ANY upstream dependency is in-flight, still open, or itself
+   blocked. Walk the chain - multi-hop (A blocks B blocks C) MUST be caught;
+   treat dependency cycles as blocked. Closed/merged upstreams satisfy the
+   dependency.
+
+```
+IN_FLIGHT_ISSUES: [#N, ...]
+BLOCKED_ISSUES:   [#X (by #N), ...]
+AVAILABLE_ISSUES: [everything open and in neither list]
+```
+
+**Validation (mandatory):** every open issue lands in exactly one list; no
+issue from IN_FLIGHT_ISSUES or BLOCKED_ISSUES may appear among the
+recommendations. Critical/security issues are the one exception: always
+surface them, flagged with their in-flight/blocked state.
+
+---
+
+## Step 3: Rank AVAILABLE_ISSUES
+
+Order by, in sequence:
+
+1. **Critical** - labels `security`, `blocker`, or `bug` + `priority-high`.
+2. **Priority labels** - `p1` before `p2` before unlabeled.
+3. **Phase order** - lower `phase-N` label (or Wave/Phase number in the title)
+   first.
+4. **Tie-break** - lower issue number (first-filed).
+
+Note quick wins (labels `documentation`, `chore`, or obviously small scope) in
+the rationale - they are good picks when a worktree is already active.
+
+If no priority/phase labels exist at all, fall back to issue-number order and
+warn: "No priority labels detected - ordering by issue number."
+
+---
+
+## Step 4: Spec sync check (only if `.specify/` exists)
+
+```bash
 for d in .specify/specs/*/; do
     [ -d "$d" ] || continue
     feat=$(basename "$d")
-    have_spec=$([ -s "${d}spec.md" ] && echo "✓" || echo "✗")
-    have_plan=$([ -s "${d}plan.md" ] && echo "✓" || echo "✗")
-    have_tasks=$([ -s "${d}tasks.md" ] && echo "✓" || echo "✗")
+    have_spec=$([ -s "${d}spec.md" ] && echo "y" || echo "n")
+    have_plan=$([ -s "${d}plan.md" ] && echo "y" || echo "n")
+    have_tasks=$([ -s "${d}tasks.md" ] && echo "y" || echo "n")
     echo "${feat}|${have_spec}|${have_plan}|${have_tasks}"
 done 2>/dev/null || echo "no .specify/specs"
 ```
 
-Note for output:
-- Feature names and their spec/plan/tasks presence
-- Which features have a `tasks.md` ready to turn into GitHub issues
-- Action needed: run `scripts/speckit-tasks-to-issues.sh` for features with tasks, then
-  `/flow:auto <issue>` per created issue
+Surface a pointer ONLY when a feature has a `tasks.md` with no matching GitHub
+issues yet: "Spec `{feat}` has tasks not yet synced - run
+`scripts/speckit-tasks-to-issues.sh`, then `/flow:auto <issue>` per issue."
+In `--full` mode, show the full feature table instead.
 
 ---
 
-## Step 3: Gather GitHub Issues
+## Step 5: Output
 
-Fetch open issues with metadata:
-
-```bash
-# List all open issues
-gh issue list --state open --limit 50
-
-# For important issues, get details
-gh issue view <NUMBER>
-```
-
-### 3.1 Categorize Issues
-
-Group issues by type based on labels and title patterns:
-
-| Category | Detection Method |
-|----------|------------------|
-| **CRITICAL** | Labels: `bug` + `priority-high`, `security`, `blocker` |
-| **BUGS** | Labels: `bug` (without priority-high) |
-| **FEATURES** | Labels: `feature`, `enhancement`, `feature-request` |
-| **DOCUMENTATION** | Labels: `documentation`, `docs` |
-| **TECH DEBT** | Labels: `refactor`, `cleanup`, `technical-debt`, `chore` |
-| **PLANNING** | Title starts with "Wave", "Phase", or "Plan" |
-| **OTHER** | No matching labels |
-
-### 3.2 Detect Issue Hierarchy
-
-Look for parent-child relationships:
-
-| Pattern | Example | Detection |
-|---------|---------|-----------|
-| Wave/Phase | `Wave 5c.3: Title` | Title regex: `^(Wave|Phase)\s+[\d.]+[a-z]?[\d.]*:` |
-| Parent Reference | `**Parent Issue:** #63` | Body contains `Parent Issue:.*#\d+` |
-| Epic Link | `Part of #25` | Body contains `Part of #\d+` or `Related:.*#\d+` |
-
----
-
-## Step 4: Analyze Worktree State
-
-For each worktree, check:
-
-```bash
-# Check status of each worktree
-git -C <worktree_path> status --short
-
-# Check recent commits
-git -C <worktree_path> log --oneline -5
-
-# Check branch info
-git -C <worktree_path> branch -vv
-```
-
-Look for:
-- **Uncommitted changes** - Work in progress
-- **Stale branches** - No commits in 7+ days
-- **Merged but open** - Branch merged to main but issue still open
-- **Divergence** - Branches that need rebasing
-
----
-
-## Step 5: State Materialization (MANDATORY)
-
-You MUST build three explicit lists and write them out before generating any recommendations.
-Failure to materialize these lists causes downstream filtering failures. This is a strict gate.
-
-### 5.1 Build IN_FLIGHT_ISSUES
-
-Collect every issue number that meets ANY of these criteria into `IN_FLIGHT_ISSUES`:
-- Has a matching branch anywhere (`git branch --list 'issue-{N}-*'`)
-- Has a mapped worktree directory (from Step 4)
-- Is claimed by an Active or Idle session
-
-### 5.2 Build DEPENDENCY_MAP
-
-Parse all open issues for dependency relationships. For each issue, record its upstream dependencies:
-
-| Detection Pattern | Example | Extraction |
-|-------------------|---------|------------|
-| "Depends on #N" | `Depends on #100` | upstream = #100 |
-| "Blocked by #N" | `Blocked by #100` | upstream = #100 |
-| "After #N" | `After #100` | upstream = #100 |
-| "Requires #N" | `Requires #100` | upstream = #100 |
-| Parent wave incomplete | Child of Wave 5, Wave 5 still open | upstream = Wave 5 issue |
-| Checklist reference | `- [ ] #100` in parent body | upstream = parent for #100 |
-
-### 5.3 Build BLOCKED_ISSUES
-
-Use the following graph traversal to compute transitive blocking. Do NOT use a single-pass check -
-multi-hop dependencies (A blocks B blocks C) MUST be caught.
-
-```pseudocode
-function compute_blocked(dependency_map, in_flight_issues, all_open_issues):
-    blocked = set()
-    visited = set()
-
-    function dfs(issue):
-        if issue in visited:
-            return                          # cycle detected - already handled
-        visited.add(issue)
-
-        for upstream in dependency_map.get(issue, []):
-            if upstream in in_flight_issues:
-                blocked.add(issue)          # upstream is active work, not done
-            elif upstream in all_open_issues:
-                dfs(upstream)               # recurse to check upstream's deps
-                if upstream in blocked:
-                    blocked.add(issue)      # transitively blocked
-            # if upstream is closed/merged, it is satisfied - no block
-
-    for issue in all_open_issues:
-        dfs(issue)
-
-    # Handle cycles: any issue still in visited but with unresolved
-    # circular refs gets marked blocked
-    return blocked
-```
-
-An issue is blocked if ANY of these are true:
-- It has an explicit dependency (Depends on/Blocked by/Requires/After) on an in-flight issue
-- It has an explicit dependency on an open issue that is itself blocked (transitive)
-- It is a child of a parent wave that still has incomplete tasks
-- It participates in a circular dependency chain
-
-**Important:** Only block on explicit dependency keywords from section 5.2. Do NOT treat every
-open issue reference (e.g. "Related to #N" or "See also #N") as a blocking dependency.
-
-### 5.4 Write Out All Three Lists
-
-You MUST explicitly output these three lists in your thinking before proceeding to Step 6.
-If you skip this step, your recommendations WILL contain errors.
-
-```
-IN_FLIGHT_ISSUES: [#N, #M, ...]
-BLOCKED_ISSUES: [#X (blocked by #N), #Y (blocked by #M), ...]
-AVAILABLE_ISSUES: [all open issues NOT in either list above]
-```
-
-**Worked example** (5 issues, 2 worktrees):
-```
-Open issues: #10, #11, #12, #13, #14
-Worktrees: issue-10-auth, issue-11-api
-Dependencies: #12 "Depends on #10", #13 "Requires #12", #14 has no deps
-
-IN_FLIGHT_ISSUES: [#10, #11]           -- have worktrees
-BLOCKED_ISSUES:   [#12 (by #10), #13 (by #12, transitive)]
-AVAILABLE_ISSUES: [#14]                -- only this is "Ready to Start"
-```
-
-### 5.5 Issue-to-Spec Mapping (if .specify/ exists)
-
-For each issue, check if it was created by spec sync:
-
-1. **Label Matching**: Look for labels matching feature names in `.specify/specs/`
-2. **Body References**: Check issue body for "Spec:" or "Feature:" references
-3. **Wave Title Pattern**: Match issue title with wave names from tasks.md (e.g., "Wave 1: Description")
-
-For each worktree, determine if it links to a spec feature:
-- Extract issue number from branch name
-- Look up issue labels
-- Match label to feature directory in `.specify/specs/`
-
-### 5.6 Orphaned Work
-
-Identify branches/worktrees without corresponding open issues (merged or closed).
-
----
-
-## Step 6: Verification Gate (MANDATORY)
-
-You MUST execute the following pseudocode logic against EVERY open issue to determine its placement.
-Do NOT skip this step. Do NOT assign issues without running them through this gate.
-
-```pseudocode
-for issue in all_open_issues:
-    if issue.number in IN_FLIGHT_ISSUES:
-        assign_to(PRIORITY_2_ACTIVE_WORK)
-        continue                              # STOP - do not consider further
-
-    if issue.number in BLOCKED_ISSUES:
-        assign_to(BLOCKED_SECTION)
-        continue                              # STOP - do not recommend
-
-    if is_critical_or_security_blocker(issue):
-        assign_to(PRIORITY_1_CRITICAL)
-        continue
-
-    if is_quick_win(issue):
-        assign_to(PRIORITY_4_QUICK_WINS)
-        continue
-
-    if is_planning_or_discussion(issue):
-        assign_to(PRIORITY_5_PLANNING)
-        continue
-
-    assign_to(PRIORITY_3_READY_TO_START)
-```
-
-### Post-Gate Validation (MANDATORY)
-
-After running the gate, execute this validation. Do NOT skip it.
-
-```pseudocode
-# Validation 1: No in-flight or blocked issues leaked into recommendable tiers
-for tier in [PRIORITY_3, PRIORITY_4, PRIORITY_5]:
-    for issue in tier:
-        assert issue not in IN_FLIGHT_ISSUES    # FAIL = move to Priority 2
-        assert issue not in BLOCKED_ISSUES      # FAIL = move to Blocked section
-        for upstream in DEPENDENCY_MAP.get(issue, []):
-            if upstream in all_open_issues:
-                assert upstream not in IN_FLIGHT_ISSUES  # FAIL = move issue to Blocked
-                assert upstream not in BLOCKED_ISSUES    # FAIL = move issue to Blocked
-
-# Validation 2: Coverage - every open issue accounted for exactly once
-assigned = P1 + P2 + BLOCKED + P3 + P3b + P4 + P5
-assert len(assigned) == len(all_open_issues)    # FAIL = find and classify missing issues
-```
-
-If any assertion fails, fix the assignment before generating output. If you cannot resolve
-a classification, report it as an error to the user rather than silently misclassifying.
-
-**STRICTLY FORBIDDEN:** An issue in `IN_FLIGHT_ISSUES` MUST NOT appear in Priority 3, 4, or 5.
-An issue in `BLOCKED_ISSUES` MUST NOT appear in Priority 3, 4, or 5. No exceptions.
-
----
-
-## Step 7: Generate Recommendations
-
-Output the prioritized list based EXACTLY on the Step 6 verification gate results.
-
-### Priority 1: Critical/Blocking
-- Security issues, breaking bugs, deployment blockers
-- These bypass the in-flight/blocked filter (critical issues are always surfaced)
-
-### Priority 2: Active Work (In Progress)
-- ONLY issues from `IN_FLIGHT_ISSUES`
-- Include worktree path, branch status, uncommitted changes, session claim
-
-### Blocked (Not Actionable)
-- Issues from `BLOCKED_ISSUES`
-- For each, show WHY it is blocked: "Blocked by #N (in-flight)" or "Blocked by #N (not started)"
-- Do NOT assign effort estimates or suggest starting these
-
-### Priority 3: Ready to Start
-- Issues that passed the Step 6 gate with no blockers
-- Child issues of COMPLETED parent waves only
-- Issues with clear acceptance criteria
-
-### Priority 3b: Pending Spec Sync (if .specify/ exists)
-- Features with a `tasks.md` not yet turned into GitHub issues
-- **Why:** Spec work is defined but not yet tracked in GitHub issues
-- **Action:** `./scripts/speckit-tasks-to-issues.sh` (then `/flow:auto <issue>` per issue)
-
-### Priority 4: Quick Wins
-- Low effort issues, documentation updates, simple fixes
-- MUST have passed the Step 6 gate
-
-### Priority 5: Planning/Discussion
-- Wave/Phase planning issues, feature discussions, architecture decisions
-- MUST have passed the Step 6 gate
-
----
-
-## Step 8: Output Format
-
-Present findings as:
+### Default (compact)
 
 ```markdown
-## {REPO_NAME} - Recommended Next Steps
+## {REPO} - Next Steps
 
-### Current State Summary
-- **Repository:** {owner}/{name}
-- **Open Issues:** {count} ({critical} critical, {bugs} bugs, {features} features)
-- **Worktrees:** {count} active
-  - {worktree_path} ({branch}) - Issue #{N}
-- **Uncommitted Work:** {list or "None"}
+**State:** {N} open | {K} in-flight ({#a, #b}) | {M} blocked
 
-### Spec Features (if .specify/ exists)
+### Ready to start (top 3)
+1. #{N} {title}  [{p1|p2|-}, {phase|-}]
+   {one-line rationale} -> /flow:auto {N}
+2. ...
+3. ...
 
-📋 **Spec-Driven Development:**
+### In flight
+| # | branch | status |
+|---|--------|--------|
+| {N} | issue-{N}-... | clean|dirty |
 
-| Feature | Spec | Plan | Tasks | Action |
-|---------|------|------|-------|--------|
-| {name} | ✓/○/✗ | ✓/○/✗ | ✓/○/✗ | {action} |
+### Blocked
+| # | by | reason |
+|---|-----|--------|
+| {X} | #{N} | in-flight|open dep|transitive |
 
-**Legend:**
-- ✓ = File exists and has content
-- ○ = File exists but empty/incomplete
-- ✗ = File missing
-
-**Example:**
-| Feature | Spec | Plan | Tasks | Action |
-|---------|------|------|-------|--------|
-| user-auth | ✓ | ✓ | ✓ | `./scripts/speckit-tasks-to-issues.sh` |
-| api-refactor | ✓ | ✓ | ○ | Add tasks to tasks.md |
-| dashboard | ✓ | ✓ | ✗ | Run `/speckit-tasks` |
-
-### Issue Hierarchy
-- **Waves/Phases in Progress:** {list with status}
-- **Blocked Issues:** {count} (waiting on parent completion)
-
-### Priority Actions
-
-1. **[CRITICAL]** Issue #{N}: {Title}
-   - **Why:** {reasoning}
-   - **Effort:** Small/Medium/Large
-   - **Command:** `git worktree add -b issue-{N}-desc ../{repo}-issue-{N}`
-
-2. **[READY]** Issue #{N}: {Title}
-   - **Why:** {reasoning}
-   - **Effort:** {estimate}
-
-3. **[QUICK WIN]** Issue #{N}: {Title}
-   - **Why:** {reasoning}
-
-### Blocked Issues (Not Actionable)
-
-| Issue | Title | Blocked By | Reason |
-|-------|-------|------------|--------|
-| #{X} | {Title} | #{N} | In-flight (active worktree) |
-| #{Y} | {Title} | #{M} | Not started (open dependency) |
-
-### Worktree Status
-
-| Directory | Branch | Issue | Spec Feature | Status | Session |
-|-----------|--------|-------|--------------|--------|---------|
-| {path} | issue-{N}-desc | #{N} | user-auth | Uncommitted changes | session-abc (active) |
-| {path} | issue-{M}-desc | #{M} | api-refactor | Clean | - |
-| {path} | issue-{K}-desc | #{K} | - | Clean | - |
-
-*Spec Feature column shows the linked feature from `.specify/specs/` if the issue was created via `scripts/speckit-tasks-to-issues.sh`*
-
-### Recommendations
-- **Cleanup:** {worktrees with merged branches}
-- **Stale:** {worktrees with no recent commits}
+{spec-sync pointer, only if applicable}
+(--full for the 5-tier report, --brief for a single pick)
 ```
 
----
+Omit any empty section. Rationales are one line each - do not expand into
+per-issue analysis.
 
-## Step 9: Present Follow-up Options
-
-After presenting recommendations, offer:
-
-1. **Start Priority #1** - Create worktree and begin work on top priority
-2. **View Issue Details** - Get full details on any specific issue
-3. **Create New Issue** - Document discovered work
-4. **Clean Up** - Remove stale worktrees/branches
-5. **Refresh** - Re-scan for updates
-6. **Sync Pending Specs** - Run `./scripts/speckit-tasks-to-issues.sh` to turn a feature's `tasks.md` into GitHub issues (if .specify/ exists)
-
----
-
-## Step 10: Handle User Selection
-
-When the user selects an issue to work on, follow this sequence:
-
-### 9.1 Create Worktree (if needed)
-
-If the issue doesn't have an existing worktree:
-
-```bash
-# Create worktree for the issue
-git worktree add -b issue-{N}-{description} ../{repo}-issue-{N}
-```
-
-### 9.4 Confirmation
-
-Report to user:
-- Issue #{N} claimed by this session
-- Worktree created (if applicable)
-- Shell prompt will show `[PREFIX #N]` when in worktree
-- Ready to begin work
-
----
-
-## Notes for Non-Worktree Repositories
-
-If the repository doesn't use worktrees (only main worktree detected):
-
-1. Skip worktree analysis sections
-2. Focus on branch-to-issue mapping
-3. Suggest worktree setup for complex projects:
-   > "Consider using git worktrees for parallel issue development. See `ISSUE_DRIVEN_DEVELOPMENT.md` for guidance."
-
----
-
-## Configuration via CLAUDE.md
-
-Projects can optionally add this configuration block to their CLAUDE.md:
+### --brief
 
 ```markdown
-## Project-Next Configuration
+Recommended next issue:
 
-| Setting | Value | Description |
-|---------|-------|-------------|
-| **Prompt Prefix** | NHL | Short prefix for shell prompt context |
-| **Issue Pattern** | wave | Hierarchy style: wave, epic, parent-child, flat |
-| **Priority Labels** | critical, urgent | Labels indicating critical priority |
+  #{N}  {title}
+  Priority: {p1|p2|-} | Phase: {phase|-} | Blocked by: none
+  Rationale: {one sentence}
+
+  -> /flow:auto {N}
 ```
+
+### --full
+
+The deep report - all sections:
+
+1. **Current State Summary** - repo, open-issue counts by category (critical /
+   bugs / features / docs / tech-debt / planning), worktree list, uncommitted
+   work.
+2. **Spec Features table** (if `.specify/` exists) - feature | spec | plan |
+   tasks | action.
+3. **Priority tiers:**
+   - Priority 1: Critical/blocking (surfaced even when in-flight/blocked,
+     flagged).
+   - Priority 2: Active work - IN_FLIGHT_ISSUES only, with worktree path,
+     branch status, uncommitted changes.
+   - Blocked (not actionable) - table with issue | title | blocked-by |
+     reason. No effort estimates; never suggest starting these.
+   - Priority 3: Ready to start - gate-passed issues, with Why / Effort /
+     `/flow:auto` command per issue.
+   - Priority 3b: Pending spec sync (if applicable).
+   - Priority 4: Quick wins (gate-passed only).
+   - Priority 5: Planning/discussion issues.
+4. **Worktree Status table** - directory | branch | issue | status.
+5. **Recommendations** - cleanup candidates (merged/stale worktrees).
+
+The tier assignments come EXACTLY from the Step 2 gate - an issue in
+IN_FLIGHT_ISSUES or BLOCKED_ISSUES must never appear in tiers 3-5.
+
+---
+
+## Edge cases
+
+- **All open issues blocked:** report the unique set of blockers and which
+  in-flight work resolves them.
+- **Top pick already has a worktree:** it belongs in the in-flight table, not
+  the recommendations - recommend the next available issue instead.
+- **Worktree without an open issue** (merged/closed): list under a one-line
+  cleanup note - "run `/flow:cleanup`".
+
+## Notes
+
+- To act on a recommendation: `/flow:auto {N}` (full lifecycle) or
+  `/flow:start {N}` (worktree only).
+- For a quick orientation without issue analysis, use `/project-lite`.
+- Optional per-project tuning via a "Project-Next Configuration" block in
+  CLAUDE.md (priority labels, hierarchy style: wave / epic / parent-child /
+  flat).

--- a/.claude/commands/project/help.md
+++ b/.claude/commands/project/help.md
@@ -42,7 +42,7 @@ One-command project setup that orchestrates:
 
 ## /project-next
 
-Full GitHub issue analysis with prioritized recommendations. Scans open issues, maps worktrees, detects hierarchy (Waves/Phases), and suggests what to work on next.
+Prioritized next-step report. Scans open issues in one batched call, maps worktrees, applies a blocked/in-flight verification gate, and recommends what to work on next. Compact by default; `--full` for the deep 5-tier analysis, `--brief` for a single top pick.
 
 **Use when:** Unsure what to work on, need issue triage, or want cleanup suggestions.
 

--- a/.claude/deprecated-skills.yaml
+++ b/.claude/deprecated-skills.yaml
@@ -102,6 +102,30 @@ deprecated:
     cleanup: |
       rm -rf ~/.claude/skills/skills-patterns ~/.claude/skills/skills-patterns.md
 
+  - family: project
+    entire_family: true
+    reason: >-
+      The generated project-* skills came from the defunct manifests/project/*.yaml
+      architecture and diverged badly from the live .claude/commands sources:
+      project-next is a "single best issue" picker that silently shadows the full
+      /project-next analysis command (issue #475); project-lite is a bootstrap
+      scaffolder, not the quick status report; project-init still offers the
+      retired Plane + Wiki.js wizard and predates the thin /project:init (#441).
+      The live commands under .claude/commands/ (project-next.md, project-lite.md,
+      project/init.md) are the sole source of truth.
+    replacement: /project-next, /project-lite, /project:init (live commands)
+    skills:
+      - project-next
+      - project-lite
+      - project-init
+    # Manual fallback; the #395 skill-orphan prune in /cpp:update consumes this
+    # file and offers guarded, user-confirmed removal. Safe: generated artifacts,
+    # not user content.
+    cleanup: |
+      rm -rf ~/.claude/skills/project-next \
+             ~/.claude/skills/project-lite \
+             ~/.claude/skills/project-init
+
 # Plane has no entry: it was never integrated as a CPP skill or command, so
 # there is nothing installed to remove. It is recorded here only to make the
 # "GitHub Issues is the sole scaffolding backend" decision explicit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ canonical repo first, then re-vendoring).
 
 ### Project
 - `/project:init <name>` - Full project scaffolding (zero to GitHub repo)
-- `/project-next` - Full issue analysis and prioritization (~15-30K tokens)
+- `/project-next` - Prioritized next-step report (compact default ~2-4K tokens; `--full` deep 5-tier analysis ~15-30K, `--brief` single pick)
 - `/project-lite` - Quick project reference (~500-800 tokens)
 
 `/project:init` delegates config scaffolding (CLAUDE.md, skills, hooks) to Claude


### PR DESCRIPTION
## Summary

- Adds a `project` family entry to `.claude/deprecated-skills.yaml`: the manifest-generated `project-next` / `project-lite` / `project-init` skills under `~/.claude/skills/` came from the defunct `manifests/project/*.yaml` architecture and silently shadowed the live commands (the documented skill-drift "silent drift" limitation, live in the wild). Transcripts 2026-07-01 through 2026-07-04 show every `/project-next` invocation loaded the stale single-pick stub instead of the full analysis command; the stale `project-lite` was a bootstrap scaffolder and the stale `project-init` still offered the retired Plane + Wiki.js wizard.
- Redesigns `.claude/commands/project-next.md` (496 -> 246 lines) as a tuned compact report (owner-approved design): one batched `gh issue list --json` fetch (no per-issue `gh issue view` loops), no plan mode, positional project arg + `CLAUDE_PROJECT` fallback, and the in-flight/blocked state-materialization verification gate KEPT (added in eb5090c to fix real misclassification). Default output = state summary + top-3 ready-to-start + in-flight/blocked tables; `--full` = the previous 5-tier deep report; `--brief` = single top pick.
- Updates references: CLAUDE.md commands section, `/project-lite` token comparisons, `/project:help`.
- Host-side (already executed, user-confirmed): `scripts/skill-drift.py --prune project-next project-lite project-init` - moved to `~/.claude/.backup/skills/20260704T133845Z/`.

## Test plan

- `python -m lib.cicd run --plan finish`: lint PASS, test PASS (security_scan finding = known #441 false positive: 3 CRITICALs all in gitignored, untracked `.claude/settings.local.json`; verified untracked, friction-logged)
- `test_fallback_parser_matches_real_file` guard: verified PyYAML and the fallback parser agree on the updated real file (families, skills lists, entire_family flags)
- `scripts/skill-drift.py --check`: flags the three orphans DEPRECATED with the new entry; after prune, no project-* skills remain installed
- No em/en dashes introduced (checked all changed files)

Closes #475
