### PR TITLE
feat(flow): detect a stale base early at Step 4/6, not only at the Step-7 #462 guard (Closes #473)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -221,6 +221,30 @@ Report: `Step 3/9: ELI5 complete - verdict: {Still needed|Partially addressed|No
 
 ### Step 4: Implement - Write the Code
 
+**Early stale-base check (issue #473) - run BEFORE editing.** A sibling PR that
+merges during implementation moves `origin/main` under you; discovering it only
+at the Step-7 #462 guard means your edits were already made against stale copies
+of the very files the sibling changed. Surface it now:
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+done
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/flow-stale-check.sh" ]; then
+    "$CPP_DIR/scripts/flow-stale-check.sh" origin/main   # advisory: warns, never blocks
+fi
+```
+
+- If it reports `FLOW_STALE_BASE: collision` - or names a file you are about to
+  touch under "Changed upstream" - bring the base in now, before piling edits on
+  a stale tree: `git merge --no-edit origin/main`, resolve any conflict in the
+  named file(s), then implement. If the note says flow command files changed
+  upstream, re-run `python3 "$CPP_DIR/scripts/flow-skill-sync.py" --write` after
+  merging so the global `flow-*` mirror does not drift.
+- If it reports `current` or `moved-clean` with no overlap, proceed - the Step-7
+  #462 guard remains the final backstop.
+
 Execute the approved plan from the Step 3 ELI5 gate:
 
 1. **Make all code changes** in the worktree.
@@ -271,6 +295,35 @@ Report: `Step 5/9: Update Docs complete - {N} files updated` or `Step 5/9: Updat
 ```bash
 BRANCH=$(git branch --show-current)
 ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+```
+
+**Stale-base pre-check (issue #473) - run BEFORE the quality gates and commit**,
+so the commit lands on a current tree and the gate reflects what will merge (the
+#462 Step-7 guard stays the final backstop):
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+done
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/flow-stale-check.sh" ]; then
+    "$CPP_DIR/scripts/flow-stale-check.sh" origin/main
+fi
+
+# If the base moved, merge it in now so the gate + commit ride the current tree.
+git fetch origin main --quiet
+if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
+    if ! git merge --no-edit origin/main; then
+        echo "STOP: resolve the listed conflicts, 'git add' + 'git commit', then re-run Step 6."
+        git diff --name-only --diff-filter=U
+        exit 1
+    fi
+    # Keep the global flow-* mirror from drifting when the merge pulled flow
+    # command changes - the mirror is what EXECUTES (issues #457/#461/#473).
+    if [ -n "$CPP_DIR" ] && git diff --name-only ORIG_HEAD..HEAD | grep -q '^\.claude/commands/flow/.*\.md$'; then
+        python3 "$CPP_DIR/scripts/flow-skill-sync.py" --write || true
+    fi
+fi
 ```
 
 1. **Quality gates** - use the deterministic runner as primary path:
@@ -371,6 +424,11 @@ Report: `Step 6/9: Finish complete - PR #XX created`
        for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
          [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
        done
+       # If the merge pulled flow command changes, re-sync the global flow-*
+       # mirror so it does not drift - the mirror is what EXECUTES (issue #473).
+       if [ -n "$CPP_DIR" ] && git diff --name-only ORIG_HEAD..HEAD | grep -q '^\.claude/commands/flow/.*\.md$'; then
+           python3 "$CPP_DIR/scripts/flow-skill-sync.py" --write || true
+       fi
        if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
            PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
            REGATE_EXIT=$?

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -20,6 +20,39 @@ fi
 ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
 ```
 
+### Step 1b: Stale-base Pre-check (issue #473)
+
+A sibling PR that merged while you were working moves `origin/main` under you; if
+you commit onto a stale base, you rediscover the collision only at merge time (the
+#462 guard). Surface it now, before the quality gate runs, and if the base moved,
+bring it in so the gate below rides the current tree:
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+done
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/flow-stale-check.sh" ]; then
+    "$CPP_DIR/scripts/flow-stale-check.sh" origin/main   # advisory: names colliding files
+fi
+
+git fetch origin main --quiet
+if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
+    if ! git merge --no-edit origin/main; then
+        echo "STOP: resolve the listed conflicts, 'git add' + 'git commit', then re-run /flow:finish."
+        git diff --name-only --diff-filter=U
+        exit 1
+    fi
+    # Re-sync the global flow-* mirror if the merge pulled flow command changes.
+    if [ -n "$CPP_DIR" ] && git diff --name-only ORIG_HEAD..HEAD | grep -q '^\.claude/commands/flow/.*\.md$'; then
+        python3 "$CPP_DIR/scripts/flow-skill-sync.py" --write || true
+    fi
+fi
+```
+
+This is the early half of the #462 stale-branch guard; the Step-7 `/flow:merge`
+guard remains the final backstop.
+
 ### Step 2: Run Quality Gates via Deterministic Runner (primary path)
 
 **Primary path:** Use the deterministic CI/CD runner for reproducible quality gates:

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -69,6 +69,11 @@ if [[ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]]; then
     for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
       [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
     done
+    # If the merge pulled flow command changes, re-sync the global flow-* mirror
+    # so it does not drift - the mirror is what EXECUTES (issue #473).
+    if [ -n "$CPP_DIR" ] && git diff --name-only ORIG_HEAD..HEAD | grep -q '^\.claude/commands/flow/.*\.md$'; then
+        python3 "$CPP_DIR/scripts/flow-skill-sync.py" --write || true
+    fi
     if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
         PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
         REGATE_EXIT=$?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@
 
 ### Added
 
+- **Early stale-base detection in the flow** (issue #473) - a new advisory,
+  fail-open `scripts/flow-stale-check.sh` surfaces a base that moved on
+  `origin/main` at **Step 4 (start of implement)** and **Step 6 (before the
+  commit)** of `/flow:auto` (and in `/flow:finish`), instead of first discovering
+  it at the Step-7 #462 guard. It NAMES the file(s) you have already edited that
+  also changed upstream (committed or dirty in the work tree), so you can
+  `git merge --no-edit origin/main` before more edits pile onto a stale base -
+  the rework tax seen on flow:auto #444/#463/#461. The Step-7 #462 guard remains
+  the final backstop. When a merge (early or at Step 7) pulls in
+  `.claude/commands/flow/*.md` changes, the guards now re-run
+  `scripts/flow-skill-sync.py --write` so the global `flow-*` mirror does not
+  drift (#457/#461). Covered by `tests/test_flow_stale_check.py`.
+
 - **`/flow:eli5` extracted to the standalone `eli5-gate` plugin** (issue #443,
   epic #417 Phase C) - the necessity gate (plain-language intent ELI5 +
   staleness/necessity verdict + plan-approval pause) now lives in its own public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Core components and their locations:
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
 - `lib/cpp_memory/` - Common-memory client: fail-open Postgres ledger of *portable* CPP learnings/infra traps shared across the VM fleet (bucket-2-plus), plus a dedup/rejection ledger and a learnings->GitHub-issue bridge (`--emit-issue-candidate` / `link-issue`, #463). Store provisioned by `scripts/memories-db-setup.sh`. Consult-not-push; see `/self-improvement:memory`.
-- `scripts/` - Shell utilities (prompt-context, worktree-remove, gh-pr-merge (layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`), hooks, drift-detect, skill-drift, mcp-drift, flow-skill-sync, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
+- `scripts/` - Shell utilities (prompt-context, worktree-remove, gh-pr-merge (layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`), flow-stale-check (advisory early stale-base detector for `/flow:auto` Step 4/6 + `/flow:finish`, #473), hooks, drift-detect, skill-drift, mcp-drift, flow-skill-sync, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
 - `templates/` - Makefile, workflow, container templates
 - `docker-compose.yml` - MCP server orchestration (profile: `core`)
 - `.woodpecker.yml` - Woodpecker CI pipeline (lint, test, typecheck, image security gates, runtime smoke)

--- a/scripts/flow-stale-check.sh
+++ b/scripts/flow-stale-check.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# flow-stale-check.sh - Detect a STALE BASE early in the flow (issue #473).
+#
+# Problem:
+#   /flow:auto's #462 guard only notices that `origin/main` moved at Step 7
+#   (merge time). When sibling PRs land DURING implementation - the common case
+#   for serialization hotspots (.claude/commands/flow/*.md, CHANGELOG.md, the
+#   CLAUDE.md inventory) - the edits were made against stale versions of the very
+#   files the siblings changed, forcing a `git reset`/`git merge` + re-apply cycle
+#   regardless. Observed on flow:auto #444, #463, #461.
+#
+# This helper surfaces the collision EARLY (Step 4 start-of-implement and Step 6
+# finish), NAMING which file(s) you have touched that also changed upstream, so
+# you can merge `origin/main` in now - before more edits pile onto a stale base.
+# It COMPLEMENTS the #462 Step-7 guard (which stays as the final backstop); it
+# does not replace it.
+#
+# It is ADVISORY and FAIL-OPEN: it never blocks the flow (exit 0) unless
+# --exit-code is passed, and a missing base ref / not-a-repo / fetch failure is
+# reported and shrugged off, never fatal.
+#
+# Usage:
+#   flow-stale-check.sh [BASE_REF] [--no-fetch] [--exit-code]
+#
+#   BASE_REF     Ref to compare against (default: origin/main).
+#   --no-fetch   Skip `git fetch` (offline / tests / already fetched).
+#   --exit-code  Return non-zero (1) when a COLLISION is detected; still 0 for
+#                "current" and "moved-clean". Default is always-0 (advisory).
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_STALE_BASE: current | moved-clean | collision | unknown
+#
+# Env (test hook - unset in normal use):
+#   FLOW_STALE_GIT   override the `git` binary (default: git)
+
+set -uo pipefail
+
+BASE_REF=""
+DO_FETCH=1
+WANT_EXIT_CODE=0
+for arg in "$@"; do
+    case "$arg" in
+        --no-fetch)  DO_FETCH=0 ;;
+        --exit-code) WANT_EXIT_CODE=1 ;;
+        --help|-h)
+            sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --*)
+            echo "flow-stale-check: unknown option: $arg" >&2
+            exit 2
+            ;;
+        *)
+            if [[ -z "$BASE_REF" ]]; then
+                BASE_REF="$arg"
+            else
+                echo "flow-stale-check: unexpected argument: $arg" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+BASE_REF="${BASE_REF:-origin/main}"
+GIT_BIN="${FLOW_STALE_GIT:-git}"
+
+git_() { "$GIT_BIN" "$@"; }
+verdict() { echo "FLOW_STALE_BASE: $1"; }
+
+# Cap noisy lists so a large upstream diff does not scroll the whole flow away.
+print_list() {
+    local max=20 n=0 f
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        n=$((n + 1))
+        [[ $n -le $max ]] && echo "    - $f"
+    done <<< "$1"
+    [[ $n -gt $max ]] && echo "    ... and $((n - max)) more"
+    return 0
+}
+
+# --- Fail-open guards -------------------------------------------------------
+if ! git_ rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "flow-stale-check: not inside a git work tree - skipping (advisory)." >&2
+    verdict unknown
+    exit 0
+fi
+
+# Best-effort refresh of the base's remote-tracking ref. A network hiccup must
+# never break the flow - the check just runs against whatever ref is on disk.
+if [[ "$DO_FETCH" -eq 1 ]]; then
+    if [[ "$BASE_REF" == */* ]]; then
+        remote="${BASE_REF%%/*}"
+        rbranch="${BASE_REF#*/}"
+        git_ fetch "$remote" "$rbranch" --quiet 2>/dev/null \
+            || echo "flow-stale-check: 'git fetch $remote $rbranch' failed - using on-disk ref." >&2
+    else
+        git_ fetch --quiet 2>/dev/null || true
+    fi
+fi
+
+if ! git_ rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+    echo "flow-stale-check: base ref '$BASE_REF' not found - skipping (advisory)." >&2
+    verdict unknown
+    exit 0
+fi
+
+# --- Is the base ahead of us at all? ---------------------------------------
+behind=$(git_ rev-list --count "HEAD..${BASE_REF}" 2>/dev/null || echo 0)
+if [[ "${behind:-0}" -eq 0 ]]; then
+    echo "flow-stale-check: base '$BASE_REF' is current (HEAD is not behind)."
+    verdict current
+    exit 0
+fi
+
+# --- The base moved. What changed upstream, and did it hit my edits? --------
+# `git diff A...B` == `git diff $(git merge-base A B) B`, so:
+#   HEAD...BASE  -> files changed on the BASE side since we diverged (upstream).
+#   BASE...HEAD  -> files this branch changed since we diverged (my commits).
+upstream_changed=$(git_ diff --name-only "HEAD...${BASE_REF}" 2>/dev/null | sed '/^$/d' | sort -u)
+my_committed=$(git_ diff --name-only "${BASE_REF}...HEAD" 2>/dev/null)
+# Anything dirty in the work tree counts as "touched" too (staged/unstaged/new).
+# Strip the 2-char status + space; for renames "old -> new" keep the new path.
+my_worktree=$(git_ status --porcelain 2>/dev/null | sed 's/^...//' | sed 's/.* -> //')
+my_edits=$(printf '%s\n%s\n' "$my_committed" "$my_worktree" | sed '/^$/d' | sort -u)
+
+if [[ -n "$my_edits" ]]; then
+    collisions=$(printf '%s\n' "$my_edits" | grep -Fxf <(printf '%s\n' "$upstream_changed") 2>/dev/null || true)
+else
+    collisions=""
+fi
+
+# Secondary (issue #473): if a flow command file changed upstream, the global
+# flow-* mirror will drift after you merge; remind to re-sync it.
+flow_cmd_changed=$(printf '%s\n' "$upstream_changed" | grep -E '^\.claude/commands/flow/.*\.md$' || true)
+
+echo "flow-stale-check: base '$BASE_REF' moved - HEAD is $behind commit(s) behind."
+
+if [[ -n "$collisions" ]]; then
+    echo ""
+    echo "  COLLISION: file(s) you have edited ALSO changed on ${BASE_REF}:"
+    print_list "$collisions"
+    echo ""
+    echo "  Merge the new base in NOW, before more edits pile onto a stale base:"
+    echo "      git merge --no-edit ${BASE_REF}"
+    echo "  (Resolve any conflict in the file(s) above, then continue.)"
+    result="collision"
+elif [[ -z "$my_edits" ]]; then
+    # Step-4 case: nothing edited yet. Show what moved so you can merge proactively
+    # before touching any of these files.
+    echo ""
+    echo "  Base moved but you have not edited anything yet. Changed upstream:"
+    print_list "$upstream_changed"
+    echo ""
+    echo "  If you plan to touch any of these, merge the base in first:"
+    echo "      git merge --no-edit ${BASE_REF}"
+    result="moved-clean"
+else
+    echo "  No overlap: none of the file(s) you edited changed on ${BASE_REF}."
+    echo "  Safe to continue; the Step-7 #462 guard merges the base in before the squash."
+    result="moved-clean"
+fi
+
+if [[ -n "$flow_cmd_changed" ]]; then
+    echo ""
+    echo "  NOTE: flow command file(s) changed upstream:"
+    print_list "$flow_cmd_changed"
+    echo "  After merging the base in, re-run:  python3 scripts/flow-skill-sync.py --write"
+    echo "  so the global flow-* mirror does not drift (issues #457/#461)."
+fi
+
+verdict "$result"
+
+if [[ "$WANT_EXIT_CODE" -eq 1 && "$result" == "collision" ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/test_flow_stale_check.py
+++ b/tests/test_flow_stale_check.py
@@ -1,0 +1,241 @@
+"""Tests for scripts/flow-stale-check.sh - early stale-base detection (issue #473).
+
+Contract:
+- When ``origin/main`` (the base ref) has not moved past HEAD, the verdict is
+  ``current`` and exit is 0.
+- When the base moved but none of the files this branch touched changed upstream,
+  the verdict is ``moved-clean``.
+- When the base moved AND a file this branch edited also changed upstream, the
+  verdict is ``collision`` and the colliding file(s) are NAMED in the output.
+- When a ``.claude/commands/flow/*.md`` file changed upstream, the output reminds
+  the user to re-run ``flow-skill-sync.py --write`` so the mirror does not drift.
+- The check is advisory (exit 0) by default; ``--exit-code`` returns 1 on a
+  collision so a caller can gate on it.
+
+The tests build REAL throwaway git repos so the diff/intersection logic is
+exercised for real; ``--no-fetch`` keeps them offline (no remote).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "flow-stale-check.sh"
+
+FLOW_CMD = ".claude/commands/flow/auto.md"
+
+# The behaviour tests drive real `git` and `bash` subprocesses. The Woodpecker
+# `validate` step runs in `uv:python3.11-bookworm-slim`, which ships bash but NOT
+# git, so those tests are skipped there (issue #430). The read-only wiring tests
+# below need neither and always run.
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="requires git and bash on PATH (absent in the CI validate container)",
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+    )
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+
+def _write(repo: Path, rel: str, content: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """A repo on ``main`` with a couple of files, then a feature branch cut off it."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _write(repo, "a.txt", "a0\n")
+    _write(repo, "shared.txt", "s0\n")
+    _write(repo, FLOW_CMD, "flow0\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    _git(repo, "checkout", "-q", "-b", "feature")
+    return repo
+
+
+def _advance_main(repo: Path, rel: str, content: str) -> None:
+    """Simulate a sibling PR landing on ``main`` while ``feature`` is checked out."""
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, rel, content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", f"upstream change to {rel}")
+    _git(repo, "checkout", "-q", "feature")
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args, "--no-fetch"],
+        cwd=repo,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _verdict(out: str) -> str:
+    for line in out.splitlines():
+        if line.startswith("FLOW_STALE_BASE:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def test_script_is_executable():
+    assert SCRIPT.exists()
+    assert os.access(SCRIPT, os.X_OK), "flow-stale-check.sh must be executable"
+
+
+@requires_git
+def test_base_current_when_not_behind(tmp_path: Path):
+    repo = _make_repo(tmp_path)  # feature == main, nothing moved
+    result = _run(repo, "main")
+    assert result.returncode == 0, result.stderr
+    assert _verdict(result.stdout) == "current"
+
+
+@requires_git
+def test_moved_clean_when_no_overlap(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    # Feature edits a.txt; main advances a DIFFERENT file.
+    _write(repo, "a.txt", "a-mine\n")
+    _git(repo, "commit", "-qam", "my edit")
+    _advance_main(repo, "shared.txt", "s-upstream\n")
+    result = _run(repo, "main")
+    assert result.returncode == 0, result.stderr
+    assert _verdict(result.stdout) == "moved-clean"
+    assert "No overlap" in result.stdout
+    assert "COLLISION" not in result.stdout
+
+
+@requires_git
+def test_collision_is_named(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    # Both feature and main touch shared.txt -> collision.
+    _write(repo, "shared.txt", "s-mine\n")
+    _git(repo, "commit", "-qam", "my edit to shared")
+    _advance_main(repo, "shared.txt", "s-upstream\n")
+    result = _run(repo, "main")
+    assert result.returncode == 0, result.stderr  # advisory: still 0 by default
+    assert _verdict(result.stdout) == "collision"
+    assert "COLLISION" in result.stdout
+    assert "shared.txt" in result.stdout, "the colliding file must be named"
+    assert "git merge --no-edit main" in result.stdout
+
+
+@requires_git
+def test_collision_from_uncommitted_worktree_edit(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    _advance_main(repo, "shared.txt", "s-upstream\n")
+    # Dirty the work tree without committing - still counts as "touched".
+    _write(repo, "shared.txt", "s-dirty\n")
+    result = _run(repo, "main")
+    assert _verdict(result.stdout) == "collision"
+    assert "shared.txt" in result.stdout
+
+
+@requires_git
+def test_exit_code_flag_fails_on_collision(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    _write(repo, "shared.txt", "s-mine\n")
+    _git(repo, "commit", "-qam", "my edit")
+    _advance_main(repo, "shared.txt", "s-upstream\n")
+    result = _run(repo, "main", "--exit-code")
+    assert result.returncode == 1, "collision + --exit-code must return non-zero"
+    assert _verdict(result.stdout) == "collision"
+
+
+@requires_git
+def test_exit_code_flag_passes_when_clean(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    _write(repo, "a.txt", "a-mine\n")
+    _git(repo, "commit", "-qam", "my edit")
+    _advance_main(repo, "shared.txt", "s-upstream\n")
+    result = _run(repo, "main", "--exit-code")
+    assert result.returncode == 0, result.stderr
+
+
+@requires_git
+def test_flow_command_change_reminds_to_resync(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    _advance_main(repo, FLOW_CMD, "flow-upstream\n")
+    result = _run(repo, "main")
+    assert "flow-skill-sync.py --write" in result.stdout, (
+        "a flow command change upstream must remind to re-sync the mirror"
+    )
+    assert FLOW_CMD in result.stdout
+
+
+@requires_git
+def test_fail_open_outside_git_repo(tmp_path: Path):
+    outside = tmp_path / "plain"
+    outside.mkdir()
+    result = _run(outside, "main")
+    assert result.returncode == 0, "must fail open outside a git repo"
+    assert _verdict(result.stdout) == "unknown"
+
+
+@requires_git
+def test_fail_open_when_base_ref_missing(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    result = _run(repo, "origin/does-not-exist")
+    assert result.returncode == 0
+    assert _verdict(result.stdout) == "unknown"
+
+
+# --- Wiring: the flow surfaces must call the early check / re-sync ----------
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_auto_wires_early_check_at_step4_and_step6():
+    text = _read(".claude/commands/flow/auto.md")
+    # Referenced at least twice: Step 4 (early) and Step 6 (pre-commit).
+    assert text.count("flow-stale-check.sh") >= 2, (
+        "auto.md must run the early stale-base check at both Step 4 and Step 6"
+    )
+    # Step-7 #462 backstop is preserved.
+    assert "git merge --no-edit origin/main" in text
+
+
+def test_finish_wires_early_check():
+    text = _read(".claude/commands/flow/finish.md")
+    assert "flow-stale-check.sh" in text, "finish.md must run the early stale-base check"
+
+
+def test_guards_resync_flow_mirror_on_flow_command_merge():
+    # When the Step-7 guard merges main in and it pulled flow command changes, the
+    # global mirror must be re-synced (issue #473 secondary ask).
+    for rel in (".claude/commands/flow/auto.md", ".claude/commands/flow/merge.md"):
+        text = _read(rel)
+        assert "flow-skill-sync.py" in text, f"{rel} must re-sync the flow mirror after a merge"
+        assert "ORIG_HEAD..HEAD" in text, f"{rel} must scope the re-sync to what the merge pulled"


### PR DESCRIPTION
## Summary

`/flow:auto` only noticed a base that moved on `origin/main` at the **Step-7 #462 guard** (merge time). When sibling PRs land *during* implementation - the common case for serialization hotspots (`flow/*.md`, `CHANGELOG.md`, the CLAUDE.md inventory) - the edits were already made against stale copies, forcing a `git reset`/`merge` + re-apply cycle regardless (seen on flow:auto #444/#463/#461).

This adds an **early** stale-base check at Step 4 and Step 6.

- **New `scripts/flow-stale-check.sh`** - advisory, fail-open helper. Fetches the base (default `origin/main`), and if it moved, intersects *files changed upstream* with *files this branch touched* (committed **and** dirty in the work tree) and **names the collisions**. Emits a machine-readable `FLOW_STALE_BASE: current|moved-clean|collision|unknown` line; `--exit-code` opt-in for gating; `--no-fetch` / `FLOW_STALE_GIT` test hooks. Mirrors the `gh-pr-merge.sh` / `check-ignored-additions.sh` pattern.
- **Wired into `auto.md` Step 4** (start of implement, before edits) and **Step 6** (before the commit), and into **`finish.md`** (the standalone Step-6 surface).
- **Step-7 #462 guard preserved** as the final backstop, in both `auto.md` and `merge.md`.
- **Secondary (mirror drift):** when an early or Step-7 merge pulls in `.claude/commands/flow/*.md` changes, the guards now re-run `scripts/flow-skill-sync.py --write` so the global `flow-*` mirror does not drift (#457/#461).

Dogfooded on its own run: the helper caught `origin/main` moving 2 commits (#474/#476) mid-implementation and correctly reported `moved-clean` (no file overlap).

## Acceptance

- [x] A base that goes stale during implement is surfaced at Step 4/6, not first at Step 7
- [x] The check names which edited files changed upstream
- [x] The Step-7 #462 guard remains as the final backstop

## Test plan

- [x] `tests/test_flow_stale_check.py` - 13 tests: current / moved-clean / collision (named) / uncommitted-worktree collision / `--exit-code` both ways / flow-command re-sync reminder / fail-open (no repo, missing ref) + read-only wiring assertions on auto.md/finish.md/merge.md
- [x] Real-git behaviour tests gated on `git`/`bash` availability (CI `validate` container has no git, #430); wiring tests always run
- [x] `lib.cicd run --plan finish` green on the post-merge tree (lint + full suite + security scan)

Closes #473