### PR TITLE
test(flow): guard git-subprocess friction-log tests for the no-git CI container

### DIFF
--- a/tests/test_friction_log.py
+++ b/tests/test_friction_log.py
@@ -12,11 +12,21 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 FRICTION_LOG = ROOT / "scripts" / "friction-log.sh"
+
+# Some tests drive a real `git` subprocess to build a worktree. The Woodpecker
+# `validate` container (uv:python3.11-bookworm-slim) has no git, so guard those
+# tests rather than error the whole suite on collection/run (cf. #451).
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not available (e.g. Woodpecker validate container)"
+)
 
 
 def _run(
@@ -180,6 +190,7 @@ def _run_no_env(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+@requires_git
 def test_default_targets_main_repo_from_worktree(tmp_path: Path):
     """Issue #471: a signal captured inside a linked worktree must land in the
     MAIN repo's buffer, so it survives the worktree being removed at cleanup."""
@@ -203,6 +214,7 @@ def test_default_targets_main_repo_from_worktree(tmp_path: Path):
     assert not worktree_buffer.exists(), "signal must NOT land in the worktree buffer"
 
 
+@requires_git
 def test_default_targets_repo_root_from_subdir(tmp_path: Path):
     """From a subdirectory of the main repo, the default resolves to the repo
     root's .claude/friction.jsonl (not a cwd-relative buffer in the subdir)."""


### PR DESCRIPTION
## Summary

The friction-log tests added in #488 build a real git worktree via `git` subprocess. The Woodpecker `validate` container (`uv:python3.11-bookworm-slim`) ships no git, so those tests errored and turned `main` red — CI was green on the parent commit, red on the #488 merge.

This guards the two git-requiring tests with `@pytest.mark.skipif(shutil.which("git") is None)`, the same no-git-CI idiom already used in `test_check_ignored_additions.py` (cf. #451). The no-git *fallback* test needs no guard — it exercises the script's git-absent path and passes without git.

## Test plan
- `make lint` clean, finish gate green (3/3)
- git present -> **13 passed**
- git absent (simulated by stripping `git` from PATH) -> **11 passed, 2 skipped** (the fallback test still passes, exercising the real CI condition)

Follow-up to #471 / #488. Fixes red CI on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)