### PR TITLE
feat(plugin): scaffold marketplace.json + flow POC plugin (Closes #477)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "cpp",
+  "description": "Claude Power Pack - per-family Claude Code plugins (phased migration off the legacy symlink installer; see ADR 0001, epic #417 Phase B).",
+  "owner": {
+    "name": "cooneycw",
+    "url": "https://github.com/cooneycw"
+  },
+  "plugins": [
+    {
+      "name": "flow",
+      "source": "./plugins/flow",
+      "description": "Worktree-based GitHub issue lifecycle: start, eli5 necessity gate, check, finish, merge, deploy, auto, sync, cleanup, status, and doctor. Issue-anchored branch naming and quality gates, no locks or Redis - just git."
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ desktop.ini
 !renovate.json
 !templates/claude-settings-permissions.json
 !templates/playwright-pool.example.json
+# Plugin marketplace manifests (issue #477, ADR 0001) - tracked despite *.json
+# above. The `**` glob keeps future per-family plugins (Phase B2) covered.
+!.claude-plugin/marketplace.json
+!plugins/**/.claude-plugin/plugin.json
 node_modules/
 .claude/settings*.json
 .claude/plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Plugin-marketplace scaffold + `flow` proof-of-concept plugin** (issue #477,
+  epic #417 Phase B1, ADR `docs/decisions/0001-plugin-marketplace-packaging.md`) -
+  first implementation phase of the migration off the legacy symlink installer to
+  the Claude Code plugin-marketplace distribution model. Adds
+  `.claude-plugin/marketplace.json` (marketplace name `cpp`) and packages the
+  `flow` command family as an installable plugin under `plugins/flow/`, so the
+  install path is `/plugin marketplace add cooneycw/claude-power-pack` then
+  `/plugin install flow@cpp`. During the parallel B1->B4 window the source of
+  truth stays `.claude/commands/flow/*.md`; `plugins/flow/commands/` holds
+  byte-identical copies kept honest by `scripts/plugin-flow-sync.sh`
+  (`--check` guard / `--write` regen), covered by `tests/test_plugin_marketplace.py`.
+  Both manifests pass `claude plugin validate`, and `/plugin install flow@cpp` was
+  verified end to end against a local marketplace. **Nothing is retired** - the
+  installer runs untouched until parity is proven in Phase B4.
+
 ### Changed
 
 - **Browser automation migrated to upstream `@playwright/mcp`** (issue #423) -

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,10 @@ Core components and their locations:
 - `lib/security/` - Security scanning (native + external tools)
 - `lib/cicd/` - CI/CD framework detection, Makefile generation, health/smoke checks, deterministic runner, deployment strategies, Pydantic v2 config validation
 - `lib/cpp_memory/` - Common-memory client: fail-open Postgres ledger of *portable* CPP learnings/infra traps shared across the VM fleet (bucket-2-plus), plus a dedup/rejection ledger and a learnings->GitHub-issue bridge (`--emit-issue-candidate` / `link-issue`, #463). Store provisioned by `scripts/memories-db-setup.sh`. Consult-not-push; see `/self-improvement:memory`.
-- `scripts/` - Shell utilities (prompt-context, worktree-remove, gh-pr-merge (layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`), hooks, drift-detect, skill-drift, mcp-drift, flow-skill-sync, speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
+- `scripts/` - Shell utilities (prompt-context, worktree-remove, gh-pr-merge (layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`), hooks, drift-detect, skill-drift, mcp-drift, flow-skill-sync, plugin-flow-sync (byte-identical drift guard keeping the `flow` POC plugin in sync with its command source, #477), speckit-tasks-to-issues, playwright-desk lease-desk ledger, check-ignored-additions)
 - `templates/` - Makefile, workflow, container templates
+- `.claude-plugin/marketplace.json` - Plugin-marketplace manifest (marketplace name `cpp`) listing CPP's per-family plugins. Install path: `/plugin marketplace add cooneycw/claude-power-pack` then `/plugin install <family>@cpp` (ADR 0001, epic #417 Phase B).
+- `plugins/` - Per-family Claude Code plugins. Phase B1 (#477) ships `plugins/flow/` as a proof-of-concept: byte-identical copies of `.claude/commands/flow/*.md` (source of truth), kept honest by `scripts/plugin-flow-sync.sh`. The legacy symlink installer runs in parallel; nothing is retired until parity is proven in Phase B4.
 - `docker-compose.yml` - MCP server orchestration (profile: `core`)
 - `.woodpecker.yml` - Woodpecker CI pipeline (lint, test, typecheck, image security gates, runtime smoke)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ cd ~/Projects/my-project
 claude-power-pack/
   .claude/commands/     Slash commands (/flow:*, /cicd:*, /security:*, etc.)
   .claude/hooks.json    Safety hooks (pre/post tool use)
+  .claude-plugin/       Plugin-marketplace manifest (marketplace name: cpp)
+  plugins/flow/         POC flow plugin: /plugin install flow@cpp (#477, ADR 0001)
   aws-secrets-agent/    AWS Secrets Manager sidecar (Rust, port 2773)
   mcp-second-opinion/   Code review MCP server
   lib/creds/            Secrets management library

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "flow",
+  "description": "Worktree-based GitHub issue lifecycle for Claude Code: /flow:start, /flow:eli5 (necessity gate), /flow:check, /flow:finish, /flow:merge, /flow:deploy, /flow:auto (full lifecycle in one shot), plus sync, cleanup, status, and doctor helpers. Issue-anchored branch naming and quality gates on top of native worktrees.",
+  "version": "1.0.0",
+  "author": {
+    "name": "cooneycw",
+    "url": "https://github.com/cooneycw"
+  },
+  "homepage": "https://github.com/cooneycw/claude-power-pack",
+  "repository": "https://github.com/cooneycw/claude-power-pack",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "worktree",
+    "issue-driven-development",
+    "git",
+    "ci-cd",
+    "pull-request"
+  ]
+}

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -37,16 +37,23 @@ end. The richest friction is on runs that fail partway, so capture must fire on
 every step, success OR failure, and before any STOP. Whenever you hit one of these,
 append a record via the fail-open capture helper (it never blocks the flow):
 
-- a **permission prompt** the user had to approve for a Bash/tool call
 - a **quality-gate failure or retry** (lint/test/build/deploy)
 - **red output** you narrated past or worked around instead of resolving
 - a **manual intervention / correction** the user had to make
 
 ```bash
-scripts/friction-log.sh --class <permission-prompt|gate-failure|red-output|manual-intervention> \
+scripts/friction-log.sh --class <gate-failure|red-output|manual-intervention> \
   --signal "<what happened>" --fix "<proposed fix, if obvious>" \
-  --scope <local|portable> --run "flow:auto #$ISSUE_NUM" --step "<N/9 Name>" --outcome "<approved|retried|worked-around|corrected>"
+  --scope <local|portable> --run "flow:auto #$ISSUE_NUM" --step "<N/9 Name>" --outcome "<retried|worked-around|corrected>"
 ```
+
+The fourth class, **permission-prompt**, is NOT model-captured here: the model
+cannot tell an approved tool call from an auto-allowed one. It is captured by the
+harness `PermissionRequest` hook (`scripts/hook-permission-census.sh`, registered
+in `~/.claude/settings.json` by `/cpp:init` / `/cpp:update`), which records a
+risk-rated record with a derived allow-rule candidate on every prompt shown -
+across every session, not just flow runs (issue #482). Do not log this class by
+hand.
 
 Records go to the main repo's `.claude/friction.jsonl` (a queue drained by
 `/self-improvement:retro`). The helper resolves that durable buffer automatically

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -1,0 +1,772 @@
+# Flow: Auto - Full Issue Lifecycle in One Shot
+
+Complete end-to-end workflow: start worktree → analyze issue → ELI5 plan + necessity gate → implement → finish (PR) → merge → deploy.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+
+## Instructions
+
+When the user invokes `/flow:auto <ISSUE>`, perform these steps sequentially. Stop immediately if any step fails.
+
+Report at the start:
+
+```
+Flow Auto: Issue #42 - Full Lifecycle
+
+Step 1/9: Start (create worktree and branch)
+Step 2/9: Analyze (understand issue and codebase)
+Step 3/9: ELI5 (plain-language intent + necessity verdict + plan approval gate)
+Step 4/9: Implement (write the code)
+Step 5/9: Update Docs (regenerate C4 diagrams, review CLAUDE.md/README.md)
+Step 6/9: Finish (lint, test, commit, push, create PR)
+Step 7/9: Merge (squash-merge PR, clean up worktree)
+Step 8/9: Verify CI (confirm pipeline passes on main)
+Step 9/9: Deploy (make deploy, if target exists)
+
+Proceeding...
+```
+
+---
+
+### Friction Capture (always-on)
+
+Throughout this run, record friction the moment it happens - do NOT wait for the
+end. The richest friction is on runs that fail partway, so capture must fire on
+every step, success OR failure, and before any STOP. Whenever you hit one of these,
+append a record via the fail-open capture helper (it never blocks the flow):
+
+- a **permission prompt** the user had to approve for a Bash/tool call
+- a **quality-gate failure or retry** (lint/test/build/deploy)
+- **red output** you narrated past or worked around instead of resolving
+- a **manual intervention / correction** the user had to make
+
+```bash
+scripts/friction-log.sh --class <permission-prompt|gate-failure|red-output|manual-intervention> \
+  --signal "<what happened>" --fix "<proposed fix, if obvious>" \
+  --scope <local|portable> --run "flow:auto #$ISSUE_NUM" --step "<N/9 Name>" --outcome "<approved|retried|worked-around|corrected>"
+```
+
+Records go to `.claude/friction.jsonl` (a queue drained by `/self-improvement:retro`).
+This is capture only - proposing and applying fixes happens in the retro, not here.
+
+---
+
+### Step 1: Start - Create Worktree
+
+**CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master. This step is NOT optional - if worktree creation fails, STOP immediately.**
+
+Worktree mechanics ride Claude Code's **native worktrees**: the `EnterWorktree`
+tool creates a checkout under `.claude/worktrees/<name>` on a new branch and
+switches the session into it. CPP keeps and enforces the issue-anchored
+`issue-<N>-<slug>` branch name (the gate policy the native tool does not absorb).
+
+```bash
+ISSUE_NUM="$1"
+
+# Fetch issue details
+gh issue view "$ISSUE_NUM" --json number,title,state,body
+```
+
+- If issue is not OPEN, warn the user and ask whether to proceed.
+- Extract the title for branch naming.
+
+```bash
+# Sanitize title for branch name (cut keeps within EnterWorktree's 64-char limit)
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
+BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+```
+
+**Check for existing work, then pick exactly one path:**
+
+```bash
+# Check if already on the issue's branch
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Check if a worktree already exists for this issue
+git worktree list | grep "issue-${ISSUE_NUM}"
+
+# Check if a remote branch exists (cross-machine pickup)
+git fetch origin
+git branch -r | grep "issue-${ISSUE_NUM}-"
+```
+
+- **Already on issue branch** (`$CURRENT_BRANCH` matches `issue-${ISSUE_NUM}-`):
+  verify you are NOT on main/master and use the current directory. This is a
+  resumed run - remember it so Step 7 uses the git cleanup fallback, not
+  `ExitWorktree`.
+- **Worktree exists** (prior session): switch into it with
+  `EnterWorktree(path="<path from git worktree list>")`. Resumed run - Step 7 uses
+  the git cleanup fallback.
+- **Remote branch exists, no local worktree** (cross-machine pickup): the native
+  tool cannot check out an existing remote branch, so add it with git, then switch
+  in:
+  ```bash
+  REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
+  LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
+  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  ```
+  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`. Step 7 uses
+  the git cleanup fallback (a `path`-entered worktree is not removed by
+  `ExitWorktree`).
+- **Neither exists** (fresh start): create and enter natively by calling the
+  `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
+  `origin/<default-branch>` (default `worktree.baseRef: fresh`) and switches the
+  session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to `git worktree
+  add` for the fresh path. This is a session-created worktree - Step 7 removes it
+  with `ExitWorktree`.
+
+#### Verification Gate (MANDATORY - do NOT skip)
+
+Before proceeding to Step 2, verify you are in the worktree and enforce the
+issue-anchored branch name (the moat every later step relies on):
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "ERROR: Still on main/master after Step 1. EnterWorktree did not switch the session."
+    echo "STOP: Cannot proceed. You MUST be on an issue branch, not main."
+    exit 1
+fi
+
+# Native worktree creation derives the branch from the worktree name; normalize
+# to the issue-anchored convention so downstream steps can parse the issue number.
+if [[ "$CURRENT_BRANCH" != "$BRANCH" && ! "$CURRENT_BRANCH" =~ ^issue-${ISSUE_NUM}- ]]; then
+    git branch -m "$BRANCH"
+    CURRENT_BRANCH="$BRANCH"
+fi
+echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
+```
+
+**If this verification fails, STOP immediately. Report the failure using the error template at the bottom of this file. Do NOT proceed to Step 2.**
+
+Report: `Step 1/9: Start complete - worktree at {path}, verified on branch {branch}`
+
+---
+
+### Step 2: Analyze - Understand the Issue
+
+Working from the worktree, analyze the issue and codebase to form an implementation plan.
+
+1. **Parse the issue body:**
+   - Extract acceptance criteria (checkbox items `- [ ]`)
+   - Identify referenced files, components, or areas
+   - Note any dependencies or constraints mentioned
+
+2. **Explore the codebase:**
+   - Read files referenced in the issue
+   - Understand existing patterns and conventions
+   - Identify all files that need to be created or modified
+
+3. **Form an implementation plan:**
+   - List the specific changes needed
+   - Note any edge cases or risks
+
+4. **Report the plan to the user:**
+
+```
+Step 2/9: Analysis Complete
+
+Issue #42: "Fix login redirect loop"
+
+Acceptance Criteria:
+  - [ ] Login redirects to dashboard after auth
+  - [ ] Invalid sessions redirect to /login
+  - [ ] Tests pass
+
+Implementation Plan:
+  1. Modify src/auth/login.py - fix redirect logic in handle_login()
+  2. Update tests/test_auth.py - add redirect test cases
+  3. Update config/routes.py - add dashboard route
+
+Files to modify: 3
+Estimated scope: Small
+
+Proceeding to ELI5 review...
+```
+
+Report: `Step 2/9: Analyze complete - {N} files to modify`
+
+---
+
+### Step 3: ELI5 - Plan + Necessity Gate (Approval Checkpoint)
+
+Before writing any code, run the `/flow:eli5` review (see `.claude/commands/flow/eli5.md`) using the issue and the Step 2 analysis. This is the post-analysis, pre-implementation communication and approval gate. Produce the three-section reviewer report:
+
+1. **ELI5 overview of intent** - what the issue is really trying to accomplish, in plain language a reviewer can sanity-check for a misread.
+2. **Necessity / staleness analysis** - whether the issue is still worth doing given anything merged since it was filed. Anchor the check to the issue's creation date:
+   ```bash
+   ISSUE_DATE=$(gh issue view "$ISSUE_NUM" --json createdAt --jq '.createdAt')
+   git log --since="$ISSUE_DATE" --oneline -- <relevant/paths>
+   gh pr list --state merged --search "merged:>=${ISSUE_DATE%%T*}" --json number,title,mergedAt
+   gh issue list --state all --search "<key terms>" --json number,title,state
+   ```
+   Output one verdict with evidence: **Still needed / Partially addressed / No longer needed / Needs reframing**.
+3. **Proposed changes (pending approval)** - the files and edits that will close the issue, framed as a plan awaiting reviewer approval.
+
+**This is a gate:**
+
+- **Verdict `No longer needed`** -> do NOT implement. Recommend closing the issue with an evidence-based comment and **STOP**:
+  ```bash
+  gh issue close "$ISSUE_NUM" --comment "Closed via /flow:auto ELI5 review - <reason; cite superseding PR/issue>."
+  ```
+  Run the close only with reviewer assent; surface the recommendation either way.
+- **Verdict `Partially addressed` or `Needs reframing`** -> the plan to approve is the adjusted one (remaining work / corrected approach), not the original issue body.
+- **Approval:** By default, **pause and wait for reviewer approval** of the plan before continuing to Step 4. For unattended runs, accept `--yes` (alias `--auto-approve`) on `/flow:auto`, or an `eli5: auto-approve` trailer in the issue body or HEAD commit message, to proceed without pausing. Auto-approve never overrides a `No longer needed` verdict.
+
+Report: `Step 3/9: ELI5 complete - verdict: {Still needed|Partially addressed|No longer needed|Needs reframing}; approval: {granted|auto-granted|close recommended}`
+
+---
+
+### Step 4: Implement - Write the Code
+
+Execute the approved plan from the Step 3 ELI5 gate:
+
+1. **Make all code changes** in the worktree.
+2. **Follow existing conventions** - match the code style, patterns, and structure of the project.
+3. **Run tests locally** if a quick feedback loop is available (e.g., `make test` or the project's test command).
+4. **Verify the changes** address all acceptance criteria from the issue.
+
+If implementation hits a blocker that cannot be resolved:
+- **STOP** and report the blocker.
+- Suggest manual intervention.
+
+Report: `Step 4/9: Implement complete - {summary of changes}`
+
+---
+
+### Step 5: Update Docs - Regenerate C4 Diagrams and Review Docs
+
+If the Makefile has an `update_docs` target:
+
+```bash
+if [[ -f "Makefile" ]] && grep -q "^update_docs:" Makefile; then
+    echo "Running: make update_docs"
+    make update_docs
+fi
+```
+
+Then perform these documentation tasks:
+
+1. **Regenerate C4 diagrams** - If `docs/architecture/` exists or significant code changes were made, run the `/documentation:c4` workflow:
+   - Analyze the project architecture
+   - Generate L1-L4 C4 diagrams to `docs/architecture/`
+   - Screenshot via Playwright if available
+
+2. **Review CLAUDE.md** - Check that repository structure, command references, and component descriptions match the current state. Fix any stale references.
+
+3. **Review README.md** - Check that the project description, setup instructions, and feature list reflect the changes just implemented. Fix any inaccuracies.
+
+4. **Stage doc changes** - `git add` any modified documentation files.
+
+If no `update_docs` target exists in the Makefile, skip this step.
+
+Report: `Step 5/9: Update Docs complete - {N} files updated` or `Step 5/9: Update Docs skipped (no Makefile target)`
+
+---
+
+### Step 6: Finish - Quality Gates, Commit, Push, PR
+
+```bash
+BRANCH=$(git branch --show-current)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+```
+
+1. **Quality gates** - use the deterministic runner as primary path:
+
+   **Primary path:** Call the CI/CD runner for reproducible quality gates:
+   ```bash
+   CPP_DIR=""
+   for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+     if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+       CPP_DIR="$dir"
+       break
+     fi
+   done
+
+   RUNNER_RAN=0
+   if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+       # Invoke through uv so lib/cicd's deps (pydantic) resolve and the
+       # interpreter is pinned >= 3.11. Bare `python3 -m lib.cicd` uses the
+       # system interpreter (often 3.10, no venv) inside a fresh worktree and
+       # dies on ModuleNotFoundError - silently degrading to the fallback in
+       # exactly the environment /flow:auto always creates (issue #430).
+       # PYTHONPATH must point at CPP_DIR (the PARENT of lib/) so `-m lib.cicd`
+       # resolves for external projects too, not just when dogfooding CPP.
+       PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
+       RUNNER_EXIT=$?
+       RUNNER_RAN=1
+   fi
+
+   if [ "$RUNNER_RAN" -eq 0 ]; then
+       REASON=$([ -z "$CPP_DIR" ] && echo "CPP checkout not found" || echo "uv not installed")
+       echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback." >&2
+   fi
+   ```
+
+   - If runner ran and **succeeds** (exit 0): quality gates passed, proceed to commit.
+   - If runner ran and **fails**: parse JSON output, report the failed step, **STOP**.
+
+   **Fallback** (only when the runner did not run, `RUNNER_RAN=0`): Run `make lint` and `make test` directly (these bootstrap the venv via `uv run`).
+   - If either fails: **STOP**. Report the failure and exit.
+
+   **Ignored-additions guard** (issue #430, Finding 1): before committing, warn
+   if a blanket `.gitignore` rule silently swallowed a new file you meant to
+   track (`git add` no-ops with no error):
+   ```bash
+   if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/check-ignored-additions.sh" ]; then
+       "$CPP_DIR/scripts/check-ignored-additions.sh"   # advisory: warns, never blocks
+   fi
+   ```
+   If it warns, add a `!negation` to `.gitignore` for any intended file and re-stage.
+
+2. **Commit** - if there are uncommitted changes:
+   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+
+3. **Push** the branch:
+   ```bash
+   git push -u origin "$BRANCH"
+   ```
+
+4. **Create PR** - if no PR exists:
+   ```bash
+   gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
+   ```
+   - If PR already exists, report its URL and continue.
+   - PR body: Summary of changes + test plan + `Closes #N`
+   - Analyze all commits on the branch to draft the summary.
+
+Report: `Step 6/9: Finish complete - PR #XX created`
+
+---
+
+### Step 7: Merge - Squash-Merge and Clean Up
+
+1. **Sync with `origin/main` and re-gate (stale-branch guard, issue #462):**
+   A branch cut earlier - common on resumed or cross-machine worktrees - can have
+   fallen behind `main` while the PR was open. Squash-merging it then fails at the
+   last step on a content conflict (the flow:auto #433 run hit a CLAUDE.md
+   collision), forcing a manual `git merge origin/main` + resolve + re-gate
+   mid-flow. Bring the branch current and re-run the gate on the **post-merge
+   tree** first, so the squash is deterministic and the gate reflects exactly what
+   lands on `main`:
+
+   ```bash
+   BRANCH=$(git branch --show-current)
+   git fetch origin main
+   if [[ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]]; then
+       echo "Branch is behind origin/main - merging main in before the squash."
+       if ! git merge --no-edit origin/main; then
+           echo "STOP: merging origin/main hit conflicts:"
+           git diff --name-only --diff-filter=U
+           echo "Resolve them, 'git add' + 'git commit', then re-run /flow:merge."
+           echo "(Do NOT 'git merge --abort' - that discards the resolution.)"
+           exit 1
+       fi
+       # Re-run the FULL quality gate on the MERGED tree (not the pre-merge branch)
+       # - same deterministic runner as Step 6, with the same Makefile fallback.
+       CPP_DIR=""
+       for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+         [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+       done
+       if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+           PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
+           REGATE_EXIT=$?
+       else
+           echo "NOTE: deterministic runner unavailable; re-gating via Makefile fallback." >&2
+           make lint && make test
+           REGATE_EXIT=$?
+       fi
+       if [ "$REGATE_EXIT" -ne 0 ]; then
+           echo "STOP: quality gate failed on the post-merge tree. Fix, commit, then re-run /flow:merge."
+           exit 1
+       fi
+       # Push the merge so the PR reflects the post-merge tree before squashing.
+       git push origin "$BRANCH"
+   fi
+   ```
+
+2. **Merge the PR:**
+   ```bash
+   PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+
+   # Merge robustly across worktree layouts. Run from inside a linked worktree,
+   # `gh pr merge --delete-branch` fails AFTER the remote squash succeeds - gh
+   # tries to switch this worktree off the merged branch onto the default branch,
+   # which is checked out in the primary worktree ("fatal: 'main' is already
+   # checked out"), and exits non-zero. The merge still landed; treating that exit
+   # as a failure is a false STOP (issue #461). The helper drops --delete-branch in
+   # a linked worktree, deletes the remote branch itself, and verifies the PR
+   # reached MERGED before reporting failure. Local worktree/branch cleanup is left
+   # to step 4 below, so the native ExitWorktree path is unaffected.
+   if [[ -x ~/.claude/scripts/gh-pr-merge.sh ]]; then
+       ~/.claude/scripts/gh-pr-merge.sh "$PR_NUMBER" "$BRANCH"
+       MERGE_RC=$?
+   else
+       # Inline fallback (helper not installed): same linked-worktree guard.
+       if [[ -f ".git" ]]; then
+           gh pr merge "$PR_NUMBER" --squash
+           git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+       else
+           gh pr merge "$PR_NUMBER" --squash --delete-branch
+       fi
+       # Trust PR state over the local exit code.
+       [[ "$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null)" == "MERGED" ]]
+       MERGE_RC=$?
+   fi
+   ```
+   - If the merge genuinely failed (`MERGE_RC` non-zero - conflicts, failing
+     checks, PR not `MERGED`): **STOP**. Report and exit. A non-zero `gh` exit
+     whose PR is nonetheless `MERGED` is NOT a failure - the helper already treats
+     it as success and continues to cleanup.
+
+3. **Capture the worktree and main repo paths (before leaving the worktree):**
+   ```bash
+   if [[ -f ".git" ]]; then
+       WORKTREE_PATH=$(pwd)
+       MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+   else
+       WORKTREE_PATH=""   # not in a worktree - on a feature branch in the main repo
+       MAIN_REPO=$(pwd)
+   fi
+   ```
+
+4. **Clean up worktree and branch:**
+
+   **If Step 1 created the worktree this session via `EnterWorktree(name=...)`**
+   (the fresh-start path), remove it natively - a single tool call that deletes the
+   worktree and its branch and restores the session to the main repo, with no
+   manual `cd`-before-remove dance:
+
+   `ExitWorktree(action="remove", discard_changes=true)`
+
+   `discard_changes=true` is required because the squash-merge leaves the local
+   branch with commits not on `main`; discarding the now-merged local branch is
+   correct. After this the session cwd is back in the main repo.
+
+   **Otherwise** (Step 1 resumed an existing worktree, entered via
+   `EnterWorktree(path=...)`, or you are on a feature branch in the main repo)
+   `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
+   the main repo BEFORE removing the worktree - never remove a worktree while your
+   cwd is inside it. Execute as SEPARATE Bash calls.**
+
+   **Step 7a - Return to the main repo (separate Bash call):**
+   ```bash
+   cd "$MAIN_REPO"
+   pwd  # Verify you are in the main repo, NOT the worktree
+   ```
+
+   **Step 7b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
+   ```bash
+   if [[ -n "$WORKTREE_PATH" && "$WORKTREE_PATH" != "$MAIN_REPO" ]]; then
+       if [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
+           ~/.claude/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
+       else
+           git worktree remove "$WORKTREE_PATH" --force
+           git branch -D "$BRANCH" 2>/dev/null || true
+       fi
+   else
+       # On a feature branch in the main repo (no worktree) - just delete the branch
+       git branch -D "$BRANCH" 2>/dev/null || true
+   fi
+   ```
+
+5. **Update local main:**
+   ```bash
+   git -C "$MAIN_REPO" checkout main 2>/dev/null || true
+   git -C "$MAIN_REPO" pull origin main
+   ```
+
+   **Verify working directory is valid:**
+   ```bash
+   pwd  # MUST show main repo path, NOT the deleted worktree
+   git status  # MUST succeed - if this fails, your CWD was deleted
+   ```
+
+6. **Close issue** (if still open):
+   ```bash
+   if [[ -n "$ISSUE_NUM" ]]; then
+       ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
+       if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+           gh issue close "$ISSUE_NUM" --comment "Closed via /flow:auto - PR #${PR_NUMBER} merged."
+       fi
+   fi
+   ```
+
+Report: `Step 7/9: Merge complete - worktree cleaned up`
+
+---
+
+### Step 8: Verify CI (after merge)
+
+After merging to main, verify that the CI pipeline passes before deploying.
+
+1. **Detect CI system and poll for results:**
+
+```bash
+cd "$MAIN_REPO"
+COMMIT_SHA=$(git rev-parse HEAD)
+SHORT_SHA=$(git rev-parse --short HEAD)
+REPO_FULL=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+```
+
+2. **Check Woodpecker CI** (if `WOODPECKER_API_TOKEN` is set):
+
+```bash
+if [[ -n "$WOODPECKER_API_TOKEN" ]]; then
+    WOODPECKER_SERVER="${WOODPECKER_SERVER:-https://woodpecker.essent-ai.com}"
+    echo "Polling Woodpecker CI for commit $SHORT_SHA..."
+
+    # Woodpecker v3 API requires numeric repo ID, not owner/name
+    # First resolve repo ID via lookup endpoint
+    REPO_ID=$(curl -s -H "Authorization: Bearer $WOODPECKER_API_TOKEN" \
+        -H "Accept: application/json" \
+        "$WOODPECKER_SERVER/api/repos/lookup/$REPO_FULL" | jq -r '.id' 2>/dev/null)
+
+    if [[ -z "$REPO_ID" || "$REPO_ID" == "null" ]]; then
+        echo "WARNING: Could not resolve Woodpecker repo ID for $REPO_FULL. Skipping CI verification."
+    else
+        # Poll up to 10 minutes (60 attempts, 10s apart)
+        for i in $(seq 1 60); do
+            PIPELINE_JSON=$(curl -s -H "Authorization: Bearer $WOODPECKER_API_TOKEN" \
+                -H "Accept: application/json" \
+                "$WOODPECKER_SERVER/api/repos/$REPO_ID/pipelines?per_page=5" | \
+                jq --arg sha "$COMMIT_SHA" '[.[] | select(.commit == $sha)] | .[0]' 2>/dev/null)
+
+            if [[ -n "$PIPELINE_JSON" && "$PIPELINE_JSON" != "null" ]]; then
+                STATUS=$(echo "$PIPELINE_JSON" | jq -r '.status')
+                PIPELINE_NUM=$(echo "$PIPELINE_JSON" | jq -r '.number')
+
+                case "$STATUS" in
+                    success)
+                        echo "Woodpecker pipeline #$PIPELINE_NUM passed."
+                        break
+                        ;;
+                    failure|error|killed)
+                        echo "Woodpecker pipeline #$PIPELINE_NUM FAILED (status: $STATUS)."
+                        echo "View: $WOODPECKER_SERVER/repos/$REPO_FULL/pipeline/$PIPELINE_NUM"
+                        # STOP - do not deploy
+                        exit 1
+                        ;;
+                    *)
+                        echo "Pipeline #$PIPELINE_NUM status: $STATUS (attempt $i/60)..."
+                        sleep 10
+                        ;;
+                esac
+            else
+                if [[ $i -ge 60 ]]; then
+                    echo "WARNING: No Woodpecker pipeline found for $SHORT_SHA after 10 minutes."
+                    break
+                fi
+                sleep 10
+            fi
+        done
+    fi
+fi
+```
+
+3. **Check GitHub Actions** (fallback if no Woodpecker token):
+
+```bash
+if [[ -z "$WOODPECKER_API_TOKEN" ]]; then
+    echo "Polling GitHub Actions for commit $SHORT_SHA..."
+
+    for i in $(seq 1 60); do
+        RUN_JSON=$(gh run list --commit "$COMMIT_SHA" --json status,conclusion,databaseId,name --jq '.[0]' 2>/dev/null)
+
+        if [[ -n "$RUN_JSON" && "$RUN_JSON" != "null" ]]; then
+            GH_STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+            GH_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
+            RUN_ID=$(echo "$RUN_JSON" | jq -r '.databaseId')
+
+            if [[ "$GH_STATUS" == "completed" ]]; then
+                if [[ "$GH_CONCLUSION" == "success" ]]; then
+                    echo "GitHub Actions run #$RUN_ID passed."
+                    break
+                else
+                    echo "GitHub Actions run #$RUN_ID FAILED (conclusion: $GH_CONCLUSION)."
+                    echo "View: gh run view $RUN_ID"
+                    exit 1
+                fi
+            else
+                echo "Run #$RUN_ID status: $GH_STATUS (attempt $i/60)..."
+                sleep 10
+            fi
+        else
+            if [[ $i -ge 60 ]]; then
+                echo "WARNING: No GitHub Actions run found for $SHORT_SHA after 10 minutes."
+                break
+            fi
+            sleep 10
+        fi
+    done
+fi
+```
+
+4. **No CI detected:**
+
+If neither `WOODPECKER_API_TOKEN` is set nor GitHub Actions runs are found, skip with a warning:
+
+```
+WARNING: No CI system detected. Skipping verification.
+```
+
+- If CI **passes**: proceed to Step 9.
+- If CI **fails**: **STOP**. Report the failure and exit. Do not deploy broken code.
+- If CI **not found** after timeout: warn and proceed (non-blocking).
+
+Report: `Step 8/9: Verify CI complete - pipeline #{N} passed` or `Step 8/9: Verify CI skipped (no CI detected)`
+
+---
+
+### Step 9: Deploy (optional)
+
+Only if a Makefile with a `deploy` target exists in the main repo. Because
+`/flow:auto` runs `make deploy` inline (it does NOT call `/flow:deploy`), the
+deploy-verification gate is wired in here too - otherwise the flagship
+"one command to ship" path would deploy without validating the deployment.
+
+```bash
+cd "$MAIN_REPO"
+
+# Locate CPP source for lib/cicd (deploy verification)
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+VERIFY_ENABLED=0
+if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
+    VERIFY_ENABLED=1
+fi
+
+if [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+    # Pre-deploy: capture the baseline (before make deploy) so the post-deploy
+    # verify can detect regressions.
+    if [ "$VERIFY_ENABLED" -eq 1 ]; then
+        echo "Capturing pre-deploy baseline..."
+        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+    fi
+
+    echo "Running: make deploy"
+    make deploy
+    DEPLOY_EXIT=$?
+
+    # Post-deploy: verify against the baseline and emit a proceed/rollback verdict.
+    VERDICT="none"
+    if [ "$VERIFY_ENABLED" -eq 1 ]; then
+        echo "Running deploy verification..."
+        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+        VERIFY_EXIT=$?
+        VERDICT=$( [ "$VERIFY_EXIT" -eq 1 ] && echo "rollback" || echo "proceed/review" )
+        if [ "$VERIFY_EXIT" -eq 1 ]; then
+            echo "DEPLOY VERIFICATION: ROLLBACK - a probe that passed pre-deploy fails now."
+            echo "Recommend rolling back (redeploy previous commit) or investigating with /cicd:health + /cicd:smoke."
+        fi
+    fi
+
+    mkdir -p .claude
+    echo "$(date -Iseconds) | deploy | $(git rev-parse --short HEAD) | main | ${DEPLOY_EXIT} | verify:${VERDICT}" >> .claude/deploy.log
+else
+    echo "No deploy target in Makefile - skipping deployment."
+fi
+```
+
+- Verification is fail-open and inert unless `health.deploy_verification.enabled`
+  is set in `.claude/cicd.yml`. A ROLLBACK verdict is surfaced to the user but
+  never rolls back automatically - it is an actionable signal, not an action.
+
+Report: `Step 9/9: Deploy complete (verify: {proceed|review|rollback|none})` or
+`Step 9/9: Deploy skipped (no Makefile target)`
+
+---
+
+### Final Summary
+
+```
+Flow Auto Complete
+
+  Issue:    #42 - Fix login bug
+  ELI5:     Still needed (plan approved)
+  Changes:  Modified 3 files (src/auth/login.py, tests/test_auth.py, config/routes.py)
+  PR:       #78 (squash-merged)
+  Branch:   issue-42-fix-login (deleted)
+  Worktree: .claude/worktrees/issue-42-fix-login (removed)
+  CI:       Woodpecker pipeline #5 passed | GitHub Actions run #123 passed | skipped
+  Deploy:   make deploy (success) | skipped
+  Verify:   PROCEED | REVIEW | ROLLBACK | not configured
+  Friction: 4 signals captured (.claude/friction.jsonl)
+  Location: /home/user/Projects/my-project (main)
+```
+
+---
+
+### Post-run: Friction Retro (optional, non-blocking)
+
+After the summary, if `.claude/friction.jsonl` recorded any signals this run, offer
+the codify step - do not block or auto-run it:
+
+```
+Friction retro: this run recorded N friction signal(s). Run /self-improvement:retro
+to turn them into confirmed fixes (permission allowlist, Make targets, hooks,
+CLAUDE.md, portable learnings)? [y/N]
+```
+
+Declining is free - capture already persisted the signals for a later retro. This
+offer also appears at the end of `/flow:merge`.
+
+---
+
+## Error Handling
+
+At each step, if something fails:
+
+```
+Flow Auto stopped at Step N/9: {Step Name}
+
+  Failed: [description of what failed]
+  Fix:    [actionable suggestion]
+
+  To resume manually:
+    /flow:start N    (if step 1 failed)
+    [investigate]    (if step 2 failed)
+    /flow:eli5 N     (if step 3 failed)
+    [implement]      (if step 4 failed)
+    /documentation:c4 (if step 5 failed)
+    /flow:finish     (if step 6 failed)
+    /flow:merge      (if step 7 failed)
+    [check CI dashboard] (if step 8 failed)
+    /flow:deploy     (if step 9 failed)
+```
+
+Key failure scenarios:
+- **Issue not found:** Stop at step 1
+- **Issue closed:** Warn at step 1, ask to proceed
+- **Analysis unclear:** Stop at step 2, ask user for clarification
+- **ELI5 verdict `No longer needed`:** Stop at step 3, recommend closing the issue instead of implementing
+- **Plan rejected at ELI5 gate:** Stop at step 3, revise the plan (or close) before proceeding
+- **Implementation blocker:** Stop at step 4, report what's blocking
+- **Doc update fails:** Non-blocking at step 5, warn and continue
+- **Lint/test fails:** Stop at step 6, show test output
+- **Push fails:** Stop at step 6, suggest `git pull --rebase`
+- **PR merge conflicts:** Stop at step 7, suggest manual resolution
+- **CI pipeline fails:** Stop at step 8, link to pipeline/run for investigation
+- **CI not detected:** Non-blocking at step 8, warn and continue to deploy
+- **Deploy fails:** Report but don't roll back (deploy is best-effort)
+- **Inside worktree being removed:** `ExitWorktree(action="remove")` restores the session cwd for session-created worktrees; the git fallback path uses `worktree-remove.sh`, which also handles removing from inside safely
+
+## Notes
+
+- This is the "one command to ship" - takes an issue number and delivers it end-to-end
+- The analyze step ensures Claude understands the issue before writing code
+- The ELI5 step (Step 3) is a human checkpoint: it restates intent in plain language, verifies the issue is still worth doing, and gates implementation on plan approval. Use `--yes` (or an `eli5: auto-approve` trailer) for fully unattended runs; a `No longer needed` verdict never auto-implements
+- Each step builds on the previous one; there's no skipping
+- Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
+- The deploy step is always optional - it only runs if a deploy target exists
+- After completion, the user is in the main repo on the main branch
+- For step-by-step control, use individual commands: `/flow:start`, `/flow:eli5`, `/flow:finish`, `/flow:merge`, `/flow:deploy`
+- Friction capture runs throughout (always-on, fail-open, `scripts/friction-log.sh` -> `.claude/friction.jsonl`) and the run offers `/self-improvement:retro` at the end to codify fixes - the grill-me cycle (issue #426)

--- a/plugins/flow/commands/check.md
+++ b/plugins/flow/commands/check.md
@@ -1,0 +1,170 @@
+---
+description: Run quality checks (lint + security) without committing
+allowed-tools: Bash(make:*), Bash(grep:*), Bash(test:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(git:*), Read
+---
+
+# Flow: Check - Run Quality Gates Without Committing
+
+Run lint and security checks to verify code quality. Does not commit, push, or create a PR.
+
+Use this to validate your changes before running `/flow:finish`.
+
+## Instructions
+
+When the user invokes `/flow:check`, perform these steps:
+
+### Step 1: Detect Available Checks
+
+```bash
+CHECKS_RUN=0
+CHECKS_PASS=0
+CHECKS_WARN=0
+CHECKS_FAIL=0
+
+# Detect Makefile targets
+HAS_LINT=false
+HAS_TEST=false
+if [[ -f "Makefile" ]]; then
+    grep -q "^lint:" Makefile && HAS_LINT=true
+    grep -q "^test:" Makefile && HAS_TEST=true
+fi
+
+# Detect security scanner
+HAS_SECURITY=false
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/lib/security/__init__.py" ]; then
+    CPP_DIR="$dir"
+    HAS_SECURITY=true
+    break
+  fi
+done
+
+# Detect Makefile completeness checker
+HAS_CICD=false
+if [ -n "$CPP_DIR" ] && [ -f "$CPP_DIR/lib/cicd/__init__.py" ]; then
+    HAS_CICD=true
+fi
+```
+
+### Step 2: Run Lint
+
+```bash
+if [[ "$HAS_LINT" == "true" ]]; then
+    echo "Running: make lint"
+    make lint
+    LINT_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $LINT_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    else
+        CHECKS_FAIL=$((CHECKS_FAIL + 1))
+    fi
+fi
+```
+
+### Step 3: Run Tests
+
+```bash
+if [[ "$HAS_TEST" == "true" ]]; then
+    echo "Running: make test"
+    make test
+    TEST_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $TEST_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    else
+        CHECKS_FAIL=$((CHECKS_FAIL + 1))
+    fi
+fi
+```
+
+### Step 4: Run Security Quick Scan
+
+```bash
+if [[ "$HAS_SECURITY" == "true" ]]; then
+    echo "Running: security gate (flow_finish)"
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.security gate flow_finish
+    SEC_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $SEC_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    elif [[ $SEC_EXIT -eq 2 ]]; then
+        # Exit code 2 = warnings only (HIGH findings)
+        CHECKS_WARN=$((CHECKS_WARN + 1))
+    else
+        CHECKS_FAIL=$((CHECKS_FAIL + 1))
+    fi
+fi
+```
+
+### Step 5: Run Makefile Completeness Check (optional)
+
+Invoke via `uv run` so `lib/cicd`'s deps resolve under a pinned >= 3.11
+interpreter; bare `python3` crashes in a fresh worktree (#430).
+
+```bash
+if [[ "$HAS_CICD" == "true" ]] && [[ -f "Makefile" ]] && command -v uv >/dev/null 2>&1; then
+    PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd check --summary
+    CICD_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $CICD_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    else
+        CHECKS_WARN=$((CHECKS_WARN + 1))  # Non-blocking
+    fi
+fi
+```
+
+### Step 5b: Guard Against Silently-Ignored New Files (advisory)
+
+A blanket `.gitignore` rule (e.g. `*.json`) can swallow a file you meant to
+commit - `git add` no-ops with no error (issue #430, Finding 1). Surface it:
+
+```bash
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/check-ignored-additions.sh" ]; then
+    "$CPP_DIR/scripts/check-ignored-additions.sh"
+    IGN_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    # Advisory only: the script exits 0 even when it warns, so this never fails
+    # the check. Any warning it prints is surfaced to the user for review.
+    CHECKS_PASS=$((CHECKS_PASS + 1))
+fi
+```
+
+### Step 6: Report Results
+
+Present a summary report:
+
+```markdown
+## Flow Check Results
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Lint (`make lint`) | PASS/FAIL/SKIP | All checks passed / 3 errors / No Makefile |
+| Tests (`make test`) | PASS/FAIL/SKIP | 211 passed / 2 failed / No Makefile |
+| Security scan | PASS/WARN/FAIL/SKIP | Clean / 1 HIGH warning / 1 CRITICAL / lib/security not available |
+| Makefile completeness | PASS/WARN/SKIP | 6/6 targets / 1 missing / lib/cicd not available |
+
+**Summary: {CHECKS_PASS} passed, {CHECKS_WARN} warnings, {CHECKS_FAIL} failed ({CHECKS_RUN} checks run)**
+```
+
+Status symbols:
+- **PASS** - Check succeeded
+- **WARN** - Non-blocking issue found (proceed with caution)
+- **FAIL** - Blocking issue found (fix before `/flow:finish`)
+- **SKIP** - Check not available (no Makefile, lib not installed)
+
+### Final Message
+
+Based on results:
+- **All pass:** "Ready for `/flow:finish`."
+- **Warnings only:** "Warnings found but non-blocking. Review before `/flow:finish`."
+- **Failures:** "Failing checks must be fixed before `/flow:finish`."
+
+## Notes
+
+- This command is **read-only** - it never commits, pushes, or modifies files
+- It runs the same checks as `/flow:finish` Step 2, extracted for standalone use
+- Use it to validate changes before committing or as a pre-flight check
+- The security gate uses the same `.claude/security.yml` configuration as `/flow:finish`

--- a/plugins/flow/commands/cleanup.md
+++ b/plugins/flow/commands/cleanup.md
@@ -1,0 +1,140 @@
+---
+description: Clean up stale worktree references and merged branches
+allowed-tools: Bash(git:*), Bash(grep:*), Bash(wc:*), Bash(echo:*), Read
+---
+
+# Flow: Cleanup - Prune Stale Worktrees and Branches
+
+Remove orphaned worktree references, delete local branches already merged to main, and prune stale remote tracking branches.
+
+Native worktrees live under `.claude/worktrees/`. `git worktree list`,
+`git worktree prune`, and `git worktree remove` operate on them exactly as they do
+on any worktree, so this command is the correct cross-session cleanup path -
+native `ExitWorktree` only removes worktrees created by `EnterWorktree` in the
+current session and cannot prune stale or prior-session ones.
+
+## Arguments
+
+- No arguments required. Run from the main repo or any worktree.
+
+## Instructions
+
+When the user invokes `/flow:cleanup`, perform these steps:
+
+### Step 1: Detect Repository Root
+
+```bash
+# Find the main repo (works from worktree or main)
+if [[ -f ".git" ]]; then
+    MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+else
+    MAIN_REPO=$(git rev-parse --show-toplevel)
+fi
+REPO=$(basename "$MAIN_REPO")
+```
+
+### Step 2: Prune Stale Worktree References
+
+When worktree folders are deleted manually, git still tracks them. This cleans those references.
+
+```bash
+# Show stale worktree references before pruning
+STALE_WORKTREES=$(git -C "$MAIN_REPO" worktree list --porcelain | grep -B2 "prunable" | grep "worktree " | sed 's/worktree //' || true)
+
+# Prune them
+git -C "$MAIN_REPO" worktree prune
+```
+
+Report what was pruned (or "No stale worktree references found").
+
+### Step 3: Find and Delete Merged Local Branches
+
+Delete local `issue-*` branches that have been merged to main. Protect `main`, `master`, and any branch with an active worktree.
+
+```bash
+# Get list of branches with active worktrees (these are protected)
+WORKTREE_BRANCHES=$(git -C "$MAIN_REPO" worktree list --porcelain | grep "^branch " | sed 's|branch refs/heads/||')
+
+# Make sure main is up to date
+git -C "$MAIN_REPO" fetch origin main
+
+# Find merged branches (excluding main/master and worktree branches)
+MERGED_BRANCHES=$(git -C "$MAIN_REPO" branch --merged main | grep -v '^\*' | grep -v 'main$' | grep -v 'master$' | sed 's/^[ ]*//')
+```
+
+For each merged branch:
+1. Skip if it has an active worktree
+2. Delete it with `git -C "$MAIN_REPO" branch -d "$BRANCH"`
+
+**Important:** Some branches from squash-merged PRs won't show as `--merged`. Also check for branches whose remote counterpart has been deleted:
+
+```bash
+# Find local issue-* branches whose remote tracking branch is gone
+for branch in $(git -C "$MAIN_REPO" branch | grep 'issue-' | sed 's/^[ *]*//' ); do
+    # Skip if branch has an active worktree
+    echo "$WORKTREE_BRANCHES" | grep -q "^${branch}$" && continue
+
+    # Check if remote tracking branch exists
+    REMOTE=$(git -C "$MAIN_REPO" config "branch.${branch}.remote" 2>/dev/null || echo "")
+    MERGE_REF=$(git -C "$MAIN_REPO" config "branch.${branch}.merge" 2>/dev/null || echo "")
+
+    if [[ -n "$REMOTE" && -n "$MERGE_REF" ]]; then
+        REMOTE_REF="refs/remotes/${REMOTE}/$(echo "$MERGE_REF" | sed 's|refs/heads/||')"
+        if ! git -C "$MAIN_REPO" show-ref --verify --quiet "$REMOTE_REF" 2>/dev/null; then
+            # Remote branch is gone - safe to delete locally
+            # (The PR was merged and remote branch deleted)
+            echo "Remote deleted: $branch"
+        fi
+    fi
+done
+```
+
+For branches where the remote was deleted (PR merged + `--delete-branch`), use `git branch -D` since squash merges don't register as fully merged.
+
+Report each branch deleted and the reason (merged to main, or remote branch deleted).
+
+### Step 4: Prune Stale Remote Tracking Branches
+
+```bash
+git -C "$MAIN_REPO" fetch --prune
+```
+
+This removes `remotes/origin/issue-*` references for branches already deleted on the remote.
+
+Report how many remote tracking branches were pruned.
+
+### Step 5: Summary Output
+
+```markdown
+## Flow Cleanup - {repo}
+
+### Worktree References
+  {N} stale references pruned (or "None found")
+
+### Local Branches Deleted
+  {branch-1} (merged to main)
+  {branch-2} (remote branch deleted - squash-merged PR)
+  ... or "No stale branches found"
+
+### Remote Tracking Branches
+  {N} stale remote references pruned (or "Already clean")
+
+### Current State
+  {M} worktrees active
+  {N} local issue branches remaining
+```
+
+## Error Handling
+
+- **Not a git repo:** Report error and exit
+- **Uncommitted changes on a branch:** Never delete - skip and warn
+- **Protected branches:** Never delete `main` or `master`
+- **Active worktree branches:** Never delete branches with active worktrees
+
+## Notes
+
+- Safe to run multiple times (fully idempotent)
+- Only deletes `issue-*` pattern branches in the squash-merge detection path (other branches require `--merged` confirmation)
+- Use `git branch -d` (safe delete) for merged branches, `git branch -D` (force) only for branches whose remote was deleted
+- Run automatically after `/flow:merge` or manually anytime
+- Does not require network access except for `git fetch --prune`

--- a/plugins/flow/commands/deploy.md
+++ b/plugins/flow/commands/deploy.md
@@ -1,0 +1,271 @@
+# Flow: Deploy via Makefile
+
+Run deployment using the project's Makefile targets.
+
+## Arguments
+
+- `TARGET` (optional): Makefile target to run (default: `deploy`)
+
+## Instructions
+
+When the user invokes `/flow:deploy [TARGET]`, perform these steps:
+
+### Step 1: Verify on Main Branch
+
+```bash
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" != "main" && "$BRANCH" != "master" ]]; then
+    echo "WARNING: Deploying from branch '$BRANCH' (not main)."
+    echo "Consider merging first with /flow:merge."
+    # Ask user to confirm or abort
+fi
+```
+
+### Step 2: Check Makefile Exists
+
+```bash
+if [[ ! -f "Makefile" ]]; then
+    echo "ERROR: No Makefile found in $(pwd)"
+    echo "Create a Makefile with a 'deploy' target, or run your deploy command directly."
+    exit 1
+fi
+```
+
+### Step 3: Verify Target Exists
+
+```bash
+TARGET="${1:-deploy}"
+
+if ! grep -q "^${TARGET}:" Makefile; then
+    echo "ERROR: No '${TARGET}' target in Makefile"
+    echo ""
+    echo "Available targets:"
+    grep -E "^[a-zA-Z_-]+:" Makefile | sed 's/:.*//' | sort
+    exit 1
+fi
+```
+
+### Step 4: Check Deploy Metadata (optional)
+
+If `.claude/deploy.yaml` exists, read it for confirmation requirements:
+
+```yaml
+# .claude/deploy.yaml (optional)
+targets:
+  deploy:
+    description: Deploy to production
+    requires_confirmation: true
+  deploy-staging:
+    description: Deploy to staging
+```
+
+- If `requires_confirmation: true`, ask the user to confirm before proceeding
+- If no deploy.yaml, proceed without extra confirmation
+
+### Step 4c: Capture Deploy-Verification Baseline (pre-deploy)
+
+Before deploying, snapshot the currently-running system so the post-deploy run
+(Step 8) can detect regressions. Only runs when
+`health.deploy_verification.enabled` is set in `.claude/cicd.yml`.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
+    echo "Capturing pre-deploy baseline..."
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+fi
+```
+
+- Captures health + smoke probes into `.claude/deploy-baseline.json`.
+- Fail-open: if `lib/cicd` is unavailable or no probes are configured, skip -
+  the deploy is never blocked by baseline capture.
+
+### Step 4b: Run Deploy via Deterministic Runner (primary path)
+
+**Primary path:** Use the deterministic CI/CD runner for reproducible deploy with security gate:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan deploy
+    RUNNER_EXIT=$?
+fi
+```
+
+- If runner **succeeds** (exit 0): deploy completed (includes security scan + make deploy), skip to Step 6.
+- If runner **fails** (exit non-zero): parse JSON output, report the failed step, and **stop**.
+- If runner is **not available**: fall back to manual execution below.
+
+**Fallback path** (only if runner unavailable):
+
+Run security scan before deploying:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate flow_deploy
+```
+
+- If the gate **fails** (critical or high findings): **stop and report**. Show findings.
+- If the gate produces **warnings** (medium findings): display them but proceed.
+- If `lib/security` is not available, skip this step.
+
+### Step 5: Run Deploy (fallback only - runner includes this)
+
+**Skip this step if the deterministic runner was used above** (it already runs make deploy).
+
+Only run manually if the runner was unavailable:
+
+```bash
+echo "Running: make $TARGET"
+make "$TARGET"
+```
+
+### Step 6: Log Deployment
+
+Append to `.claude/deploy.log`:
+
+```bash
+mkdir -p .claude
+echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $?" >> .claude/deploy.log
+```
+
+Format: `timestamp | target | commit | branch | exit_code`
+
+### Step 7: Output
+
+On success:
+```
+Deployment complete ✅
+
+  Target:  make deploy
+  Commit:  abc1234
+  Branch:  main
+  Time:    2026-02-16T14:30:00-05:00
+
+  Log: .claude/deploy.log
+```
+
+On failure:
+```
+Deployment failed ❌
+
+  Target:  make deploy
+  Exit:    1
+
+Review the output above for errors.
+```
+
+### Step 8: Post-Deploy Verification (optional)
+
+After a successful deployment, automatically run health checks and smoke tests if configured.
+
+**Condition:** Only run if `.claude/cicd.yml` exists AND contains `health.post_deploy: true`.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found and `.claude/cicd.yml` exists:
+
+1. **Check if post-deploy verification is enabled:**
+   ```bash
+   if grep -q "post_deploy:" .claude/cicd.yml 2>/dev/null; then
+       # Verification enabled
+   else
+       # Skip - not configured
+   fi
+   ```
+
+2. **Run health checks:**
+   ```bash
+   echo "Running post-deploy health checks..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd health --summary
+   HEALTH_EXIT=$?
+   ```
+
+3. **Run smoke tests:**
+   ```bash
+   echo "Running post-deploy smoke tests..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd smoke --summary
+   SMOKE_EXIT=$?
+   ```
+
+3b. **Run deploy verification (baseline comparison + verdict):**
+
+   When a baseline was captured in Step 4c, diff the post-deploy probes against
+   it and emit an actionable verdict. This is the deploy-confidence gate - it
+   catches a deploy that made things *worse* than before, which raw health/smoke
+   cannot.
+
+   ```bash
+   echo "Running deploy verification..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+   VERIFY_EXIT=$?
+   ```
+
+   - `VERIFY_EXIT == 0` (PROCEED or REVIEW): keep the deployment. On REVIEW,
+     surface the flagged probes to the user.
+   - `VERIFY_EXIT == 1` (ROLLBACK): a probe that passed in the baseline fails
+     now. **Report the regression prominently** and recommend rolling back
+     (redeploy the previous commit or run the rollback target) or investigating
+     with `/cicd:health` + `/cicd:smoke`. Verification does not roll back
+     automatically - the human decides.
+
+4. **Report results:**
+   - If verification PROCEEDs (or health + smoke pass with no baseline):
+     `"Deploy verified ✅ - no regression vs baseline"`
+   - If verification returns ROLLBACK: Report the regression and recommend
+     rollback + `/self-improvement:deployment`
+   - If any raw check fails: Report failures and suggest `/self-improvement:deployment`
+
+5. **Log verification results** (extends deploy.log format):
+   ```bash
+   HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
+   SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
+   VERDICT=$( PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
+   echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS} | verify:${VERDICT:-none}" >> .claude/deploy.log
+   ```
+
+   Extended log format: `timestamp | target | commit | branch | deploy_exit | health:pass/fail | smoke:pass/fail | verify:proceed/review/rollback/none`
+
+**Skip conditions:**
+- No `.claude/cicd.yml` → skip silently
+- No `post_deploy:` in config → skip silently
+- `lib/cicd` not available (no CPP_DIR) → skip with warning
+- Verification failures do NOT roll back the deployment - they only report
+
+## Error Handling
+
+- **No Makefile:** Report error with guidance to create one
+- **Target not found:** List available targets
+- **Deploy fails:** Report exit code, show output
+- **Not on main:** Warn but allow (user may want staging deploy from branch)
+
+## Notes
+
+- Deployment always goes through `make` - the Makefile is the single source of truth
+- The `.claude/deploy.log` provides an audit trail of all deployments
+- The optional `.claude/deploy.yaml` adds metadata without changing the Makefile
+- This command works from any directory that has a Makefile

--- a/plugins/flow/commands/doctor.md
+++ b/plugins/flow/commands/doctor.md
@@ -1,0 +1,396 @@
+---
+description: Diagnose flow workflow setup and environment
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(command:*), Bash(test:*), Bash(ls:*), Bash(readlink:*), Bash(grep:*), Bash(make:*), Bash(python3:*), Bash(PYTHONPATH=*), Read
+---
+
+# Flow: Doctor - Diagnose Workflow Environment
+
+Check that the environment is properly configured for the `/flow` workflow.
+
+## Instructions
+
+When the user invokes `/flow:doctor`, run all diagnostic checks and present a single report.
+
+### Step 1: Environment Prerequisites
+
+Check required tools:
+
+```bash
+# git
+git --version 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# gh CLI
+gh --version 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# gh authentication
+gh auth status 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# uv (optional but recommended)
+uv --version 2>/dev/null || echo "NOT_FOUND"
+```
+
+### Step 2: Git Repository State
+
+```bash
+# In a git repository?
+git rev-parse --show-toplevel 2>/dev/null || echo "NOT_A_REPO"
+
+# Remote origin configured?
+git remote get-url origin 2>/dev/null || echo "NO_REMOTE"
+
+# Default branch
+git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'
+
+# User identity
+git config user.name 2>/dev/null || echo "NOT_SET"
+git config user.email 2>/dev/null || echo "NOT_SET"
+```
+
+### Step 3: Makefile Targets
+
+```bash
+# Makefile exists?
+if [ -f "Makefile" ]; then
+  # List standard targets (lint, test, deploy, format, etc.)
+  grep -E '^[a-zA-Z_-]+:' Makefile | sed 's/:.*//' | sort
+else
+  echo "NO_MAKEFILE"
+fi
+```
+
+Report which of these standard targets exist: `lint`, `test`, `format`, `deploy`.
+
+**If no Makefile found:** Detect the framework and suggest the matching template:
+
+```bash
+# Only if CPP lib is available
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir/lib/cicd" ]; then CPP_DIR="$dir"; break; fi
+done
+
+# Invoke lib.cicd via uv so its deps (pydantic) resolve under a pinned >= 3.11
+# interpreter; PYTHONPATH points at CPP_DIR (parent of lib/) so `-m lib.cicd`
+# resolves from any project cwd. Bare python3 crashes in a venv-less tree (#430).
+if [ -n "$CPP_DIR" ] && [ ! -f "Makefile" ] && command -v uv >/dev/null 2>&1; then
+  DETECTED=$(PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -c "
+from lib.cicd.detector import detect_framework
+info = detect_framework('.')
+print(f'{info.framework.value}:{info.package_manager.value}')
+" 2>/dev/null)
+  echo "Detected: $DETECTED"
+fi
+```
+
+Use the detection result to suggest the specific template file in the Actions Needed section (e.g., `django-uv.mk` for Django projects, `python-uv.mk` for Python+uv).
+
+### Step 4: Hooks Configuration
+
+```bash
+# hooks.json exists?
+if [ -f ".claude/hooks.json" ]; then
+  # Check for expected hooks
+  grep -l "SessionStart\|PostToolUse" .claude/hooks.json
+fi
+```
+
+Check for the two expected hook types:
+- **SessionStart**: Upstream change detection
+- **PostToolUse (Bash/Read)**: Secret masking via `hook-mask-output.sh`
+
+The PreToolUse dangerous-command hook was retired (issue #439); native
+destructive-git blocking + OS sandboxing cover it.
+
+### Step 5: Scripts Availability
+
+Check that core scripts exist in `~/.claude/scripts/`:
+
+```bash
+for script in prompt-context.sh hook-mask-output.sh secrets-mask.sh; do
+  if [ -x "$HOME/.claude/scripts/$script" ]; then
+    echo "PASS $script"
+  elif [ -f "$HOME/.claude/scripts/$script" ]; then
+    echo "WARN $script (not executable)"
+  else
+    echo "FAIL $script"
+  fi
+done
+
+# worktree-remove.sh is now a FALLBACK, not a hard requirement: `/flow` creates
+# and removes worktrees with the native EnterWorktree/ExitWorktree tools; the
+# script is only used for cross-session / cross-machine worktree cleanup. Missing
+# is a WARN, not a FAIL.
+if [ -x "$HOME/.claude/scripts/worktree-remove.sh" ]; then
+  echo "PASS worktree-remove.sh (optional fallback)"
+elif [ -f "$HOME/.claude/scripts/worktree-remove.sh" ]; then
+  echo "WARN worktree-remove.sh (not executable)"
+else
+  echo "WARN worktree-remove.sh (optional fallback not installed; native ExitWorktree covers same-session cleanup)"
+fi
+```
+
+### Step 5b: User-Level Flow Allowlist
+
+Check whether the flow read-only permission allowlist
+(`templates/claude-settings-permissions.json`) is merged into
+`~/.claude/settings.json`. Without it, every `/flow:*` run prompts for its
+read-only git/gh plumbing (issue reads, worktree creation, slug pipeline).
+
+```bash
+TEMPLATE="$CPP_DIR/templates/claude-settings-permissions.json"
+TARGET="$HOME/.claude/settings.json"
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "SKIP flow allowlist (template not found - CPP checkout incomplete?)"
+elif [ ! -f "$TARGET" ]; then
+  echo "FAIL flow allowlist (~/.claude/settings.json missing - all $(jq '.permissions.allow | length' "$TEMPLATE") rules absent)"
+else
+  TOTAL=$(jq '.permissions.allow | length' "$TEMPLATE")
+  MISSING=$(jq -s '(.[1].permissions.allow - (.[0].permissions.allow // [])) | length' "$TARGET" "$TEMPLATE")
+  if [ "$MISSING" -eq 0 ]; then
+    echo "PASS flow allowlist ($TOTAL/$TOTAL rules present)"
+  else
+    echo "WARN flow allowlist ($((TOTAL - MISSING))/$TOTAL rules present, $MISSING missing)"
+  fi
+fi
+```
+
+### Step 5c: Flow Skill Mirror Sync
+
+CPP's `/flow:*` commands execute from the global mirror at
+`~/.claude/skills/flow-*`, regenerated from the `.claude/commands/flow/*` source
+of truth by `scripts/flow-skill-sync.py`. When the mirror drifts from the source
+(as it did when #453 rebased the commands onto native worktrees but left the
+mirror on the old manual `git worktree add` path - issue #457), the surface that
+actually runs is stale. Detect that drift:
+
+```bash
+# Locate CPP source for the sync script
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/scripts/flow-skill-sync.py" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "SKIP flow skill mirror (CPP checkout not found)"
+elif python3 "$CPP_DIR/scripts/flow-skill-sync.py" --check >/dev/null 2>&1; then
+  echo "PASS flow skill mirror (global ~/.claude/skills/flow-* matches repo commands)"
+else
+  echo "WARN flow skill mirror (out of sync with .claude/commands/flow/; run: python3 $CPP_DIR/scripts/flow-skill-sync.py --write)"
+fi
+```
+
+This is a WARN, not a FAIL: the skills still run, they are just behind the repo.
+Regenerate with `--write` to reconcile.
+
+### Step 6: Active Worktrees
+
+```bash
+git worktree list
+```
+
+For each worktree (skip main), check:
+- Branch name and linked issue number
+- Uncommitted changes (`git -C <path> status --porcelain | wc -l`)
+- Unpushed commits (`git -C <path> rev-list --count origin/main..HEAD 2>/dev/null`)
+
+### Step 7: GitHub Integration
+
+```bash
+# Can list issues?
+gh issue list --limit 1 --json number 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# Can list PRs?
+gh pr list --limit 1 --json number 2>/dev/null && echo "PASS" || echo "FAIL"
+```
+
+### Step 7b: CI/CD Readiness
+
+Check CI/CD configuration and tooling. This section is **optional** - skip entirely if `lib/cicd` is not available.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found, run these checks:
+
+```bash
+# 1. cicd.yml config file
+[ -f ".claude/cicd.yml" ] && echo "PASS cicd.yml" || echo "MISSING cicd.yml"
+
+# 2. Framework detection (via uv so deps resolve; PYTHONPATH=CPP_DIR, see #430)
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd detect --quiet 2>/dev/null
+
+# 3. Makefile completeness (uses lib/cicd check)
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd check --summary 2>/dev/null
+
+# 4. Health check configuration
+grep -q "endpoints:" .claude/cicd.yml 2>/dev/null && echo "PASS health endpoints" || echo "MISSING health endpoints"
+grep -q "smoke_tests:" .claude/cicd.yml 2>/dev/null && echo "PASS smoke tests" || echo "MISSING smoke tests"
+
+# 5. CI pipeline files
+[ -f ".github/workflows/ci.yml" ] || [ -f ".woodpecker.yml" ] && echo "PASS CI pipeline" || echo "MISSING CI pipeline"
+
+# 6. Dockerfile (optional)
+[ -f "Dockerfile" ] && echo "PASS Dockerfile" || echo "OPTIONAL Dockerfile"
+```
+
+If `CPP_DIR` is not found, skip this entire section and note in the report:
+```
+CI/CD Readiness: skipped (lib/cicd not available)
+```
+
+### Step 7c: MCP Server Connectivity
+
+Check whether MCP servers are reachable on their expected ports:
+
+```bash
+echo ""
+echo "MCP Server Connectivity:"
+
+MCP_ISSUES=0
+# Browser automation is upstream @playwright/mcp over npx/stdio - no port to probe.
+for entry in "8080:second-opinion"; do
+  PORT="${entry%%:*}"
+  NAME="${entry#*:}"
+  if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "  [x] $NAME (port $PORT): reachable"
+  elif ss -tlnp 2>/dev/null | grep -q ":${PORT} " 2>/dev/null; then
+    echo "  [~] $NAME (port $PORT): port open (no /health endpoint)"
+  else
+    echo "  [ ] $NAME (port $PORT): not reachable"
+    MCP_ISSUES=$((MCP_ISSUES + 1))
+  fi
+done
+
+if (( MCP_ISSUES > 0 )); then
+  echo "  Status: $MCP_ISSUES server(s) not reachable"
+else
+  echo "  Status: All MCP servers reachable"
+fi
+```
+
+### Step 8: Generate Report
+
+Output a single diagnostic report in this format:
+
+```markdown
+## Flow Doctor - {repo}
+
+### Environment
+
+| Check | Status | Details |
+|-------|--------|---------|
+| git | ✅ | v2.43.0 |
+| gh CLI | ✅ | v2.62.0 |
+| gh auth | ✅ | Logged in as {user} |
+| uv | ✅ | v0.5.14 |
+
+### Repository
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Git repo | ✅ | claude-power-pack |
+| Remote | ✅ | github.com/cooneycw/claude-power-pack |
+| User identity | ✅ | {name} <{email}> |
+
+### Workflow Readiness
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Makefile | ✅/⚠️/❌ | Targets: lint, test, deploy / Not found |
+| hooks.json | ✅/❌ | 2 hooks configured / Not found |
+| mask-output hook | ✅/❌ | ~/.claude/scripts/hook-mask-output.sh |
+| prompt-context.sh | ✅/❌ | Shell prompt context |
+| worktree-remove.sh | ✅/⚠️ | Optional fallback (native ExitWorktree is primary) |
+| secrets-mask.sh | ✅/❌ | Output masking filter |
+| Flow allowlist | ✅/⚠️/❌ | 32/32 rules in ~/.claude/settings.json / N missing / settings.json missing |
+| Flow skill mirror | ✅/⚠️ | Global flow-* matches repo commands / out of sync (run flow-skill-sync.py --write) |
+
+### MCP Server Connectivity
+
+| Server | Port | Status | Details |
+|--------|------|--------|---------|
+| second-opinion | 8080 | ✅/⚠️/❌ | Reachable / Port open (no /health) / Not reachable |
+| playwright | stdio | - | Upstream @playwright/mcp over npx/stdio (no port) |
+
+### Active Worktrees
+
+| Worktree | Issue | Branch | Status |
+|----------|-------|--------|--------|
+| ../{repo}-issue-42 | #42 | issue-42-fix-auth | 3 dirty, 1 unpushed |
+| ../{repo}-issue-55 | #55 | issue-55-add-tests | Clean |
+
+*No worktrees* → "No active worktrees. Run `/flow:start <issue>` to begin."
+
+### GitHub Integration
+
+| Check | Status |
+|-------|--------|
+| List issues | ✅/❌ |
+| List PRs | ✅/❌ |
+
+### CI/CD & Verification
+
+*(Only shown when lib/cicd is available. If not available, show: "CI/CD Readiness: skipped (lib/cicd not available - install CPP for CI/CD features)")*
+
+| Check | Status | Details |
+|-------|--------|---------|
+| .claude/cicd.yml | ✅/❌ | Config file present / missing |
+| Framework detected | ✅ | Python (uv) / Node (npm) / etc. |
+| Makefile completeness | ✅/⚠️ | 6/7 targets (typecheck missing) |
+| Health endpoints | ✅/⚠️ | 2 configured / Not configured |
+| Smoke tests | ✅/⚠️ | 3 configured / Not configured |
+| CI pipeline | ✅/❌ | .github/workflows/ci.yml / Not found |
+| Dockerfile | ⚠️ | Not configured (optional) |
+
+### Actions Needed
+
+(Only if there are failures or warnings)
+
+1. ❌ **Makefile missing** - Create a Makefile with `lint`, `test`, and `deploy` targets for `/flow:finish` and `/flow:deploy`. Run `/cicd:init` to auto-generate from a stack-specific template, or copy one manually:
+   - Python (uv): `cp ~/Projects/claude-power-pack/templates/makefiles/python-uv.mk Makefile`
+   - Python (pip): `cp ~/Projects/claude-power-pack/templates/makefiles/python-pip.mk Makefile`
+   - Django (uv): `cp ~/Projects/claude-power-pack/templates/makefiles/django-uv.mk Makefile`
+   - Node (npm): `cp ~/Projects/claude-power-pack/templates/makefiles/node-npm.mk Makefile`
+   - Node (yarn): `cp ~/Projects/claude-power-pack/templates/makefiles/node-yarn.mk Makefile`
+   - Go: `cp ~/Projects/claude-power-pack/templates/makefiles/go.mk Makefile`
+   - Rust: `cp ~/Projects/claude-power-pack/templates/makefiles/rust.mk Makefile`
+   - Monorepo: `cp ~/Projects/claude-power-pack/templates/makefiles/multi.mk Makefile`
+2. ⚠️ **worktree-remove.sh not found (optional)** - `/flow` uses the native `EnterWorktree`/`ExitWorktree` tools for same-session worktrees; the script is only a fallback for cross-session / cross-machine cleanup. Install if you want it: `ln -sf ~/Projects/claude-power-pack/scripts/worktree-remove.sh ~/.claude/scripts/`
+2b. ⚠️ **Flow allowlist missing/incomplete** - `/flow:*` will prompt for read-only git/gh plumbing on every run. Merge via `/cpp:update` (Step 7.6) or `/cpp:init`; rationale and caveats in `templates/claude-settings-permissions.md`
+2c. ⚠️ **Flow skill mirror drift** - the global `~/.claude/skills/flow-*` skills (the surface that actually runs) are out of sync with `.claude/commands/flow/`. Regenerate: `python3 ~/Projects/claude-power-pack/scripts/flow-skill-sync.py --write`
+3. ⚠️ **uv not installed** - Install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+4. ❌ **cicd.yml missing** - Run `/cicd:init` to auto-detect framework and generate configuration
+5. ⚠️ **Makefile gaps** - Run `/cicd:check` for details or `/cicd:init` to add missing targets
+6. ❌ **No CI pipeline** - Run `/cicd:pipeline` to generate GitHub Actions or Woodpecker CI config
+7. ⚠️ **No health endpoints** - Add `health.endpoints` to `.claude/cicd.yml` for post-deploy verification
+8. ⚠️ **No smoke tests** - Add `health.smoke_tests` to `.claude/cicd.yml` for post-deploy testing
+9. ⚠️ **MCP server(s) not reachable** - Start servers: `cd mcp-second-opinion && ./start-server.sh` (or use stdio transport)
+
+*All checks passed!* → "Environment is ready for `/flow` workflow."
+```
+
+## Status Symbols
+
+- ✅ = Check passed
+- ⚠️ = Optional/non-critical issue
+- ❌ = Required check failed - action needed
+
+## Notes
+
+- This is a read-only diagnostic - it never modifies anything
+- `uv` is recommended but not required (⚠️ if missing, not ❌)
+- Makefile is recommended but not required (⚠️ if missing)
+- Scripts and hooks are ❌ if missing since they provide security protection
+- Keep the report concise - one table per section, actions at the end

--- a/plugins/flow/commands/eli5.md
+++ b/plugins/flow/commands/eli5.md
@@ -1,0 +1,168 @@
+<!-- VENDORED CORE (issue #443): the section between the eli5-core markers below
+     is vendored verbatim from https://github.com/cooneycw/eli5-gate
+     (commands/eli5.md), the canonical standalone home of the necessity gate.
+     Edit the core UPSTREAM first, then re-vendor here; scripts/eli5-core-drift.sh
+     warns on drift. CPP-specific /flow wiring lives outside the markers. -->
+# Flow: ELI5 - Post-Analysis Plan + Necessity Gate
+
+The post-analysis, pre-implementation communication and approval gate. Restates an issue's intent in plain language, checks whether the issue is still worth doing given code merged since it was filed, and presents the proposed changes for reviewer approval before any code is written.
+
+This gate also ships standalone as **eli5-gate**
+(https://github.com/cooneycw/eli5-gate): installable by any Claude Code user via
+`/plugin marketplace add cooneycw/eli5-gate` then `/plugin install
+eli5-gate@eli5-gate`, or into ~40 other harnesses via `npx skills add
+cooneycw/eli5-gate`. That repo is canonical for the gate's core; improvement
+issues for the gate itself belong there, not in CPP.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+- `--yes` (optional, alias `--auto-approve`): skip the interactive approval pause for unattended runs. The ELI5 report is still produced and recorded. A `No longer needed` verdict is NEVER auto-approved - it always stops for a human decision.
+
+<!-- eli5-core:begin (canonical: https://github.com/cooneycw/eli5-gate commands/eli5.md) -->
+## What this is for
+
+Automated implement-from-issue pipelines jump from analysis straight to
+implementation with only a terse implementer-facing plan in between. That gives a
+human reviewer no clear, plain-language checkpoint to approve, redirect, or reject
+before effort is spent. Two gaps in particular:
+
+1. **No staleness / necessity check.** An issue filed weeks ago may already be
+   solved (or made obsolete) by code merged since. The default flow assumes the
+   issue is still valid and just implements it.
+2. **No reviewer-friendly intent summary.** The implementer-term plan is not the
+   fastest way for a reviewer to catch a misread of intent.
+
+This gate closes both gaps: it tells the reviewer, in their language, what the
+issue means, whether it is still worth doing, and what will change - then waits
+for approval.
+
+## Instructions
+
+When the gate is invoked with an issue number, perform the following. This command
+is read-only with respect to the codebase: it inspects and reports, it does not
+write implementation code.
+
+### Step 1: Gather context
+
+If this gate is being run as a step inside a larger pipeline that has already
+analyzed the issue, reuse that analysis and skip re-reading the codebase. When run
+standalone, gather context first:
+
+```bash
+ISSUE_NUM="$1"
+# Pull the body AND the creation timestamp - the timestamp drives staleness.
+gh issue view "$ISSUE_NUM" --json number,title,state,body,createdAt,labels,closedAt
+ISSUE_DATE=$(gh issue view "$ISSUE_NUM" --json createdAt --jq '.createdAt')
+```
+
+- Parse acceptance criteria (`- [ ]` items), referenced files/components, and any
+  task IDs or dependencies.
+- Read the files the issue references and the surrounding patterns so the
+  proposed-changes section is concrete.
+
+### Step 2: Produce the three-section report
+
+Emit all three sections every time. Do not skip a section even if it is short.
+
+**Section A - ELI5 overview of intent.** A plain-language restatement of what the
+issue is trying to accomplish and why, free of implementation jargon. Two to four
+sentences a non-author reviewer can sanity-check for a misread of intent.
+
+**Section B - Necessity / staleness analysis.** Assess whether the issue is still
+necessary given the current code and anything merged *after* it was filed. Inspect
+post-filing history explicitly:
+
+```bash
+# Commits landed since the issue was filed (global, then scoped to the files
+# the issue touches - substitute the relevant paths).
+git log --since="$ISSUE_DATE" --oneline
+git log --since="$ISSUE_DATE" --oneline -- <relevant/paths>
+
+# Pull requests merged since the issue was filed.
+gh pr list --state merged --search "merged:>=${ISSUE_DATE%%T*}" \
+    --json number,title,mergedAt
+
+# Duplicate / superseding issues (open or closed).
+gh issue list --state all --search "<key terms from the issue>" \
+    --json number,title,state,closedAt
+```
+
+Explicitly check for: (a) work already merged that closes or partially closes the
+issue, (b) design changes that make the original ask obsolete or misframed, (c)
+duplicate or superseding issues. Then output one verdict, with the evidence
+(commits, PRs, files, issue numbers) behind it:
+
+| Verdict | Meaning |
+|---------|---------|
+| **Still needed** | Nothing since filing addresses it; proceed as written |
+| **Partially addressed** | Some of the ask already landed; implement only the remainder (list what is left) |
+| **No longer needed** | Already solved or made obsolete; recommend closing instead of implementing |
+| **Needs reframing** | The surrounding design changed enough that the plan is wrong; restate the corrected approach |
+
+**Section C - Proposed changes (pending approval).** An overview of the changes
+proposed to close the issue, framed as a plan awaiting reviewer approval: files to
+create or modify, the gist of each change, scope estimate, and notable risks or
+edge cases. No code is written until this plan is approved.
+
+### Step 3: The approval gate
+
+The verdict drives what happens next:
+
+- **No longer needed** -> do NOT implement, even with `--yes`. Recommend closing
+  the issue and provide a ready-to-paste closing comment citing the evidence:
+  ```bash
+  gh issue close "$ISSUE_NUM" --comment "<evidence-based reason; reference the superseding PR/issue>"
+  ```
+  Surface the recommendation and STOP. Closing is the reviewer's call.
+- **Still needed**, **Partially addressed**, or **Needs reframing** -> present
+  Section C and gate on approval:
+  - **Default (interactive):** pause and ask the reviewer to approve, redirect,
+    or reject the plan. Only proceed once approved. For `Partially addressed` /
+    `Needs reframing`, the approved plan is the adjusted one, not the original
+    issue body.
+  - **`--yes` / `--auto-approve`, or an `eli5: auto-approve` trailer in the issue
+    body or HEAD commit message:** proceed without pausing, but still print the
+    full report for the record and note that approval was auto-granted.
+
+## Output format
+
+```
+ELI5 Gate: Issue #398
+
+== A. What this issue actually wants (ELI5) ==
+{plain-language intent, 2-4 sentences}
+
+== B. Is it still needed? ==
+Verdict: Still needed | Partially addressed | No longer needed | Needs reframing
+
+Evidence (since {ISSUE_DATE}):
+  - commits:  {sha list or "none touching <paths>"}
+  - PRs:      {merged PR numbers or "none"}
+  - dup/super:{issue numbers or "none"}
+Reasoning: {1-3 sentences tying evidence to the verdict}
+
+== C. Proposed changes (pending approval) ==
+  1. {file} - {what changes and why}
+  2. {file} - {what changes and why}
+Scope: {N files, ~L lines}
+Risks: {edge cases / unknowns}
+
+Approval: REQUIRED (interactive) | AUTO-GRANTED (--yes) | N/A (No longer needed -> close recommended)
+```
+<!-- eli5-core:end -->
+
+## When run inside /flow:auto
+
+`/flow:auto` invokes `/flow:eli5` as the step between Analyze and Implement and treats it as an approval gate:
+
+- Verdict **No longer needed** -> `/flow:auto` stops and surfaces the close-issue recommendation instead of implementing.
+- Verdicts **Still needed / Partially addressed / Needs reframing** -> `/flow:auto` pauses for approval unless invoked with `--yes` (or an `eli5: auto-approve` trailer is present), then proceeds to Implement using the approved plan.
+
+## Notes
+
+- This command is the communication and approval checkpoint: intent in the reviewer's language, an honest necessity verdict, and the plan that is about to be executed.
+- It never writes implementation code; the only mutating action it suggests is `gh issue close` on a `No longer needed` verdict, and that is a recommendation for the reviewer to run.
+- The staleness check is only meaningful when it inspects history *after* the issue's `createdAt`; always anchor `git log --since` and the PR/issue searches to that timestamp.
+- For step-by-step control outside the full lifecycle, run `/flow:eli5 <ISSUE>` on its own before deciding whether to `/flow:start`.
+- The vendored core between the markers must stay byte-identical to the canonical https://github.com/cooneycw/eli5-gate copy; `scripts/eli5-core-drift.sh` checks this (advisory, fail-open).

--- a/plugins/flow/commands/finish.md
+++ b/plugins/flow/commands/finish.md
@@ -1,0 +1,260 @@
+# Flow: Finish - Quality Gates, Commit, Push, and Create PR
+
+Run quality checks, commit changes, push the branch, and create a pull request.
+
+## Instructions
+
+When the user invokes `/flow:finish`, perform these steps:
+
+### Step 1: Validate Context
+
+```bash
+# Ensure we're on a feature branch (not main)
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    echo "ERROR: Cannot finish from main/master. Switch to a feature branch or worktree."
+    exit 1
+fi
+
+# Extract issue number from branch
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+```
+
+### Step 2: Run Quality Gates via Deterministic Runner (primary path)
+
+**Primary path:** Use the deterministic CI/CD runner for reproducible quality gates:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+RUNNER_RAN=0
+if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+    # Invoke through uv so lib/cicd's deps (pydantic) resolve and the
+    # interpreter is pinned >= 3.11. Bare `python3 -m lib.cicd` uses the
+    # system interpreter (often 3.10, no venv) inside a fresh worktree and
+    # dies on ModuleNotFoundError, silently degrading to the fallback (#430).
+    # PYTHONPATH must point at CPP_DIR (the PARENT of lib/) so `-m lib.cicd`
+    # resolves for external projects too, not just when dogfooding CPP.
+    PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
+    RUNNER_EXIT=$?
+    RUNNER_RAN=1
+fi
+
+if [ "$RUNNER_RAN" -eq 0 ]; then
+    REASON=$([ -z "$CPP_DIR" ] && echo "CPP checkout not found" || echo "uv not installed")
+    echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback." >&2
+fi
+```
+
+- If runner ran and **succeeds** (exit 0): quality gates passed, skip to Step 2d.
+- If runner ran and **fails** (exit non-zero): parse the JSON output for the failed step, report it, and **stop**.
+- If the runner **did not run** (`RUNNER_RAN=0` - no CPP_DIR or no uv): fall back to manual execution below.
+
+**Fallback path** (only if runner unavailable):
+
+```bash
+if [[ -f "Makefile" ]]; then
+    # Run lint if target exists
+    if grep -q "^lint:" Makefile; then
+        echo "Running: make lint"
+        make lint
+    fi
+
+    # Run tests if target exists
+    if grep -q "^test:" Makefile; then
+        echo "Running: make test"
+        make test
+    fi
+fi
+```
+
+- If tests or lint fail, **stop and report**. Do not proceed to PR creation.
+- If no Makefile exists, skip quality gates (warn the user).
+
+### Step 2b: Run Security Quick Scan (fallback only - runner includes this)
+
+**Skip this step if the deterministic runner was used above** (it already includes security_scan).
+
+Only run manually if the runner was unavailable:
+
+```bash
+PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" python3 -m lib.security gate flow_finish
+```
+
+- If the gate **fails** (critical findings): **stop and report**. Show findings and remediation.
+- If the gate produces **warnings** (high findings): display them but proceed.
+- If `lib/security` is not available, skip this step (warn the user).
+
+**Gate behavior by severity (defaults - configurable in `.claude/security.yml`):**
+
+| Severity | Effect on `/flow:finish` | What to do |
+|----------|--------------------------|------------|
+| CRITICAL | **BLOCKS** - flow stops, no PR created | Fix the finding, then re-run `/flow:finish` |
+| HIGH | **WARNS** - displayed, flow continues | Review finding; fix if real, suppress if false positive |
+| MEDIUM | Passes silently | No action needed |
+| LOW | Passes silently | No action needed |
+
+To suppress a known false positive, add it to `.claude/security.yml`:
+```yaml
+suppressions:
+  - id: HARDCODED_SECRET
+    path: tests/fixtures/.*
+    reason: "Test fixtures with fake credentials"
+```
+
+### Step 2d: Documentation Update Check (optional, non-blocking)
+
+If the Makefile has an `update_docs` target:
+
+```bash
+if [[ -f "Makefile" ]] && grep -q "^update_docs:" Makefile; then
+    echo "Running: make update_docs"
+    make update_docs
+fi
+```
+
+When this target exists, check documentation freshness:
+
+1. **C4 diagrams** - If `docs/architecture/` exists, check if C4 HTML files are older than recent code changes. If stale, warn:
+   ```
+   Docs may be stale - C4 diagrams last updated {date}, code changed since then.
+   Run /documentation:c4 to regenerate.
+   ```
+
+2. **CLAUDE.md / README.md** - Scan for obviously stale references (e.g., commands that no longer exist, file paths that don't match). Report as non-blocking warnings.
+
+**This step never blocks the flow** - it is purely informational.
+
+### Step 2c: Makefile Completeness Check (optional, non-blocking)
+
+If `lib/cicd` is available, run a quick Makefile validation and report any gaps as warnings:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found, `uv` is available, and a Makefile exists (invoke via
+`uv run` so `lib/cicd`'s deps resolve under a pinned >= 3.11 interpreter - bare
+`python3` crashes in a fresh worktree, see #430):
+
+```bash
+if command -v uv >/dev/null 2>&1; then
+    PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd check --summary
+    CHECK_EXIT=$?
+fi
+```
+
+- If check reports **missing required targets**: display as a warning but **do NOT block**.
+  ```
+  ⚠️  Makefile check: 1 required target missing (typecheck)
+      Run /cicd:check for details or /cicd:init to fix
+  ```
+- If check passes: report briefly - `"Makefile check: OK (6/6 targets present)"`
+- If `lib/cicd` is not available: skip silently
+- If no Makefile exists: skip silently (Step 2 already handles this)
+
+**This step never blocks the flow** - it is purely informational.
+
+### Step 3: Check for Changes
+
+```bash
+# Check for uncommitted changes
+git status --porcelain
+```
+
+**Guard against silently-ignored new files** (issue #430, Finding 1). A
+blanket `.gitignore` rule (e.g. `*.json`) can swallow a file you meant to
+commit - `git add` no-ops with no error. Surface it before committing:
+
+```bash
+if [ -n "$CPP_DIR" ] && [ -x "$CPP_DIR/scripts/check-ignored-additions.sh" ]; then
+    "$CPP_DIR/scripts/check-ignored-additions.sh"   # advisory: warns, never blocks
+fi
+```
+
+- If it warns, confirm each listed file is genuinely scratch. If any is an
+  intended addition, add a `!negation` to `.gitignore` (or narrow the blanket
+  rule) and re-stage before committing.
+
+- If there are uncommitted changes, help the user commit them using standard git commit workflow.
+- Use conventional commit format: `type(scope): Description (Closes #N)`
+- Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` if Claude helped write the code.
+
+### Step 4: Push Branch
+
+```bash
+# Push with tracking
+git push -u origin "$BRANCH"
+```
+
+### Step 5: Check for Existing PR
+
+```bash
+EXISTING_PR=$(gh pr list --head "$BRANCH" --json number,url --jq '.[0]' 2>/dev/null)
+```
+
+- If a PR already exists, report its URL and ask if the user wants to update it.
+- If no PR exists, proceed to create one.
+
+### Step 6: Create PR
+
+Use standard PR creation:
+
+```bash
+gh pr create \
+  --title "type(scope): Description (Closes #ISSUE_NUM)" \
+  --body "## Summary
+- <bullet points>
+
+## Test plan
+- [ ] Tests pass
+- [ ] Linting passes
+
+Closes #ISSUE_NUM"
+```
+
+- Title: Conventional commit style, derived from changes
+- Body: Summary of changes + test plan + `Closes #N`
+- Analyze all commits on the branch to draft the summary
+
+### Step 7: Output
+
+```
+Quality gates passed:
+  ✅ make lint
+  ✅ make test
+  ✅ security scan (quick)
+
+Branch pushed: issue-42-fix-login → origin
+
+PR created: https://github.com/owner/repo/pull/78
+  Title: fix(auth): Resolve login redirect loop (Closes #42)
+```
+
+## Error Handling
+
+- **Lint/test failure:** Stop, show output, ask user to fix
+- **Push failure:** Report error (likely needs `git pull --rebase`)
+- **PR already exists:** Report URL, offer to update
+- **No issue number in branch:** Create PR without `Closes #N` reference
+- **No Makefile:** Skip quality gates, warn user
+
+## Notes
+
+- Quality gates are optional - if no Makefile exists, the flow still works
+- The commit step follows standard git commit conventions (the user controls the message)
+- This command works from any worktree directory

--- a/plugins/flow/commands/help.md
+++ b/plugins/flow/commands/help.md
@@ -1,0 +1,119 @@
+# Flow Commands
+
+Streamlined worktree-based development workflow. No locks, no Redis - just git.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:start <issue>` | Create worktree and branch from a GitHub issue |
+| `/flow:eli5 <issue>` | Plain-language intent + necessity/staleness verdict + plan approval gate (pre-implementation) |
+| `/flow:status` | Show all active worktrees with issue/PR state |
+| `/flow:check` | Run quality checks (lint, test, security) without committing |
+| `/flow:finish` | Run quality gates, commit, push, and create PR |
+| `/flow:merge` | Merge PR, clean up worktree and branch |
+| `/flow:deploy [target]` | Run Makefile deploy target |
+| `/flow:sync` | Push WIP branch to remote for cross-machine pickup |
+| `/flow:auto <issue>` | Full lifecycle: start → analyze → ELI5 (plan + necessity gate) → implement → update docs → finish → merge → deploy |
+| `/flow:cleanup` | Prune stale worktree references and delete merged branches |
+| `/flow:doctor` | Diagnose workflow environment and readiness |
+| `/flow:help` | This help page |
+
+## The Golden Path
+
+```
+/flow:auto 42
+  ↓
+  start → analyze → ELI5 (plan + necessity gate) → implement → update docs → finish → merge → deploy
+```
+
+The ELI5 step is an approval checkpoint: it restates the issue's intent in plain language, gives a necessity verdict (Still needed / Partially addressed / No longer needed / Needs reframing) with evidence from code merged since the issue was filed, and waits for plan approval before any code is written. Run `/flow:auto <issue> --yes` (or add an `eli5: auto-approve` trailer) for unattended runs; a `No longer needed` verdict always stops for a human decision.
+
+Or step by step:
+```
+/flow:start 42  →  work  →  /flow:check  →  /flow:finish  →  /flow:merge  →  /flow:deploy
+```
+
+Cross-machine (optional):
+```
+Machine A: /flow:start 42  →  work  →  /flow:sync
+Machine B: /flow:start 42  →  picks up remote branch  →  continue working
+```
+
+## Security Gates
+
+`/flow:finish` and `/flow:deploy` run automatic security scans as quality gates. Gate behavior is controlled by `.claude/security.yml`:
+
+| Severity | `/flow:finish` (default) | `/flow:deploy` (default) |
+|----------|--------------------------|--------------------------|
+| CRITICAL | **Blocks** - must fix before PR | **Blocks** - must fix before deploy |
+| HIGH | **Warns** - shows findings, proceeds | **Blocks** - must fix before deploy |
+| MEDIUM | Passes | **Warns** - shows findings, proceeds |
+| LOW | Passes | Passes |
+
+**What happens when blocked:**
+- The flow stops and displays all blocking findings with remediation hints
+- You fix the issue, then re-run `/flow:finish` or `/flow:deploy`
+- To suppress known false positives, add entries to `.claude/security.yml` `suppressions:`
+
+**Configuration** (`.claude/security.yml`):
+```yaml
+gates:
+  flow_finish:
+    block_on: [critical]       # Severities that stop the flow
+    warn_on: [high]            # Severities shown as warnings
+  flow_deploy:
+    block_on: [critical, high]
+    warn_on: [medium]
+suppressions:
+  - id: HARDCODED_SECRET       # Finding type to suppress
+    path: tests/fixtures/.*    # Regex for file path (optional)
+    reason: "Test fixtures with fake credentials"
+```
+
+If no `.claude/security.yml` exists, the defaults above are used. If `lib/security` is not available, the gate is skipped with a warning.
+
+## Conventions
+
+- **Worktree directory:** `../{repo}-issue-{N}` (sibling to main repo)
+- **Branch name:** `issue-{N}-{slug}` (derived from issue title)
+- **Commit style:** `type(scope): Description (Closes #N)`
+- **All context is derived from git** - no external state tracking
+
+## Quick Examples
+
+```bash
+# Start working on issue #42
+/flow:start 42
+# → Creates worktree ../my-project-issue-42
+# → Branch: issue-42-fix-login-bug
+
+# Check what's active
+/flow:status
+# → Shows worktrees, dirty state, PR status
+
+# Pre-flight check (lint + test + security, no commit)
+/flow:check
+# → Reports pass/fail per check
+
+# Done coding - push and create PR
+/flow:finish
+# → Runs make test/lint if available
+# → Commits, pushes, creates PR
+
+# PR approved - merge and clean up
+/flow:merge
+# → Merges PR, deletes branch, removes worktree
+
+# Deploy to production
+/flow:deploy
+# → Runs make deploy
+
+# Sync WIP to remote (for cross-machine work)
+/flow:sync
+# → Auto-commits WIP, pushes branch to origin
+
+# Or do it all in one shot (start to deploy):
+/flow:auto 42
+# → start → analyze → implement → finish → merge → deploy
+```

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -1,0 +1,261 @@
+# Flow: Merge PR and Clean Up
+
+Merge the current branch's PR, then clean up the worktree and branch.
+
+Worktrees are Claude Code's **native worktrees** (checkouts under
+`.claude/worktrees/<name>`). `/flow:merge` is usually invoked standalone, in a
+fresh session from inside the worktree - so the worktree was NOT created by
+`EnterWorktree` in this session and `ExitWorktree` would be a no-op. The safe
+cross-session cleanup therefore stays on `git worktree remove` /
+`worktree-remove.sh`. If (and only if) you created this worktree earlier in the
+same session with `EnterWorktree(name=...)`, prefer the native
+`ExitWorktree(action="remove", discard_changes=true)` instead of Steps 5a-5c.
+
+## Instructions
+
+When the user invokes `/flow:merge`, perform these steps:
+
+### Step 1: Detect Context
+
+```bash
+BRANCH=$(git branch --show-current)
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+
+# Extract issue number
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+
+# Detect if we're in a worktree
+WORKTREE_PATH=$(pwd)
+IS_WORKTREE=false
+if [[ -f ".git" ]]; then
+    IS_WORKTREE=true
+fi
+```
+
+### Step 2: Find and Verify PR
+
+```bash
+PR_JSON=$(gh pr list --head "$BRANCH" --json number,state,mergeable,reviewDecision,statusCheckRollup --jq '.[0]')
+```
+
+- If no PR found: "No PR found for branch `$BRANCH`. Run `/flow:finish` first."
+- If PR is already merged: "PR is already merged. Run cleanup only? [y/N]"
+- Report PR state: checks passing, review status, mergeable
+
+### Step 3: Sync with main, re-gate, then merge
+
+**Stale-branch guard (issue #462):** a branch cut earlier can have fallen behind
+`main` while the PR was open; squash-merging it then fails at the last step on a
+content conflict. Bring the branch current and re-run the quality gate on the
+**post-merge tree** before merging, so the squash is deterministic and the gate
+reflects exactly what lands on `main`. (`/flow:auto` Step 7 runs the same guard;
+this covers the standalone/resume path.)
+
+```bash
+BRANCH=$(git branch --show-current)
+git fetch origin main
+if [[ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]]; then
+    echo "Branch is behind origin/main - merging main in before the squash."
+    if ! git merge --no-edit origin/main; then
+        echo "STOP: merging origin/main hit conflicts:"
+        git diff --name-only --diff-filter=U
+        echo "Resolve them, 'git add' + 'git commit', then re-run /flow:merge."
+        echo "(Do NOT 'git merge --abort' - that discards the resolution.)"
+        exit 1
+    fi
+    # Re-run the FULL quality gate on the MERGED tree (deterministic runner,
+    # Makefile fallback - same gate /flow:finish uses).
+    CPP_DIR=""
+    for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+      [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+    done
+    if [ -n "$CPP_DIR" ] && command -v uv >/dev/null 2>&1; then
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd run --plan finish
+        REGATE_EXIT=$?
+    else
+        echo "NOTE: deterministic runner unavailable; re-gating via Makefile fallback." >&2
+        make lint && make test
+        REGATE_EXIT=$?
+    fi
+    if [ "$REGATE_EXIT" -ne 0 ]; then
+        echo "STOP: quality gate failed on the post-merge tree. Fix, commit, then re-run /flow:merge."
+        exit 1
+    fi
+    # Push the merge so the PR reflects the post-merge tree before squashing.
+    git push origin "$BRANCH"
+fi
+```
+
+Then merge the PR:
+
+```bash
+PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+
+# Squash merge (default) - keeps history clean. Run from inside a linked worktree,
+# `gh pr merge --delete-branch` fails AFTER the remote squash succeeds: gh tries to
+# switch this worktree off the merged branch onto the default branch, which is
+# checked out in the primary worktree ("fatal: 'main' is already checked out"), and
+# exits non-zero even though the merge landed (issue #461). The helper drops
+# --delete-branch in a linked worktree, deletes the remote branch itself, and
+# verifies the PR reached MERGED before reporting failure. Local worktree/branch
+# cleanup stays in Step 5 below.
+if [[ -x ~/.claude/scripts/gh-pr-merge.sh ]]; then
+    ~/.claude/scripts/gh-pr-merge.sh "$PR_NUMBER" "$BRANCH"
+    MERGE_RC=$?
+else
+    # Inline fallback (helper not installed): same linked-worktree guard.
+    if [[ -f ".git" ]]; then
+        gh pr merge "$PR_NUMBER" --squash
+        git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+    else
+        gh pr merge "$PR_NUMBER" --squash --delete-branch
+    fi
+    [[ "$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null)" == "MERGED" ]]
+    MERGE_RC=$?
+fi
+```
+
+- Use `--squash` by default (clean history)
+- The remote branch is deleted by `--delete-branch` (primary repo) or by the
+  helper's explicit `git push origin --delete` (linked worktree)
+- If the merge genuinely failed (`MERGE_RC` non-zero - conflicts, checks failing,
+  PR not `MERGED`), report and stop. A non-zero `gh` exit whose PR is nonetheless
+  `MERGED` is not a failure - the helper treats it as success and cleanup proceeds
+
+### Step 4: Update Local Main
+
+Determine the main repo path:
+
+```bash
+if [[ "$IS_WORKTREE" == true ]]; then
+    # Get main repo path from worktree .git file
+    MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+else
+    MAIN_REPO=$(pwd)
+fi
+
+# Pull latest main
+git -C "$MAIN_REPO" checkout main
+git -C "$MAIN_REPO" pull origin main
+```
+
+### Step 5: Clean Up Worktree
+
+**CRITICAL: You MUST `cd` to the main repo BEFORE removing the worktree. NEVER remove a worktree while your working directory is inside it - this destroys your CWD and kills all subsequent bash commands. Execute these as SEPARATE Bash calls.**
+
+If we're in a worktree (`IS_WORKTREE=true`):
+
+**Step 5a - Exit the worktree (separate Bash call):**
+```bash
+cd "$MAIN_REPO"
+pwd  # Verify you are in the main repo, NOT the worktree
+```
+
+**Step 5b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
+```bash
+if [[ -f ~/.claude/scripts/worktree-remove.sh ]]; then
+    ~/.claude/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
+else
+    git worktree remove "$WORKTREE_PATH" --force
+    git branch -D "$BRANCH" 2>/dev/null || true
+fi
+```
+
+**Step 5c - Verify working directory is valid:**
+```bash
+pwd  # MUST show main repo path, NOT the deleted worktree
+git status  # MUST succeed - if this fails, your CWD was deleted
+```
+
+If we're in the main repo (not a worktree):
+```bash
+# Just delete the local branch
+git branch -D "$BRANCH" 2>/dev/null || true
+```
+
+### Step 6: Close Issue (if linked)
+
+```bash
+if [[ -n "$ISSUE_NUM" ]]; then
+    # Check if issue is still open (gh pr merge with Closes # may have closed it)
+    ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
+    if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+        gh issue close "$ISSUE_NUM" --comment "Closed via /flow:merge - PR #${PR_NUMBER} merged."
+    fi
+fi
+```
+
+### Step 7: Prune Stale Branches
+
+After merge cleanup, prune any other stale references:
+
+```bash
+# Prune stale worktree references (folders deleted but git still tracking)
+git -C "$MAIN_REPO" worktree prune
+
+# Delete local issue-* branches that are fully merged to main
+MERGED=$(git -C "$MAIN_REPO" branch --merged main | grep -v '^\*' | grep -v 'main$' | grep -v 'master$' | sed 's/^[ ]*//')
+# Protect branches with active worktrees
+WORKTREE_BRANCHES=$(git -C "$MAIN_REPO" worktree list --porcelain | grep "^branch " | sed 's|branch refs/heads/||')
+for b in $MERGED; do
+    echo "$WORKTREE_BRANCHES" | grep -q "^${b}$" && continue
+    git -C "$MAIN_REPO" branch -d "$b" 2>/dev/null && echo "Deleted merged branch: $b"
+done
+
+# Prune stale remote tracking branches
+git -C "$MAIN_REPO" fetch --prune
+```
+
+### Step 8: Output
+
+```
+PR #78 merged (squash) ✅
+
+Cleanup:
+  ✅ Remote branch deleted: issue-42-fix-login
+  ✅ Worktree removed: .claude/worktrees/issue-42-fix-login
+  ✅ Local branch deleted: issue-42-fix-login
+  ✅ Issue #42 closed
+  ✅ Pruned stale worktree references
+  ✅ Deleted 2 merged local branches
+  ✅ Pruned stale remote tracking branches
+
+Current directory: /home/user/Projects/my-project (main)
+```
+
+### Step 9: Post-run Friction Retro (optional, non-blocking)
+
+Capture is always-on during a flow: whenever a step in this merge triggers a
+permission prompt, a gate failure/retry, red output you worked around, or a manual
+correction, record it immediately via the fail-open helper (it never blocks):
+
+```bash
+scripts/friction-log.sh --class <permission-prompt|gate-failure|red-output|manual-intervention> \
+  --signal "<what happened>" --run "flow:merge" --step "<N/9 Name>" --outcome "<...>"
+```
+
+Then, if `.claude/friction.jsonl` recorded any signals, offer the codify step (do
+not auto-run):
+
+```
+Friction retro: this run recorded N friction signal(s). Run /self-improvement:retro
+to codify fixes? [y/N]
+```
+
+## Error Handling
+
+- **PR not found:** Direct user to `/flow:finish`
+- **Merge conflicts:** Report conflict, suggest manual resolution
+- **Checks failing:** Report which checks failed, ask if user wants to wait or force
+- **Inside worktree being removed:** `worktree-remove.sh` handles this safely
+- **Issue already closed:** Skip close step silently
+
+## Notes
+
+- Squash merge is the default - produces clean single-commit history
+- The remote branch is deleted by `gh pr merge --delete-branch`
+- Worktrees are native (`.claude/worktrees/`); cross-session cleanup uses `git worktree remove` / the safe `worktree-remove.sh` script (native `ExitWorktree` only removes worktrees created by `EnterWorktree` in the current session)
+- After merge, the user ends up in the main repo on the `main` branch
+- Automatically prunes stale worktree references, merged branches, and remote tracking branches
+- For a standalone cleanup (without merging), use `/flow:cleanup`
+- Friction capture is always-on and this command offers `/self-improvement:retro` at the end to codify fixes (the grill-me cycle, issue #426)

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -1,0 +1,136 @@
+# Flow: Start Working on an Issue
+
+Create a worktree and branch for a GitHub issue. Stateless - all context from git and GitHub.
+
+Worktree mechanics ride Claude Code's **native worktrees**: the `EnterWorktree`
+tool creates a checkout under `.claude/worktrees/<name>` on a new branch (base
+governed by the `worktree.baseRef` setting - `fresh`, the default, branches from
+`origin/<default-branch>`, matching the old `origin/main` behavior) and switches
+the session into it. The issue-anchored `issue-<N>-<slug>` branch name is the
+policy CPP keeps and enforces; it is not absorbed by the native tool.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+
+## Instructions
+
+When the user invokes `/flow:start <ISSUE>`, perform these steps:
+
+### Step 1: Validate Prerequisites
+
+```bash
+# Ensure gh is authenticated
+gh auth status
+
+# Ensure we're in a git repo
+git rev-parse --show-toplevel
+```
+
+### Step 2: Fetch Issue Details
+
+```bash
+ISSUE_NUM="$1"
+gh issue view "$ISSUE_NUM" --json number,title,state,body
+```
+
+- If issue is not OPEN, warn the user and ask whether to proceed
+- Extract the title for branch naming
+
+### Step 3: Derive Branch and Worktree Names
+
+```bash
+# Sanitize title: lowercase, replace non-alphanum with hyphens, truncate.
+# The cut -c1-64 keeps the name within the EnterWorktree 64-char limit.
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
+
+BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+```
+
+The native worktree lives under `.claude/worktrees/${BRANCH}` - you do not choose
+a sibling directory; pass `${BRANCH}` as the worktree `name` and the tool places
+and names it.
+
+### Step 4: Check for Existing Work
+
+```bash
+# Check if already on the issue's branch (do NOT re-create in that case)
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Check if a worktree already exists for this issue
+git worktree list | grep "issue-${ISSUE_NUM}"
+
+# Check if a remote branch exists (cross-machine pickup)
+git fetch origin
+git branch -r | grep "issue-${ISSUE_NUM}-"
+```
+
+Pick exactly one path:
+
+- **Already on the issue branch** (`$CURRENT_BRANCH` matches `issue-${ISSUE_NUM}-`):
+  verify you are NOT on main/master and use the current directory. Do nothing else.
+- **Worktree already exists** (from a prior session): enter it with the
+  `EnterWorktree` tool using its existing path (do NOT create a new one):
+  `EnterWorktree(path="<path from git worktree list>")`.
+- **Remote branch exists, no local worktree** (cross-machine pickup): the native
+  tool cannot check out an existing remote branch, so add the worktree with git,
+  then switch into it with `EnterWorktree`:
+  ```bash
+  REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
+  LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
+  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  ```
+  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`.
+- **Neither exists** (fresh start): create and enter the worktree natively by
+  calling the `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
+  `origin/<default-branch>` (under the default `worktree.baseRef: fresh`) and
+  switches the session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to
+  `git worktree add` for the fresh path. If your `worktree.baseRef` is set to
+  `head`, sync `main` first so the branch does not start from a stale local HEAD.
+
+### Step 5: Verify, Normalize Branch, Output
+
+**CRITICAL: Verify you are in the worktree, not on main/master.**
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "ERROR: Still on main/master. EnterWorktree did not switch the session."
+    exit 1
+fi
+```
+
+**Enforce the issue-anchored branch name (the moat).** Native worktree creation
+derives the branch from the worktree name; if the resulting branch is not exactly
+`issue-${ISSUE_NUM}-${SLUG}`, rename it so every downstream step (`/flow:merge`,
+`/flow:status`, `/flow:cleanup`) can extract the issue number from the branch:
+
+```bash
+if [[ "$CURRENT_BRANCH" != "$BRANCH" ]]; then
+    git branch -m "$BRANCH"
+    CURRENT_BRANCH="$BRANCH"
+fi
+echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
+```
+
+Report to the user:
+
+```
+Created worktree for issue #42: "Fix login bug"
+
+  Directory: .claude/worktrees/issue-42-fix-login-bug
+  Branch:    issue-42-fix-login-bug
+  Verified:  Working directory is now the worktree (not main)
+```
+
+## Error Handling
+
+- **Issue not found:** `gh issue view` fails → report "Issue #N not found"
+- **Issue closed:** Warn but allow user to proceed (they may want to reopen)
+- **Worktree exists:** Report existing path, do not error
+- **Branch name collision:** Append short hash if needed
+- **Not in a git repo:** Report error clearly
+
+## Idempotency
+
+Running `/flow:start 42` when the worktree already exists should detect it and report the path, not error or create a duplicate.

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -1,0 +1,98 @@
+# Flow: Status of Active Worktrees
+
+Show all active worktrees with their issue, branch, dirty state, and PR status.
+
+## Instructions
+
+When the user invokes `/flow:status`, perform these steps:
+
+### Step 1: Detect Repository
+
+```bash
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+```
+
+### Step 2: List Worktrees
+
+```bash
+git worktree list
+```
+
+### Step 3: For Each Worktree, Gather State
+
+For each worktree (skip the main repo entry):
+
+```bash
+# Get branch name
+BRANCH=$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null)
+
+# Extract issue number from branch name (issue-N-*)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+
+# Check for uncommitted changes
+DIRTY=$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null | wc -l)
+
+# Check for unpushed commits
+UNPUSHED=$(git -C "$WORKTREE_PATH" rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+
+# Check PR status (if branch is pushed)
+if [[ -n "$BRANCH" ]]; then
+    PR_INFO=$(gh pr list --head "$BRANCH" --json number,url,state --jq '.[0]' 2>/dev/null || echo "")
+fi
+```
+
+### Step 4: Fetch Issue Titles
+
+For each detected issue number:
+```bash
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "Unknown")
+```
+
+### Step 5: Output
+
+```markdown
+## Flow Status - {repo}
+
+| Worktree | Issue | Branch | Status | PR |
+|----------|-------|--------|--------|----|
+| .claude/worktrees/issue-42-fix-login | #42 Fix login bug | issue-42-fix-login | 3 dirty files, 2 unpushed | - |
+| .claude/worktrees/issue-55-add-tests | #55 Add tests | issue-55-add-tests | Clean | PR #78 (OPEN) |
+
+### Suggestions
+- **#42**: Has uncommitted work - commit or stash before switching
+- **#55**: PR is open - check for reviews, then `/flow:merge`
+```
+
+### Step 6: Detect Stale Branches
+
+Check for local branches that may need cleanup:
+
+```bash
+# Count local issue-* branches with no active worktree
+WORKTREE_BRANCHES=$(git worktree list --porcelain | grep "^branch " | sed 's|branch refs/heads/||')
+STALE_COUNT=0
+for branch in $(git branch | grep 'issue-' | sed 's/^[ *]*//'); do
+    echo "$WORKTREE_BRANCHES" | grep -q "^${branch}$" && continue
+    STALE_COUNT=$((STALE_COUNT + 1))
+done
+
+# Check for prunable worktree references
+PRUNABLE=$(git worktree list --porcelain | grep -c "prunable" || echo "0")
+```
+
+If stale branches or prunable references exist, append to output:
+
+```markdown
+### Cleanup Available
+- {N} local issue branches with no active worktree
+- {M} stale worktree references
+
+Run `/flow:cleanup` to remove stale branches and references.
+```
+
+## Notes
+
+- Worktrees on `main` or non-issue branches are listed but marked as "(not issue-linked)"
+- If no worktrees exist besides main, report "No active worktrees. Run `/flow:start <issue>` to begin."
+- Keep output concise - this is a quick status check
+- Stale branch detection helps identify cleanup opportunities

--- a/plugins/flow/commands/sync.md
+++ b/plugins/flow/commands/sync.md
@@ -1,0 +1,78 @@
+# Flow: Sync - Push WIP to Remote for Cross-Machine Pickup
+
+Push the current branch to the remote so you can continue work on another machine. Optional feature - most users won't need this.
+
+## Arguments
+
+None. Operates on the current worktree/branch.
+
+## Instructions
+
+When the user invokes `/flow:sync`, perform these steps:
+
+### Step 1: Validate Context
+
+```bash
+# Ensure we're in a git repo
+git rev-parse --show-toplevel
+
+# Get current branch
+BRANCH=$(git branch --show-current)
+```
+
+- If on `main` or `master`: **STOP**. Report: "Cannot sync main branch. Use `/flow:start <issue>` to create a worktree first."
+- If not on an `issue-*` branch: Warn but allow (user may have custom branch names).
+
+### Step 2: Check for Uncommitted Changes
+
+```bash
+# Check working tree status
+git status --short
+```
+
+- **If clean:** Skip to Step 3.
+- **If dirty (uncommitted changes):** Auto-commit as WIP:
+  ```bash
+  git add -A
+  git commit -m "wip: sync work in progress
+
+  Auto-committed by /flow:sync for cross-machine pickup.
+  This commit will be squash-merged - no need to clean up."
+  ```
+  Report: "Auto-committed WIP changes."
+
+### Step 3: Push to Remote
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+- If push fails (e.g., rejected): Report the error and suggest `git pull --rebase origin "$BRANCH"` to resolve.
+
+### Step 4: Output
+
+```
+Synced branch to remote.
+
+  Branch: issue-42-fix-login-bug
+  Remote: origin
+
+  To continue on another machine:
+    /flow:start 42
+    → Detects remote branch and creates worktree from it
+```
+
+## Error Handling
+
+- **Not in a git repo:** Report error clearly.
+- **On main branch:** Block sync, suggest `/flow:start`.
+- **Push rejected:** Suggest `git pull --rebase` to reconcile.
+- **No remote configured:** Report "No remote 'origin' found."
+
+## Notes
+
+- This command is intentionally simple - just commit WIP + push.
+- Cross-machine sync operates on the `issue-<N>-<slug>` **branch**, not on worktree paths, so the native `.claude/worktrees/` location (which is per-workstation and gitignored) does not affect it.
+- `/flow:start` already handles the receiving end: it detects the remote branch and, because the native `EnterWorktree` tool cannot check out an existing remote branch, adds a worktree tracking it with `git worktree add` and then switches in with `EnterWorktree(path=...)`.
+- WIP commits are harmless because `/flow:merge` uses squash-merge, collapsing all commits into one clean commit.
+- No configuration required - works with any git remote.

--- a/scripts/plugin-flow-sync.sh
+++ b/scripts/plugin-flow-sync.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# plugin-flow-sync.sh - keep the packaged flow plugin in sync with its source.
+#
+# Phase B1 of the plugin-marketplace migration (ADR docs/decisions/
+# 0001-plugin-marketplace-packaging.md, issue #477) packages the `flow` command
+# family as an installable plugin under plugins/flow/. During the B1->B4 parallel
+# window the legacy installer and the plugin BOTH ship the flow commands, so the
+# single source of truth stays .claude/commands/flow/*.md and plugins/flow/
+# commands/ holds byte-identical copies. This script is the guard that keeps the
+# copies honest:
+#
+#   plugin-flow-sync.sh            # --check (default): fail (exit 1) on any drift
+#   plugin-flow-sync.sh --check    # explicit
+#   plugin-flow-sync.sh --write    # (re)generate plugins/flow/commands/ from source
+#
+# Mirrors the scripts/flow-skill-sync.py --check/--write and eli5-core-drift.sh
+# idioms. Deterministic and git-free (byte-for-byte local diff, no network) so it
+# runs in the git-less CI validate container. Reconcile drift by editing the
+# SOURCE (.claude/commands/flow/*.md) then re-running with --write.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC_DIR="$REPO_ROOT/.claude/commands/flow"
+DEST_DIR="$REPO_ROOT/plugins/flow/commands"
+
+MODE="check"
+case "${1:-}" in
+    ""|--check) MODE="check" ;;
+    --write)    MODE="write" ;;
+    -h|--help)
+        sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+        exit 0 ;;
+    *)
+        echo "plugin-flow-sync: unknown argument '$1' (use --check or --write)" >&2
+        exit 2 ;;
+esac
+
+if [[ ! -d "$SRC_DIR" ]]; then
+    echo "plugin-flow-sync: source dir not found: $SRC_DIR" >&2
+    exit 2
+fi
+
+if [[ "$MODE" == "write" ]]; then
+    mkdir -p "$DEST_DIR"
+    # Drop orphans (a command removed from source) before copying the current set.
+    for f in "$DEST_DIR"/*.md; do
+        [[ -e "$f" ]] || continue
+        base="$(basename "$f")"
+        if [[ ! -f "$SRC_DIR/$base" ]]; then
+            rm -f "$f"
+            echo "plugin-flow-sync: removed orphan $base"
+        fi
+    done
+    count=0
+    for f in "$SRC_DIR"/*.md; do
+        [[ -e "$f" ]] || continue
+        cp "$f" "$DEST_DIR/"
+        count=$((count + 1))
+    done
+    echo "plugin-flow-sync: wrote $count command(s) to plugins/flow/commands/ from .claude/commands/flow/"
+    exit 0
+fi
+
+# --check: byte-identical parity, both directions (missing, changed, orphaned).
+drift=0
+count=0
+for f in "$SRC_DIR"/*.md; do
+    [[ -e "$f" ]] || continue
+    count=$((count + 1))
+    base="$(basename "$f")"
+    dest="$DEST_DIR/$base"
+    if [[ ! -f "$dest" ]]; then
+        echo "MISSING in plugin: $base"
+        drift=1
+        continue
+    fi
+    if ! diff -q "$f" "$dest" >/dev/null 2>&1; then
+        echo "DRIFT: $base differs from source"
+        drift=1
+    fi
+done
+for f in "$DEST_DIR"/*.md; do
+    [[ -e "$f" ]] || continue
+    base="$(basename "$f")"
+    if [[ ! -f "$SRC_DIR/$base" ]]; then
+        echo "ORPHAN in plugin: $base (no matching source command)"
+        drift=1
+    fi
+done
+
+if [[ "$drift" -ne 0 ]]; then
+    echo "" >&2
+    echo "plugin-flow-sync: DRIFT detected between .claude/commands/flow/ and" >&2
+    echo "plugins/flow/commands/. Edit the SOURCE (.claude/commands/flow/*.md), then" >&2
+    echo "run: scripts/plugin-flow-sync.sh --write" >&2
+    exit 1
+fi
+
+echo "plugin-flow-sync: plugins/flow/commands is in sync with .claude/commands/flow ($count files)"
+exit 0

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -1,0 +1,119 @@
+"""Regression tests for the plugin-marketplace scaffold + flow POC plugin (issue #477).
+
+Phase B1 of the plugin-marketplace migration (ADR docs/decisions/
+0001-plugin-marketplace-packaging.md) stands up `.claude-plugin/marketplace.json`
+and packages the `flow` command family as an installable plugin under
+`plugins/flow/`. During the B1->B4 parallel window the source of truth stays
+`.claude/commands/flow/*.md` and the plugin holds byte-identical copies kept
+honest by `scripts/plugin-flow-sync.sh`.
+
+The hazards these pin:
+  * the manifests must stay schema-valid (name/source/required fields), because
+    `/plugin install flow@cpp` resolves the marketplace by its `name` field and
+    the plugin by its `source` path;
+  * the packaged commands must stay byte-identical to their source, or the two
+    surfaces silently diverge before B4 collapses them.
+
+Hermetic and git-free: reads the REAL repo manifests + command sources and shells
+only to the git-free sync guard, so it runs in CI's git-less validate container
+(see the cpp_validate_container_no_git learning).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_DIR = ROOT / "plugins" / "flow"
+PLUGIN_MANIFEST = PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+SOURCE_COMMANDS = ROOT / ".claude" / "commands" / "flow"
+PLUGIN_COMMANDS = PLUGIN_DIR / "commands"
+SYNC_SCRIPT = ROOT / "scripts" / "plugin-flow-sync.sh"
+
+
+# --------------------------------------------------------------------------- #
+# Marketplace manifest
+# --------------------------------------------------------------------------- #
+def test_marketplace_manifest_exists_and_is_json():
+    assert MARKETPLACE.is_file(), f"missing {MARKETPLACE}"
+    data = json.loads(MARKETPLACE.read_text())
+    assert isinstance(data, dict)
+
+
+def test_marketplace_name_is_cpp():
+    # The install path is `/plugin install flow@cpp`; `cpp` is this field.
+    data = json.loads(MARKETPLACE.read_text())
+    assert data["name"] == "cpp"
+
+
+def test_marketplace_lists_flow_plugin_by_relative_source():
+    data = json.loads(MARKETPLACE.read_text())
+    plugins = data.get("plugins")
+    assert isinstance(plugins, list) and plugins, "marketplace lists no plugins"
+    flow = next((p for p in plugins if p.get("name") == "flow"), None)
+    assert flow is not None, "no `flow` plugin entry in marketplace.json"
+    assert flow["source"] == "./plugins/flow"
+    assert flow.get("description"), "flow plugin entry needs a description"
+
+
+def test_marketplace_sources_resolve_to_plugin_manifests():
+    # Every declared local source must point at a real plugin dir with a manifest.
+    data = json.loads(MARKETPLACE.read_text())
+    for entry in data["plugins"]:
+        source = entry["source"]
+        assert source.startswith("./"), f"expected relative source, got {source}"
+        manifest = (ROOT / source / ".claude-plugin" / "plugin.json").resolve()
+        assert manifest.is_file(), f"{entry['name']}: missing {manifest}"
+
+
+# --------------------------------------------------------------------------- #
+# Plugin manifest
+# --------------------------------------------------------------------------- #
+def test_plugin_manifest_required_fields():
+    assert PLUGIN_MANIFEST.is_file(), f"missing {PLUGIN_MANIFEST}"
+    data = json.loads(PLUGIN_MANIFEST.read_text())
+    # `name` derives the command namespace (/flow:*); `description` is required.
+    assert data["name"] == "flow"
+    assert data.get("description")
+    assert data.get("version"), "pin an explicit version so /plugin gates updates"
+
+
+# --------------------------------------------------------------------------- #
+# Command parity (byte-identical copies of the source of truth)
+# --------------------------------------------------------------------------- #
+def test_plugin_commands_are_byte_identical_to_source():
+    source = {p.name: p for p in SOURCE_COMMANDS.glob("*.md")}
+    packaged = {p.name: p for p in PLUGIN_COMMANDS.glob("*.md")}
+    assert source, "no source flow commands found"
+    # No missing and no orphaned commands.
+    assert set(source) == set(packaged), (
+        f"command set drift: missing={set(source) - set(packaged)}, "
+        f"orphaned={set(packaged) - set(source)}"
+    )
+    for name, src in source.items():
+        assert src.read_bytes() == packaged[name].read_bytes(), (
+            f"{name} differs between source and plugin (run "
+            f"scripts/plugin-flow-sync.sh --write)"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Drift guard
+# --------------------------------------------------------------------------- #
+def test_sync_script_check_passes():
+    if shutil.which("bash") is None:  # pragma: no cover - bash present in CI
+        pytest.skip("bash unavailable")
+    result = subprocess.run(
+        ["bash", str(SYNC_SCRIPT), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"plugin-flow-sync --check reported drift:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Phase **B1** of the plugin-marketplace migration (epic #417 Phase B, ADR `docs/decisions/0001-plugin-marketplace-packaging.md`, decided in #442/#474). First implementation phase: it **proves the packaging shape end to end and retires nothing** - the legacy symlink installer runs in parallel.

## Changes

- **`.claude-plugin/marketplace.json`** - marketplace `name: "cpp"`, lists the `flow` plugin at `./plugins/flow`. Passes `claude plugin validate` (clean).
- **`plugins/flow/`** - the `flow` family packaged as an installable plugin: `.claude-plugin/plugin.json` (`name: "flow"`, v1.0.0) + 12 command files. Namespace derives from the plugin `name`, so commands load as `/flow:*`.
- **`scripts/plugin-flow-sync.sh`** - byte-identical drift guard: `--check` (default, exit 1 on drift) / `--write` (regen from source). Keeps `plugins/flow/commands/` in sync with the `.claude/commands/flow/` **source of truth** during the B1->B4 parallel window (git-free, so it runs in CI's validate container). Mirrors the `flow-skill-sync.py` / `eli5-core-drift.sh` idiom.
- **`tests/test_plugin_marketplace.py`** - 7 tests: manifest schema/required fields, `name==cpp`, `source==./plugins/flow`, 12-file byte-identical parity, drift-guard exit 0.
- **`.gitignore`** - negate the blanket `*.json` rule for the plugin manifests (`**` glob is forward-compatible for Phase B2's per-family plugins).
- **Docs** - CLAUDE.md Project Map + `scripts/` entry, README Project Structure, CHANGELOG `Added`. (The README/CLAUDE install-path *cutover* is deliberately deferred to Phase B5.)

## Acceptance criteria (issue #477)

- [x] `.claude-plugin/marketplace.json` at the CPP root listing plugins + source dirs
- [x] Package the `flow` family as `plugins/flow/` with `.claude-plugin/plugin.json`
- [x] Prove `/plugin install flow@cpp` loads the flow commands alongside the installer
- [x] Validate the plugin.json / marketplace.json schema

## Test plan / verification

- `claude plugin validate .claude-plugin/marketplace.json` -> passed (clean, no warnings)
- `claude plugin validate plugins/flow` -> passed (only advisory "no frontmatter" warnings on the source commands, out of B1 scope)
- End-to-end proof against a local marketplace, then torn down to restore global state:
  - `claude plugin marketplace add <repo>` -> `Successfully added marketplace: cpp`
  - `claude plugin install flow@cpp` -> `Successfully installed plugin: flow@cpp (scope: user)`
  - `claude plugin details flow@cpp` -> all 12 commands (`start`, `auto`, `finish`, `merge`, `eli5`, ...) enumerated
- `python -m lib.cicd run --plan finish` -> lint + test + security_scan all SUCCESS

## Notes

- **Nothing retired.** The installer, global-skill mirror, and drift scripts are untouched. Parity-then-retire happens in Phase B4.
- The `/plugin marketplace add cooneycw/claude-power-pack` GitHub-repo form resolves once this lands on `main`; the mechanism was proven with the equivalent local-path add.
- Command frontmatter warnings are on the canonical source commands; adding frontmatter would rewrite `.claude/commands/flow/*.md` (and break the byte-identical invariant) - noted as a candidate for Phase B2.

Closes #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)