### PR TITLE
feat(security): risk-graded /security:permissions + drift guard vs #482 census (Closes #495)

### DIFF
--- a/.claude/commands/security/help.md
+++ b/.claude/commands/security/help.md
@@ -29,7 +29,15 @@ and `/security:*` for secrets, dependencies, and the flow gate.
 | `/security:quick` | Fast scan: native checks only (zero deps) |
 | `/security:deep` | Deep scan: includes git history analysis |
 | `/security:explain <ID>` | Detailed explanation of a finding type |
+| `/security:permissions` | Risk-graded permission audit (see below) |
 | `/security:help` | This help page |
+
+> **Harness permissions (not a code scanner):** `/security:permissions` is a
+> risk-graded wrapper around Claude Code's native `/fewer-permission-prompts`. It
+> audits which tool calls run without prompting and proposes an **allow / ask /
+> deny** policy (backed by `scripts/classify-tool-risk.py`), sorting every
+> observed command into tiers - read-only vs safe-local-write vs arbitrary
+> code-execution vs destructive. Distinct from the code/secret scans above.
 
 ## Scan Modes
 

--- a/.claude/commands/security/permissions.md
+++ b/.claude/commands/security/permissions.md
@@ -1,0 +1,87 @@
+---
+description: Risk-graded permission audit - wraps native /fewer-permission-prompts with allow/ask/deny tiers
+allowed-tools: Bash(python3:*), Read(*.json), Edit(*.json), Write(*.json)
+---
+
+# Security: Permissions Audit
+
+A risk-graded wrapper around Claude Code's native **`/fewer-permission-prompts`**.
+The native skill does a binary read-only / skip split and emits an allowlist only.
+This command adds `scripts/classify-tool-risk.py` to sort every observed tool call
+into risk tiers, then proposes a full **allow / ask / deny** policy.
+
+> Use the native `/fewer-permission-prompts` for the quick read-only allowlist.
+> Use this when you also want the mutation and danger tiers surfaced and guarded
+> (it never edits `permissions.ask` / `permissions.deny` unless you asked for the
+> graded policy, which this command does by design).
+
+## What it produces
+
+- **allow** - read-only commands not already auto-allowed (e.g. `git fetch`) +
+  the *safe, reversible* subset of local writes (`git add`, `git commit`,
+  `mkdir`, `git worktree add`) + read-only MCP tools seen >= 3 times.
+- **ask** - the recoverable-but-dangerous tier, gated *even under auto-accept*:
+  `git push --force`, `git reset --hard`, `rm -rf`.
+- **deny** - secrets that must never be auto-edited: `.env`, `*.pem`, `*.key`,
+  `id_rsa*`.
+
+## Steps
+
+1. **Run the graded classifier** over recent transcripts:
+   ```bash
+   python3 scripts/classify-tool-risk.py --limit 50
+   ```
+   (Run from the CPP checkout. It scans `~/.claude/projects/**/*.jsonl` across all
+   projects, not just the current one.)
+
+2. **Present the tiers** as a table (tier, count, examples, verdict). Note that
+   the READONLY-AUTO tier is already covered by Claude Code and needs no rule -
+   do not propose those (see the native skill's auto-allow list).
+
+3. **Propose the policy from the tiers:**
+   - `allow`: READONLY-ADDABLE + the SAFE subset of WRITE-LOCAL. Exclude anything
+     with a data-loss mode - `git checkout`, `git rm`, `git branch -D`,
+     `git worktree remove`, `git reset` classify as DESTRUCTIVE, not allow.
+     CODE-EXEC / DUAL-USE-NET / SCRIPT-EXEC are **never** allowlisted (arbitrary
+     execution or ambiguous network I/O).
+   - `ask`: the DESTRUCTIVE tier (force push, `reset --hard`, `rm -rf`) so it
+     prompts even under auto-accept.
+   - `deny`: secret files (`.env`, `**/.env`, `*.pem`, `*.key`, `id_rsa*`).
+
+4. **Merge into the project `.claude/settings.json`** (NOT `settings.local.json`,
+   NOT `~/.claude/settings.json`): preserve existing keys and entries,
+   de-duplicate, never remove or reorder. Precedence is **deny > ask > allow**, so
+   a secret `deny` overrides a broad `Edit(**)` allow.
+
+5. **Report**: what was added to each tier, what was already covered by Claude
+   Code's auto-allow (so no rule was needed), and what was excluded and why
+   (e.g. dropped `python3`/`uv`/`make` - arbitrary code execution; dropped
+   `curl`/`gh api` - dual-use network).
+
+## File-edit scope (the git-tracked nuance)
+
+To auto-allow file edits "only within the git commit list": Claude Code
+permissions are path-glob based, not git-aware, so this cannot be expressed
+directly. Two implementations:
+
+- **Approximation (default):** `Edit(**)` / `Write(**)` for the repo tree plus a
+  `deny` list for sensitive gitignored files (`.env`, keys).
+- **Exact (offer):** a `PreToolUse` hook that runs `git check-ignore` on the edit
+  target and blocks ignored paths. This literally scopes edits to tracked files.
+  Offered, not applied by default.
+
+## Notes
+
+- Wraps, does not replace, the native `/fewer-permission-prompts` (a built-in
+  Claude Code skill, not a CPP skill - which is why its graded extension lives
+  in CPP).
+- Classifier: `scripts/classify-tool-risk.py` (the **canonical** risk taxonomy).
+  Re-run anytime for a fresh view.
+- Complements the **real-time** side: the `#482` permission-census hook
+  (`scripts/hook-permission-census.sh`) captures prompts as they happen and
+  vendors the same taxonomy inline. This command is the **retroactive** side
+  (mine all transcripts, propose a policy in one pass). `scripts/tool-risk-drift.py`
+  guards the two taxonomies' safety-critical sets in sync.
+- The destructive `ask`/`deny` guards are more protective in
+  `~/.claude/settings.json` (global, every project); the allowlist is
+  project-scoped by design. Offer to promote the guards to global.

--- a/scripts/classify-tool-risk.py
+++ b/scripts/classify-tool-risk.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Risk-graded classifier for observed Bash/MCP tool calls in Claude Code transcripts.
+
+Complements the native /fewer-permission-prompts skill (which does a binary
+read-only/skip split) by sorting every observed command into risk tiers, so you
+can tell a safe-reversible local write (git add) from arbitrary code execution
+(python3) from a destructive op (rm -rf).
+
+Usage:
+    python3 scripts/classify-tool-risk.py [--limit N] [--projects DIR]
+
+Tiers (best -> worst):
+    READONLY-AUTO     already auto-allowed by Claude Code; informative
+    READONLY-ADDABLE  read-only but not auto-allowed -> safe allowlist candidate
+    WRITE-LOCAL       mutates local state, reversible, low blast radius
+    WRITE-OUTWARD     creates/publishes to a remote (GitHub, git push); reversible-ish
+    DUAL-USE-NET      reads OR writes over the network (curl, gh api); ambiguous
+    CODE-EXEC         interpreters / package runners / shells -> arbitrary execution
+    SCRIPT-EXEC       opaque local scripts; vet individually
+    DESTRUCTIVE       irreversible / data-loss (rm, --force, --hard)
+    SHELL-CTL/OTHER   shell keywords and tokenizer noise
+"""
+# CANONICAL taxonomy: this file is CPP's source of truth for permission risk
+# tiers. scripts/hook-permission-census.sh (the #482 real-time census hook)
+# carries a vendored inline copy for fail-open self-containment;
+# scripts/tool-risk-drift.py guards the safety-critical sets (DESTRUCTIVE_TOKENS,
+# CODE_EXEC) between the two so a new dangerous command cannot be missed by one.
+import argparse
+import glob
+import json
+import os
+import re
+from collections import Counter, defaultdict
+
+PREFIX = {"sudo", "command", "nice", "nohup", "time", "env"}
+SHELL_KW = {"for", "if", "while", "set", "case", "function", "then", "do", "done",
+            "fi", "else", "elif", "{", "}", "(", "[[", "]]", ":", "&&", "||", "#", "\\"}
+RO_ANY = {
+    "cal", "uptime", "cat", "head", "tail", "wc", "stat", "strings", "hexdump", "od",
+    "nl", "id", "uname", "free", "df", "du", "locale", "groups", "nproc", "basename",
+    "dirname", "realpath", "cut", "paste", "tr", "column", "tac", "rev", "fold",
+    "expand", "unexpand", "fmt", "comm", "cmp", "numfmt", "readlink", "diff", "true",
+    "false", "sleep", "which", "type", "expr", "seq", "tsort", "pr", "echo", "ls", "cd",
+    "xargs", "file", "sed", "sort", "man", "help", "netstat", "ps", "base64", "grep",
+    "egrep", "fgrep", "sha256sum", "sha1sum", "md5sum", "tree", "date", "hostname",
+    "lsof", "pgrep", "tput", "ss", "fd", "fdfind", "rg", "jq", "uniq", "history",
+    "arch", "ifconfig", "pyright", "find", "printf", "test", "pwd", "whoami",
+}
+CODE_EXEC = {"python", "python3", "node", "bun", "deno", "ruby", "perl", "php", "lua",
+             "npx", "bunx", "uvx", "uv", "pip", "pip3", "eval", "exec", "bash", "sh",
+             "zsh", "fish", "ssh", "gcc", "cc"}
+TASK_RUNNER = {"make", "just", "rake", "task", "cargo", "go", "npm", "yarn", "pnpm",
+               "gradle", "mvn", "tsc"}
+DUAL_NET = {"curl", "wget", "http", "https", "aws", "gcloud", "az", "scp", "rsync",
+            "nc", "telnet"}
+GIT_RO = {"status", "log", "diff", "show", "blame", "tag", "remote", "ls-files",
+          "ls-remote", "rev-parse", "describe", "reflog", "shortlog", "cat-file",
+          "for-each-ref", "stash", "rev-list", "check-ignore", "symbolic-ref",
+          "name-rev", "cherry", "whatchanged", "grep", "count-objects", "merge-base"}
+GIT_REMOTE_READ = {"fetch", "clone"}
+GIT_REMOTE_WRITE = {"push", "pull"}
+GIT_WRITE = {"add", "checkout", "switch", "restore", "mv", "reset", "commit", "branch",
+             "worktree", "merge", "rebase", "cherry-pick", "apply", "am", "clean",
+             "gc", "init", "config", "update-ref", "update-index", "notes", "revert",
+             "filter-branch", "filter-repo", "subtree", "stash-push"}
+GH_RO = {"view", "list", "status", "diff", "checks"}
+GH_WRITE_ACTS = {"create", "close", "comment", "edit", "delete", "merge", "reopen",
+                 "ready", "add", "remove", "rename", "develop"}
+DESTRUCTIVE_TOKENS = {"rm", "rmdir", "shred", "mkfs", "dd", "truncate", "fdisk"}
+
+
+def tokens(cmd):
+    seg = re.split(r'\|\||&&|[|;]', cmd, 1)[0].strip()
+    t = seg.split()
+    while t and re.match(r'^[A-Za-z_][A-Za-z0-9_]*=', t[0]):
+        t.pop(0)
+    while t and t[0] in PREFIX:
+        t.pop(0)
+        while t and re.match(r'^[A-Za-z_][A-Za-z0-9_]*=', t[0]):
+            t.pop(0)
+    if t and t[0] == "timeout":
+        t.pop(0)
+        if t:
+            t.pop(0)
+    return t
+
+
+def _git_sub(t):
+    rest = t[1:]
+    i = 0
+    while i < len(rest):
+        x = rest[i]
+        if x in ("-C", "-c"):
+            i += 2
+            continue
+        if x.startswith("-"):
+            i += 1
+            continue
+        return rest[i:]
+    return []
+
+
+def classify(cmd):
+    """Return (tier, label) for a shell command string."""
+    t = tokens(cmd)
+    if not t:
+        return ("OTHER", "?")
+    c = t[0].split('/')[-1]
+    if c in SHELL_KW:
+        return ("SHELL-CTL", c)
+    if c in DESTRUCTIVE_TOKENS:
+        return ("DESTRUCTIVE", c)
+    if c == "git":
+        sub = _git_sub(t)
+        s = sub[0] if sub else ""
+        flags = {x for x in sub if x.startswith("-")}
+        if s in GIT_REMOTE_WRITE:
+            if flags & {"-f", "--force", "--force-with-lease"}:
+                return ("DESTRUCTIVE", f"git {s} --force")
+            return ("WRITE-OUTWARD", f"git {s}")
+        if s in GIT_REMOTE_READ:
+            return ("READONLY-ADDABLE", f"git {s}")
+        if s == "reset" and (flags & {"--hard"}):
+            return ("DESTRUCTIVE", "git reset --hard")
+        if s in ("checkout", "restore", "clean"):
+            return ("DESTRUCTIVE", f"git {s} (can discard changes)")
+        if s == "rm":
+            return ("DESTRUCTIVE", "git rm")
+        if s == "branch" and (flags & {"-D", "-d", "--delete"}):
+            return ("DESTRUCTIVE", "git branch -D")
+        if s == "worktree":
+            ss = sub[1] if len(sub) > 1 else ""
+            if ss == "list":
+                return ("READONLY-AUTO", "git worktree list")
+            if ss == "remove":
+                return ("DESTRUCTIVE", "git worktree remove")
+            return ("WRITE-LOCAL", f"git worktree {ss}")
+        if s in GIT_RO:
+            return ("READONLY-AUTO", f"git {s}")
+        if s in GIT_WRITE:
+            return ("WRITE-LOCAL", f"git {s}")
+        return ("OTHER", f"git {s}")
+    if c == "gh":
+        grp = t[1] if len(t) > 1 else ""
+        act = t[2] if len(t) > 2 else ""
+        if grp == "api":
+            return ("DUAL-USE-NET", "gh api")
+        if act in GH_RO or (grp == "auth" and act == "status"):
+            return ("READONLY-AUTO", f"gh {grp} {act}")
+        if act in GH_WRITE_ACTS:
+            return ("WRITE-OUTWARD", f"gh {grp} {act}")
+        return ("OTHER", f"gh {grp} {act}".strip())
+    if c == "docker":
+        sub = t[1] if len(t) > 1 else ""
+        if sub in ("ps", "images", "logs", "inspect", "version", "info", "top", "port", "stats"):
+            return ("READONLY-AUTO", f"docker {sub}")
+        return ("WRITE-LOCAL", f"docker {sub}")
+    if c in CODE_EXEC:
+        return ("CODE-EXEC", c)
+    if c in TASK_RUNNER:
+        return ("CODE-EXEC", f"{c} (task-runner)")
+    if c in DUAL_NET:
+        return ("DUAL-USE-NET", c)
+    if c in RO_ANY:
+        return ("READONLY-AUTO", c)
+    if c in ("mkdir", "touch", "tee", "cp", "ln", "chmod", "chown"):
+        return ("WRITE-LOCAL", c)
+    if c.endswith(".sh"):
+        return ("SCRIPT-EXEC", c)
+    return ("OTHER", c)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--limit", type=int, default=50,
+                    help="scan the N most-recently-modified transcripts (default 50)")
+    ap.add_argument("--projects", default=os.path.expanduser("~/.claude/projects"),
+                    help="Claude Code projects dir")
+    args = ap.parse_args()
+
+    files = sorted(glob.glob(os.path.join(args.projects, "**", "*.jsonl"), recursive=True),
+                   key=os.path.getmtime, reverse=True)[:args.limit]
+
+    tier = defaultdict(Counter)
+    mcp = Counter()
+    for fp in files:
+        try:
+            for line in open(fp, errors="ignore"):
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                content = (obj.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                for it in content:
+                    if not isinstance(it, dict) or it.get("type") != "tool_use":
+                        continue
+                    name = it.get("name", "")
+                    if name == "Bash":
+                        t, label = classify((it.get("input") or {}).get("command", ""))
+                        tier[t][label] += 1
+                    elif name.startswith("mcp__"):
+                        mcp[name] += 1
+        except OSError:
+            continue
+
+    order = ["READONLY-AUTO", "READONLY-ADDABLE", "WRITE-LOCAL", "WRITE-OUTWARD",
+             "DUAL-USE-NET", "CODE-EXEC", "SCRIPT-EXEC", "DESTRUCTIVE", "SHELL-CTL", "OTHER"]
+    print(f"scanned {len(files)} transcripts under {args.projects}\n")
+    for t in order:
+        if t not in tier:
+            continue
+        print(f"### {t}  (total {sum(tier[t].values())})")
+        for label, cnt in tier[t].most_common(15):
+            print(f"  {cnt:5d}  {label}")
+        print()
+    if mcp:
+        print("### MCP")
+        for name, cnt in mcp.most_common():
+            ro = any(k in name for k in ("read", "get", "list", "search", "view", "health"))
+            print(f"  {cnt:5d}  {name}  {'[read-only]' if ro else '[check: may mutate]'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tool-risk-drift.py
+++ b/scripts/tool-risk-drift.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Drift guard for CPP's shared permission-risk taxonomy.
+
+CPP classifies command risk in two places that MUST agree on what is dangerous:
+
+  - scripts/classify-tool-risk.py      canonical taxonomy; used by
+                                       /security:permissions (retroactive audit)
+  - scripts/hook-permission-census.sh  a vendored inline copy (#482 census hook,
+                                       kept self-contained so it stays fail-open)
+
+This checks that the two SAFETY-CRITICAL sets are identical between them:
+
+  - DESTRUCTIVE_TOKENS  commands that are never allowlisted (rm, dd, ...)
+  - CODE_EXEC           interpreters / runners = arbitrary execution
+
+so a new dangerous command added to one classifier can never be silently missed
+by the other. Non-safety sets (task-runner, dual-use-net) may differ benignly and
+are deliberately NOT guarded - they land in never-allowlist tiers either way.
+
+Advisory + fail-open: warns and exits 0 by default; `--strict` exits 1 on drift
+(for CI). A missing or unparseable source is skipped, never fatal.
+
+Same discipline as scripts/eli5-core-drift.sh (the eli5-gate vendor guard).
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+CANONICAL = "scripts/classify-tool-risk.py"
+VENDORED = "scripts/hook-permission-census.sh"
+GUARDED_SETS = ("DESTRUCTIVE_TOKENS", "CODE_EXEC")
+
+
+def extract_set(text, name):
+    """Return the set of double-quoted tokens in a `NAME = { ... }` literal."""
+    m = re.search(name + r"\s*=\s*\{(.*?)\}", text, re.S)
+    if not m:
+        return None
+    return set(re.findall(r'"([^"]+)"', m.group(1)))
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 if any guarded set has drifted (CI mode)")
+    ap.add_argument("--root", default=".", help="repository root (default: cwd)")
+    args = ap.parse_args()
+    root = Path(args.root)
+
+    try:
+        canon = (root / CANONICAL).read_text()
+        vendor = (root / VENDORED).read_text()
+    except OSError as exc:
+        print(f"tool-risk-drift: cannot read a source ({exc}); skipping (fail-open)")
+        return 0
+
+    drift = False
+    for name in GUARDED_SETS:
+        a = extract_set(canon, name)
+        b = extract_set(vendor, name)
+        if a is None or b is None:
+            where = CANONICAL if a is None else VENDORED
+            print(f"tool-risk-drift: {name} not found in {where}; skipping")
+            continue
+        if a == b:
+            print(f"tool-risk-drift: {name} in sync ({len(a)} tokens)")
+        else:
+            drift = True
+            print(f"tool-risk-drift: DRIFT in {name}")
+            print(f"  only in {CANONICAL}: {sorted(a - b)}")
+            print(f"  only in {VENDORED}:  {sorted(b - a)}")
+
+    if drift:
+        print("tool-risk-drift: reconcile the two classifiers (canonical is "
+              f"{CANONICAL}).")
+        if args.strict:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The **retroactive, risk-graded** complement to native `/fewer-permission-prompts`
(flat allowlist) and #482's **real-time** risk-rated permission-census hook.

- `scripts/classify-tool-risk.py` - canonical 7-tier risk classifier
  (read-only / safe-local-write / write-outward / dual-use-net / code-exec /
  script-exec / destructive).
- `.claude/commands/security/permissions.md` - `/security:permissions`: wraps the
  native skill, proposes a full **allow / ask / deny** policy from the tiers.
- `scripts/tool-risk-drift.py` - **drift guard** against #482. Its census hook
  vendors the same taxonomy inline (fail-open self-containment); this asserts the
  safety-critical sets (`DESTRUCTIVE_TOKENS`, `CODE_EXEC`) stay identical, so a new
  dangerous command can't be missed by one classifier. Advisory + fail-open,
  `--strict` for CI. Mirrors `scripts/eli5-core-drift.sh`.
- `security/help.md` - wired in, flagged as harness-permissions (not a code scan).

## De-duplication (why the drift guard)

#482 evolved from "census" to "risk-*rated* census" and shipped an inline copy of
this taxonomy. Rather than let two copies drift, this makes
`classify-tool-risk.py` canonical and guards the census hook's vendored copy -
the CPP eli5-gate vendor+drift pattern (#443) applied to the risk taxonomy.
`DESTRUCTIVE_TOKENS` (7) and `CODE_EXEC` (24) are verified in sync.

## Not in scope

The `PreToolUse` policy hook (git-check-ignore edit scoping) is **#482's deferred
follow-up** ("file separately when census data exists").

## Test plan

- [x] `lib.cicd run --plan finish`: lint, test (full suite), security all SUCCESS
- [x] `scripts/tool-risk-drift.py`: both safety sets in sync (exit 0); `--strict` exit 0
- [x] ruff clean on both scripts; no em/en dashes

Closes #495