### PR TITLE
fix(cpp-memory): distinguish driver-load failure from store-unreachable (Closes #497)

### DIFF
--- a/.claude/commands/self-improvement/memory.md
+++ b/.claude/commands/self-improvement/memory.md
@@ -36,11 +36,17 @@ cpp-memory reject --fingerprint <fp> --actor <user> --note "<why>"        # stop
 ```
 
 If `cpp-memory` is not yet on PATH: `bash scripts/install-memory-harness.sh`, or
-run `python -m lib.cpp_memory ...` from the repo root.
+from the repo root run
+`uv run --no-project --python 3.11 --with 'psycopg[binary]>=3.1' -- python -m lib.cpp_memory ...`
+(bare `--with psycopg` has no libpq, fails to load, and misreads as
+store-down, #497).
 
 ## Routine
 
-1. `cpp-memory ping` - if unreachable, continue in degraded mode and note it.
+1. `cpp-memory ping` - if unreachable, check `driver_error` first: non-null =
+   local driver gap (store never contacted; fix with `psycopg[binary]`, #497),
+   null = real store outage. Either way continue in degraded mode and note
+   which layer failed.
 2. Gather friction signals: permission prompts, gate failures/retries, red output
    narrated-past, manual interventions, infra traps, portable knowledge.
 3. Classify each `(friction_class, fix_scope)` per the bucket rules.

--- a/codex/prompts/cpp-memory.md
+++ b/codex/prompts/cpp-memory.md
@@ -6,8 +6,10 @@ re-proposed.
 This is consult-not-push, fail-open, and human-confirmed. It never distributes
 config and never auto-applies permission fixes. The whole interface is the
 `cpp-memory` command (install once with `bash scripts/install-memory-harness.sh`
-from the claude-power-pack repo; falls back to `python -m lib.cpp_memory` from
-that repo root).
+from the claude-power-pack repo; falls back to
+`uv run --no-project --python 3.11 --with 'psycopg[binary]>=3.1' -- python -m lib.cpp_memory`
+from that repo root - bare `--with psycopg` has no libpq and misreads as
+store-down, #497).
 
 Bucket rules - what may enter the SHARED store:
 - Portable knowledge / infra trap (reusable across VMs and repos) -> SHARED
@@ -16,8 +18,11 @@ Bucket rules - what may enter the SHARED store:
 - Per-machine permission fix -> this machine only (`--local-only`); never shared.
 
 Steps:
-1. `cpp-memory ping` - if not reachable, continue in degraded mode (writes land
-   in a local `.claude/learnings.md`); say so in your summary.
+1. `cpp-memory ping` - if not reachable, check `driver_error` first: non-null
+   means the psycopg driver failed to load locally (store never contacted; fix
+   with `psycopg[binary]`, #497), null means a real store outage. Either way
+   continue in degraded mode (writes land in a local `.claude/learnings.md`);
+   say which layer failed in your summary.
 2. Scan this session for friction signals: permission prompts you needed, gate
    failures/retries, errors narrated-past, manual corrections, infra traps, and
    portable knowledge learned.

--- a/docs/skills/common-memory.md
+++ b/docs/skills/common-memory.md
@@ -38,9 +38,19 @@ cpp-memory reject --fingerprint <fp> --actor <user> --note "<why not>"     # sto
 ```
 
 `cpp-memory` is a thin wrapper: it self-locates the CPP repo, sets `PYTHONPATH`,
-and runs via `uv` (fetching psycopg on demand) or system python3. If neither the
-store nor a driver is available, every write falls back to a local note - the
-routine never blocks.
+and runs via `uv` (fetching `psycopg[binary]` on demand - the `binary` extra
+bundles libpq) or system python3. If neither the store nor a driver is
+available, every write falls back to a local note - the routine never blocks.
+
+Invoking the module by hand instead? Use
+
+```bash
+uv run --no-project --python 3.11 --with 'psycopg[binary]>=3.1' -- python -m lib.cpp_memory ping
+```
+
+Bare `--with psycopg` installs a driver with **no libpq backend**: it fails to
+load ("no pq wrapper available") and `ping` then reads as the store being down
+when only the local driver is broken (#497).
 
 ## Backends (the mini-tier: md | local-pg | remote-pg)
 
@@ -75,8 +85,12 @@ guard below keeps them local regardless of backend.
 
 ## Routine (run after a session / flow run)
 
-1. **Reachability.** `cpp-memory ping`. If `reachable:false`, continue in degraded
-   mode (writes land in `.claude/learnings.md`); note it in the report.
+1. **Reachability.** `cpp-memory ping`. If `reachable:false`, check
+   `driver_error` FIRST: non-null means the psycopg driver failed to load
+   locally and the store was never contacted - fix the invocation
+   (`psycopg[binary]`), do not report the store down (#497). Only a null
+   `driver_error` is a real store outage; either way continue in degraded mode
+   (writes land in `.claude/learnings.md`) and note which layer failed.
 2. **Gather friction signals** from the session: permission prompts, quality-gate
    failures/retries, red output narrated-past, manual interventions/corrections,
    infra traps discovered, and portable knowledge learned.

--- a/lib/cpp_memory/backend.py
+++ b/lib/cpp_memory/backend.py
@@ -77,6 +77,16 @@ class StoreBackend(ABC):
     def ping(self) -> bool:
         """Round-trip reachability check (benign False on any failure)."""
 
+    def driver_error(self) -> str | None:
+        """Why the backend's driver failed to LOAD, or None (issue #497).
+
+        Disambiguates ``ping() -> False``: non-null means the failure is local
+        (e.g. psycopg installed without libpq - "no pq wrapper available") and
+        the store was never contacted; null means the store itself did not
+        answer. Backends with no driver dependency (md) always return None.
+        """
+        return None
+
     # --- consult / dedup ---------------------------------------------------- #
     @abstractmethod
     def is_known(self, fingerprint: str) -> dict | None:

--- a/lib/cpp_memory/cli.py
+++ b/lib/cpp_memory/cli.py
@@ -105,6 +105,10 @@ def main(argv=None) -> int:
             "federation": store.federation,
             "available": store.available(),
             "reachable": ok,
+            # Non-null = the driver failed to LOAD and the store was never
+            # contacted (local gap, fix psycopg[binary]) - do NOT read
+            # reachable:false as the store being down (issue #497).
+            "driver_error": store.driver_error(),
             "dsn_present": bool(getattr(store, "dsn", None)),
         }))
         return 0 if ok else 1
@@ -144,8 +148,16 @@ def main(argv=None) -> int:
         }
         if lid is None:
             # A pg tier is unreachable - fail-open to the local md ledger.
+            # Name the actual failure layer: a driver-load error means the
+            # store was never contacted (issue #497).
             path = append_local_learning(learning, args.repo or ".")
-            out.update(stored="local-fallback", reason="store unavailable", path=str(path))
+            driver_err = store.driver_error()
+            out.update(
+                stored="local-fallback",
+                reason="driver unavailable" if driver_err else "store unavailable",
+                driver_error=driver_err,
+                path=str(path),
+            )
         elif store.name == "md":
             # Tier i: the md ledger IS the store (first-class), not a fallback.
             out.update(stored="md", path=str(lid))

--- a/lib/cpp_memory/client.py
+++ b/lib/cpp_memory/client.py
@@ -21,9 +21,14 @@ log = logging.getLogger("cpp_memory")
 try:
     import psycopg
     _HAVE_PSYCOPG = True
-except Exception:  # pragma: no cover - driver is an optional runtime dep
+    _DRIVER_ERROR: str | None = None
+except Exception as _e:  # pragma: no cover - driver is an optional runtime dep
+    # Keep the load failure (e.g. psycopg's "no pq wrapper available" when
+    # installed without libpq) so ping can distinguish a local driver gap from
+    # the store being down (issue #497).
     psycopg = None
     _HAVE_PSYCOPG = False
+    _DRIVER_ERROR = str(_e) or _e.__class__.__name__
 
 _LEARNING_COLS = (
     "id", "fingerprint", "friction_class", "fix_scope",
@@ -62,6 +67,14 @@ class MemoryStore(StoreBackend):
 
     def available(self) -> bool:
         return bool(self.dsn) and _HAVE_PSYCOPG
+
+    def driver_error(self) -> str | None:
+        """The psycopg load failure, or None when the driver imported fine.
+
+        Non-null means the store was never contacted - ``reachable: false`` is
+        a LOCAL driver gap (fix: ``psycopg[binary]``), not a store outage (#497).
+        """
+        return _DRIVER_ERROR
 
     @contextmanager
     def _conn(self):

--- a/tests/test_cpp_memory.py
+++ b/tests/test_cpp_memory.py
@@ -295,6 +295,73 @@ class TestCli:
 
 
 # --------------------------------------------------------------------------- #
+# Driver-load failure vs store-unreachable (#497): a psycopg without libpq
+# ("no pq wrapper available") must NOT read as the store being down.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def driver_gap(monkeypatch):
+    """Simulate psycopg installed without libpq: import failed, DSN present."""
+    monkeypatch.setattr(client_mod, "_HAVE_PSYCOPG", False)
+    monkeypatch.setattr(client_mod, "_DRIVER_ERROR", "no pq wrapper available")
+    monkeypatch.setattr(
+        cli_mod, "select_backend",
+        lambda *a, **k: MemoryStore(
+            dsn="postgres://u:p@127.0.0.1:5432/db", name="remote-pg", federation="fleet",
+        ),
+    )
+
+
+class TestDriverErrorDisambiguation:
+    def test_store_driver_error_surfaced(self, driver_gap):
+        store = MemoryStore(dsn="postgres://u:p@127.0.0.1:5432/db")
+        assert store.ping() is False
+        assert store.driver_error() == "no pq wrapper available"
+
+    def test_store_driver_error_none_when_driver_loaded(self, monkeypatch):
+        monkeypatch.setattr(client_mod, "_DRIVER_ERROR", None)
+        assert MemoryStore(dsn="").driver_error() is None
+
+    def test_ping_names_the_driver_gap(self, driver_gap, capsys):
+        rc = cli_mod.main(["ping"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert out["reachable"] is False
+        assert out["driver_error"] == "no pq wrapper available"
+        assert out["dsn_present"] is True
+
+    def test_ping_driver_error_null_when_store_down(self, cli_offline, capsys, monkeypatch):
+        # Driver fine, store down: driver_error must stay null so the two
+        # failure layers cannot be conflated in either direction.
+        monkeypatch.setattr(client_mod, "_DRIVER_ERROR", None)
+        rc = cli_mod.main(["ping"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert out["driver_error"] is None
+
+    def test_record_fallback_names_driver_layer(self, driver_gap, capsys, tmp_path):
+        rc = cli_mod.main([
+            "record", "--class", "knowledge", "--scope", "knowledge",
+            "--title", "t", "--body", "b", "--repo", str(tmp_path),
+        ])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["stored"] == "local-fallback"
+        assert out["reason"] == "driver unavailable"
+        assert out["driver_error"] == "no pq wrapper available"
+
+    def test_record_fallback_store_down_keeps_old_reason(self, cli_offline, capsys, tmp_path, monkeypatch):
+        monkeypatch.setattr(client_mod, "_DRIVER_ERROR", None)
+        rc = cli_mod.main([
+            "record", "--class", "knowledge", "--scope", "knowledge",
+            "--title", "t", "--body", "b", "--repo", str(tmp_path),
+        ])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["reason"] == "store unavailable"
+        assert out["driver_error"] is None
+
+
+# --------------------------------------------------------------------------- #
 # learnings -> GitHub issue bridge (#463)
 # --------------------------------------------------------------------------- #
 class TestActionable:

--- a/tests/test_cpp_memory_backends.py
+++ b/tests/test_cpp_memory_backends.py
@@ -208,6 +208,8 @@ class TestCliBackendSurface:
         assert out["backend"] == "md"
         assert out["federation"] == "none"
         assert out["reachable"] is True
+        # md has no driver dependency: driver_error is always null (#497).
+        assert out["driver_error"] is None
 
     def test_record_md_is_first_class_not_fallback(self, monkeypatch, capsys, tmp_path):
         monkeypatch.setattr(cli_mod, "select_backend", lambda *a, **k: MarkdownStore(repo_root=tmp_path))


### PR DESCRIPTION
## Summary

A psycopg installed without libpq (bare `uv run --with psycopg`) raises `ImportError: no pq wrapper available` at import time. The fail-open client swallowed this and `ping` returned the same `{"reachable": false}` as a genuine store outage - which silently manufactured the entire "pending shared codify (#433 CLI absent)" false backlog on 2026-07-04 while the fleet store (PG 17.10 over Tailscale) was up the whole time.

### Changes

- **`lib/cpp_memory/client.py`** - capture the psycopg import failure in module-level `_DRIVER_ERROR`; expose `MemoryStore.driver_error()`.
- **`lib/cpp_memory/backend.py`** - `StoreBackend.driver_error() -> str | None`, non-abstract default `None` (the md backend has no driver dependency).
- **`lib/cpp_memory/cli.py`** - `ping` JSON gains `"driver_error"`; the `record` fail-open fallback now reports `reason: "driver unavailable"` vs `"store unavailable"` and carries `driver_error`, so a retro cannot misread a local driver gap as store-down.
- **Docs** (`docs/skills/common-memory.md`, `.claude/commands/self-improvement/memory.md`, `codex/prompts/cpp-memory.md`) - spell out the correct manual fallback invocation (`uv run --no-project --python 3.11 --with 'psycopg[binary]>=3.1' -- python -m lib.cpp_memory ...`) and the degraded-mode rule: non-null `driver_error` means fix the local driver, the store was never contacted. Note: `scripts/cpp-memory` (the wrapper) has used `psycopg[binary]` since #433 - the defect lived in the documented bare-module fallback path.

### Test plan

- [x] 6 new tests: driver-gap ping emits non-null `driver_error` with `dsn_present:true`; store-down ping keeps `driver_error:null`; `record` fallback names the correct layer in both directions; md backend always null.
- [x] Full suite: 844 passed.
- [x] Deterministic runner `--plan finish`: lint + test + security 3/3 SUCCESS.
- [x] Live-verified on proxVMgemma07 against the fleet store: bare psycopg -> `reachable:false` + full "no pq wrapper available" chain in `driver_error`; `psycopg[binary]` -> `reachable:true, driver_error:null`.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)