### PR TITLE
fix(deps): declare pydantic/pyyaml as main dependencies (Closes #500)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,13 @@
 name = "claude-power-pack"
 version = "7.3.0"
 requires-python = ">=3.11"
-dependencies = []
+# pydantic/pyyaml are runtime deps of lib.cicd (hard imports on the CLI chain);
+# keeping them out of the dev extra lets `uv run --project` provision a working
+# runner env in fresh checkouts/worktrees (issue #500).
+dependencies = ["pydantic>=2.0", "pyyaml>=6.0"]
 
 [project.optional-dependencies]
-dev = ["mypy>=1.10", "pydantic>=2.0", "pytest>=8.0", "pyyaml>=6.0", "ruff>=0.4", "types-PyYAML>=6.0", "types-requests>=2.31"]
+dev = ["mypy>=1.10", "pytest>=8.0", "ruff>=0.4", "types-PyYAML>=6.0", "types-requests>=2.31"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -15,13 +15,15 @@ wheels = [
 name = "claude-power-pack"
 version = "7.3.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
 
 [package.optional-dependencies]
 dev = [
     { name = "mypy" },
-    { name = "pydantic" },
     { name = "pytest" },
-    { name = "pyyaml" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -30,9 +32,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31" },


### PR DESCRIPTION
## Summary

- Move `pydantic>=2.0` and `pyyaml>=6.0` from the `dev` extra into `[project].dependencies` - they are hard runtime imports on the `lib.cicd` CLI chain (`config.py` imports pydantic, `manifest.py` imports yaml at module level), not dev tooling.
- Regenerate `uv.lock`; the diff is pure recategorization with zero version changes (image-security/Trivy gate unaffected).
- This is option 2 from the issue: it fixes all nine `uv run --project` runner invocation sites (auto.md x2, finish.md x2, merge.md, check.md, doctor.md x3) structurally, including two the issue did not list, and cannot be regressed by a future call site forgetting `--extra dev`.
- Tooling (`mypy`, `pytest`, `ruff`, type stubs) stays in the `dev` extra; `uv sync --extra dev` and the Makefile targets behave as before.

## Test plan

- [x] Repro verified: from a fresh worktree with no `.venv`, `uv run --project <wt> python -m lib.cicd check --summary` now provisions the env (6 packages) and runs - previously died with `ModuleNotFoundError: pydantic`
- [x] `make lint` passes
- [x] `make test` passes (891 tests)
- [x] Deterministic finish gate passes (lint, test, security_scan 3/3)
- [x] `uv.lock` diff reviewed: recategorization only, no version bumps

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)