### PR TITLE
feat(flow): live-driver guard on /flow:auto resume path (Closes #503)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -106,7 +106,27 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   verify you are NOT on main/master and use the current directory. This is a
   resumed run - remember it so Step 7 uses the git cleanup fallback, not
   `ExitWorktree`.
-- **Worktree exists** (prior session): switch into it with
+- **Worktree exists** (prior session): before entering, guard against a
+  CONCURRENT live driver (issue #503). On a box running several Claude sessions,
+  another session may be mid-implementation in this very worktree; entering it
+  lets two drivers fight over one checkout, and THIS run's Step-7 cleanup can
+  delete the other driver's cwd. Run BOTH resume checks first:
+  ```bash
+  WT_PATH="<path from git worktree list>"
+  CPP_DIR=""
+  for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+    [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+  done
+  # 1. Fresh dirty-file mtimes => a live driver is SUSPECTED (advisory, fail-open).
+  [ -x "$CPP_DIR/scripts/flow-live-driver-guard.sh" ] && \
+    "$CPP_DIR/scripts/flow-live-driver-guard.sh" "$WT_PATH"
+  # 2. An already-shipped branch is the other resume hazard (concurrent-sessions discipline).
+  gh pr list --head "$BRANCH" --json number,state,url --jq '.[]'
+  ```
+  If the guard prints `FLOW_LIVE_DRIVER: suspected` (a dirty file touched within
+  ~30m) OR `gh pr list --head` shows an open/merged PR, STOP and require EXPLICIT
+  user confirmation that no other live session owns this worktree before calling
+  `EnterWorktree(path="$WT_PATH")`. If both are clear, switch in with
   `EnterWorktree(path="<path from git worktree list>")`. Resumed run - Step 7 uses
   the git cleanup fallback.
 - **Remote branch exists, no local worktree** (cross-machine pickup): the native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@
 
 ### Added
 
+- **Concurrent live-driver guard on the /flow:auto resume path** (issue #503) -
+  `scripts/flow-live-driver-guard.sh` inspects the dirty-file mtimes in a
+  worktree that `/flow:auto` is about to resume into and reports
+  `FLOW_LIVE_DRIVER: suspected` when any file was modified within a freshness
+  window (default 30m, `--threshold-minutes N`), the signature of ANOTHER live
+  session mid-implementation in that checkout. On a box running several Claude
+  sessions this stops a second driver from entering a worktree the first still
+  owns, whose Step-7 cleanup could then delete the first driver's cwd. The guard
+  is advisory and fail-open (exit 0 unless `--exit-code`); Step 1's "Worktree
+  exists" branch now runs it plus `gh pr list --head "$BRANCH"` and requires
+  explicit confirmation before entering when either flags a hazard. Pinned by
+  `tests/test_flow_live_driver_guard.py`.
+
 - **Multi-harness skill generation** (issue #446, epic #417 Phase C) - surviving
   CPP command families are now consumable from Codex CLI off the same single
   source Claude Code uses (`.claude/commands/<family>/*.md`, ADR 0001 section 5).

--- a/codex/prompts/flow-auto.md
+++ b/codex/prompts/flow-auto.md
@@ -115,7 +115,27 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   verify you are NOT on main/master and use the current directory. This is a
   resumed run - remember it so Step 7 uses the git cleanup fallback, not
   `ExitWorktree`.
-- **Worktree exists** (prior session): switch into it with
+- **Worktree exists** (prior session): before entering, guard against a
+  CONCURRENT live driver (issue #503). On a box running several Claude sessions,
+  another session may be mid-implementation in this very worktree; entering it
+  lets two drivers fight over one checkout, and THIS run's Step-7 cleanup can
+  delete the other driver's cwd. Run BOTH resume checks first:
+  ```bash
+  WT_PATH="<path from git worktree list>"
+  CPP_DIR=""
+  for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+    [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+  done
+  # 1. Fresh dirty-file mtimes => a live driver is SUSPECTED (advisory, fail-open).
+  [ -x "$CPP_DIR/scripts/flow-live-driver-guard.sh" ] && \
+    "$CPP_DIR/scripts/flow-live-driver-guard.sh" "$WT_PATH"
+  # 2. An already-shipped branch is the other resume hazard (concurrent-sessions discipline).
+  gh pr list --head "$BRANCH" --json number,state,url --jq '.[]'
+  ```
+  If the guard prints `FLOW_LIVE_DRIVER: suspected` (a dirty file touched within
+  ~30m) OR `gh pr list --head` shows an open/merged PR, STOP and require EXPLICIT
+  user confirmation that no other live session owns this worktree before calling
+  `EnterWorktree(path="$WT_PATH")`. If both are clear, switch in with
   `EnterWorktree(path="<path from git worktree list>")`. Resumed run - Step 7 uses
   the git cleanup fallback.
 - **Remote branch exists, no local worktree** (cross-machine pickup): the native

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -106,7 +106,27 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   verify you are NOT on main/master and use the current directory. This is a
   resumed run - remember it so Step 7 uses the git cleanup fallback, not
   `ExitWorktree`.
-- **Worktree exists** (prior session): switch into it with
+- **Worktree exists** (prior session): before entering, guard against a
+  CONCURRENT live driver (issue #503). On a box running several Claude sessions,
+  another session may be mid-implementation in this very worktree; entering it
+  lets two drivers fight over one checkout, and THIS run's Step-7 cleanup can
+  delete the other driver's cwd. Run BOTH resume checks first:
+  ```bash
+  WT_PATH="<path from git worktree list>"
+  CPP_DIR=""
+  for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-pack; do
+    [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ] && { CPP_DIR="$dir"; break; }
+  done
+  # 1. Fresh dirty-file mtimes => a live driver is SUSPECTED (advisory, fail-open).
+  [ -x "$CPP_DIR/scripts/flow-live-driver-guard.sh" ] && \
+    "$CPP_DIR/scripts/flow-live-driver-guard.sh" "$WT_PATH"
+  # 2. An already-shipped branch is the other resume hazard (concurrent-sessions discipline).
+  gh pr list --head "$BRANCH" --json number,state,url --jq '.[]'
+  ```
+  If the guard prints `FLOW_LIVE_DRIVER: suspected` (a dirty file touched within
+  ~30m) OR `gh pr list --head` shows an open/merged PR, STOP and require EXPLICIT
+  user confirmation that no other live session owns this worktree before calling
+  `EnterWorktree(path="$WT_PATH")`. If both are clear, switch in with
   `EnterWorktree(path="<path from git worktree list>")`. Resumed run - Step 7 uses
   the git cleanup fallback.
 - **Remote branch exists, no local worktree** (cross-machine pickup): the native

--- a/scripts/flow-live-driver-guard.sh
+++ b/scripts/flow-live-driver-guard.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# flow-live-driver-guard.sh - Warn when a worktree looks like ANOTHER live
+# session is mid-implementation in it, before /flow:auto's resume path enters
+# it (issue #503).
+#
+# Motivation: on a box running 3+ concurrent Claude sessions against one repo,
+# `/flow:auto <N>` can be invoked while a DIFFERENT live session is already
+# driving the issue-N worktree. If the resume path enters it anyway, two drivers
+# fight over one checkout and the second driver's Step-7 cleanup can delete the
+# first driver's cwd out from under it. The flow:auto #478 run only dodged this
+# via an ad-hoc "were files touched in the last few minutes?" check and stood
+# down. This guard makes that instinct a reusable, testable check.
+#
+# What it does: given a worktree path, it inspects the mtimes of every dirty
+# file there (tracked-modified + untracked; deleted paths skipped). If ANY was
+# modified within the freshness threshold (default 30 minutes), a live driver is
+# SUSPECTED - the caller should require explicit confirmation before entering.
+# It COMPLEMENTS `gh pr list --head <branch>` (an already-shipped branch is the
+# other resume hazard); this guard only speaks to local freshness.
+#
+# It is ADVISORY and FAIL-OPEN: it never blocks the flow (exit 0) unless
+# --exit-code is passed, and a missing path / not-a-repo / stat failure is
+# reported and shrugged off, never fatal.
+#
+# Usage:
+#   flow-live-driver-guard.sh [WORKTREE_PATH] [--threshold-minutes N] [--exit-code]
+#
+#   WORKTREE_PATH        Worktree to inspect (default: current directory).
+#   --threshold-minutes N  Freshness window in minutes (default: 30). Alias: --minutes.
+#   --exit-code          Return non-zero (1) when a live driver is SUSPECTED;
+#                        still 0 for "clear" and "unknown". Default is always-0.
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_LIVE_DRIVER: clear | suspected | unknown
+#
+# Env (test hooks - unset in normal use):
+#   FLOW_LIVE_DRIVER_NOW   override "now" as epoch seconds (default: date +%s)
+#   FLOW_LIVE_DRIVER_GIT   override the `git` binary (default: git)
+
+set -uo pipefail
+
+GIT="${FLOW_LIVE_DRIVER_GIT:-git}"
+THRESHOLD_MIN=30
+WANT_EXIT_CODE=0
+TARGET=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --threshold-minutes|--minutes)
+      shift
+      if [ "$#" -eq 0 ] || ! printf '%s' "$1" | grep -qE '^[0-9]+$'; then
+        echo "flow-live-driver-guard: --threshold-minutes needs a non-negative integer" >&2
+        exit 2
+      fi
+      THRESHOLD_MIN="$1"
+      ;;
+    --exit-code) WANT_EXIT_CODE=1 ;;
+    --help|-h)
+      sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --*)
+      echo "flow-live-driver-guard: unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [ -z "$TARGET" ]; then
+        TARGET="$1"
+      else
+        echo "flow-live-driver-guard: unexpected argument: $1" >&2
+        exit 2
+      fi
+      ;;
+  esac
+  shift
+done
+
+TARGET="${TARGET:-.}"
+verdict() { echo "FLOW_LIVE_DRIVER: $1"; }
+
+# --- Fail-open guards -------------------------------------------------------
+if [ ! -d "$TARGET" ]; then
+  echo "flow-live-driver-guard: '$TARGET' is not a directory - skipping (advisory)." >&2
+  verdict unknown
+  exit 0
+fi
+if ! "$GIT" -C "$TARGET" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "flow-live-driver-guard: '$TARGET' is not a git work tree - skipping (advisory)." >&2
+  verdict unknown
+  exit 0
+fi
+
+ROOT="$("$GIT" -C "$TARGET" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ]; then
+  verdict unknown
+  exit 0
+fi
+
+NOW="${FLOW_LIVE_DRIVER_NOW:-$(date +%s)}"
+THRESHOLD_SEC=$((THRESHOLD_MIN * 60))
+
+# Portable mtime-in-epoch for a file: GNU stat first, then BSD/macOS stat.
+mtime_of() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo ""
+}
+
+# Collect dirty file paths (tracked-modified + untracked) via NUL-delimited
+# porcelain so paths with spaces are safe. For rename/copy entries (R*/C*) the
+# porcelain emits "XY new\0old" - the NEW path (what a live driver just wrote)
+# is in the current record; the following record is the source, which we skip.
+fresh=()
+fresh_ages=()
+oldest_fresh_min=""
+pending_skip=0
+while IFS= read -r -d '' entry; do
+  if [ "$pending_skip" -eq 1 ]; then
+    pending_skip=0   # this record is a rename/copy source path - ignore it.
+    continue
+  fi
+  status="${entry:0:2}"
+  path="${entry:3}"
+  [ -n "$path" ] || continue
+  case "$status" in
+    R*|C*) pending_skip=1 ;;   # next record is the source path.
+  esac
+  # Deleted files cannot be stat'd; a live driver is signalled by writes, not
+  # deletions, so skip anything not present on disk.
+  f="$ROOT/$path"
+  [ -e "$f" ] || continue
+  mt="$(mtime_of "$f")"
+  [ -n "$mt" ] || continue
+  age=$((NOW - mt))
+  # Guard against clock skew (negative age) - treat as fresh (just written).
+  if [ "$age" -lt 0 ]; then age=0; fi
+  if [ "$age" -le "$THRESHOLD_SEC" ]; then
+    age_min=$((age / 60))
+    fresh+=("$path")
+    fresh_ages+=("$age_min")
+    if [ -z "$oldest_fresh_min" ] || [ "$age_min" -gt "$oldest_fresh_min" ]; then
+      oldest_fresh_min="$age_min"
+    fi
+  fi
+done < <("$GIT" -C "$TARGET" status --porcelain --untracked-files=all -z 2>/dev/null)
+
+if [ "${#fresh[@]}" -eq 0 ]; then
+  echo "flow-live-driver-guard: no dirty file in '$ROOT' modified within ${THRESHOLD_MIN}m - clear."
+  verdict clear
+  exit 0
+fi
+
+echo "flow-live-driver-guard: LIVE DRIVER SUSPECTED in '$ROOT'." >&2
+echo "  ${#fresh[@]} dirty file(s) modified within the last ${THRESHOLD_MIN}m:" >&2
+i=0
+max=20
+while [ "$i" -lt "${#fresh[@]}" ] && [ "$i" -lt "$max" ]; do
+  echo "  - ${fresh[$i]}  (~${fresh_ages[$i]}m ago)" >&2
+  i=$((i + 1))
+done
+if [ "${#fresh[@]}" -gt "$max" ]; then
+  echo "  ... and $(( ${#fresh[@]} - max )) more" >&2
+fi
+echo "" >&2
+echo "  Another session may be mid-implementation in this worktree (issue #503)." >&2
+echo "  Entering it now risks two drivers fighting over one checkout - the Step-7" >&2
+echo "  cleanup can delete the other driver's cwd. Before proceeding:" >&2
+echo "    1. Confirm no other live session owns this worktree (ask, or check the mtimes)." >&2
+echo "    2. gh pr list --head <branch>   # already-shipped branch is the other hazard." >&2
+echo "  Only enter after explicit confirmation." >&2
+
+if [ "$WANT_EXIT_CODE" -eq 1 ]; then
+  verdict suspected
+  exit 1
+fi
+verdict suspected
+exit 0

--- a/tests/test_flow_live_driver_guard.py
+++ b/tests/test_flow_live_driver_guard.py
@@ -1,0 +1,179 @@
+"""Tests for scripts/flow-live-driver-guard.sh - concurrent live-driver guard (issue #503).
+
+Contract:
+- With no dirty file (or every dirty file older than the threshold), the verdict
+  is ``clear`` and exit is 0.
+- With a dirty file (tracked-modified OR untracked) modified within the freshness
+  threshold, the verdict is ``suspected`` and the fresh file is NAMED in the
+  output; ``--exit-code`` then returns 1 so a caller can gate on it.
+- ``--threshold-minutes N`` narrows/widens the freshness window.
+- Outside a git work tree (or a missing path) the verdict is ``unknown`` and exit
+  is 0 (fail-open, advisory).
+
+"now" is pinned via the ``FLOW_LIVE_DRIVER_NOW`` env hook and file mtimes are set
+with ``os.utime`` so the age math is deterministic (no sleeping, no wall-clock
+flakiness). The tests build REAL throwaway git repos.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "flow-live-driver-guard.sh"
+
+# The behaviour tests drive real `git` and `bash` subprocesses. The Woodpecker
+# `validate` step runs in `uv:python3.11-bookworm-slim`, which ships bash but NOT
+# git, so those tests are skipped there (issue #430). The read-only wiring tests
+# below need neither and always run.
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="requires git and bash on PATH (absent in the CI validate container)",
+)
+
+# A fixed epoch used as "now" so age math is deterministic.
+NOW = 1_700_000_000
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+    )
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+
+def _run(*args: str, now: int | None = NOW) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if now is not None:
+        env["FLOW_LIVE_DRIVER_NOW"] = str(now)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "a.txt").write_text("a0\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _set_age(path: Path, minutes: float) -> None:
+    """Set the file's mtime so it reads as ``minutes`` old relative to NOW."""
+    ts = NOW - int(minutes * 60)
+    os.utime(path, (ts, ts))
+
+
+# --- read-only wiring (no git/bash needed) ---------------------------------
+
+
+def test_script_exists_and_executable():
+    assert SCRIPT.is_file(), f"missing {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), "guard script must be executable"
+
+
+# --- behaviour --------------------------------------------------------------
+
+
+@requires_git
+def test_clear_when_no_dirty(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    res = _run(str(repo))
+    assert res.returncode == 0
+    assert "FLOW_LIVE_DRIVER: clear" in res.stdout
+
+
+@requires_git
+def test_suspected_when_fresh_tracked_edit(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    (repo / "a.txt").write_text("a1 changed\n")
+    _set_age(repo / "a.txt", minutes=2)
+    res = _run(str(repo))
+    assert "FLOW_LIVE_DRIVER: suspected" in res.stdout
+    # the fresh file is named in the human-facing block (stderr)
+    assert "a.txt" in res.stderr
+    assert res.returncode == 0  # advisory by default
+
+
+@requires_git
+def test_suspected_when_fresh_untracked_file(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    live = repo / "live.py"
+    live.write_text("# a live driver just wrote this\n")
+    _set_age(live, minutes=1)
+    res = _run(str(repo))
+    assert "FLOW_LIVE_DRIVER: suspected" in res.stdout
+    assert "live.py" in res.stderr
+
+
+@requires_git
+def test_exit_code_flag_returns_1_on_suspected(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    (repo / "a.txt").write_text("edit\n")
+    _set_age(repo / "a.txt", minutes=0)
+    res = _run(str(repo), "--exit-code")
+    assert "FLOW_LIVE_DRIVER: suspected" in res.stdout
+    assert res.returncode == 1
+
+
+@requires_git
+def test_clear_when_dirty_but_stale(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    (repo / "a.txt").write_text("edited long ago\n")
+    _set_age(repo / "a.txt", minutes=120)  # 2h old, past the 30m default
+    res = _run(str(repo), "--exit-code")
+    assert "FLOW_LIVE_DRIVER: clear" in res.stdout
+    assert res.returncode == 0
+
+
+@requires_git
+def test_threshold_option_narrows_window(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    (repo / "a.txt").write_text("edited 10m ago\n")
+    _set_age(repo / "a.txt", minutes=10)
+    # default 30m -> suspected
+    assert "FLOW_LIVE_DRIVER: suspected" in _run(str(repo)).stdout
+    # narrowed to 5m -> the 10m-old edit is now clear
+    res = _run(str(repo), "--threshold-minutes", "5")
+    assert "FLOW_LIVE_DRIVER: clear" in res.stdout
+
+
+@requires_git
+def test_unknown_outside_git(tmp_path: Path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    res = _run(str(plain))
+    assert "FLOW_LIVE_DRIVER: unknown" in res.stdout
+    assert res.returncode == 0
+
+
+def test_unknown_missing_path(tmp_path: Path):
+    res = _run(str(tmp_path / "does-not-exist"))
+    assert "FLOW_LIVE_DRIVER: unknown" in res.stdout
+    assert res.returncode == 0


### PR DESCRIPTION
## Summary

Adds a concurrent **live-driver guard** to `/flow:auto`'s Step 1 resume path (issue #503).

On a box running several Claude sessions against one repo, `/flow:auto <N>` can be invoked while a *different* live session is already mid-implementation in the `issue-N` worktree. If the resume path enters it anyway, two drivers fight over one checkout and the second driver's Step-7 cleanup can delete the first driver's cwd. The flow:auto #478 run only dodged this via an ad-hoc "were files touched in the last few minutes?" check and stood down. This makes that instinct a reusable, tested guard.

## Changes

- **`scripts/flow-live-driver-guard.sh`** (new): given a worktree path, inspects the mtimes of every dirty file (tracked-modified + untracked) and reports `FLOW_LIVE_DRIVER: suspected` when any was modified within a freshness window (default 30m, `--threshold-minutes N`). Advisory and fail-open (exit 0 unless `--exit-code`); machine-readable verdict line (`clear|suspected|unknown`). Mirrors the existing `flow-worktree-guard.sh` / `flow-stale-check.sh` conventions (header, `--help`, `FLOW_LIVE_DRIVER_NOW`/`FLOW_LIVE_DRIVER_GIT` test hooks).
- **`.claude/commands/flow/auto.md`** Step 1 "Worktree exists" branch: before `EnterWorktree(path=...)`, run the guard **and** `gh pr list --head "$BRANCH"`; require explicit confirmation before entering when either flags a hazard (fresh mtimes or an already-shipped PR).
- **`tests/test_flow_live_driver_guard.py`** (new): 9 tests over real throwaway repos (clear / suspected on fresh tracked+untracked edits / `--exit-code` / stale-is-clear / threshold narrowing / unknown outside git / missing path). `@requires_git` skip for the CI validate container (issue #430); "now" pinned via env hook so age math is deterministic.
- Regenerated committed mirrors: `plugins/flow/commands/auto.md` (`plugin-sync.sh`) and `codex/prompts/flow-auto.md` (`codex-prompt-sync.py`); both drift guards green.
- CHANGELOG entry under Unreleased / Added.

## Test plan

- `python -m lib.cicd run --plan finish` -> lint + full pytest + security_scan all green on the post-merge tree.
- `scripts/plugin-sync.sh --check` and `codex-prompt-sync.py --check` clean.
- Manual: `clear`, `suspected` (rc 1 with `--exit-code`), stale-mtime `clear`, non-repo `unknown`, `--help` all verified.

Scoped to the worktree-exists resume path only (the already-on-branch and cross-machine remote-branch paths cannot host a separate *local* live driver). Guard stays advisory + confirm, per CPP's fail-open convention.

Closes #503.