### PR TITLE
fix(census): derive allow-candidate from the first not-already-allowed segment (Closes #519)

### DIFF
--- a/scripts/hook-permission-census.sh
+++ b/scripts/hook-permission-census.sh
@@ -84,6 +84,20 @@ if not tool:
 # riskier tier is recorded but never allowlisted by the census.
 SAFE_TIERS = {"READONLY-AUTO", "READONLY-ADDABLE", "WRITE-LOCAL"}
 
+# Severity ranking for the compound-command walk (issue #519): when a command is
+# a chain, the recorded risk is the WORST tier among its not-already-allowed
+# segments, so `<safe> && <dangerous>` is never under-rated.
+SEVERITY = {
+    "READONLY-AUTO": 0, "READONLY-ADDABLE": 1, "WRITE-LOCAL": 2, "OTHER": 3,
+    "WRITE-OUTWARD": 4, "DUAL-USE-NET": 5, "SCRIPT-EXEC": 6, "CODE-EXEC": 7,
+    "DESTRUCTIVE": 8,
+}
+
+# Leading no-op / navigation commands that produce no useful allow candidate.
+# They are stepped over so the candidate is derived from the real driver of the
+# prompt (`cd DIR && git commit ...` -> git commit, not the already-allowed cd).
+TRIVIAL_PREFIX = {"cd", "pushd", "popd", ":"}
+
 RO_ANY = {
     "cat", "head", "tail", "wc", "stat", "nl", "id", "uname", "df", "du", "cut",
     "paste", "tr", "column", "tac", "rev", "comm", "cmp", "readlink", "diff",
@@ -118,15 +132,8 @@ GH_RO = {"view", "list", "status", "diff", "checks"}
 GH_WRITE_ACTS = {"create", "close", "comment", "edit", "delete", "merge", "reopen", "ready"}
 
 
-def first_segment_tokens(cmd):
-    """Tokens of the first simple command, stripping env-assignments/prefixes."""
-    seg = re.split(r"\|\||&&|[|;\n><]", cmd, 1)[0].strip()
-    if not seg:
-        return []
-    try:
-        t = shlex.split(seg)
-    except ValueError:
-        t = seg.split()
+def _strip_prefixes(t):
+    """Drop leading env-assignments and command wrappers (sudo/timeout/...)."""
     while t and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", t[0]):
         t.pop(0)
     while t and t[0] in {"sudo", "command", "nice", "nohup", "time", "env"}:
@@ -138,6 +145,30 @@ def first_segment_tokens(cmd):
         if t:
             t.pop(0)
     return t
+
+
+def split_commands(cmd):
+    """Split a compound command into simple-command segments on shell separators
+    (`&&`, `||`, `|`, `;`, newline). Redirections are handled per-segment."""
+    return [s for s in (p.strip() for p in re.split(r"\|\||&&|;|\n|\|", cmd)) if s]
+
+
+def segment_tokens(seg):
+    """Tokens of ONE already-split segment (redirect target + prefixes dropped)."""
+    seg = re.split(r"[<>]", seg, 1)[0].strip()
+    if not seg:
+        return []
+    try:
+        t = shlex.split(seg)
+    except ValueError:
+        t = seg.split()
+    return _strip_prefixes(t)
+
+
+def first_segment_tokens(cmd):
+    """Tokens of the first simple command, stripping env-assignments/prefixes."""
+    segs = split_commands(cmd)
+    return segment_tokens(segs[0]) if segs else []
 
 
 def git_sub(t):
@@ -243,6 +274,97 @@ def derive_rule(t):
     return "Bash(%s:*)" % prefix
 
 
+def load_allowlist(cwd):
+    """Rules already in the installed allow-list, so the walk can step past
+    leading segments that would never prompt. Sourced from the user settings
+    (~/.claude/settings.json) plus any project settings at <cwd>/.claude/. An
+    env override (CENSUS_ALLOWLIST_JSON, a JSON array of rule strings) replaces
+    the file read for hermetic tests. Fail-open: any error -> empty set."""
+    raw = os.environ.get("CENSUS_ALLOWLIST_JSON")
+    if raw is not None:
+        try:
+            return {r for r in json.loads(raw) if isinstance(r, str)}
+        except Exception:
+            return set()
+    paths = []
+    home = os.environ.get("HOME")
+    if home:
+        paths.append(os.path.join(home, ".claude", "settings.json"))
+    if cwd:
+        paths.append(os.path.join(cwd, ".claude", "settings.json"))
+        paths.append(os.path.join(cwd, ".claude", "settings.local.json"))
+    allow = set()
+    for p in paths:
+        try:
+            with open(p) as fh:
+                d = json.load(fh)
+            for r in (d.get("permissions") or {}).get("allow") or []:
+                if isinstance(r, str):
+                    allow.add(r)
+        except Exception:
+            continue
+    return allow
+
+
+def _covered(rule, allow):
+    """True when `rule` is already granted by the installed allow-list. The bare
+    `Bash(P)` and wildcard `Bash(P:*)` forms are treated as equivalent, since an
+    argless already-allowlisted subcommand (derive_rule -> bare) would never have
+    prompted under its `Bash(P:*)` grant."""
+    if not rule:
+        return False
+    if rule in allow:
+        return True
+    if rule.startswith("Bash(") and rule.endswith(")"):
+        inner = rule[5:-1]
+        base = inner[:-2] if inner.endswith(":*") else inner
+        return ("Bash(%s)" % base) in allow or ("Bash(%s:*)" % base) in allow
+    return rule in allow
+
+
+def analyze_command(cmd, allow):
+    """Return (fix, risk) for a (possibly compound) Bash command (issue #519).
+
+    Walk the segments, stepping over leading trivial-nav commands (cd/pushd/...)
+    and any segment whose derived rule is ALREADY in the installed allow-list -
+    those never drove the prompt. Then:
+      - risk = the WORST tier among the not-already-allowed segments, so a
+        `<safe> && <dangerous>` chain is never under-rated;
+      - fix  = the narrowest allow-rule for the FIRST not-already-allowed
+        segment, emitted ONLY when that worst risk is a SAFE tier (a command
+        that also does something risky never yields a blind allow candidate).
+    A shown prompt almost always has a not-already-allowed segment; if every
+    segment is trivial/allowed, fall back to the first SUBSTANTIVE segment (so a
+    `cd DIR && <allowed>` degenerate case never re-suggests the noise cd), or to
+    the literal first segment when the whole command is trivial (a bare `cd DIR`
+    still yields its own candidate)."""
+    first_sub = None   # first non-trivial segment (the fallback candidate)
+    lead_any = None    # very first segment, trivial or not (bare-cd fallback)
+    fresh = []         # (tokens, tier) for not-already-allowed, non-trivial segments
+    for seg in split_commands(cmd):
+        toks = segment_tokens(seg)
+        if not toks:
+            continue
+        if lead_any is None:
+            lead_any = toks
+        if toks[0].split("/")[-1] in TRIVIAL_PREFIX:
+            continue
+        if first_sub is None:
+            first_sub = toks
+        if _covered(derive_rule(toks), allow):
+            continue
+        fresh.append((toks, classify(toks)))
+    if not fresh:
+        toks = first_sub or lead_any or []
+        if not toks:
+            return "", "OTHER"
+        tier = classify(toks)
+        return (derive_rule(toks) if tier in SAFE_TIERS else ""), tier
+    risk = max((tier for _, tier in fresh), key=lambda t: SEVERITY.get(t, 3))
+    fix = derive_rule(fresh[0][0]) if risk in SAFE_TIERS else ""
+    return fix, risk
+
+
 def truncate(s, n=100):
     s = " ".join(s.split())
     return s if len(s) <= n else s[: n - 3] + "..."
@@ -254,13 +376,15 @@ if not isinstance(ti, dict):
 
 if tool == "Bash":
     cmd = str(ti.get("command") or "")
-    toks = first_segment_tokens(cmd)
-    if not toks:
+    # Empty / unparseable command -> record nothing (fail-open).
+    if not first_segment_tokens(cmd):
         sys.exit(0)
-    tier = classify(toks)
     summary = truncate(cmd)
     signal = "Bash: %s" % summary
-    fix = derive_rule(toks) if tier in SAFE_TIERS else ""
+    # The SIGNAL keeps the full command; the candidate + risk are derived from
+    # the first segment that actually drove the prompt (issue #519).
+    cwd = data.get("cwd") if isinstance(data.get("cwd"), str) else ""
+    fix, tier = analyze_command(cmd, load_allowlist(cwd))
 else:
     # Non-Bash tool (Read/Write/WebFetch/MCP/...): the rule is just the tool name.
     tier = "READONLY-ADDABLE" if re.search(r"read|get|list|search|view|fetch|health", tool, re.I) else "OTHER"

--- a/tests/test_hook_permission_census.py
+++ b/tests/test_hook_permission_census.py
@@ -35,10 +35,16 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _run(tmp_path: Path, payload: dict | str) -> tuple[subprocess.CompletedProcess[str], Path]:
+def _run(
+    tmp_path: Path, payload: dict | str, allow: list[str] | None = None
+) -> tuple[subprocess.CompletedProcess[str], Path]:
     log = tmp_path / ".claude" / "friction.jsonl"
     env = os.environ.copy()
     env["CPP_FRICTION_LOG"] = str(log)
+    # Hermetic allow-list for the #519 segment-walk: default empty so a test's
+    # output never depends on the developer's real ~/.claude/settings.json. Pass
+    # `allow` to exercise the "already-allowed leading segment is skipped" path.
+    env["CENSUS_ALLOWLIST_JSON"] = json.dumps(allow or [])
     stdin = payload if isinstance(payload, str) else json.dumps(payload)
     proc = subprocess.run(
         ["bash", str(CENSUS)],
@@ -59,8 +65,8 @@ def _records(log: Path) -> list[dict]:
     return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
 
 
-def _one(tmp_path: Path, payload: dict) -> dict:
-    proc, log = _run(tmp_path, payload)
+def _one(tmp_path: Path, payload: dict, allow: list[str] | None = None) -> dict:
+    proc, log = _run(tmp_path, payload, allow=allow)
     assert proc.returncode == 0, proc.stderr
     recs = _records(log)
     assert len(recs) == 1, recs
@@ -150,6 +156,82 @@ def test_dual_use_net_not_allowlisted(tmp_path: Path):
     rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "curl https://example.com"}})
     assert rec["risk"] == "DUAL-USE-NET"
     assert rec["fix"] == ""
+
+
+# --- Compound commands: candidate from the real driver (issue #519) ----------
+
+def test_cd_prefix_is_stepped_over_to_the_real_command(tmp_path: Path):
+    # The dominant flow shape: `cd $(...) && <real command>`. The candidate must
+    # be the real command, NOT the already-allowed leading cd (that was 106 of
+    # 109 useless Bash(cd:*) records in one retro).
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": 'cd "$(git rev-parse --show-toplevel)" && git commit -m wip'}})
+    assert rec["fix"] == "Bash(git commit:*)"  # not Bash(cd:*)
+    assert rec["risk"] == "WRITE-LOCAL"
+    assert "cd " in rec["signal"]  # the signal still keeps the FULL command
+
+
+def test_cd_prefix_then_outward_action_gets_no_candidate(tmp_path: Path):
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": "cd /repo && gh pr create --fill"}})
+    assert rec["risk"] == "WRITE-OUTWARD"
+    assert rec["fix"] == ""  # cd stepped over; the real driver is not allowlistable
+
+
+def test_worst_risk_across_segments_wins(tmp_path: Path):
+    # A safe leading segment must NOT mask a destructive later one, and any risky
+    # segment blanks the candidate.
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": "git commit -m wip && rm -rf build/"}})
+    assert rec["risk"] == "DESTRUCTIVE"
+    assert rec["fix"] == ""
+
+
+def test_already_allowed_leading_segment_is_skipped(tmp_path: Path):
+    # echo is already in the allow-list -> the candidate is the first NOT-allowed
+    # driver, not the noise-header echo.
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": 'echo "=== status ===" && git commit -m wip'}},
+        allow=["Bash(echo:*)"])
+    assert rec["fix"] == "Bash(git commit:*)"
+    assert rec["risk"] == "WRITE-LOCAL"
+
+
+def test_all_segments_allowed_falls_back_to_first(tmp_path: Path):
+    # Degenerate case: every segment already allowed -> emit the first
+    # substantive segment's own rule (pre-#519 behaviour), never crash.
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": "git status && git diff"}},
+        allow=["Bash(git status:*)", "Bash(git diff:*)"])
+    assert rec["fix"] == "Bash(git status)"  # argless -> bare form; :* allow covers it
+    assert rec["risk"] == "READONLY-AUTO"
+
+
+def test_bare_cd_still_yields_its_own_candidate(tmp_path: Path):
+    # A lone `cd DIR` prompt (no real driver behind it) should still suggest
+    # Bash(cd:*) - the walk only steps OVER cd when a real command follows.
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "cd /some/dir"}})
+    assert rec["fix"] == "Bash(cd:*)"
+    assert rec["risk"] == "READONLY-ADDABLE"
+
+
+def test_cd_then_allowed_command_does_not_resurrect_cd(tmp_path: Path):
+    # cd + an already-allowed command: the fallback must NOT re-suggest the noise
+    # cd; it surfaces the (allowed) real segment instead.
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": "cd /repo && git status"}},
+        allow=["Bash(git status:*)"])
+    assert rec["fix"] == "Bash(git status)"
+    assert rec["risk"] == "READONLY-AUTO"
+
+
+def test_pipeline_is_a_segment_boundary(tmp_path: Path):
+    # A pipe splits segments too: `grep ... | wc -l` with grep allowed surfaces wc.
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {
+        "command": "grep -c foo file | wc -l"}},
+        allow=["Bash(grep:*)"])
+    assert rec["fix"] == "Bash(wc:*)"
+    assert rec["risk"] == "READONLY-ADDABLE"
 
 
 # --- Non-Bash tools ----------------------------------------------------------


### PR DESCRIPTION
## Summary

The PermissionRequest census hook (`scripts/hook-permission-census.sh`, #482) derived its candidate allow-rule from the **first** segment of a compound command. For the dominant `cd DIR && <real cmd>` shape this yielded the already-allowed `Bash(cd:*)` - **106 of 109** safe-tier candidates in one `/self-improvement:retro` were this useless noise, burying the genuine adds (`Read`, `docker ps`) and making the census/retro allowlist loop nearly information-free.

## Change

`analyze_command()` now walks the command's segments:
- steps over leading trivial-nav commands (`cd`/`pushd`/`popd`/`:`) and any segment whose derived rule is **already in the installed allow-list**;
- derives the candidate `fix` + `risk` from the first genuinely-new (prompt-driving) segment;
- `risk` = the **worst** tier among the not-already-allowed segments, so a `<safe> && <dangerous>` chain is never under-rated;
- `fix` is emitted **only** when that worst risk is a SAFE tier (a command that also does something risky never yields a blind allow rule);
- a bare `cd DIR` (no real driver behind it) still yields its own `Bash(cd:*)` candidate.

Allow-list is read from `~/.claude/settings.json` (+ project `.claude/settings.json`/`.local.json`), overridable via `CENSUS_ALLOWLIST_JSON` for hermetic tests. Fail-open and observe-only contracts preserved (no stdout, never exits non-zero).

The risk taxonomy (`DESTRUCTIVE_TOKENS`, `CODE_EXEC`, `classify`, `derive_rule`) is **untouched**, so `scripts/tool-risk-drift.py` stays green (verified `--strict`).

## Test plan

- 8 new compound-command tests (cd-stepover, outward-action no-candidate, worst-risk-wins, already-allowed-lead skip, all-allowed fallback, pipeline boundary, bare-cd, cd-then-allowed no-resurrect).
- Census suite 20 -> 28; full suite **810 passed**.
- `make lint` clean; `tool-risk-drift.py --strict` in sync (DESTRUCTIVE_TOKENS 7, CODE_EXEC 24).

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)