### PR TITLE
fix(flow): admin/branch-protection retry in gh-pr-merge.sh for owner merges (Closes #517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@
 
 ### Changed
 
+- **`gh-pr-merge.sh` handles branch-protection blocks on owner merges**
+  (issue #517) - on branch-protected `main` (the #449 posture: PR + review + CI
+  required), a repo owner's squash was rejected by GitHub until it was re-run
+  manually with `gh pr merge --squash --admin`. The helper now accepts an opt-in
+  `--admin` flag (forces the override from the first attempt) and, when a squash
+  fails with a branch-protection message, the caller did not pass `--admin`, and
+  the actor is a repo admin (`gh repo view --json viewerPermission`), retries the
+  squash once with `--admin`. The override is bounded to a single retry, never
+  fires for a non-admin or a non-protection failure, and the post-merge
+  MERGED-state check stays authoritative. No caller change is needed - the
+  `/flow` merge paths pick up the auto-retry transparently.
 - **eli5 gate report depth floor + /flow:auto full-spec load** (issue #509) -
   the vendored eli5 core (re-vendored from canonical cooneycw/eli5-gate
   `f2a0b2e`) now sets an explicit depth floor: Section B must enumerate the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Core components and their locations:
 - `scripts/` - Shell utilities, one per sub-bullet (add new scripts as their own line, #501):
   - prompt-context
   - worktree-remove
-  - gh-pr-merge - layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`; polls mergeability to wait out a transient `UNKNOWN` right after push (#485); bounded refetch+retry when the squash fails on `Base branch was modified` (sibling merge race, #502)
+  - gh-pr-merge - layout-aware PR squash-merge used by `/flow:auto` + `/flow:merge`; polls mergeability to wait out a transient `UNKNOWN` right after push (#485); bounded refetch+retry when the squash fails on `Base branch was modified` (sibling merge race, #502); opt-in `--admin` flag plus a single admin-gated auto-retry when a squash is rejected by branch protection on an owner merge (#517)
   - flow-stale-check - advisory early stale-base detector for `/flow:auto` Step 4/6 + `/flow:finish` (#473)
   - flow-worktree-guard - advisory leaked-edit detector: warns when a `/flow:auto` edit landed in the MAIN tree instead of the worktree (#486)
   - hooks

--- a/scripts/gh-pr-merge.sh
+++ b/scripts/gh-pr-merge.sh
@@ -34,6 +34,18 @@
 #   that specific error - and no other - refetch, re-poll mergeability, and
 #   re-attempt the squash a bounded number of times before reporting failure.
 #
+# Branch protection blocks an owner merge (issue #517):
+#   With main branch-protected (PR + review + CI required, the #449 posture), a
+#   repo owner's squash is rejected by GitHub until it is re-run with --admin, so
+#   every owner merge otherwise stalls at a manual `gh pr merge --squash --admin`.
+#   Handle it two ways: an opt-in --admin flag that forces the override from the
+#   first attempt, and - when a squash fails with a protection-block message, the
+#   caller did not pass --admin, and the actor is a repo admin - a single
+#   automatic retry with --admin. The override only ever fires for a repo admin,
+#   only once, and the MERGED-state check below stays authoritative. --admin
+#   bypasses every protection at once (including a red required check), so the
+#   auto-retry is deliberately bounded and admin-gated.
+#
 # This wrapper makes the merge layout-aware:
 #   * Linked worktree (cwd's `.git` is a FILE): run `gh pr merge --squash` WITHOUT
 #     --delete-branch so gh never attempts the local branch switch, then delete the
@@ -45,7 +57,11 @@
 #   * Either way, verify the PR actually reached MERGED before returning non-zero,
 #     so a stray local post-merge error is never mistaken for a merge failure.
 #
-# Usage:  gh-pr-merge.sh <pr-number> <branch-name>
+# Usage:  gh-pr-merge.sh [--admin] <pr-number> <branch-name>
+#           --admin  force `gh pr merge --admin` from the first attempt (opt-in
+#                    branch-protection override, issue #517). Without it, an admin
+#                    override is still applied automatically on a protection-block
+#                    failure when the actor is a repo admin.
 # Exit:   0 if the PR is merged on the remote; 1 only if it genuinely did not merge.
 #
 # Env (test hooks - unset in normal use):
@@ -58,20 +74,67 @@
 
 set -uo pipefail
 
-PR_NUMBER="${1:-}"
-BRANCH="${2:-}"
+# Parse an optional --admin flag from anywhere in the argv, keeping the two
+# positional args (pr-number, branch-name) backward-compatible for every caller.
+ADMIN_OPT_IN=0
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --admin)
+            ADMIN_OPT_IN=1
+            shift
+            ;;
+        --)
+            shift
+            while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done
+            ;;
+        -*)
+            echo "gh-pr-merge.sh: unknown option '$1'" >&2
+            echo "Usage: gh-pr-merge.sh [--admin] <pr-number> <branch-name>" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+PR_NUMBER="${POSITIONAL[0]:-}"
+BRANCH="${POSITIONAL[1]:-}"
 
 if [[ -z "$PR_NUMBER" || -z "$BRANCH" ]]; then
-    echo "Usage: gh-pr-merge.sh <pr-number> <branch-name>" >&2
+    echo "Usage: gh-pr-merge.sh [--admin] <pr-number> <branch-name>" >&2
     exit 2
 fi
 
 GH_BIN="${GH_PR_MERGE_GH:-gh}"
 GIT_BIN="${GH_PR_MERGE_GIT:-git}"
 
+# stderr of the last `gh pr merge` attempt - inspected by is_protection_block.
+LAST_MERGE_ERR=""
+
 # A linked worktree has a `.git` FILE (a gitdir pointer); the primary repo has a
 # `.git` DIRECTORY. This is the exact condition under which --delete-branch trips.
 in_linked_worktree() { [[ -f .git ]]; }
+
+# A squash rejected by branch protection (issue #517) vs. any other failure.
+# Matches the required-review / required-status-check / protected-branch families
+# GitHub returns, and deliberately NOT the #502 "Base branch was modified" text -
+# that race has its own bounded retry and must never trigger an --admin override.
+is_protection_block() {
+    grep -qiE \
+        'required status check|approving review|review is required|changes must be made through|protected branch|branch protection|not authorized to push|base branch policy|at least [0-9]+ (approving )?review' \
+        <<<"$LAST_MERGE_ERR"
+}
+
+# True when the authenticated actor has admin permission on the repo - the only
+# actor for whom `gh pr merge --admin` can override protection (issue #517).
+is_repo_admin() {
+    local perm
+    perm=$("$GH_BIN" repo view --json viewerPermission --jq '.viewerPermission' 2>/dev/null)
+    [[ "$perm" == "ADMIN" ]]
+}
 
 # Wait out a transient `mergeable=UNKNOWN` before attempting the squash (issue
 # #485). Returns 0 to proceed (MERGEABLE, or fail-open after the poll never
@@ -141,6 +204,7 @@ run_squash() {
         "$GH_BIN" pr merge "$PR_NUMBER" --squash "$@" 2>"$errfile"
         merge_exit=$?
         cat "$errfile" >&2
+        LAST_MERGE_ERR=$(cat "$errfile")
         if [[ $merge_exit -eq 0 ]] || ! grep -q "Base branch was modified" "$errfile"; then
             break
         fi
@@ -148,15 +212,30 @@ run_squash() {
     rm -f "$errfile"
 }
 
-if in_linked_worktree; then
-    run_squash
-    # Delete the remote branch ourselves - this is what --delete-branch would have
-    # done, minus the local branch switch that fails in a linked worktree.
-    if [[ $merge_exit -eq 0 ]]; then
-        "$GIT_BIN" push origin --delete "$BRANCH" >/dev/null 2>&1 || true
-    fi
-else
-    run_squash --delete-branch
+# Assemble the squash flags once: --admin if explicitly opted in, plus
+# --delete-branch in the primary repo (a linked worktree deletes the remote
+# branch itself below, to avoid the #461 local branch-switch failure).
+BASE_FLAGS=()
+(( ADMIN_OPT_IN )) && BASE_FLAGS+=(--admin)
+in_linked_worktree || BASE_FLAGS+=(--delete-branch)
+
+run_squash ${BASE_FLAGS+"${BASE_FLAGS[@]}"}
+
+# Branch-protection auto-retry (issue #517): if the squash was rejected by branch
+# protection, the caller did not already force --admin, and the actor is a repo
+# admin, retry once with --admin. Any non-protection failure, or a non-admin
+# actor, is left to the MERGED-state check below - never an --admin override.
+if [[ $merge_exit -ne 0 && $ADMIN_OPT_IN -eq 0 ]] && is_protection_block && is_repo_admin; then
+    echo "note: PR #$PR_NUMBER was blocked by branch protection and the actor is a" \
+         "repo admin - retrying the squash once with --admin (issue #517)." >&2
+    run_squash --admin ${BASE_FLAGS+"${BASE_FLAGS[@]}"}
+fi
+
+# In a linked worktree, delete the remote branch ourselves once the squash has
+# landed - what --delete-branch would have done, minus the local branch switch
+# that fails there (issue #461).
+if in_linked_worktree && [[ $merge_exit -eq 0 ]]; then
+    "$GIT_BIN" push origin --delete "$BRANCH" >/dev/null 2>&1 || true
 fi
 
 # Trust the PR state over the exit code: a non-zero from a local post-merge step

--- a/tests/test_gh_pr_merge.py
+++ b/tests/test_gh_pr_merge.py
@@ -38,6 +38,7 @@ def _make_stubs(
     pr_state: str = "MERGED",
     mergeable: str | list[str] = "MERGEABLE",
     merge_outcomes: list[tuple[int, str]] | None = None,
+    viewer_permission: str = "ADMIN",
 ) -> dict:
     """Create fake gh/git that log their args and honour a scripted outcome.
 
@@ -48,6 +49,9 @@ def _make_stubs(
     ``merge_outcomes`` scripts successive ``gh pr merge`` calls (issue #502) as
     ``(exit_code, stderr_message)`` pairs consumed one per call, staying on the
     last once exhausted. Defaults to ``[(merge_exit, "")]``.
+
+    ``viewer_permission`` scripts ``gh repo view --json viewerPermission`` - the
+    repo-admin check that gates the branch-protection --admin retry (issue #517).
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -91,6 +95,9 @@ def _make_stubs(
         "  else\n"
         f'    echo "{pr_state}"\n'
         "  fi\n"
+        "  exit 0\n"
+        'elif [[ "$1 $2" == "repo view" ]]; then\n'
+        f'  echo "{viewer_permission}"\n'
         "  exit 0\n"
         "fi\n"
         "exit 0\n",
@@ -314,3 +321,89 @@ def test_flow_commands_wire_the_helper():
         # The inline fallback keeps the linked-worktree guard even without the helper.
         assert "git push origin --delete" in text, f"{rel} missing remote-branch delete fallback"
         assert "MERGED" in text, f"{rel} must verify PR state, not just the exit code"
+
+
+# The stderr GitHub returns when branch protection blocks a merge (issue #517):
+# the sole-owner case is a required review that cannot be satisfied.
+PROTECTION_BLOCKED = (
+    "failed to merge pull request: GraphQL: At least 1 approving review is "
+    "required by reviewers with write access. (mergePullRequest)"
+)
+
+
+def test_admin_flag_passthrough_primary_repo(tmp_path: Path):
+    # Issue #517: --admin opt-in forces the override from the first attempt; the
+    # primary repo still keeps --delete-branch. One merge call, no auto-retry.
+    stubs = _make_stubs(tmp_path, merge_exit=0, pr_state="MERGED")
+    result = _run(_primary_repo(tmp_path), stubs, "--admin", "42", "issue-517-fix")
+    assert result.returncode == 0, result.stderr
+    merge_calls = [c for c in _calls(stubs) if c.startswith("gh pr merge")]
+    assert len(merge_calls) == 1, merge_calls
+    assert "--admin" in merge_calls[0]
+    assert "--delete-branch" in merge_calls[0]
+
+
+def test_admin_flag_passthrough_linked_worktree(tmp_path: Path):
+    # --admin in a linked worktree carries --admin but NOT --delete-branch (the
+    # #461 guard still applies); the remote branch is deleted by us.
+    stubs = _make_stubs(tmp_path, merge_exit=0, pr_state="MERGED")
+    result = _run(_linked_worktree(tmp_path), stubs, "--admin", "42", "issue-517-fix")
+    assert result.returncode == 0, result.stderr
+    calls = _calls(stubs)
+    merge_calls = [c for c in calls if c.startswith("gh pr merge")]
+    assert len(merge_calls) == 1, merge_calls
+    assert "--admin" in merge_calls[0]
+    assert "--delete-branch" not in merge_calls[0]
+    assert any(c == "git push origin --delete issue-517-fix" for c in calls), calls
+
+
+def test_protection_block_admin_retries_with_admin(tmp_path: Path):
+    # The #517 trap: a repo admin's squash is rejected by branch protection; the
+    # helper retries once with --admin and it lands. The first attempt must NOT
+    # force --admin (only the retry does).
+    stubs = _make_stubs(
+        tmp_path,
+        pr_state="MERGED",
+        viewer_permission="ADMIN",
+        merge_outcomes=[(1, PROTECTION_BLOCKED), (0, "")],
+    )
+    result = _run(_linked_worktree(tmp_path), stubs, "42", "issue-517-fix")
+    assert result.returncode == 0, result.stderr
+    assert "merged" in result.stdout
+    merge_calls = [c for c in _calls(stubs) if c.startswith("gh pr merge")]
+    assert len(merge_calls) == 2, merge_calls
+    assert "--admin" not in merge_calls[0], "first attempt must not force --admin"
+    assert "--admin" in merge_calls[1], "protection-block retry must add --admin"
+
+
+def test_protection_block_non_admin_does_not_retry(tmp_path: Path):
+    # A non-admin actor cannot use --admin, so the protection block is left to the
+    # MERGED-state check (genuine failure). No --admin retry is attempted.
+    stubs = _make_stubs(
+        tmp_path,
+        pr_state="OPEN",
+        viewer_permission="WRITE",
+        merge_outcomes=[(1, PROTECTION_BLOCKED)],
+    )
+    result = _run(_linked_worktree(tmp_path), stubs, "42", "issue-517-fix")
+    assert result.returncode == 1
+    assert "did not merge" in result.stderr
+    merge_calls = [c for c in _calls(stubs) if c.startswith("gh pr merge")]
+    assert len(merge_calls) == 1, merge_calls
+    assert not any("--admin" in c for c in merge_calls)
+
+
+def test_non_protection_failure_no_admin_retry(tmp_path: Path):
+    # Only a branch-protection block triggers the --admin override. A different
+    # merge failure must not, even when the actor is a repo admin.
+    stubs = _make_stubs(
+        tmp_path,
+        pr_state="OPEN",
+        viewer_permission="ADMIN",
+        merge_outcomes=[(1, "GraphQL: Pull Request is not mergeable (mergePullRequest)")],
+    )
+    result = _run(_linked_worktree(tmp_path), stubs, "42", "issue-517-fix")
+    assert result.returncode == 1
+    merge_calls = [c for c in _calls(stubs) if c.startswith("gh pr merge")]
+    assert len(merge_calls) == 1, merge_calls
+    assert not any("--admin" in c for c in merge_calls)


### PR DESCRIPTION
## Summary

`scripts/gh-pr-merge.sh` already survives three known merge failure modes (linked-worktree branch switch #461, transient `UNKNOWN` mergeability #485, base-moved race #502), but had **no** handling for a branch-protection block. On branch-protected `main` (the #449 posture: PR + review + CI required), a repo *owner's* squash is rejected by GitHub until re-run manually with `gh pr merge --squash --admin` (verified live at `aaa5ebe`, recurs across `/flow:auto` runs).

This adds two complementary paths, exactly as the issue proposed:

1. **Opt-in `--admin` flag** — parsed from anywhere in argv (the two positional args stay backward-compatible); forces the override from the first attempt.
2. **Admin-gated auto-retry** — when a squash fails with a branch-protection signature, the caller did not pass `--admin`, and the actor is a repo admin (`gh repo view --json viewerPermission == ADMIN`), retry the squash **once** with `--admin`.

Guardrails:
- `is_protection_block()` matches required-review / required-status-check / protected-branch messages and **deliberately not** the #502 `Base branch was modified` text (that race keeps its own bounded retry, never triggers an override).
- The override is bounded to a single retry, never fires for a non-admin or a non-protection failure, and the post-merge **MERGED-state check stays authoritative**.
- `--admin` bypasses all protections at once (including a red required check), so the auto-retry is deliberately admin-gated and bounded; `/flow:auto` already runs the full local quality gate (Step 6/7) and verifies CI post-merge (Step 8).

No caller change needed — the `/flow:auto` + `/flow:merge` paths pick up the auto-retry transparently.

## Test plan

- `tests/test_gh_pr_merge.py`: 5 new cases — `--admin` passthrough (linked + primary layouts), protection-block → admin retry succeeds, protection-block + non-admin → no retry (genuine failure), non-protection failure + admin → no retry. Stub extended to serve `gh repo view --json viewerPermission`.
- Full file: **19 passed**. Deterministic `finish` gate (ruff + pytest + security quick) green.
- `bash -n` clean; verified on bash 5.1 (the `${BASE_FLAGS+...}` empty-array idiom).

Docs: CLAUDE.md helper line + CHANGELOG `[Unreleased] > Changed`.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)