### PR TITLE
docs(claude-md): avoid cd-prefix on Bash calls (permission-prompt hygiene)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,18 @@ Steps 4/6 run `scripts/flow-worktree-guard.sh` - an advisory, fail-open guard
 that warns (never blocks) when the main tree has tracked modifications, the
 signature of a leaked edit - so the trap is caught before commit.
 
+**Bash cwd + permission-prompt hygiene (retro #480):** the Bash tool's working
+directory persists across calls, and the harness prompts on a `cd` inside a
+compound command. Do NOT prefix Bash calls with `cd "$(git rev-parse
+--show-toplevel)" && ...` - it forces a permission prompt on nearly every call
+AND prevents the shipped read-only allowlist
+(`templates/claude-settings-permissions.json`) from matching the real
+sub-command (`cd X && git fetch` prompts on the `cd`, so `Bash(git fetch:*)`
+never fires). Rely on cwd persistence, use absolute paths, or `git -C <dir>`; add
+an explicit `cd` only when the cwd must actually change. This is the behavioral
+counterpart to the census classifier fix (#519), which stopped mis-deriving
+`Bash(cd:*)` allow candidates.
+
 **Standalone skill extractions (issue #443):** skills with standalone value are
 extracted to their own public plugin repos so users never have to clone CPP -
 they install via `/plugin marketplace add cooneycw/<repo>` or `npx skills add


### PR DESCRIPTION
## Summary

Codifies the `/flow:auto #480` friction-retro finding into `CLAUDE.md` - the canonical, git-committed, auto-loaded surface - so the lesson actually reaches other VMs' sessions.

**Why CLAUDE.md and not just the store:** the retro already recorded this to the #433 shared store (`id=19`) and the local ledger, but the shared store is pull-on-demand (only consulted during a retro's dedup) and `.claude/learnings.md` is gitignored (local-only). Neither changes another VM's default behavior. CLAUDE.md loads every CPP session on every checkout.

**The directive:** the Bash tool cwd persists across calls and the harness prompts on `cd`-in-compound, so `cd "$(git rev-parse --show-toplevel)" && <cmd>` forces a prompt on nearly every call AND prevents the shipped 32-rule allowlist from matching the real sub-command (`cd X && git fetch` prompts on the `cd`). Use cwd persistence / absolute paths / `git -C`. Behavioral counterpart to the census classifier fix #519.

Placed next to the existing worktree path-resolution rule (#486) in the flow operating-conventions block. ASCII hyphens only (CLAUDE.md core directive).

## Test plan
- Deterministic `finish` gate (ruff lint + full pytest incl. `test_flow_worktree_native.py` which reads CLAUDE.md + security quick scan): all green
- No em/en dashes in the diff

Ledger: fp `2711b88dec656da6` (applied) | shared store `id=19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)