### PR TITLE
fix(drift): prune .claude/worktrees from repo-root finds in drift-detect.sh (Closes #518)

### DIFF
--- a/scripts/drift-detect.sh
+++ b/scripts/drift-detect.sh
@@ -133,7 +133,11 @@ is_systemd_unit_present() {
 
 repo_ships_systemd_unit() {
     local unit="$1"
-    find "$REPO_ROOT" -path "*/deploy/${unit}.service" -o -path "*/deploy/${unit}.service.template" 2>/dev/null | grep -q .
+    # Prune .claude/worktrees: sibling flow:auto checkouts live there, and a
+    # pre-retirement deploy template inside one must not count as "repo ships
+    # it" for THIS checkout (issue #518 - flaky orphan detection).
+    find "$REPO_ROOT" -path '*/.claude/worktrees' -prune -o \
+        \( -path "*/deploy/${unit}.service" -o -path "*/deploy/${unit}.service.template" \) -print 2>/dev/null | grep -q .
 }
 
 canonical_server_for_unit() {
@@ -606,11 +610,13 @@ check_shared_scripts() {
         fi
     done
 
-    # Also check bash-prep.sh if it exists in multiple locations
+    # Also check bash-prep.sh if it exists in multiple locations. Prune
+    # .claude/worktrees so sibling checkouts never enter the comparison
+    # (issue #518); -maxdepth 3 alone only excludes them incidentally.
     local bash_preps=()
     while IFS= read -r -d '' f; do
         bash_preps+=("$f")
-    done < <(find "$REPO_ROOT" -maxdepth 3 -name "bash-prep.sh" -print0 2>/dev/null)
+    done < <(find "$REPO_ROOT" -maxdepth 3 -path '*/.claude/worktrees' -prune -o -name "bash-prep.sh" -print0 2>/dev/null)
 
     if (( ${#bash_preps[@]} > 1 )); then
         local ref_hash

--- a/tests/test_drift_detect.py
+++ b/tests/test_drift_detect.py
@@ -328,3 +328,83 @@ def test_drift_detect_flags_orphaned_docker_mcp(tmp_path: Path) -> None:
     assert "orphaned Docker MCP mcp-nano-banana" in output
     assert "docker rm -f mcp-nano-banana" in output          # teardown plan under --fix
     assert "claude mcp remove nano-banana" in output
+
+
+def test_orphan_detection_ignores_sibling_worktree_templates(tmp_path: Path) -> None:
+    """A deploy template inside .claude/worktrees/<sibling>/ (another session's
+    checkout) must not make repo_ships_systemd_unit() treat the unit as shipped -
+    otherwise orphan detection flakes on multi-session boxes depending on what
+    sibling worktrees hold on disk (issue #518)."""
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    script = repo / "scripts" / "drift-detect.sh"
+    script.write_text(DRIFT_SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    # Sibling worktree still carrying a pre-retirement deploy template.
+    sibling_deploy = repo / ".claude" / "worktrees" / "issue-999-sibling" / "mcp-second-opinion" / "deploy"
+    sibling_deploy.mkdir(parents=True)
+    (sibling_deploy / "mcp-second-opinion.service.template").write_text(
+        "[Service]\nExecStart=stale\n", encoding="utf-8"
+    )
+
+    home = tmp_path / "home"
+    user_units = home / ".config" / "systemd" / "user"
+    user_units.mkdir(parents=True)
+    (user_units / "mcp-second-opinion.service").write_text("[Service]\nExecStart=fake\n", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "uv", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(
+        bin_dir / "docker",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "--version" ]]; then echo "Docker version 26.0.0"; exit 0; fi
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "systemctl",
+        """
+        #!/usr/bin/env bash
+        args="$*"
+        if [[ "$args" == *"show -p LoadState"* ]]; then echo "not-found"; exit 0; fi
+        if [[ "$args" == *"is-active"* ]]; then echo "inactive"; exit 0; fi
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "ss",
+        "#!/usr/bin/env bash\necho 'State Recv-Q Send-Q Local Address:Port Peer Address:Port Process'\n",
+    )
+    _write_executable(
+        bin_dir / "sysctl",
+        """
+        #!/usr/bin/env bash
+        case "$2" in
+          vm.swappiness) echo 10 ;;
+          vm.vfs_cache_pressure) echo 50 ;;
+          fs.inotify.max_user_watches) echo 524288 ;;
+          fs.inotify.max_user_instances) echo 512 ;;
+          *) echo unknown ;;
+        esac
+        """,
+    )
+
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "PATH": f"{bin_dir}:{env['PATH']}", "USER": "tester"})
+
+    result = subprocess.run(
+        ["bash", str(script), "--fix"],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    output = result.stdout
+    assert result.returncode == 1
+    # The sibling worktree's template must NOT suppress orphan detection.
+    assert "orphaned systemd unit mcp-second-opinion" in output


### PR DESCRIPTION
## Summary

`repo_ships_systemd_unit()` in `scripts/drift-detect.sh` ran an unbounded `find` over `$REPO_ROOT`, which contains `.claude/worktrees/*` - concurrent flow:auto sessions' checkouts. A sibling worktree still holding a pre-retirement `deploy/<unit>.service(.template)` made the match true, so orphan detection was suppressed and `test_drift_detect` flaked on a multi-session box.

- **`repo_ships_systemd_unit()`**: prune `*/.claude/worktrees` from the find (explicit `\( \)` grouping + `-print`). Chose prune over the issue's `git ls-files` alternative because the Woodpecker validate container has no git - `ls-files` there would silently change semantics.
- **`check_shared_scripts()`**: same prune on the `bash-prep.sh` find, which `-maxdepth 3` only excluded incidentally (closes the issue's "audit the other `$REPO_ROOT` finds" ask). The `mcp-*/deploy` shell globs are single-level and cannot bleed; no other `$REPO_ROOT` finds exist.
- **Regression test**: copies `drift-detect.sh` into a tmp fake repo containing `.claude/worktrees/<sibling>/.../deploy/mcp-second-opinion.service.template` plus an installed fake unit, and asserts the unit is still reported as an orphan.

## Test plan

- [x] `bash -n scripts/drift-detect.sh`
- [x] `uv run pytest tests/test_drift_detect.py` - 4/4 pass
- [x] Regression test verified to FAIL against the unfixed script (reverted, ran, restored)
- [x] `lib.cicd run --plan finish` - lint, test, security_scan all SUCCESS

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)