### PR TITLE
[codex] Fix CI runner security scan path

### DIFF
--- a/lib/cicd/manifest.py
+++ b/lib/cicd/manifest.py
@@ -305,12 +305,12 @@ def generate_manifest(
     # Add security_scan step if lib.security is available
     steps["security_scan"] = StepModel(
         command=(
-            'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '
+            'PYTHONPATH="${HOME}/Projects/claude-power-pack" '
             "python3 -m lib.security gate flow_finish"
         ),
         description="Run security quick scan",
         timeout=120,
-        skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+        skip_if='! PYTHONPATH="${HOME}/Projects/claude-power-pack" python3 -c \'import lib.security\' 2>/dev/null',
     )
 
     # Add any extra Makefile targets not already covered

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -206,13 +206,13 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
         StepDef(
             id="security_scan",
             command=(
-                'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '
+                'PYTHONPATH="${HOME}/Projects/claude-power-pack" '
                 "python3 -m lib.security gate flow_finish"
             ),
             description="Run security quick scan",
             timeout_seconds=120,
             max_attempts=1,
-            skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+            skip_if='! PYTHONPATH="${HOME}/Projects/claude-power-pack" python3 -c \'import lib.security\' 2>/dev/null',
         ),
     ],
     "check": [
@@ -262,13 +262,13 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
         StepDef(
             id="security_scan",
             command=(
-                'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '
+                'PYTHONPATH="${HOME}/Projects/claude-power-pack" '
                 "python3 -m lib.security gate flow_deploy"
             ),
             description="Run security scan before deploy",
             timeout_seconds=120,
             max_attempts=1,
-            skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+            skip_if='! PYTHONPATH="${HOME}/Projects/claude-power-pack" python3 -c \'import lib.security\' 2>/dev/null',
         ),
         StepDef(
             id="deploy",


### PR DESCRIPTION
## Summary

Fixes the deterministic CI/CD runner security scan step so it can import `lib.security` when launched with the standard `python -m lib.cicd` flow:

- sets `PYTHONPATH` to the `claude-power-pack` repo root instead of the nested `lib/` directory
- applies the same import path to the built-in finish/deploy security steps and generated manifest defaults
- makes `skip_if` evaluate the same import path the step command uses

## Root Cause

The runner strips launcher-provided `PYTHONPATH` before executing child steps. The built-in security step then set `PYTHONPATH=${HOME}/Projects/claude-power-pack/lib` while invoking `python3 -m lib.security`, which makes Python look for `lib/lib/security` and fail with `ModuleNotFoundError`.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_runner.py tests/test_manifest.py -q` - 53 passed
- Reproduced the original agentic-asst finish command successfully after this fix: lint, test, and security_scan completed 3/3 steps