### PR TITLE
fix(flow): pin COMPOSE_PROJECT_NAME + external opt-out for make deploy (Closes #535)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -819,7 +819,39 @@ if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/n
     VERIFY_ENABLED=1
 fi
 
-if [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+# Out-of-band deploy opt-out (issue #535): a repo whose real deploy path is a host
+# timer / CI on origin/main - not `make deploy` from a dev box - declares
+# `mode: external` in .claude/deploy.yaml. flow:auto then SKIPS the inline deploy
+# rather than staging a throwaway per-worktree compose stack that collides with
+# fixed prod container_name values and leaks orphaned volumes/networks.
+DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+
+if [ "$DEPLOY_MODE" = "external" ]; then
+    echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main). Skipping inline 'make deploy'."
+elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+    # Compose-project safety (issue #535): when COMPOSE_PROJECT_NAME is unset,
+    # docker compose derives it from the current directory basename. Run from a
+    # worktree or /tmp recovery clone, that basename diverges from the prod project
+    # (agentic-asst-issue-516 vs agentic-asst), collides with compose files that pin
+    # prod container_name values, and the failed rollback leaks orphaned
+    # <basename>_* volumes/networks. Pin it to a STABLE name: an explicit
+    # .claude/deploy.yaml override, else the CANONICAL primary-checkout name from
+    # git's common dir (never the worktree/tmp basename).
+    if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+        DEPLOY_PROJECT=$(grep -oP '^\s*compose_project_name:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+        if [ -z "$DEPLOY_PROJECT" ]; then
+            GCD=$(git rev-parse --git-common-dir 2>/dev/null)
+            if [ -n "$GCD" ]; then
+                COMMON_GIT_DIR=$(cd "$GCD" 2>/dev/null && pwd)
+                [ -n "$COMMON_GIT_DIR" ] && DEPLOY_PROJECT=$(basename "$(dirname "$COMMON_GIT_DIR")" | tr 'A-Z' 'a-z')
+            fi
+        fi
+        if [ -n "$DEPLOY_PROJECT" ]; then
+            export COMPOSE_PROJECT_NAME="$DEPLOY_PROJECT"
+            echo "Pinned COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME (issue #535: canonical prod project, not the worktree basename)."
+        fi
+    fi
+
     # Pre-deploy: capture the baseline (before make deploy) so the post-deploy
     # verify can detect regressions.
     if [ "$VERIFY_ENABLED" -eq 1 ]; then

--- a/.claude/commands/flow/deploy.md
+++ b/.claude/commands/flow/deploy.md
@@ -45,6 +45,48 @@ if ! grep -q "^${TARGET}:" Makefile; then
 fi
 ```
 
+### Step 3b: Deploy Compose-Project Safety + Out-of-Band Opt-Out (issue #535)
+
+`make deploy` (both the deterministic runner in Step 4b and the fallback in Step 5)
+shells out to `docker compose`, which derives `COMPOSE_PROJECT_NAME` from the
+current directory basename when it is unset. Run from a worktree or a `/tmp`
+recovery clone, that basename diverges from the prod project
+(`agentic-asst-issue-516` vs `agentic-asst`), collides with compose files that pin
+prod `container_name` values, and the failed rollback leaks orphaned
+`<basename>_*` volumes/networks. Handle both escapes before any deploy runs:
+
+```bash
+DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+
+# 1. Out-of-band deploy: a repo whose real deploy path is a host timer / CI on
+#    origin/main declares `mode: external` in .claude/deploy.yaml. Do NOT stage a
+#    throwaway per-worktree compose stack from a dev box.
+if [ "$DEPLOY_MODE" = "external" ]; then
+    echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main)."
+    echo "Nothing to do here; skipping /flow:deploy."
+    exit 0
+fi
+
+# 2. Otherwise pin COMPOSE_PROJECT_NAME (when unset) to a STABLE name so compose
+#    never uses the worktree/tmp basename: an explicit .claude/deploy.yaml override,
+#    else the CANONICAL primary-checkout name from git's common dir. Exported here
+#    so BOTH the runner (Step 4b) and the fallback (Step 5) inherit it.
+if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+    DEPLOY_PROJECT=$(grep -oP '^\s*compose_project_name:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+    if [ -z "$DEPLOY_PROJECT" ]; then
+        GCD=$(git rev-parse --git-common-dir 2>/dev/null)
+        if [ -n "$GCD" ]; then
+            COMMON_GIT_DIR=$(cd "$GCD" 2>/dev/null && pwd)
+            [ -n "$COMMON_GIT_DIR" ] && DEPLOY_PROJECT=$(basename "$(dirname "$COMMON_GIT_DIR")" | tr 'A-Z' 'a-z')
+        fi
+    fi
+    if [ -n "$DEPLOY_PROJECT" ]; then
+        export COMPOSE_PROJECT_NAME="$DEPLOY_PROJECT"
+        echo "Pinned COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME (issue #535: canonical prod project, not the worktree basename)."
+    fi
+fi
+```
+
 ### Step 4: Check Deploy Metadata (optional)
 
 If `.claude/deploy.yaml` exists, read it for confirmation requirements:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,8 @@ Flow commands use Makefile targets as the canonical build interface:
 - `/flow:auto` runs `make update_docs` after implement, verifies CI after merge, then `make deploy`
 - `/flow:doctor` reports which standard targets are available
 - Deploy metadata in `.claude/deploy.yaml` (optional, created manually when needed)
+  - `mode: external` - deploy runs out of band (host timer / CI on origin/main); `/flow:auto` Step 9 and `/flow:deploy` skip the inline `make deploy` rather than staging a throwaway per-worktree compose stack (#535)
+  - `compose_project_name: <name>` - pins `COMPOSE_PROJECT_NAME` for `make deploy` so docker compose never derives it from a worktree/tmp directory basename and collides with fixed prod `container_name` values; defaults to the canonical primary-checkout name when unset (#535)
 - Deploy history logged to `.claude/deploy.log`
 - Starter template at `templates/Makefile.example`
 

--- a/codex/prompts/flow-auto.md
+++ b/codex/prompts/flow-auto.md
@@ -828,7 +828,39 @@ if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/n
     VERIFY_ENABLED=1
 fi
 
-if [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+# Out-of-band deploy opt-out (issue #535): a repo whose real deploy path is a host
+# timer / CI on origin/main - not `make deploy` from a dev box - declares
+# `mode: external` in .claude/deploy.yaml. flow:auto then SKIPS the inline deploy
+# rather than staging a throwaway per-worktree compose stack that collides with
+# fixed prod container_name values and leaks orphaned volumes/networks.
+DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+
+if [ "$DEPLOY_MODE" = "external" ]; then
+    echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main). Skipping inline 'make deploy'."
+elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+    # Compose-project safety (issue #535): when COMPOSE_PROJECT_NAME is unset,
+    # docker compose derives it from the current directory basename. Run from a
+    # worktree or /tmp recovery clone, that basename diverges from the prod project
+    # (agentic-asst-issue-516 vs agentic-asst), collides with compose files that pin
+    # prod container_name values, and the failed rollback leaks orphaned
+    # <basename>_* volumes/networks. Pin it to a STABLE name: an explicit
+    # .claude/deploy.yaml override, else the CANONICAL primary-checkout name from
+    # git's common dir (never the worktree/tmp basename).
+    if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+        DEPLOY_PROJECT=$(grep -oP '^\s*compose_project_name:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+        if [ -z "$DEPLOY_PROJECT" ]; then
+            GCD=$(git rev-parse --git-common-dir 2>/dev/null)
+            if [ -n "$GCD" ]; then
+                COMMON_GIT_DIR=$(cd "$GCD" 2>/dev/null && pwd)
+                [ -n "$COMMON_GIT_DIR" ] && DEPLOY_PROJECT=$(basename "$(dirname "$COMMON_GIT_DIR")" | tr 'A-Z' 'a-z')
+            fi
+        fi
+        if [ -n "$DEPLOY_PROJECT" ]; then
+            export COMPOSE_PROJECT_NAME="$DEPLOY_PROJECT"
+            echo "Pinned COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME (issue #535: canonical prod project, not the worktree basename)."
+        fi
+    fi
+
     # Pre-deploy: capture the baseline (before make deploy) so the post-deploy
     # verify can detect regressions.
     if [ "$VERIFY_ENABLED" -eq 1 ]; then

--- a/codex/prompts/flow-deploy.md
+++ b/codex/prompts/flow-deploy.md
@@ -47,6 +47,48 @@ if ! grep -q "^${TARGET}:" Makefile; then
 fi
 ```
 
+### Step 3b: Deploy Compose-Project Safety + Out-of-Band Opt-Out (issue #535)
+
+`make deploy` (both the deterministic runner in Step 4b and the fallback in Step 5)
+shells out to `docker compose`, which derives `COMPOSE_PROJECT_NAME` from the
+current directory basename when it is unset. Run from a worktree or a `/tmp`
+recovery clone, that basename diverges from the prod project
+(`agentic-asst-issue-516` vs `agentic-asst`), collides with compose files that pin
+prod `container_name` values, and the failed rollback leaks orphaned
+`<basename>_*` volumes/networks. Handle both escapes before any deploy runs:
+
+```bash
+DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+
+# 1. Out-of-band deploy: a repo whose real deploy path is a host timer / CI on
+#    origin/main declares `mode: external` in .claude/deploy.yaml. Do NOT stage a
+#    throwaway per-worktree compose stack from a dev box.
+if [ "$DEPLOY_MODE" = "external" ]; then
+    echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main)."
+    echo "Nothing to do here; skipping /flow-deploy."
+    exit 0
+fi
+
+# 2. Otherwise pin COMPOSE_PROJECT_NAME (when unset) to a STABLE name so compose
+#    never uses the worktree/tmp basename: an explicit .claude/deploy.yaml override,
+#    else the CANONICAL primary-checkout name from git's common dir. Exported here
+#    so BOTH the runner (Step 4b) and the fallback (Step 5) inherit it.
+if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+    DEPLOY_PROJECT=$(grep -oP '^\s*compose_project_name:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+    if [ -z "$DEPLOY_PROJECT" ]; then
+        GCD=$(git rev-parse --git-common-dir 2>/dev/null)
+        if [ -n "$GCD" ]; then
+            COMMON_GIT_DIR=$(cd "$GCD" 2>/dev/null && pwd)
+            [ -n "$COMMON_GIT_DIR" ] && DEPLOY_PROJECT=$(basename "$(dirname "$COMMON_GIT_DIR")" | tr 'A-Z' 'a-z')
+        fi
+    fi
+    if [ -n "$DEPLOY_PROJECT" ]; then
+        export COMPOSE_PROJECT_NAME="$DEPLOY_PROJECT"
+        echo "Pinned COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME (issue #535: canonical prod project, not the worktree basename)."
+    fi
+fi
+```
+
 ### Step 4: Check Deploy Metadata (optional)
 
 If `.claude/deploy.yaml` exists, read it for confirmation requirements:

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -819,7 +819,39 @@ if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/n
     VERIFY_ENABLED=1
 fi
 
-if [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+# Out-of-band deploy opt-out (issue #535): a repo whose real deploy path is a host
+# timer / CI on origin/main - not `make deploy` from a dev box - declares
+# `mode: external` in .claude/deploy.yaml. flow:auto then SKIPS the inline deploy
+# rather than staging a throwaway per-worktree compose stack that collides with
+# fixed prod container_name values and leaks orphaned volumes/networks.
+DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+
+if [ "$DEPLOY_MODE" = "external" ]; then
+    echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main). Skipping inline 'make deploy'."
+elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+    # Compose-project safety (issue #535): when COMPOSE_PROJECT_NAME is unset,
+    # docker compose derives it from the current directory basename. Run from a
+    # worktree or /tmp recovery clone, that basename diverges from the prod project
+    # (agentic-asst-issue-516 vs agentic-asst), collides with compose files that pin
+    # prod container_name values, and the failed rollback leaks orphaned
+    # <basename>_* volumes/networks. Pin it to a STABLE name: an explicit
+    # .claude/deploy.yaml override, else the CANONICAL primary-checkout name from
+    # git's common dir (never the worktree/tmp basename).
+    if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+        DEPLOY_PROJECT=$(grep -oP '^\s*compose_project_name:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+        if [ -z "$DEPLOY_PROJECT" ]; then
+            GCD=$(git rev-parse --git-common-dir 2>/dev/null)
+            if [ -n "$GCD" ]; then
+                COMMON_GIT_DIR=$(cd "$GCD" 2>/dev/null && pwd)
+                [ -n "$COMMON_GIT_DIR" ] && DEPLOY_PROJECT=$(basename "$(dirname "$COMMON_GIT_DIR")" | tr 'A-Z' 'a-z')
+            fi
+        fi
+        if [ -n "$DEPLOY_PROJECT" ]; then
+            export COMPOSE_PROJECT_NAME="$DEPLOY_PROJECT"
+            echo "Pinned COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME (issue #535: canonical prod project, not the worktree basename)."
+        fi
+    fi
+
     # Pre-deploy: capture the baseline (before make deploy) so the post-deploy
     # verify can detect regressions.
     if [ "$VERIFY_ENABLED" -eq 1 ]; then

--- a/plugins/flow/commands/deploy.md
+++ b/plugins/flow/commands/deploy.md
@@ -45,6 +45,48 @@ if ! grep -q "^${TARGET}:" Makefile; then
 fi
 ```
 
+### Step 3b: Deploy Compose-Project Safety + Out-of-Band Opt-Out (issue #535)
+
+`make deploy` (both the deterministic runner in Step 4b and the fallback in Step 5)
+shells out to `docker compose`, which derives `COMPOSE_PROJECT_NAME` from the
+current directory basename when it is unset. Run from a worktree or a `/tmp`
+recovery clone, that basename diverges from the prod project
+(`agentic-asst-issue-516` vs `agentic-asst`), collides with compose files that pin
+prod `container_name` values, and the failed rollback leaks orphaned
+`<basename>_*` volumes/networks. Handle both escapes before any deploy runs:
+
+```bash
+DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+
+# 1. Out-of-band deploy: a repo whose real deploy path is a host timer / CI on
+#    origin/main declares `mode: external` in .claude/deploy.yaml. Do NOT stage a
+#    throwaway per-worktree compose stack from a dev box.
+if [ "$DEPLOY_MODE" = "external" ]; then
+    echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main)."
+    echo "Nothing to do here; skipping /flow:deploy."
+    exit 0
+fi
+
+# 2. Otherwise pin COMPOSE_PROJECT_NAME (when unset) to a STABLE name so compose
+#    never uses the worktree/tmp basename: an explicit .claude/deploy.yaml override,
+#    else the CANONICAL primary-checkout name from git's common dir. Exported here
+#    so BOTH the runner (Step 4b) and the fallback (Step 5) inherit it.
+if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+    DEPLOY_PROJECT=$(grep -oP '^\s*compose_project_name:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
+    if [ -z "$DEPLOY_PROJECT" ]; then
+        GCD=$(git rev-parse --git-common-dir 2>/dev/null)
+        if [ -n "$GCD" ]; then
+            COMMON_GIT_DIR=$(cd "$GCD" 2>/dev/null && pwd)
+            [ -n "$COMMON_GIT_DIR" ] && DEPLOY_PROJECT=$(basename "$(dirname "$COMMON_GIT_DIR")" | tr 'A-Z' 'a-z')
+        fi
+    fi
+    if [ -n "$DEPLOY_PROJECT" ]; then
+        export COMPOSE_PROJECT_NAME="$DEPLOY_PROJECT"
+        echo "Pinned COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME (issue #535: canonical prod project, not the worktree basename)."
+    fi
+fi
+```
+
 ### Step 4: Check Deploy Metadata (optional)
 
 If `.claude/deploy.yaml` exists, read it for confirmation requirements:


### PR DESCRIPTION
## Problem

`/flow:auto` Step 9 and `/flow:deploy` run `make deploy` inline. When that runs from a **worktree** or a `/tmp` recovery clone (recovered/failed runs), `docker compose` derives `COMPOSE_PROJECT_NAME` from the **directory basename** (`agentic-asst-issue-516`, `agentic-asst-deploy-484`). Compose files that pin prod `container_name` values then collide, the rollback `compose up` fails, and the aborted run leaks orphaned `<basename>_pgdata` / `_voice-sockets` volumes and a `_net` network. Observed on `flow:auto` #484 and #516 (Closes #535).

## Fix (command-markdown only; no Python/schema change)

Two escapes, wired into both `.claude/commands/flow/auto.md` (Step 9) and `.claude/commands/flow/deploy.md` (new Step 3b, covering both the deterministic runner and the inline fallback):

1. **Out-of-band opt-out** - a repo whose real deploy is a host timer / CI on `origin/main` declares `mode: external` in `.claude/deploy.yaml`; flow then **skips** the inline `make deploy` instead of staging a throwaway per-worktree stack.
2. **Stable project name** - otherwise pin `COMPOSE_PROJECT_NAME` (only when unset) to an explicit `.claude/deploy.yaml: compose_project_name` override, else the **canonical primary-checkout name** from `git rev-parse --git-common-dir` (never the worktree/tmp basename).

`.claude/deploy.yaml` is free-form and already documented as the optional deploy-config home; the `cicd.yml` Pydantic models are `extra=ignore`, so no schema work needed.

## Changes

- `.claude/commands/flow/auto.md` - Step 9 external-skip + COMPOSE_PROJECT_NAME pinning
- `.claude/commands/flow/deploy.md` - new Step 3b, same guard before runner + fallback
- `CLAUDE.md` - document the two optional `.claude/deploy.yaml` keys (one sub-bullet each)
- `plugins/flow/commands/{auto,deploy}.md`, `codex/prompts/flow-{auto,deploy}.md` - regenerated mirrors

## Test plan

- `plugin-sync.sh --check` + `codex-prompt-sync.py --check`: in sync (rc=0)
- `python -m lib.cicd run --plan finish`: lint + test + security_scan all SUCCESS (3/3)
- `bash -n` on the injected blocks: clean
- No behavior change for repos already deploying from their canonical checkout (name only pins when unset, to the same value compose would derive there); the guard only bites the worktree/tmp case
- CPP's own `make deploy` is a no-op (#469), so this cannot be E2E-deployed here; verified via the gates above

Zero-config default preserved; opt-in `mode: external` is the durable fix for host-timer repos (e.g. agentic-asst).