### PR TITLE
fix(flow): quiet false stale-check fetch-fail + worktree-guard leak warnings (Closes #536)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,10 @@ from the session cwd; **never hand-build a `.claude/worktrees/<name>/...`
 absolute path**, which has been observed to land the edit in the MAIN repo
 working tree instead of the worktree (flow:auto #442 x2, #471). `/flow:auto`
 Steps 4/6 run `scripts/flow-worktree-guard.sh` - an advisory, fail-open guard
-that warns (never blocks) when the main tree has tracked modifications, the
-signature of a leaked edit - so the trap is caught before commit.
+that warns (never blocks) when a path this run edited is ALSO modified in the
+main tree, the signature of a leaked edit - so the trap is caught before commit.
+Pre-existing main dirt that does not overlap this run's edits is downgraded to a
+quiet info note rather than a false leak warning (#536).
 
 **Standalone skill extractions (issue #443):** skills with standalone value are
 extracted to their own public plugin repos so users never have to clone CPP -

--- a/scripts/flow-stale-check.sh
+++ b/scripts/flow-stale-check.sh
@@ -66,6 +66,17 @@ GIT_BIN="${FLOW_STALE_GIT:-git}"
 git_() { "$GIT_BIN" "$@"; }
 verdict() { echo "FLOW_STALE_BASE: $1"; }
 
+# True when FETCH_HEAD was written recently (within the last 5 minutes), i.e. a
+# fetch already succeeded this run. Used to suppress the alarming "fetch failed"
+# line when the on-disk ref is in fact fresh - the common sandbox-DNS case where
+# an earlier fetch worked and only a redundant one failed (issue #536).
+fetch_head_is_fresh() {
+    local fh
+    fh="$(git_ rev-parse --git-path FETCH_HEAD 2>/dev/null)" || return 1
+    [[ -s "$fh" ]] || return 1
+    [[ -n "$(find "$fh" -mmin -5 2>/dev/null)" ]]
+}
+
 # Cap noisy lists so a large upstream diff does not scroll the whole flow away.
 print_list() {
     local max=20 n=0 f
@@ -87,12 +98,24 @@ fi
 
 # Best-effort refresh of the base's remote-tracking ref. A network hiccup must
 # never break the flow - the check just runs against whatever ref is on disk.
+# On failure, cry wolf only when it matters: if a fetch already succeeded this
+# run (fresh FETCH_HEAD) the on-disk ref is current, so stay silent; otherwise
+# surface the ACTUAL git error instead of a generic line, so a blocked-DNS
+# sandbox is distinguishable from a real fetch problem (issue #536).
 if [[ "$DO_FETCH" -eq 1 ]]; then
     if [[ "$BASE_REF" == */* ]]; then
         remote="${BASE_REF%%/*}"
         rbranch="${BASE_REF#*/}"
-        git_ fetch "$remote" "$rbranch" --quiet 2>/dev/null \
-            || echo "flow-stale-check: 'git fetch $remote $rbranch' failed - using on-disk ref." >&2
+        # Record freshness BEFORE the attempt: a failing fetch can itself clobber
+        # FETCH_HEAD, which would otherwise erase the evidence that an earlier
+        # fetch this run already succeeded.
+        was_fresh=0; fetch_head_is_fresh && was_fresh=1
+        if ! fetch_err="$(git_ fetch "$remote" "$rbranch" --quiet 2>&1)"; then
+            if [[ "$was_fresh" -eq 0 ]] && ! fetch_head_is_fresh; then
+                echo "flow-stale-check: 'git fetch $remote $rbranch' failed - using on-disk ref." >&2
+                [[ -n "$fetch_err" ]] && printf '%s\n' "$fetch_err" | sed 's/^/  git: /' >&2
+            fi
+        fi
     else
         git_ fetch --quiet 2>/dev/null || true
     fi

--- a/scripts/flow-worktree-guard.sh
+++ b/scripts/flow-worktree-guard.sh
@@ -14,9 +14,19 @@
 # `git rev-parse --show-toplevel` (the active worktree root), never a hand-built
 # `.claude/worktrees/...` absolute path. This guard is the VERIFIABLE backstop for
 # that directive: run from inside a linked worktree, it inspects the MAIN repo's
-# TRACKED working tree and warns loudly if anything there is modified - the
-# signature of a leaked edit - so the trap is caught before commit rather than
-# discovered later.
+# TRACKED working tree for the leaked-edit signature - so the trap is caught
+# before commit rather than discovered later.
+#
+# To avoid crying wolf (issue #536), it does NOT warn about every dirty file in
+# main: the main checkout often carries PRE-EXISTING local modifications
+# unrelated to this run (deploy configs, etc.), and flagging those as a leak
+# buries the real signal. A dirty main file is treated as a leak only when it
+# ALSO appears among the paths THIS run edited (branch commits vs the base, plus
+# worktree dirt) - i.e. the run tried to touch that path yet it shows up modified
+# in main. Overlapping dirt -> a loud WARNING (and a --strict failure);
+# non-overlapping dirt -> a quiet info note, never a failure. Trade-off: a pure
+# leak of a file the worktree never also edited is downgraded to info - the
+# accepted cost of killing the recurring false positives.
 #
 # Scope: only meaningful in a linked-worktree session (`.git` is a file). In the
 # main checkout itself (`.git` is a directory) there is no "other tree" to leak
@@ -28,13 +38,17 @@
 #   flow-worktree-guard.sh [--strict]
 #
 # Options:
-#   --strict   Exit non-zero (3) when the main working tree has tracked
-#              modifications. Default is advisory: always exit 0, just warn.
+#   --strict   Exit non-zero (3) ONLY when a main modification OVERLAPS a path
+#              this run edited (the leak signature). Non-overlapping pre-existing
+#              dirt never fails, even under --strict. Default is advisory:
+#              always exit 0, just warn/note.
 #
 # Output:
-#   Prints a "[flow] WARNING" block naming the modified main-repo paths with a
-#   remediation hint. Prints nothing (exit 0) when main is clean or when not in
-#   a linked worktree.
+#   - Overlap (leak): a "[flow] WARNING" block naming the overlapping paths with
+#     a remediation hint (and, under --strict, exit 3).
+#   - Non-overlap only: a quiet "[flow] note" listing the pre-existing main
+#     modifications, exit 0.
+#   - Nothing (exit 0) when main is clean or when not in a linked worktree.
 #
 # Env (test hook - unset in normal use):
 #   FLOW_WORKTREE_GIT   override the `git` binary (default: git)
@@ -86,25 +100,73 @@ fi
 # --untracked-files=no keeps normal scratch/untracked noise out; the worktree's
 # own files live under main's gitignored `.claude/worktrees/` and never appear
 # here, so they cannot false-positive.
-leaked=()
+main_dirty=()
 while IFS= read -r -d '' entry; do
   # porcelain -z: 2-char status, a space, then the path.
   path="${entry:3}"
   [ -n "$path" ] || continue
-  leaked+=("$path")
+  main_dirty+=("$path")
 done < <("$GIT" -C "$MAIN_REPO" status --porcelain --untracked-files=no -z 2>/dev/null)
 
-if [ "${#leaked[@]}" -eq 0 ]; then
+if [ "${#main_dirty[@]}" -eq 0 ]; then
   exit 0
 fi
 
-echo "[flow] WARNING: the MAIN repo working tree has ${#leaked[@]} modified tracked file(s):" >&2
+# Not every dirty file in main is a leak: the main checkout often carries
+# PRE-EXISTING local modifications unrelated to this run (e.g. deploy configs),
+# and screaming "LEAKED" about them buries the real signal (issue #536). A dirty
+# main file is a leak only when it ALSO appears among the paths THIS run edited -
+# the run tried to touch that path, yet it shows up modified in main. So compute
+# this run's edited set (branch commits vs the base + anything dirty in the
+# worktree) and partition main-dirty into overlap (leak) vs unrelated (info).
+run_edited=""
+base_ref=""
+for cand in origin/main main; do
+  if "$GIT" rev-parse --verify --quiet "${cand}^{commit}" >/dev/null 2>&1; then
+    base_ref="$cand"; break
+  fi
+done
+if [ -n "$base_ref" ]; then
+  mb="$("$GIT" merge-base HEAD "$base_ref" 2>/dev/null || true)"
+  [ -n "$mb" ] && run_edited="$("$GIT" diff --name-only "$mb"..HEAD 2>/dev/null)"
+fi
+# Worktree dirt (staged/unstaged/new): strip status, keep the rename destination.
+wt_dirty="$("$GIT" status --porcelain 2>/dev/null | sed 's/^...//' | sed 's/.* -> //')"
+run_edited="$(printf '%s\n%s\n' "$run_edited" "$wt_dirty" | sed '/^$/d' | sort -u)"
+
+overlap=()
+unrelated=()
+for p in "${main_dirty[@]}"; do
+  if [ -n "$run_edited" ] && printf '%s\n' "$run_edited" | grep -qxF -- "$p"; then
+    overlap+=("$p")
+  else
+    unrelated+=("$p")
+  fi
+done
+
+# No overlap -> pre-existing/unrelated dirt in main. Downgrade to an info note
+# (never a WARNING, never a --strict failure) so it stops drowning real signals.
+if [ "${#overlap[@]}" -eq 0 ]; then
+  echo "[flow] note: main has ${#unrelated[@]} modified tracked file(s) unrelated to this run's edits (pre-existing, not a leak; issue #536):" >&2
+  for p in "${unrelated[@]}"; do
+    echo "  - $p" >&2
+  done
+  echo "         main: $MAIN_REPO" >&2
+  exit 0
+fi
+
+# Overlap -> a file this run edited is ALSO dirty in main: the leaked-edit
+# signature (issue #486). Warn loudly (and fail under --strict).
+echo "[flow] WARNING: ${#overlap[@]} file(s) this run edited are ALSO modified in the MAIN working tree:" >&2
 echo "         main: $MAIN_REPO" >&2
-for p in "${leaked[@]}"; do
+for p in "${overlap[@]}"; do
   echo "  - $p" >&2
 done
+if [ "${#unrelated[@]}" -gt 0 ]; then
+  echo "  (${#unrelated[@]} further pre-existing main modification(s) unrelated to this run - ignored.)" >&2
+fi
 echo "" >&2
-echo "  If you meant to edit these in the worktree, an edit LEAKED into main (issue #486)." >&2
+echo "  An edit likely LEAKED into main instead of the worktree (issue #486)." >&2
 echo "  Fix: resolve edit paths from 'git rev-parse --show-toplevel' (the worktree root)," >&2
 echo "  never a hand-built '.claude/worktrees/<name>/...' absolute path. Move the change" >&2
 echo "  into the worktree, then revert main:  git -C \"$MAIN_REPO\" checkout -- <path>" >&2

--- a/tests/test_flow_stale_check.py
+++ b/tests/test_flow_stale_check.py
@@ -210,6 +210,64 @@ def test_fail_open_when_base_ref_missing(tmp_path: Path):
     assert _verdict(result.stdout) == "unknown"
 
 
+# --- Fetch-failure messaging (issue #536) -----------------------------------
+# These run WITHOUT --no-fetch so the fetch path is exercised. The "remote" is an
+# empty bare repo, so `git fetch origin main` deterministically fails ("couldn't
+# find remote ref main") without contacting the network.
+
+
+def _run_online(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=repo,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _wire_failing_remote(repo: Path, tmp_path: Path) -> str:
+    """Point origin at an empty bare repo (fetch of `main` fails) and seed an
+    on-disk origin/main == HEAD so the base ref exists. Returns HEAD sha."""
+    remote = tmp_path / "remote.git"
+    _git(repo, "init", "-q", "--bare", str(remote))
+    _git(repo, "remote", "add", "origin", str(remote))
+    sha = _git(repo, "rev-parse", "HEAD").strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", sha)
+    return sha
+
+
+@requires_git
+def test_fetch_failure_suppressed_when_fetch_head_fresh(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    sha = _wire_failing_remote(repo, tmp_path)
+    # A fresh FETCH_HEAD stands in for "a fetch already succeeded this run".
+    (repo / ".git" / "FETCH_HEAD").write_text(f"{sha}\t\tbranch 'main'\n")
+    result = _run_online(repo, "origin/main")
+    assert result.returncode == 0
+    assert "failed - using on-disk ref" not in result.stderr, (
+        "a fresh FETCH_HEAD must suppress the alarming generic failure line (#536)"
+    )
+    assert _verdict(result.stdout) == "current"
+
+
+@requires_git
+def test_fetch_failure_surfaces_real_git_error(tmp_path: Path):
+    repo = _make_repo(tmp_path)
+    _wire_failing_remote(repo, tmp_path)
+    fh = repo / ".git" / "FETCH_HEAD"
+    if fh.exists():
+        fh.unlink()  # not fresh -> the real failure must be surfaced
+    result = _run_online(repo, "origin/main")
+    assert result.returncode == 0, "still fail-open (advisory) on a fetch failure"
+    assert "failed - using on-disk ref" in result.stderr
+    assert "git:" in result.stderr, (
+        "the ACTUAL git error must be surfaced, not just the generic line (#536)"
+    )
+    assert _verdict(result.stdout) == "current"
+
+
 # --- Wiring: the flow surfaces must call the early check / re-sync ----------
 
 

--- a/tests/test_flow_worktree_native.py
+++ b/tests/test_flow_worktree_native.py
@@ -193,8 +193,11 @@ def test_guard_silent_when_main_clean(tmp_path: Path) -> None:
 
 @requires_git
 def test_guard_warns_on_leaked_edit_from_worktree(tmp_path: Path) -> None:
+    # The leak signature (issue #486/#536): a path this run edited in the worktree
+    # ALSO shows up modified in MAIN. The overlap is what makes it a leak rather
+    # than unrelated pre-existing dirt.
     main, wt = _make_repo_with_worktree(tmp_path)
-    # Simulate the trap: a tracked file in MAIN gets modified while working the wt.
+    (wt / "tracked.txt").write_text("intended-in-worktree\n")
     (main / "tracked.txt").write_text("LEAKED\n")
     res = _run(wt)
     assert res.returncode == 0  # advisory: never blocks
@@ -206,9 +209,42 @@ def test_guard_warns_on_leaked_edit_from_worktree(tmp_path: Path) -> None:
 @requires_git
 def test_guard_strict_exits_nonzero_on_leak(tmp_path: Path) -> None:
     main, wt = _make_repo_with_worktree(tmp_path)
+    (wt / "tracked.txt").write_text("intended-in-worktree\n")
     (main / "tracked.txt").write_text("LEAKED\n")
     res = _run(wt, "--strict")
     assert res.returncode == 3
+    assert "tracked.txt" in res.stderr
+
+
+@requires_git
+def test_guard_downgrades_nonoverlapping_main_dirt_to_info(tmp_path: Path) -> None:
+    """Issue #536: pre-existing main dirt on a file THIS run did not touch is not a
+    leak - downgrade to a quiet info note, never a WARNING or a --strict failure."""
+    main, wt = _make_repo_with_worktree(tmp_path)
+    # Main carries a pre-existing modification unrelated to this run...
+    (main / "tracked.txt").write_text("pre-existing-unrelated\n")
+    # ...while the run edits a DIFFERENT file in the worktree.
+    (wt / "other.txt").write_text("mine\n")
+    res = _run(wt, "--strict")
+    assert res.returncode == 0, "non-overlapping main dirt must not fail, even --strict"
+    assert "WARNING" not in res.stderr
+    assert "note" in res.stderr and "tracked.txt" in res.stderr
+    assert "#536" in res.stderr
+
+
+@requires_git
+def test_guard_warns_on_overlap_even_with_unrelated_dirt(tmp_path: Path) -> None:
+    """A real overlap still warns even when other unrelated main dirt is present."""
+    main, wt = _make_repo_with_worktree(tmp_path)
+    (main / "tracked.txt").write_text("also-in-main\n")  # overlaps the wt edit
+    (wt / "tracked.txt").write_text("edited-here\n")
+    (main / "other.txt").write_text("unrelated\n")  # pre-existing, no overlap
+    _git(main, "add", "other.txt")  # make it a tracked pre-existing mod
+    _git(main, "commit", "-qm", "add other")
+    (main / "other.txt").write_text("unrelated-dirty\n")
+    res = _run(wt, "--strict")
+    assert res.returncode == 3
+    assert "WARNING" in res.stderr
     assert "tracked.txt" in res.stderr
 
 


### PR DESCRIPTION
## Summary

Two advisory `/flow:auto` helper scripts cried wolf and buried the real signals they exist to raise (issue #536).

- **`scripts/flow-stale-check.sh`** printed a generic `'git fetch <remote> <branch>' failed - using on-disk ref` line even when a fetch had already succeeded this run and the branch was current -- the common sandbox-DNS case where only a redundant fetch fails. Now it records `FETCH_HEAD` freshness **before** the attempt (a failing fetch can clobber `FETCH_HEAD` itself) and re-checks after: if a fetch already succeeded recently it stays silent; otherwise it surfaces the **actual git stderr** (prefixed `git:`) instead of a generic line, so a DNS/sandbox block is distinguishable from a real fetch problem.
- **`scripts/flow-worktree-guard.sh`** warned `edit LEAKED into main (#486)` for **any** tracked modification in the main checkout, including pre-existing local dirt unrelated to the run (e.g. deploy configs). Now it computes this run's edited paths (branch commits vs base + worktree dirt) and partitions main-dirty files:
  - **overlap** (a path this run edited that is *also* dirty in main) -> the real leak signature -> loud `WARNING`, and a `--strict` failure;
  - **non-overlap** (pre-existing/unrelated dirt) -> a quiet `[flow] note`, never a failure (even under `--strict`).

### Trade-off (documented inline)

A *pure* leak -- a file that leaked to main but was **never also edited in the worktree** -- is now downgraded to an info note rather than a warning. This is the accepted cost, chosen by the issue, of killing the recurring false positives (#486 guard fired 3x on unrelated pre-existing dirt).

## Test plan

- `tests/test_flow_stale_check.py`: +2 online tests -- warning suppressed on fresh `FETCH_HEAD`; real git error surfaced otherwise.
- `tests/test_flow_worktree_native.py`: updated the 2 leak tests to model overlap; added a non-overlap-downgrade test (exit 0 even under `--strict`) and an overlap-amid-unrelated-dirt test.
- `CLAUDE.md`: guard description updated to the overlap semantics.
- Deterministic finish gate green on the post-merge tree: lint + full pytest + security scan (3/3). Both fixed guards dogfooded live during this run (stale-check correctly flagged the real #538 collision; worktree-guard stayed silent on untracked scaffolding).

Closes #536