### PR TITLE
fix(cicd): make the flow quality-gate runner sandbox-aware (Closes #534)

### DIFF
--- a/.claude/cicd_tasks.yml
+++ b/.claude/cicd_tasks.yml
@@ -36,25 +36,24 @@ steps:
     skip_if: '! grep -q "^typecheck:" Makefile 2>/dev/null'
 
   security_scan:
-    command: >-
-      PYTHONPATH="${HOME}/Projects/claude-power-pack/lib"
-      python3 -m lib.security gate flow_finish
+    # No hardcoded PYTHONPATH: this manifest only runs with the runner's cwd at
+    # the CPP repo root, so `lib.security` / `lib.cicd.bootstrap` resolve via
+    # cwd. The old `${HOME}/Projects/claude-power-pack/lib` prefix was both wrong
+    # for `-m lib.<pkg>` (that needs the parent of lib/) and broke under a
+    # sandbox or alternate checkout (issue #534).
+    command: python3 -m lib.security gate flow_finish
     description: Run security quick scan
     timeout: 120
     skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
 
   deploy_security_scan:
-    command: >-
-      PYTHONPATH="${HOME}/Projects/claude-power-pack/lib"
-      python3 -m lib.security gate flow_deploy
+    command: python3 -m lib.security gate flow_deploy
     description: Run security scan before deploy
     timeout: 120
     skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
 
   bootstrap_check:
-    command: >-
-      PYTHONPATH="${HOME}/Projects/claude-power-pack/lib"
-      python3 -m lib.cicd.bootstrap check
+    command: python3 -m lib.cicd.bootstrap check
     description: Check admin-only bootstrap dependencies are satisfied
     timeout: 30
     skip_if: '! [ -f .claude/bootstrap.yaml ]'

--- a/lib/cicd/manifest.py
+++ b/lib/cicd/manifest.py
@@ -302,15 +302,18 @@ def generate_manifest(
             skip_if=skip_if,
         )
 
-    # Add security_scan step if lib.security is available
+    # Add security_scan step if lib.security is available. PYTHONPATH is set via
+    # the step env (derived from the CPP checkout location, not a hardcoded
+    # "${HOME}/Projects/..." that breaks under a sandbox / alternate checkout) so
+    # ``python3 -m lib.security`` resolves wherever CPP lives (issue #534).
+    from .steps import _CPP_ROOT
+
     steps["security_scan"] = StepModel(
-        command=(
-            'PYTHONPATH="${HOME}/Projects/claude-power-pack" '
-            "python3 -m lib.security gate flow_finish"
-        ),
+        command="python3 -m lib.security gate flow_finish",
         description="Run security quick scan",
         timeout=120,
-        skip_if='! PYTHONPATH="${HOME}/Projects/claude-power-pack" python3 -c \'import lib.security\' 2>/dev/null',
+        skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+        env={"PYTHONPATH": _CPP_ROOT},
     )
 
     # Add any extra Makefile targets not already covered

--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import socket
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,18 +28,79 @@ from typing import Any, Optional, TextIO
 from .state import RunState
 from .steps import ShellStep, StepDef, get_plan_steps
 
-RUNNER_STRIP_VARS = frozenset({"PYTHONPATH"})
+# Variables the runner launcher injects (or a parent venv leaks) that must NOT
+# reach child step processes: PYTHONPATH is added so ``python -m lib.cicd`` can
+# import itself but would shadow the target project's imports; VIRTUAL_ENV /
+# PYTHONHOME inherited from the CPP venv pin child ``uv run`` to the wrong
+# interpreter and hide the project's own dev deps (e.g. pytest-cov), so the
+# child must re-resolve the project venv from scratch (issue #534).
+RUNNER_STRIP_VARS = frozenset({"PYTHONPATH", "VIRTUAL_ENV", "PYTHONHOME"})
 
 
-def _build_step_env() -> dict[str, str]:
+def _project_python_floor(project_root: Optional[Path]) -> Optional[str]:
+    """Return the target project's minimum Python version (e.g. "3.12").
+
+    Parsed from the project's ``pyproject.toml`` ``requires-python`` floor so
+    child ``uv run`` steps pin the interpreter the project actually needs,
+    rather than whatever system Python the sandbox defaults to (issue #534,
+    part #2). Returns None when it cannot be determined - the caller then
+    leaves UV_PYTHON unset rather than guessing.
+    """
+    if project_root is None:
+        return None
+    pyproject = Path(project_root) / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r'requires-python\s*=\s*["\']([^"\']+)["\']', text)
+    if not match:
+        return None
+    # Take the first "3.N" that appears in the specifier (the floor for the
+    # common ">=3.N" / ">=3.N,<3.M" forms).
+    ver = re.search(r"(\d+\.\d+)", match.group(1))
+    return ver.group(1) if ver else None
+
+
+def _is_offline() -> bool:
+    """Best-effort detection that the runner has no outbound network.
+
+    A restricted sandbox (Codex) blocks DNS/outbound sockets, so network
+    steps (git fetch, secret managers) fail loudly. Steps can consult this to
+    skip-with-a-message instead of hard-failing (issue #534, part #5). An
+    explicit ``CPP_OFFLINE`` env value short-circuits the probe - for tests and
+    for sandboxes that also block the probe itself.
+    """
+    flag = os.environ.get("CPP_OFFLINE", "").strip().lower()
+    if flag in {"1", "true", "yes"}:
+        return True
+    if flag in {"0", "false", "no"}:
+        return False
+    try:
+        with socket.create_connection(("github.com", 443), timeout=2.0):
+            return False
+    except OSError:
+        return True
+
+
+def _build_step_env(project_root: Optional[Path] = None) -> dict[str, str]:
     """Build a sanitized copy of os.environ for child step processes.
 
-    Strips variables injected by the runner launcher (e.g. PYTHONPATH added
-    so ``python -m lib.cicd`` can import itself) and sets defaults required
-    by common build tools (UV_CACHE_DIR).
+    Makes the child environment sandbox-aware (issue #534):
+    - strips launcher/parent-venv leakage (see RUNNER_STRIP_VARS),
+    - defaults UV_CACHE_DIR to a writable path (sandbox ~/.cache is read-only),
+    - pins UV_PYTHON to the target project's required floor so child ``uv run``
+      steps do not fall back to a stale system interpreter.
+    All defaults use ``setdefault`` so an explicit caller env always wins.
+
+    Kept pure (no network) so it stays cheap and hermetic; the offline probe
+    that materializes CPP_OFFLINE runs once in the runner's execute loop.
     """
     env = {k: v for k, v in os.environ.items() if k not in RUNNER_STRIP_VARS}
     env.setdefault("UV_CACHE_DIR", "/tmp/uv-cache")
+    floor = _project_python_floor(project_root)
+    if floor:
+        env.setdefault("UV_PYTHON", floor)
     return env
 
 
@@ -147,11 +210,17 @@ class DeterministicRunner:
         if step_defs is None:
             step_defs = get_plan_steps(state.plan_name, project_root=str(self.project_root))
 
+        # Materialize CPP_OFFLINE once per run (the probe is the only network
+        # touch) so shell ``skip_if`` expressions can skip network steps in a
+        # sandbox instead of hard-failing (issue #534, part #5).
+        step_env = _build_step_env(self.project_root)
+        step_env.setdefault("CPP_OFFLINE", "1" if _is_offline() else "0")
+
         context = {
             "project_root": str(self.project_root),
             "run_id": state.run_id,
             "plan": state.plan_name,
-            "env": _build_step_env(),
+            "env": step_env,
         }
 
         completed = state.current_index

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -10,9 +10,17 @@ import os
 import subprocess
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional, Protocol
 
 from .state import StepStatus
+
+# Root of the CPP checkout (the parent of ``lib/``), derived from this file's
+# own location so ``python3 -m lib.security`` / ``-m lib.cicd.bootstrap`` resolve
+# regardless of where CPP is checked out - the hardcoded "${HOME}/Projects/
+# claude-power-pack" prefix broke under a sandbox or an alternate checkout
+# (/opt, ~/.claude-power-pack), the very fallbacks flow:auto searches (#534).
+_CPP_ROOT = str(Path(__file__).resolve().parents[2])
 
 
 class StepExecutor(Protocol):
@@ -90,6 +98,19 @@ class ShellStep:
         self.description = step_def.description
         self.env = step_def.env
 
+    def _resolve_env(self, context: dict[str, Any]) -> Optional[dict[str, str]]:
+        """Merge the sanitized runner env with this step's env overrides.
+
+        Both ``skip_if`` and the command run in the same environment so a
+        ``skip_if`` probe (e.g. ``import lib.security``) and the command it
+        guards see the same PYTHONPATH / CPP_OFFLINE the runner set (#534).
+        """
+        env = context.get("env")
+        if self.env:
+            env = dict(env) if env is not None else dict(os.environ)
+            env.update(self.env)
+        return env
+
     def should_skip(self, context: dict[str, Any]) -> bool:
         """Check if this step should be skipped."""
         if not self.skip_if:
@@ -101,6 +122,7 @@ class ShellStep:
                 capture_output=True,
                 timeout=10,
                 cwd=context.get("project_root"),
+                env=self._resolve_env(context),
             )
             return result.returncode == 0
         except (subprocess.TimeoutExpired, OSError):
@@ -109,14 +131,7 @@ class ShellStep:
     def execute(self, context: dict[str, Any]) -> StepResult:
         """Execute the shell command with timeout."""
         cwd = context.get("project_root")
-        env = context.get("env")
-
-        if self.env:
-            if env is None:
-                env = dict(os.environ)
-            else:
-                env = dict(env)
-            env.update(self.env)
+        env = self._resolve_env(context)
 
         try:
             proc = subprocess.run(
@@ -205,14 +220,12 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
         ),
         StepDef(
             id="security_scan",
-            command=(
-                'PYTHONPATH="${HOME}/Projects/claude-power-pack" '
-                "python3 -m lib.security gate flow_finish"
-            ),
+            command="python3 -m lib.security gate flow_finish",
             description="Run security quick scan",
             timeout_seconds=120,
             max_attempts=1,
-            skip_if='! PYTHONPATH="${HOME}/Projects/claude-power-pack" python3 -c \'import lib.security\' 2>/dev/null',
+            skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+            env={"PYTHONPATH": _CPP_ROOT},
         ),
     ],
     "check": [
@@ -236,14 +249,12 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
     "deploy": [
         StepDef(
             id="bootstrap_check",
-            command=(
-                'PYTHONPATH="${HOME}/Projects/claude-power-pack/lib" '
-                "python3 -m lib.cicd.bootstrap check"
-            ),
+            command="python3 -m lib.cicd.bootstrap check",
             description="Check admin-only bootstrap dependencies",
             timeout_seconds=30,
             max_attempts=1,
             skip_if="! [ -f .claude/bootstrap.yaml ]",
+            env={"PYTHONPATH": _CPP_ROOT},
         ),
         StepDef(
             id="stale_commit_check",
@@ -257,18 +268,18 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
             description="Verify HEAD matches origin/main (stale commit guard)",
             timeout_seconds=30,
             max_attempts=1,
-            skip_if='[ "$(git branch --show-current)" != "main" ]',
+            # Skip off main, or when offline: the git fetch cannot reach the
+            # remote in a sandbox, so skip-with-a-message beats a hard fail (#534).
+            skip_if='[ "$(git branch --show-current)" != "main" ] || [ "${CPP_OFFLINE:-0}" = "1" ]',
         ),
         StepDef(
             id="security_scan",
-            command=(
-                'PYTHONPATH="${HOME}/Projects/claude-power-pack" '
-                "python3 -m lib.security gate flow_deploy"
-            ),
+            command="python3 -m lib.security gate flow_deploy",
             description="Run security scan before deploy",
             timeout_seconds=120,
             max_attempts=1,
-            skip_if='! PYTHONPATH="${HOME}/Projects/claude-power-pack" python3 -c \'import lib.security\' 2>/dev/null',
+            skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+            env={"PYTHONPATH": _CPP_ROOT},
         ),
         StepDef(
             id="deploy",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -389,6 +389,17 @@ class TestGenerateManifest:
         # Should still have security_scan at minimum
         assert "security_scan" in manifest.steps
 
+    def test_generated_security_scan_dehardcoded(self, tmp_path):
+        """Generated security_scan derives PYTHONPATH via step env, not a
+        hardcoded ${HOME}/Projects/claude-power-pack prefix (#534)."""
+        from lib.cicd.steps import _CPP_ROOT
+
+        manifest = generate_manifest(tmp_path)
+        step = manifest.steps["security_scan"]
+        assert "Projects/claude-power-pack" not in step.command
+        assert "Projects/claude-power-pack" not in (step.skip_if or "")
+        assert dict(step.env).get("PYTHONPATH") == _CPP_ROOT
+
 
 # -- write_manifest tests --
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,9 +7,15 @@ from unittest.mock import patch
 
 import pytest
 
-from lib.cicd.runner import DeterministicRunner, RunResult, _build_step_env
+from lib.cicd.runner import (
+    DeterministicRunner,
+    RunResult,
+    _build_step_env,
+    _is_offline,
+    _project_python_floor,
+)
 from lib.cicd.state import RunState
-from lib.cicd.steps import StepDef
+from lib.cicd.steps import _CPP_ROOT, BUILTIN_PLANS, ShellStep, StepDef
 
 
 @pytest.fixture
@@ -263,3 +269,98 @@ class TestBuildStepEnv:
         with patch.dict(os.environ, {"UV_CACHE_DIR": "/custom/cache"}):
             env = _build_step_env()
             assert env["UV_CACHE_DIR"] == "/custom/cache"
+
+    def test_strips_parent_venv_leakage(self):
+        """Inherited VIRTUAL_ENV / PYTHONHOME must not reach child steps (#534)."""
+        with patch.dict(
+            os.environ,
+            {"VIRTUAL_ENV": "/parent/.venv", "PYTHONHOME": "/parent/home"},
+        ):
+            env = _build_step_env()
+            assert "VIRTUAL_ENV" not in env
+            assert "PYTHONHOME" not in env
+
+    def test_pins_uv_python_to_project_floor(self, tmp_path: Path):
+        """UV_PYTHON defaults to the target project's requires-python floor (#534)."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nrequires-python = ">=3.12"\n'
+        )
+        env_without = {k: v for k, v in os.environ.items() if k != "UV_PYTHON"}
+        with patch.dict(os.environ, env_without, clear=True):
+            env = _build_step_env(tmp_path)
+            assert env["UV_PYTHON"] == "3.12"
+
+    def test_uv_python_explicit_wins(self, tmp_path: Path):
+        """An explicit UV_PYTHON is never overridden by the derived floor."""
+        (tmp_path / "pyproject.toml").write_text('requires-python = ">=3.11"\n')
+        with patch.dict(os.environ, {"UV_PYTHON": "3.13"}):
+            env = _build_step_env(tmp_path)
+            assert env["UV_PYTHON"] == "3.13"
+
+    def test_no_uv_python_when_floor_unknown(self, tmp_path: Path):
+        """No pyproject / no requires-python -> UV_PYTHON left unset, not guessed."""
+        env_without = {k: v for k, v in os.environ.items() if k != "UV_PYTHON"}
+        with patch.dict(os.environ, env_without, clear=True):
+            env = _build_step_env(tmp_path)  # empty dir
+            assert "UV_PYTHON" not in env
+
+    def test_build_step_env_is_pure_no_offline_probe(self):
+        """_build_step_env must not materialize CPP_OFFLINE (stays network-free)."""
+        env_without = {k: v for k, v in os.environ.items() if k != "CPP_OFFLINE"}
+        with patch.dict(os.environ, env_without, clear=True):
+            env = _build_step_env()
+            assert "CPP_OFFLINE" not in env
+
+
+class TestSandboxHelpers:
+    def test_project_python_floor_parses_requires_python(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text('requires-python = ">=3.11,<3.14"\n')
+        assert _project_python_floor(tmp_path) == "3.11"
+
+    def test_project_python_floor_missing_pyproject(self, tmp_path: Path):
+        assert _project_python_floor(tmp_path) is None
+
+    def test_project_python_floor_none_root(self):
+        assert _project_python_floor(None) is None
+
+    def test_is_offline_honors_env_override(self):
+        with patch.dict(os.environ, {"CPP_OFFLINE": "1"}):
+            assert _is_offline() is True
+        with patch.dict(os.environ, {"CPP_OFFLINE": "0"}):
+            assert _is_offline() is False
+
+    def test_offline_flag_skips_network_step(self, tmp_project: Path):
+        """With CPP_OFFLINE=1 the deploy stale-commit (git fetch) step skips (#534)."""
+        stale = {s.id: s for s in BUILTIN_PLANS["deploy"]}["stale_commit_check"]
+        step = ShellStep(stale)
+        ctx_offline = {"project_root": str(tmp_project), "env": {"CPP_OFFLINE": "1"}}
+        assert step.should_skip(ctx_offline) is True
+
+
+class TestStepDefinitionsSandboxAware:
+    """The security/import steps derive PYTHONPATH from the CPP checkout, not a
+    hardcoded ${HOME} path that breaks under a sandbox / alternate checkout (#534)."""
+
+    def test_finish_security_scan_dehardcoded(self):
+        step = {s.id: s for s in BUILTIN_PLANS["finish"]}["security_scan"]
+        assert "Projects/claude-power-pack" not in step.command
+        assert "Projects/claude-power-pack" not in (step.skip_if or "")
+        assert step.env.get("PYTHONPATH") == _CPP_ROOT
+
+    def test_deploy_bootstrap_check_path_fixed(self):
+        """bootstrap_check previously pointed PYTHONPATH at .../lib (wrong for
+        -m lib.cicd.bootstrap); it now derives the parent-of-lib root."""
+        step = {s.id: s for s in BUILTIN_PLANS["deploy"]}["bootstrap_check"]
+        assert step.command == "python3 -m lib.cicd.bootstrap check"
+        assert step.env.get("PYTHONPATH") == _CPP_ROOT
+
+    def test_deploy_security_scan_dehardcoded(self):
+        step = {s.id: s for s in BUILTIN_PLANS["deploy"]}["security_scan"]
+        assert "Projects/claude-power-pack" not in step.command
+        assert step.env.get("PYTHONPATH") == _CPP_ROOT
+
+    def test_cpp_root_is_parent_of_lib(self):
+        """_CPP_ROOT must be the parent of lib/ so `-m lib.security` resolves."""
+        assert (Path(_CPP_ROOT) / "lib" / "security").exists() or (
+            Path(_CPP_ROOT) / "lib"
+        ).is_dir()


### PR DESCRIPTION
## Summary

Makes the deterministic CI/CD quality-gate runner (`lib/cicd`) sandbox-aware so
`/flow:auto`'s own finish gate stops failing before it runs any checks under a
Codex restricted sandbox (recurred across #456/#457/#488/#505/#516).

Completes issue #534's five-part scope. Part #1 (UV_CACHE_DIR) and half of part
#4 (the security_scan PYTHONPATH) had already landed via PR #533; this finishes
the rest.

## What changed

Centralized in the one env chokepoint every step's environment flows through,
`runner._build_step_env()`:

- **#3 VIRTUAL_ENV**: strip inherited VIRTUAL_ENV + PYTHONHOME so child `uv run`
  re-resolves the project venv instead of reusing the launcher's, which was
  hiding pytest-cov and rejecting `--cov`.
- **#2 UV_PYTHON**: pin to the target project's `requires-python` floor (parsed
  from its pyproject.toml); `setdefault` so an explicit env always wins. Stops
  the fallback to a stale system interpreter.
- **#5 offline**: `_is_offline()` + `CPP_OFFLINE` materialized once per run; the
  deploy stale-commit git-fetch step now skips-with-a-message when offline
  instead of hard-failing. `_build_step_env` stays pure (no network) so it is
  cheap and hermetic.
- **#4 PYTHONPATH de-hardcode**: security_scan / bootstrap_check derive the CPP
  root from the module location (`_CPP_ROOT` = parent of `lib/`) instead of a
  fixed `${HOME}/Projects/claude-power-pack` path that breaks under a sandbox or
  an alternate checkout (`/opt`, `~/.claude-power-pack` - the fallbacks
  `/flow:auto` itself searches). Also fixes the bootstrap_check path bug (it
  pointed at `.../lib`, wrong for `-m lib.cicd.bootstrap`) that PR #533 left.
- `should_skip` and `execute` now share one env-resolution helper so a `skip_if`
  probe and the command it guards run in the same sanitized + step env.
- `.claude/cicd_tasks.yml`: dropped the hardcoded PYTHONPATH prefixes; that
  manifest only runs with the runner cwd at the CPP root, where `lib` resolves
  via cwd.

## Test plan

- 15 new tests: VIRTUAL_ENV/PYTHONHOME stripping, UV_PYTHON floor derivation +
  explicit-wins + unknown-floor, `_build_step_env` purity (no offline probe),
  `_project_python_floor` parsing, `_is_offline` override, offline network-step
  skip, de-hardcoded built-in step defs, generated-manifest de-hardcoding.
- Full cicd-related suite green (355 passed).
- Deterministic finish gate run end-to-end against the worktree runner code:
  lint + test + security_scan all SUCCESS (security_scan runs via the
  de-hardcoded command).

## Follow-up (out of scope)

The same hardcoded `${HOME}/Projects/claude-power-pack/lib` pattern appears in
the interactive command-prompt surfaces (`secrets/*`, `security/*` command `.md`
plus their `codex/prompts/` and `plugins/` copies, and `lib/security/README.md`).
Those are user-facing slash-command invocations of `lib.security` / `lib.creds`,
a separate concern from the CI/CD runner; worth a dedicated follow-up rather than
expanding this PR (it would touch 60+ files across 3 generated surfaces).

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
