### PR TITLE
fix(cicd): stream step output live and preserve partial output on timeout (Closes #537)

### DIFF
--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -152,6 +152,9 @@ class DeterministicRunner:
             "run_id": state.run_id,
             "plan": state.plan_name,
             "env": _build_step_env(),
+            # Steps tee live output here; self.output is stderr by default, so
+            # stdout stays clean for the machine-readable JSON result (issue #537).
+            "output_stream": self.output,
         }
 
         completed = state.current_index

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -7,7 +7,9 @@ Each step type knows how to execute a specific kind of operation
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Optional, Protocol
@@ -107,9 +109,19 @@ class ShellStep:
             return False
 
     def execute(self, context: dict[str, Any]) -> StepResult:
-        """Execute the shell command with timeout."""
+        """Execute the shell command, streaming output live while capturing it.
+
+        Output is teed line-by-line to ``context['output_stream']`` (when
+        present) as the child produces it, so a slow-but-progressing command
+        (e.g. a large ``pytest`` suite) shows live progress instead of going
+        silent until it exits - a slow run is then distinguishable from a real
+        hang. Both stdout and stderr are still captured in the StepResult, and
+        partial output is preserved on a timeout so the wall-clock kill shows
+        *where* the command was rather than discarding everything (issue #537).
+        """
         cwd = context.get("project_root")
         env = context.get("env")
+        stream = context.get("output_stream")
 
         if self.env:
             if env is None:
@@ -119,36 +131,16 @@ class ShellStep:
             env.update(self.env)
 
         try:
-            proc = subprocess.run(
+            proc = subprocess.Popen(
                 self.command,
                 shell=True,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=self.timeout_seconds,
+                bufsize=1,  # line-buffered so tee'd progress appears promptly
                 cwd=cwd,
                 env=env,
-            )
-
-            if proc.returncode == 0:
-                return StepResult(
-                    status=StepStatus.SUCCESS,
-                    exit_code=0,
-                    output=proc.stdout,
-                )
-            else:
-                return StepResult(
-                    status=StepStatus.FAILED,
-                    exit_code=proc.returncode,
-                    output=proc.stdout,
-                    error=proc.stderr,
-                )
-
-        except subprocess.TimeoutExpired as e:
-            return StepResult(
-                status=StepStatus.FAILED,
-                exit_code=124,  # standard timeout exit code
-                output=e.stdout or "" if isinstance(e.stdout, str) else "",
-                error=f"Step timed out after {self.timeout_seconds}s",
+                start_new_session=True,  # own process group -> whole tree killable on timeout
             )
         except OSError as e:
             return StepResult(
@@ -156,6 +148,83 @@ class ShellStep:
                 exit_code=1,
                 error=str(e),
             )
+
+        out_chunks: list[str] = []
+        err_chunks: list[str] = []
+        tee_lock = threading.Lock()
+
+        def _pump(pipe: Any, sink: list[str]) -> None:
+            try:
+                for line in pipe:
+                    sink.append(line)
+                    if stream is not None:
+                        with tee_lock:
+                            stream.write(line)
+                            stream.flush()
+            finally:
+                pipe.close()
+
+        readers = [
+            threading.Thread(target=_pump, args=(proc.stdout, out_chunks), daemon=True),
+            threading.Thread(target=_pump, args=(proc.stderr, err_chunks), daemon=True),
+        ]
+        for reader in readers:
+            reader.start()
+
+        timed_out = False
+        try:
+            proc.wait(timeout=self.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            self._kill_process_tree(proc)
+
+        # Let the reader threads drain buffered output before assembling the
+        # result; capped so a child that leaked a pipe to a survivor can't hang.
+        for reader in readers:
+            reader.join(timeout=5)
+
+        output = "".join(out_chunks)
+        error = "".join(err_chunks)
+
+        if timed_out:
+            timeout_msg = f"Step timed out after {self.timeout_seconds}s"
+            return StepResult(
+                status=StepStatus.FAILED,
+                exit_code=124,  # standard timeout exit code
+                output=output,
+                error=f"{error}\n{timeout_msg}".strip() if error else timeout_msg,
+            )
+
+        if proc.returncode == 0:
+            return StepResult(
+                status=StepStatus.SUCCESS,
+                exit_code=0,
+                output=output,
+            )
+        return StepResult(
+            status=StepStatus.FAILED,
+            exit_code=proc.returncode if proc.returncode is not None else 1,
+            output=output,
+            error=error,
+        )
+
+    @staticmethod
+    def _kill_process_tree(proc: subprocess.Popen[str]) -> None:
+        """Kill a timed-out child and its process group.
+
+        The step runs ``shell=True`` and often spawns children (``make`` ->
+        ``pytest``). Killing only the shell leaves those children holding the
+        output pipes open, so the reader threads never reach EOF. Signalling the
+        whole process group tears the tree down and lets the readers drain.
+        """
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
 
     def execute_with_retry(self, context: dict[str, Any]) -> StepResult:
         """Execute with retry policy (exponential backoff)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,15 @@ requires-python = ">=3.11"
 dependencies = ["pydantic>=2.0", "pyyaml>=6.0"]
 
 [project.optional-dependencies]
-dev = ["mypy>=1.10", "pytest>=8.0", "ruff>=0.4", "types-PyYAML>=6.0", "types-requests>=2.31"]
+dev = ["mypy>=1.10", "pytest>=8.0", "pytest-timeout>=2.3", "ruff>=0.4", "types-PyYAML>=6.0", "types-requests>=2.31"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+# Per-test wall-clock cap: a single wedged test aborts with a traceback instead
+# of silently eating the runner's whole-suite budget (issue #537). Dogfoods the
+# per-test-timeout the finish runner recommends to every project.
+timeout = 120
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,7 +9,7 @@ import pytest
 
 from lib.cicd.runner import DeterministicRunner, RunResult, _build_step_env
 from lib.cicd.state import RunState
-from lib.cicd.steps import StepDef
+from lib.cicd.steps import ShellStep, StepDef
 
 
 @pytest.fixture
@@ -244,6 +244,54 @@ class TestDeterministicRunner:
 
         assert result.success
         assert env_file.read_text().strip() == "from_step"
+
+
+class TestShellStepStreaming:
+    """Live-streaming + partial-output-on-timeout behavior (issue #537)."""
+
+    def test_output_teed_live_to_stream(self, tmp_project: Path):
+        """Child stdout is teed to the runner stream, not only captured at exit."""
+        stream = StringIO()
+        step = ShellStep(StepDef(id="emit", command="echo hello-stream", timeout_seconds=30))
+        result = step.execute({"project_root": str(tmp_project), "output_stream": stream})
+
+        assert result.success
+        assert "hello-stream" in result.output        # captured in the result
+        assert "hello-stream" in stream.getvalue()     # AND streamed live
+
+    def test_no_stream_is_backwards_compatible(self, tmp_project: Path):
+        """Without an output_stream the step still captures output (pure capture)."""
+        step = ShellStep(StepDef(id="emit", command="echo captured-only", timeout_seconds=30))
+        result = step.execute({"project_root": str(tmp_project)})
+
+        assert result.success
+        assert "captured-only" in result.output
+
+    def test_timeout_preserves_partial_output(self, tmp_project: Path):
+        """A wall-clock timeout keeps output produced before the hang."""
+        stream = StringIO()
+        step = ShellStep(
+            StepDef(id="slow", command="echo partial-line; sleep 30", timeout_seconds=1)
+        )
+        result = step.execute({"project_root": str(tmp_project), "output_stream": stream})
+
+        assert not result.success
+        assert result.exit_code == 124
+        assert "timed out" in result.error
+        # The line printed before the sleep is NOT discarded - it shows where it hung.
+        assert "partial-line" in result.output
+        assert "partial-line" in stream.getvalue()
+
+    def test_stderr_still_captured(self, tmp_project: Path):
+        """stderr remains captured separately in the error field on failure."""
+        step = ShellStep(
+            StepDef(id="fail", command="echo oops 1>&2; exit 3", timeout_seconds=30)
+        )
+        result = step.execute({"project_root": str(tmp_project)})
+
+        assert not result.success
+        assert result.exit_code == 3
+        assert "oops" in result.error
 
 
 class TestBuildStepEnv:

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -34,6 +35,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -342,6 +344,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The deterministic finish/quality-gate runner ran each step via
`subprocess.run(capture_output=True)`, buffering all output until the process
exited. A slow-but-progressing `make test` was then indistinguishable from a
real hang (#516 timed out at 600s, #311 hung >10min, #488/#505 stalled), and a
wall-clock timeout discarded the partial output so you could not see *where* it
hung.

## Changes

- **`lib/cicd/steps.py`** - `ShellStep.execute()` now runs via `Popen` with two
  reader threads that tee stdout and stderr line-by-line to the runner's output
  stream while still capturing both. On timeout the child *process group* is
  SIGKILLed (`start_new_session=True`), so a spawned `make -> pytest` tree is
  fully torn down and the reader threads drain; the partial output is preserved
  with exit 124. New `_kill_process_tree()` helper.
- **`lib/cicd/runner.py`** - passes `output_stream: self.output` into the step
  context. `self.output` is stderr by default, so the machine-readable JSON on
  stdout stays clean.
- **`pyproject.toml`** - dogfoods the recommended per-test timeout: adds
  `pytest-timeout` to the `dev` extra with `timeout = 120`, so a single wedged
  test aborts with a traceback instead of silently eating the whole-suite
  budget. `uv.lock` regenerated so CI `uv sync --frozen` stays green.
- **`tests/test_runner.py`** - `TestShellStepStreaming`: live tee, backward-compat
  (no stream), partial-output-on-timeout (exit 124 + "timed out"), stderr split.

## Test plan

- `uv run --extra dev pytest` -> 840 passed (17.6s); no test approaches the 120s cap.
- Deterministic finish gate (`python -m lib.cicd run --plan finish`) passes 3/3,
  and pytest per-file progress now **streams live** through the runner instead of
  being buffered until exit - the fix verified end-to-end by dogfooding it.
- ruff + mypy clean on changed files.

Rebased onto `origin/main` (merged #534 sandbox-aware runner + #536); the env
resolution now flows through the upstream `_resolve_env()` helper.

Closes #537