### PR TITLE
fix(cpp): derive /cpp:update version from CLAUDE.md, not the CHANGELOG head (Closes #544)

### DIFF
--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -37,8 +37,16 @@ echo "Found claude-power-pack at: $CPP_DIR"
 ```bash
 cd "$CPP_DIR"
 
-# Get current version from CHANGELOG.md
-CURRENT_VERSION=$(grep -oP '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1 || echo "unknown")
+# Get current version from CLAUDE.md - the maintained source of truth (issue
+# #544: the CHANGELOG head can be a digit-less "[Unreleased]" block, so a grep
+# for the first bracketed version silently falls through to the PREVIOUS
+# release and reports a stale no-op update). Fall back to the newest bracketed
+# CHANGELOG release only if the CLAUDE.md line is missing.
+CURRENT_VERSION=$(grep -oPm1 '^Current version: \K[0-9]+\.[0-9]+\.[0-9]+' CLAUDE.md 2>/dev/null)
+if [ -z "$CURRENT_VERSION" ]; then
+  CURRENT_VERSION=$(grep -oPm1 '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md 2>/dev/null)
+fi
+CURRENT_VERSION="${CURRENT_VERSION:-unknown}"
 CURRENT_COMMIT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git branch --show-current)
 
@@ -97,9 +105,22 @@ fi
 git pull origin $CURRENT_BRANCH
 
 NEW_COMMIT=$(git rev-parse --short HEAD)
-NEW_VERSION=$(grep -oP '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1 || echo "unknown")
+# Same source-of-truth derivation as Step 2 (issue #544).
+NEW_VERSION=$(grep -oPm1 '^Current version: \K[0-9]+\.[0-9]+\.[0-9]+' CLAUDE.md 2>/dev/null)
+if [ -z "$NEW_VERSION" ]; then
+  NEW_VERSION=$(grep -oPm1 '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md 2>/dev/null)
+fi
+NEW_VERSION="${NEW_VERSION:-unknown}"
 echo ""
-echo "Updated: v$CURRENT_VERSION -> v$NEW_VERSION ($NEW_COMMIT)"
+# Never report a same-version pull as a no-op: when the release number did not
+# move but the commit did, say so and point at the unreleased delta instead of
+# printing a misleading "vX -> vX" (issue #544).
+if [ "$CURRENT_VERSION" = "$NEW_VERSION" ] && [ "$CURRENT_COMMIT" != "$NEW_COMMIT" ]; then
+  echo "Updated: v$NEW_VERSION unchanged, code moved $CURRENT_COMMIT -> $NEW_COMMIT"
+  echo "(unreleased changes - see the [Unreleased] section of CHANGELOG.md)"
+else
+  echo "Updated: v$CURRENT_VERSION ($CURRENT_COMMIT) -> v$NEW_VERSION ($NEW_COMMIT)"
+fi
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/cpp:update` no longer reports a stale version** (issue #544) - Steps 2/3
+  derive the version from CLAUDE.md's `Current version:` line (the maintained
+  source of truth), falling back to the newest bracketed CHANGELOG release,
+  instead of grepping the CHANGELOG head - where a digit-less `[Unreleased]`
+  block made the grep fall through to the previous release and print a
+  misleading no-op like "Updated: v7.2.0 -> v7.2.0" for a real 19-commit
+  upgrade. A same-version pull now reports the commit movement and points at
+  the `[Unreleased]` delta explicitly. Also promoted the accumulated
+  `[Unreleased]` block below to `[7.3.0]` so CHANGELOG and CLAUDE.md agree.
+
+## [7.3.0] - 2026-07-04
+
 ### Added
 
 - **Plugins now bundle the masking hook and the second-opinion MCP pointer**


### PR DESCRIPTION
## Summary

`/cpp:update` Steps 2/3 grepped the FIRST bracketed version in `CHANGELOG.md`, but the file head is a digit-less `## [Unreleased]` block, so the grep fell through to the previous release: a real 19-commit upgrade (`7a9f6d6` -> `4e3a36b`) printed **"Updated: v7.2.0 -> v7.2.0"** while the tree was actually at 7.3.0 (per CLAUDE.md). A no-op-looking summary invites skipping the drift/remediation review.

## Changes

- **`.claude/commands/cpp/update.md`** - derive `CURRENT_VERSION`/`NEW_VERSION` from CLAUDE.md's `Current version:` line (the maintained source of truth), falling back to the newest bracketed CHANGELOG release, then `unknown`. When the version is unchanged but the commit moved, report the commit movement and point at the `[Unreleased]` delta explicitly instead of a misleading "vX -> vX".
- **`CHANGELOG.md`** - promote the accumulated `[Unreleased]` block to `## [7.3.0] - 2026-07-04` so CHANGELOG agrees with CLAUDE.md (`Current version: 7.3.0`) and README's own version history (`v7.3.0 (2026-07-04)`); a fresh `[Unreleased]` section holds this fix's entry.

No generated surfaces change: the `cpp` plugin is help-only and codex prompts exclude the repo-local installer commands (`plugin-sync.sh --check` and `codex-prompt-sync.py --check` both pass).

## Test plan

- [x] `python -m lib.cicd run --plan finish`: lint + 844 tests + security scan all pass
- [x] New derivation verified against the tree: CLAUDE.md path returns `7.3.0`; CHANGELOG fallback returns `7.3.0` post-promotion
- [x] `plugin-sync.sh --check` / `codex-prompt-sync.py --check` clean
- [x] No em/en dashes introduced (CLAUDE.md core directive)

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)