### PR TITLE
fix(cpp): re-read /cpp:update after the pull that may have changed it (Closes #545)

### DIFF
--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -125,6 +125,51 @@ fi
 
 ---
 
+## Step 3.5: Re-read Self (the pull may have changed this command)
+
+`/cpp:update` is **self-modifying**: the Step 3 pull can change *this very file*
+(`.claude/commands/cpp/update.md`). The copy of these instructions loaded into
+context is the **pre-pull** version, so every step below may now be stale - a
+removed step could run against a deleted script, or a renamed step could act on a
+changed tree (issue #545: a `/cpp:update` run pulled #522, which deleted
+`scripts/skill-drift.py` and stripped a whole step from this command; the pre-pull
+context still contained that step and would have executed it against a now-deleted
+script).
+
+**First, surface any change to this command.** `git pull` set `ORIG_HEAD` to the
+pre-pull commit, so no variable needs to survive between bash blocks:
+
+```bash
+cd "$CPP_DIR"
+SELF=".claude/commands/cpp/update.md"
+SELF_CHANGED=unknown
+if git rev-parse -q --verify ORIG_HEAD >/dev/null 2>&1; then
+  if git diff --quiet ORIG_HEAD..HEAD -- "$SELF"; then
+    SELF_CHANGED=no
+    echo "No change to /cpp:update in this pull - the steps in context are current."
+  else
+    SELF_CHANGED=yes
+    echo ""
+    echo "NOTE: this pull modified /cpp:update itself. Diff since the pre-pull copy:"
+    git --no-pager diff ORIG_HEAD..HEAD -- "$SELF"
+    echo ""
+    echo "The /cpp:update steps loaded in context are now STALE."
+  fi
+else
+  echo "Could not determine ORIG_HEAD - treat the in-context steps as possibly stale."
+fi
+```
+
+**Then, unless `SELF_CHANGED` is `no`, STOP following the in-context steps and
+RE-READ the on-disk command before continuing.** Open
+`$CPP_DIR/.claude/commands/cpp/update.md` (resolve `$CPP_DIR` from Step 1) and
+follow **its** Step 4 onward - the freshly-pulled file on disk is authoritative
+now, not the copy this run started with. Only when `SELF_CHANGED` is `no` may you
+continue with the in-context steps as-is. This is the one point where re-reading is
+mandatory; everything below is what you execute *after* confirming it is current.
+
+---
+
 ## Step 4: Update Dependencies
 
 CPP no longer ships in-repo MCP server venvs. The second-opinion server is an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Fixed
 
+- **`/cpp:update` re-reads itself after the pull** (issue #545) - the command is
+  self-modifying: Step 3 pulls the CPP repo, and that same pull can change
+  `.claude/commands/cpp/update.md` itself, leaving the model executing the
+  **pre-pull** steps it loaded into context against a repo the pull already
+  changed (a removed step run against a deleted script, a renamed step acting on a
+  changed tree). A new **Step 3.5 (Re-read Self)** diffs the command across
+  `ORIG_HEAD..HEAD`, prints the self-diff when the pull touched it, and directs the
+  model to STOP following the in-context copy and re-read the on-disk command
+  before continuing with Step 4 onward. Uses `ORIG_HEAD` (set by `git pull`) so no
+  variable needs to survive between bash blocks; relies only on already-allowed
+  `Bash(git:*)`.
 - **`/cpp:update` no longer reports a stale version** (issue #544) - Steps 2/3
   derive the version from CLAUDE.md's `Current version:` line (the maintained
   source of truth), falling back to the newest bracketed CHANGELOG release,


### PR DESCRIPTION
## Summary

`/cpp:update` is a self-modifying command: **Step 3 pulls the CPP repo, and that same pull can change `.claude/commands/cpp/update.md` itself**. The copy of the command loaded into the model's context is the *pre-pull* version, so the post-pull steps executed are stale — a removed step could run against a deleted script, or a renamed step could act on a changed tree (issue #545 cites a real run that pulled #522, which deleted `scripts/skill-drift.py` and stripped a whole step; the run only stayed correct because the model happened to notice the self-diff).

## Change

Adds a new **Step 3.5: Re-read Self**, inserted immediately after Step 3 (Pull Updates), before Step 4:

1. Diffs the command across `ORIG_HEAD..HEAD` (`git pull` sets `ORIG_HEAD` to the pre-pull commit, so no variable needs to survive between the command's separate bash blocks). Prints the self-diff and sets `SELF_CHANGED=yes` when the pull touched `update.md`; reports it current otherwise.
2. Directs the model, unless `SELF_CHANGED` is `no`, to STOP following the in-context steps, re-read `$CPP_DIR/.claude/commands/cpp/update.md` from disk, and follow **its** Step 4 onward — the freshly-pulled on-disk file is authoritative.

This is the exact fix proposed in the issue. It relies only on the already-allowed `Bash(git:*)` and the Read tool — no new permissions.

## Scope / surfaces

- One command file edited (`.claude/commands/cpp/update.md`) + a CHANGELOG entry.
- No generated-surface re-sync: `cpp/update.md` is excluded from **both** `plugin-sync.sh` (the `cpp` plugin ships `help.md` only) and `codex-prompt-sync.py` (cpp `init/status/update` excluded), so no `plugins/` or `codex/prompts/` copies exist to drift.

## Test plan

- `lib.cicd run --plan finish` green: ruff lint clean, **844 tests pass**, security scan passed.
- Manually verified the `ORIG_HEAD..HEAD` diff block only fires when `ORIG_HEAD` verifies and differs (no false-positive on a no-op pull).

Closes #545