### PR TITLE
fix(friction): attribute Claude captures as harness=claude (Closes #563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@
 
 ### Fixed
 
+- **Friction ledger attributes Claude captures as `harness=claude`** (issue #563,
+  completing #557) - #557 added the `harness` dimension end to end, but the Claude
+  capture side never set it, so every flow-captured and permission-census row
+  landed `unattributed` and the retro "By harness" split was empty in practice (a
+  drain of an 855-row buffer reported `{unattributed: 855}`).
+  `scripts/friction-log.sh` now defaults an unset harness to `claude` when
+  `$CLAUDECODE` is set, mirroring `resolve_harness()`'s precedence (flag ->
+  `$CPP_HARNESS` -> `$CLAUDECODE` => `claude` -> empty), and
+  `scripts/hook-permission-census.sh` passes `--harness claude` explicitly (the
+  census is a Claude Code PermissionRequest hook by construction). A plain-shell
+  caller with none of the three signals still records an empty harness, so the
+  change is backward compatible.
 - **`/cpp:update` re-reads itself after the pull** (issue #545) - the command is
   self-modifying: Step 3 pulls the CPP repo, and that same pull can change
   `.claude/commands/cpp/update.md` itself, leaving the model executing the

--- a/codex/skills/flow-auto/scripts/friction-log.sh
+++ b/codex/skills/flow-auto/scripts/friction-log.sh
@@ -32,11 +32,16 @@
 #                    WRITE-LOCAL, DESTRUCTIVE). Set by the permission-prompt census
 #                    hook so retro can allowlist only safe tiers; empty otherwise.
 #   --harness <h>    producing agent harness (claude | codex | shell) so a mixed
-#                    buffer can be attributed per harness (#557); defaults to
-#                    $CPP_HARNESS, else empty.
+#                    buffer can be attributed per harness (#557). Precedence
+#                    mirrors resolve_harness() in lib/cpp_memory/harness.py:
+#                    this flag -> $CPP_HARNESS -> $CLAUDECODE (=> claude) ->
+#                    empty (#563).
 #
 # Environment:
 #   CPP_HARNESS       default --harness value (a non-Claude harness declares itself)
+#   CLAUDECODE        set by Claude Code; when --harness and $CPP_HARNESS are both
+#                     unset, the harness defaults to `claude` so a Claude capture
+#                     self-attributes instead of landing unattributed (#563)
 #   CPP_FRICTION_LOG  override the buffer path (default: the main repo's
 #                     .claude/friction.jsonl, resolved via git-common-dir so a
 #                     run inside a worktree still writes to the durable buffer)
@@ -58,9 +63,16 @@ OUTCOME=""
 RUN=""
 STEP=""
 RISK=""
-# Default the harness from $CPP_HARNESS so a non-Claude harness that exports it
-# tags every capture without repeating --harness on each call (#557).
+# Default the harness so a capture is attributed even when neither --harness nor
+# $CPP_HARNESS is set. Precedence mirrors resolve_harness() in
+# lib/cpp_memory/harness.py: --harness arg (parsed below) -> $CPP_HARNESS ->
+# Claude Code auto-detect ($CLAUDECODE => claude) -> empty. Without the
+# $CLAUDECODE step every flow-captured signal in a Claude Code session lands
+# unattributed even though it is always Claude here (#563 completing #557).
 HARNESS="${CPP_HARNESS:-}"
+if [ -z "$HARNESS" ] && [ -n "${CLAUDECODE:-}" ]; then
+  HARNESS="claude"
+fi
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/codex/skills/flow-auto/scripts/hook-permission-census.sh
+++ b/codex/skills/flow-auto/scripts/hook-permission-census.sh
@@ -423,7 +423,10 @@ RISK="$(printf '%s' "$DERIVED" | cut -f3)"
 
 # A prompt that was SHOWN (not necessarily approved - the hook cannot observe the
 # click). --scope local: census records are per-machine and never pushed to the
-# shared store. Everything is silenced so no stray byte reaches stdout.
+# shared store. --harness claude: the census only ever runs inside Claude Code (it
+# is a Claude Code PermissionRequest hook), so it attributes explicitly rather than
+# leaning on friction-log.sh's $CLAUDECODE default (#563). Everything is silenced
+# so no stray byte reaches stdout.
 bash "$FRICTION_LOG" \
   --class permission-prompt \
   --signal "$SIGNAL" \
@@ -431,6 +434,7 @@ bash "$FRICTION_LOG" \
   --risk "$RISK" \
   --scope local \
   --outcome "shown" \
+  --harness claude \
   --run "permission-census" >/dev/null 2>&1 || true
 
 exit 0

--- a/codex/skills/flow-merge/scripts/friction-log.sh
+++ b/codex/skills/flow-merge/scripts/friction-log.sh
@@ -32,11 +32,16 @@
 #                    WRITE-LOCAL, DESTRUCTIVE). Set by the permission-prompt census
 #                    hook so retro can allowlist only safe tiers; empty otherwise.
 #   --harness <h>    producing agent harness (claude | codex | shell) so a mixed
-#                    buffer can be attributed per harness (#557); defaults to
-#                    $CPP_HARNESS, else empty.
+#                    buffer can be attributed per harness (#557). Precedence
+#                    mirrors resolve_harness() in lib/cpp_memory/harness.py:
+#                    this flag -> $CPP_HARNESS -> $CLAUDECODE (=> claude) ->
+#                    empty (#563).
 #
 # Environment:
 #   CPP_HARNESS       default --harness value (a non-Claude harness declares itself)
+#   CLAUDECODE        set by Claude Code; when --harness and $CPP_HARNESS are both
+#                     unset, the harness defaults to `claude` so a Claude capture
+#                     self-attributes instead of landing unattributed (#563)
 #   CPP_FRICTION_LOG  override the buffer path (default: the main repo's
 #                     .claude/friction.jsonl, resolved via git-common-dir so a
 #                     run inside a worktree still writes to the durable buffer)
@@ -58,9 +63,16 @@ OUTCOME=""
 RUN=""
 STEP=""
 RISK=""
-# Default the harness from $CPP_HARNESS so a non-Claude harness that exports it
-# tags every capture without repeating --harness on each call (#557).
+# Default the harness so a capture is attributed even when neither --harness nor
+# $CPP_HARNESS is set. Precedence mirrors resolve_harness() in
+# lib/cpp_memory/harness.py: --harness arg (parsed below) -> $CPP_HARNESS ->
+# Claude Code auto-detect ($CLAUDECODE => claude) -> empty. Without the
+# $CLAUDECODE step every flow-captured signal in a Claude Code session lands
+# unattributed even though it is always Claude here (#563 completing #557).
 HARNESS="${CPP_HARNESS:-}"
+if [ -z "$HARNESS" ] && [ -n "${CLAUDECODE:-}" ]; then
+  HARNESS="claude"
+fi
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/codex/skills/security-permissions/scripts/hook-permission-census.sh
+++ b/codex/skills/security-permissions/scripts/hook-permission-census.sh
@@ -423,7 +423,10 @@ RISK="$(printf '%s' "$DERIVED" | cut -f3)"
 
 # A prompt that was SHOWN (not necessarily approved - the hook cannot observe the
 # click). --scope local: census records are per-machine and never pushed to the
-# shared store. Everything is silenced so no stray byte reaches stdout.
+# shared store. --harness claude: the census only ever runs inside Claude Code (it
+# is a Claude Code PermissionRequest hook), so it attributes explicitly rather than
+# leaning on friction-log.sh's $CLAUDECODE default (#563). Everything is silenced
+# so no stray byte reaches stdout.
 bash "$FRICTION_LOG" \
   --class permission-prompt \
   --signal "$SIGNAL" \
@@ -431,6 +434,7 @@ bash "$FRICTION_LOG" \
   --risk "$RISK" \
   --scope local \
   --outcome "shown" \
+  --harness claude \
   --run "permission-census" >/dev/null 2>&1 || true
 
 exit 0

--- a/codex/skills/self-improvement-retro/scripts/friction-log.sh
+++ b/codex/skills/self-improvement-retro/scripts/friction-log.sh
@@ -32,11 +32,16 @@
 #                    WRITE-LOCAL, DESTRUCTIVE). Set by the permission-prompt census
 #                    hook so retro can allowlist only safe tiers; empty otherwise.
 #   --harness <h>    producing agent harness (claude | codex | shell) so a mixed
-#                    buffer can be attributed per harness (#557); defaults to
-#                    $CPP_HARNESS, else empty.
+#                    buffer can be attributed per harness (#557). Precedence
+#                    mirrors resolve_harness() in lib/cpp_memory/harness.py:
+#                    this flag -> $CPP_HARNESS -> $CLAUDECODE (=> claude) ->
+#                    empty (#563).
 #
 # Environment:
 #   CPP_HARNESS       default --harness value (a non-Claude harness declares itself)
+#   CLAUDECODE        set by Claude Code; when --harness and $CPP_HARNESS are both
+#                     unset, the harness defaults to `claude` so a Claude capture
+#                     self-attributes instead of landing unattributed (#563)
 #   CPP_FRICTION_LOG  override the buffer path (default: the main repo's
 #                     .claude/friction.jsonl, resolved via git-common-dir so a
 #                     run inside a worktree still writes to the durable buffer)
@@ -58,9 +63,16 @@ OUTCOME=""
 RUN=""
 STEP=""
 RISK=""
-# Default the harness from $CPP_HARNESS so a non-Claude harness that exports it
-# tags every capture without repeating --harness on each call (#557).
+# Default the harness so a capture is attributed even when neither --harness nor
+# $CPP_HARNESS is set. Precedence mirrors resolve_harness() in
+# lib/cpp_memory/harness.py: --harness arg (parsed below) -> $CPP_HARNESS ->
+# Claude Code auto-detect ($CLAUDECODE => claude) -> empty. Without the
+# $CLAUDECODE step every flow-captured signal in a Claude Code session lands
+# unattributed even though it is always Claude here (#563 completing #557).
 HARNESS="${CPP_HARNESS:-}"
+if [ -z "$HARNESS" ] && [ -n "${CLAUDECODE:-}" ]; then
+  HARNESS="claude"
+fi
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/codex/skills/self-improvement-retro/scripts/hook-permission-census.sh
+++ b/codex/skills/self-improvement-retro/scripts/hook-permission-census.sh
@@ -423,7 +423,10 @@ RISK="$(printf '%s' "$DERIVED" | cut -f3)"
 
 # A prompt that was SHOWN (not necessarily approved - the hook cannot observe the
 # click). --scope local: census records are per-machine and never pushed to the
-# shared store. Everything is silenced so no stray byte reaches stdout.
+# shared store. --harness claude: the census only ever runs inside Claude Code (it
+# is a Claude Code PermissionRequest hook), so it attributes explicitly rather than
+# leaning on friction-log.sh's $CLAUDECODE default (#563). Everything is silenced
+# so no stray byte reaches stdout.
 bash "$FRICTION_LOG" \
   --class permission-prompt \
   --signal "$SIGNAL" \
@@ -431,6 +434,7 @@ bash "$FRICTION_LOG" \
   --risk "$RISK" \
   --scope local \
   --outcome "shown" \
+  --harness claude \
   --run "permission-census" >/dev/null 2>&1 || true
 
 exit 0

--- a/scripts/friction-log.sh
+++ b/scripts/friction-log.sh
@@ -32,11 +32,16 @@
 #                    WRITE-LOCAL, DESTRUCTIVE). Set by the permission-prompt census
 #                    hook so retro can allowlist only safe tiers; empty otherwise.
 #   --harness <h>    producing agent harness (claude | codex | shell) so a mixed
-#                    buffer can be attributed per harness (#557); defaults to
-#                    $CPP_HARNESS, else empty.
+#                    buffer can be attributed per harness (#557). Precedence
+#                    mirrors resolve_harness() in lib/cpp_memory/harness.py:
+#                    this flag -> $CPP_HARNESS -> $CLAUDECODE (=> claude) ->
+#                    empty (#563).
 #
 # Environment:
 #   CPP_HARNESS       default --harness value (a non-Claude harness declares itself)
+#   CLAUDECODE        set by Claude Code; when --harness and $CPP_HARNESS are both
+#                     unset, the harness defaults to `claude` so a Claude capture
+#                     self-attributes instead of landing unattributed (#563)
 #   CPP_FRICTION_LOG  override the buffer path (default: the main repo's
 #                     .claude/friction.jsonl, resolved via git-common-dir so a
 #                     run inside a worktree still writes to the durable buffer)
@@ -58,9 +63,16 @@ OUTCOME=""
 RUN=""
 STEP=""
 RISK=""
-# Default the harness from $CPP_HARNESS so a non-Claude harness that exports it
-# tags every capture without repeating --harness on each call (#557).
+# Default the harness so a capture is attributed even when neither --harness nor
+# $CPP_HARNESS is set. Precedence mirrors resolve_harness() in
+# lib/cpp_memory/harness.py: --harness arg (parsed below) -> $CPP_HARNESS ->
+# Claude Code auto-detect ($CLAUDECODE => claude) -> empty. Without the
+# $CLAUDECODE step every flow-captured signal in a Claude Code session lands
+# unattributed even though it is always Claude here (#563 completing #557).
 HARNESS="${CPP_HARNESS:-}"
+if [ -z "$HARNESS" ] && [ -n "${CLAUDECODE:-}" ]; then
+  HARNESS="claude"
+fi
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/scripts/hook-permission-census.sh
+++ b/scripts/hook-permission-census.sh
@@ -423,7 +423,10 @@ RISK="$(printf '%s' "$DERIVED" | cut -f3)"
 
 # A prompt that was SHOWN (not necessarily approved - the hook cannot observe the
 # click). --scope local: census records are per-machine and never pushed to the
-# shared store. Everything is silenced so no stray byte reaches stdout.
+# shared store. --harness claude: the census only ever runs inside Claude Code (it
+# is a Claude Code PermissionRequest hook), so it attributes explicitly rather than
+# leaning on friction-log.sh's $CLAUDECODE default (#563). Everything is silenced
+# so no stray byte reaches stdout.
 bash "$FRICTION_LOG" \
   --class permission-prompt \
   --signal "$SIGNAL" \
@@ -431,6 +434,7 @@ bash "$FRICTION_LOG" \
   --risk "$RISK" \
   --scope local \
   --outcome "shown" \
+  --harness claude \
   --run "permission-census" >/dev/null 2>&1 || true
 
 exit 0

--- a/tests/test_friction_log.py
+++ b/tests/test_friction_log.py
@@ -130,12 +130,26 @@ def test_risk_tier_is_recorded(tmp_path: Path):
 
 
 def test_harness_defaults_to_empty(tmp_path: Path, monkeypatch):
-    # #557: callers that do not set --harness (or $CPP_HARNESS) still produce a
-    # valid record with an empty harness field (unattributed / pre-#557 shape).
+    # #557/#563: a record is unattributed (empty harness) ONLY when none of
+    # --harness, $CPP_HARNESS, or $CLAUDECODE is set - a plain-shell caller with
+    # no signal to attribute from. $CLAUDECODE must be cleared too, else the #563
+    # Claude Code auto-detect would default it to "claude".
     monkeypatch.delenv("CPP_HARNESS", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
     log = tmp_path / "friction.jsonl"
     _run(tmp_path, "--class", "gate-failure", "--signal", "make test failed", log_path=log)
     assert _read_lines(log)[0]["harness"] == ""
+
+
+def test_harness_defaults_to_claude_from_claudecode(tmp_path: Path, monkeypatch):
+    # #563: inside a Claude Code session ($CLAUDECODE set) a capture that passes
+    # neither --harness nor $CPP_HARNESS self-attributes to "claude" - mirroring
+    # resolve_harness()'s $CLAUDECODE fallback - instead of landing unattributed.
+    monkeypatch.delenv("CPP_HARNESS", raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    log = tmp_path / "friction.jsonl"
+    _run(tmp_path, "--class", "gate-failure", "--signal", "make test failed", log_path=log)
+    assert _read_lines(log)[0]["harness"] == "claude"
 
 
 def test_harness_flag_is_recorded(tmp_path: Path):
@@ -154,6 +168,30 @@ def test_harness_defaults_from_env(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("CPP_HARNESS", "codex")
     log = tmp_path / "friction.jsonl"
     _run(tmp_path, "--class", "other", "--signal", "x", log_path=log)
+    assert _read_lines(log)[0]["harness"] == "codex"
+
+
+def test_harness_env_precedence_over_claudecode(tmp_path: Path, monkeypatch):
+    # #563: $CPP_HARNESS outranks the $CLAUDECODE auto-detect, so a non-Claude
+    # harness that declares itself is never mislabelled "claude" just because it
+    # ran inside a Claude Code shell.
+    monkeypatch.setenv("CPP_HARNESS", "codex")
+    monkeypatch.setenv("CLAUDECODE", "1")
+    log = tmp_path / "friction.jsonl"
+    _run(tmp_path, "--class", "other", "--signal", "x", log_path=log)
+    assert _read_lines(log)[0]["harness"] == "codex"
+
+
+def test_harness_flag_precedence_over_claudecode(tmp_path: Path, monkeypatch):
+    # #563: an explicit --harness wins over the $CLAUDECODE auto-detect too.
+    monkeypatch.delenv("CPP_HARNESS", raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    log = tmp_path / "friction.jsonl"
+    _run(
+        tmp_path,
+        "--class", "other", "--signal", "x",
+        "--harness", "codex", log_path=log,
+    )
     assert _read_lines(log)[0]["harness"] == "codex"
 
 

--- a/tests/test_hook_permission_census.py
+++ b/tests/test_hook_permission_census.py
@@ -87,6 +87,17 @@ def test_records_permission_prompt_with_shown_outcome(tmp_path: Path):
     assert rec["ts"].endswith("Z")
 
 
+def test_census_attributes_harness_claude(tmp_path: Path, monkeypatch):
+    # #563: the census is a Claude Code PermissionRequest hook, so it stamps
+    # harness=claude EXPLICITLY. Clear both env signals first to prove the tag
+    # comes from the hook's own --harness claude, not friction-log.sh's
+    # $CLAUDECODE default - so census rows attribute even outside a Claude shell.
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CPP_HARNESS", raising=False)
+    rec = _one(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "git fetch origin"}})
+    assert rec["harness"] == "claude"
+
+
 # --- Rule derivation matches /self-improvement:retro Step 4 -------------------
 
 def test_gh_rule_is_three_deep(tmp_path: Path):


### PR DESCRIPTION
## Summary

Completes #557 (harness dimension on the shared friction ledger) by making the **Claude capture side actually set the tag**. Before this, every Claude-produced row landed `unattributed` and the retro "By harness" split was empty in practice (a real drain of an 855-row buffer reported `{unattributed: 855}`).

Two capture points are fixed:

1. **`scripts/friction-log.sh`** now defaults an unset harness to `claude` when `$CLAUDECODE` is set, mirroring `resolve_harness()`'s precedence in `lib/cpp_memory/harness.py`:
   `--harness` flag -> `$CPP_HARNESS` -> `$CLAUDECODE` (=> `claude`) -> empty.
2. **`scripts/hook-permission-census.sh`** passes `--harness claude` explicitly (the PermissionRequest census is Claude Code only by construction, ~817/855 buffer rows).

The retro "By harness" aggregation (`.claude/commands/self-improvement/retro.md`) already reads the field, so populating it on capture is the whole fix.

## Backward compatibility

A plain-shell caller with none of `--harness` / `$CPP_HARNESS` / `$CLAUDECODE` set still records an empty harness, matching pre-#557 rows. `$CPP_HARNESS` and an explicit `--harness` both still outrank the `$CLAUDECODE` auto-detect, so a declared non-Claude harness is never mislabelled.

## Test plan

- [x] `test_friction_log.py`: `$CLAUDECODE`→`claude` default; `$CPP_HARNESS`-wins and `--harness`-wins precedence over `$CLAUDECODE`; still-empty plain-shell case (now clears `$CLAUDECODE`).
- [x] `test_hook_permission_census.py`: census rows carry `harness=="claude"` even with `$CLAUDECODE`/`$CPP_HARNESS` cleared (proves the explicit flag, not the default).
- [x] Live smoke: a fresh capture in this Claude session writes `"harness":"claude"` to `.claude/friction.jsonl`; the census hook does the same; a plain shell stays `""`.
- [x] Full gate green: 874 passed, lint + security clean.
- [x] Regenerated the 6 `codex/skills/` bundled helper-script copies (`codex-skill-sync.py --write`) so the byte-identical-bundle gate stays green.

Closes #563