### PR TITLE
fix(flow): worktree-remove.sh no longer false-fails on a squash-merged branch (Closes #566)

### DIFF
--- a/codex/skills/flow-auto/scripts/worktree-remove.sh
+++ b/codex/skills/flow-auto/scripts/worktree-remove.sh
@@ -51,6 +51,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
+            echo "                   (force-deletes a squash-merged branch non-interactively)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -177,24 +178,35 @@ git -C "$MAIN_REPO" worktree remove "$WORKTREE_PATH" $FORCE
 
 echo -e "${GREEN}Worktree removed successfully.${NC}"
 
-# Optionally delete the branch
+# Optionally delete the branch.
+#
+# --delete-branch is an explicit deletion request, and by this point the worktree
+# has already been removed. Try the safe `git branch -d` first so a genuinely
+# fully-merged branch is reported as such. When it refuses with "not fully
+# merged", that is the EXPECTED squash-merge case: a squash rewrites the branch's
+# commits into one new commit on main, so the branch tip is no longer an ancestor
+# of main even though the PR is MERGED and the work is safely on main. Fall back
+# to `git branch -D` non-interactively rather than prompting.
+#
+# The old interactive `read -p` confirmation broke every non-interactive caller
+# (/flow:auto, /flow:merge): with stdin not a TTY, `read` hit EOF and returned
+# non-zero, tripping `set -e` so the whole script exited non-zero AND left the
+# branch undeleted - a false "cleanup failed" even though the worktree removal
+# succeeded (issue #566). Branch-delete outcome never fails the script now: the
+# worktree removal (above) is the only step whose failure surfaces non-zero.
 if [[ "$DELETE_BRANCH" == true && -n "$BRANCH_NAME" && "$BRANCH_NAME" != "main" && "$BRANCH_NAME" != "master" ]]; then
     echo -e "${BLUE}Deleting branch: ${BRANCH_NAME}${NC}"
 
-    # Check if branch was merged (use -d) or force delete (-D)
     if git -C "$MAIN_REPO" branch -d "$BRANCH_NAME" 2>/dev/null; then
         echo -e "${GREEN}Branch deleted (was fully merged).${NC}"
+    elif git -C "$MAIN_REPO" branch -D "$BRANCH_NAME" 2>/dev/null; then
+        # Expected for squash-merged PRs: the branch is not an ancestor of main,
+        # so -d refuses; --delete-branch already authorized the deletion.
+        echo -e "${GREEN}Branch force-deleted (squash-merged; not an ancestor of main).${NC}"
     else
-        # Branch wasn't merged - for squash-merged PRs, this is expected
-        echo -e "${YELLOW}Branch not fully merged (normal for squash-merged PRs).${NC}"
-        read -p "Force delete branch '$BRANCH_NAME'? [y/N] " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            git -C "$MAIN_REPO" branch -D "$BRANCH_NAME"
-            echo -e "${GREEN}Branch force-deleted.${NC}"
-        else
-            echo "Branch kept."
-        fi
+        # Branch removal genuinely failed (e.g. already gone) - warn, do NOT fail
+        # the run: the worktree was removed, which is this script's job.
+        echo -e "${YELLOW}Could not delete branch '${BRANCH_NAME}' (may already be gone). Worktree removal still succeeded.${NC}"
     fi
 fi
 

--- a/codex/skills/flow-doctor/scripts/worktree-remove.sh
+++ b/codex/skills/flow-doctor/scripts/worktree-remove.sh
@@ -51,6 +51,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
+            echo "                   (force-deletes a squash-merged branch non-interactively)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -177,24 +178,35 @@ git -C "$MAIN_REPO" worktree remove "$WORKTREE_PATH" $FORCE
 
 echo -e "${GREEN}Worktree removed successfully.${NC}"
 
-# Optionally delete the branch
+# Optionally delete the branch.
+#
+# --delete-branch is an explicit deletion request, and by this point the worktree
+# has already been removed. Try the safe `git branch -d` first so a genuinely
+# fully-merged branch is reported as such. When it refuses with "not fully
+# merged", that is the EXPECTED squash-merge case: a squash rewrites the branch's
+# commits into one new commit on main, so the branch tip is no longer an ancestor
+# of main even though the PR is MERGED and the work is safely on main. Fall back
+# to `git branch -D` non-interactively rather than prompting.
+#
+# The old interactive `read -p` confirmation broke every non-interactive caller
+# (/flow:auto, /flow:merge): with stdin not a TTY, `read` hit EOF and returned
+# non-zero, tripping `set -e` so the whole script exited non-zero AND left the
+# branch undeleted - a false "cleanup failed" even though the worktree removal
+# succeeded (issue #566). Branch-delete outcome never fails the script now: the
+# worktree removal (above) is the only step whose failure surfaces non-zero.
 if [[ "$DELETE_BRANCH" == true && -n "$BRANCH_NAME" && "$BRANCH_NAME" != "main" && "$BRANCH_NAME" != "master" ]]; then
     echo -e "${BLUE}Deleting branch: ${BRANCH_NAME}${NC}"
 
-    # Check if branch was merged (use -d) or force delete (-D)
     if git -C "$MAIN_REPO" branch -d "$BRANCH_NAME" 2>/dev/null; then
         echo -e "${GREEN}Branch deleted (was fully merged).${NC}"
+    elif git -C "$MAIN_REPO" branch -D "$BRANCH_NAME" 2>/dev/null; then
+        # Expected for squash-merged PRs: the branch is not an ancestor of main,
+        # so -d refuses; --delete-branch already authorized the deletion.
+        echo -e "${GREEN}Branch force-deleted (squash-merged; not an ancestor of main).${NC}"
     else
-        # Branch wasn't merged - for squash-merged PRs, this is expected
-        echo -e "${YELLOW}Branch not fully merged (normal for squash-merged PRs).${NC}"
-        read -p "Force delete branch '$BRANCH_NAME'? [y/N] " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            git -C "$MAIN_REPO" branch -D "$BRANCH_NAME"
-            echo -e "${GREEN}Branch force-deleted.${NC}"
-        else
-            echo "Branch kept."
-        fi
+        # Branch removal genuinely failed (e.g. already gone) - warn, do NOT fail
+        # the run: the worktree was removed, which is this script's job.
+        echo -e "${YELLOW}Could not delete branch '${BRANCH_NAME}' (may already be gone). Worktree removal still succeeded.${NC}"
     fi
 fi
 

--- a/codex/skills/flow-merge/scripts/worktree-remove.sh
+++ b/codex/skills/flow-merge/scripts/worktree-remove.sh
@@ -51,6 +51,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
+            echo "                   (force-deletes a squash-merged branch non-interactively)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -177,24 +178,35 @@ git -C "$MAIN_REPO" worktree remove "$WORKTREE_PATH" $FORCE
 
 echo -e "${GREEN}Worktree removed successfully.${NC}"
 
-# Optionally delete the branch
+# Optionally delete the branch.
+#
+# --delete-branch is an explicit deletion request, and by this point the worktree
+# has already been removed. Try the safe `git branch -d` first so a genuinely
+# fully-merged branch is reported as such. When it refuses with "not fully
+# merged", that is the EXPECTED squash-merge case: a squash rewrites the branch's
+# commits into one new commit on main, so the branch tip is no longer an ancestor
+# of main even though the PR is MERGED and the work is safely on main. Fall back
+# to `git branch -D` non-interactively rather than prompting.
+#
+# The old interactive `read -p` confirmation broke every non-interactive caller
+# (/flow:auto, /flow:merge): with stdin not a TTY, `read` hit EOF and returned
+# non-zero, tripping `set -e` so the whole script exited non-zero AND left the
+# branch undeleted - a false "cleanup failed" even though the worktree removal
+# succeeded (issue #566). Branch-delete outcome never fails the script now: the
+# worktree removal (above) is the only step whose failure surfaces non-zero.
 if [[ "$DELETE_BRANCH" == true && -n "$BRANCH_NAME" && "$BRANCH_NAME" != "main" && "$BRANCH_NAME" != "master" ]]; then
     echo -e "${BLUE}Deleting branch: ${BRANCH_NAME}${NC}"
 
-    # Check if branch was merged (use -d) or force delete (-D)
     if git -C "$MAIN_REPO" branch -d "$BRANCH_NAME" 2>/dev/null; then
         echo -e "${GREEN}Branch deleted (was fully merged).${NC}"
+    elif git -C "$MAIN_REPO" branch -D "$BRANCH_NAME" 2>/dev/null; then
+        # Expected for squash-merged PRs: the branch is not an ancestor of main,
+        # so -d refuses; --delete-branch already authorized the deletion.
+        echo -e "${GREEN}Branch force-deleted (squash-merged; not an ancestor of main).${NC}"
     else
-        # Branch wasn't merged - for squash-merged PRs, this is expected
-        echo -e "${YELLOW}Branch not fully merged (normal for squash-merged PRs).${NC}"
-        read -p "Force delete branch '$BRANCH_NAME'? [y/N] " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            git -C "$MAIN_REPO" branch -D "$BRANCH_NAME"
-            echo -e "${GREEN}Branch force-deleted.${NC}"
-        else
-            echo "Branch kept."
-        fi
+        # Branch removal genuinely failed (e.g. already gone) - warn, do NOT fail
+        # the run: the worktree was removed, which is this script's job.
+        echo -e "${YELLOW}Could not delete branch '${BRANCH_NAME}' (may already be gone). Worktree removal still succeeded.${NC}"
     fi
 fi
 

--- a/scripts/worktree-remove.sh
+++ b/scripts/worktree-remove.sh
@@ -51,6 +51,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
+            echo "                   (force-deletes a squash-merged branch non-interactively)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -177,24 +178,35 @@ git -C "$MAIN_REPO" worktree remove "$WORKTREE_PATH" $FORCE
 
 echo -e "${GREEN}Worktree removed successfully.${NC}"
 
-# Optionally delete the branch
+# Optionally delete the branch.
+#
+# --delete-branch is an explicit deletion request, and by this point the worktree
+# has already been removed. Try the safe `git branch -d` first so a genuinely
+# fully-merged branch is reported as such. When it refuses with "not fully
+# merged", that is the EXPECTED squash-merge case: a squash rewrites the branch's
+# commits into one new commit on main, so the branch tip is no longer an ancestor
+# of main even though the PR is MERGED and the work is safely on main. Fall back
+# to `git branch -D` non-interactively rather than prompting.
+#
+# The old interactive `read -p` confirmation broke every non-interactive caller
+# (/flow:auto, /flow:merge): with stdin not a TTY, `read` hit EOF and returned
+# non-zero, tripping `set -e` so the whole script exited non-zero AND left the
+# branch undeleted - a false "cleanup failed" even though the worktree removal
+# succeeded (issue #566). Branch-delete outcome never fails the script now: the
+# worktree removal (above) is the only step whose failure surfaces non-zero.
 if [[ "$DELETE_BRANCH" == true && -n "$BRANCH_NAME" && "$BRANCH_NAME" != "main" && "$BRANCH_NAME" != "master" ]]; then
     echo -e "${BLUE}Deleting branch: ${BRANCH_NAME}${NC}"
 
-    # Check if branch was merged (use -d) or force delete (-D)
     if git -C "$MAIN_REPO" branch -d "$BRANCH_NAME" 2>/dev/null; then
         echo -e "${GREEN}Branch deleted (was fully merged).${NC}"
+    elif git -C "$MAIN_REPO" branch -D "$BRANCH_NAME" 2>/dev/null; then
+        # Expected for squash-merged PRs: the branch is not an ancestor of main,
+        # so -d refuses; --delete-branch already authorized the deletion.
+        echo -e "${GREEN}Branch force-deleted (squash-merged; not an ancestor of main).${NC}"
     else
-        # Branch wasn't merged - for squash-merged PRs, this is expected
-        echo -e "${YELLOW}Branch not fully merged (normal for squash-merged PRs).${NC}"
-        read -p "Force delete branch '$BRANCH_NAME'? [y/N] " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            git -C "$MAIN_REPO" branch -D "$BRANCH_NAME"
-            echo -e "${GREEN}Branch force-deleted.${NC}"
-        else
-            echo "Branch kept."
-        fi
+        # Branch removal genuinely failed (e.g. already gone) - warn, do NOT fail
+        # the run: the worktree was removed, which is this script's job.
+        echo -e "${YELLOW}Could not delete branch '${BRANCH_NAME}' (may already be gone). Worktree removal still succeeded.${NC}"
     fi
 fi
 

--- a/tests/test_worktree_remove_squash.py
+++ b/tests/test_worktree_remove_squash.py
@@ -1,0 +1,157 @@
+"""Regression tests for issue #566: worktree-remove.sh must not report a false
+failure on a squash-merged branch.
+
+Root cause: under ``set -euo pipefail``, ``git branch -d`` refuses a
+squash-merged branch ("not fully merged" - the squash rewrote its commits into
+one new commit on main, so the branch tip is not an ancestor of main), and the
+old fallback was an interactive ``read -p`` confirmation. Non-interactive callers
+(``/flow:auto``, ``/flow:merge``) have no TTY: ``read`` hit EOF and returned
+non-zero, tripping ``set -e`` so the whole script exited non-zero AND left the
+branch undeleted - a false "cleanup failed" even though the worktree removal
+succeeded.
+
+The fix: try ``git branch -d`` first (clean report for the fully-merged case),
+then fall back to ``git branch -D`` non-interactively; branch-delete outcome
+never fails the script - only a worktree-removal failure surfaces non-zero.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "worktree-remove.sh"
+
+# The behaviour tests drive real ``git`` and ``bash`` subprocesses. The Woodpecker
+# ``validate`` step runs in ``uv:python3.11-bookworm-slim``, which ships bash but
+# NOT git, so those tests skip there (issue #430).
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="requires git and bash on PATH (absent in the CI validate container)",
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+    )
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+
+def _run_remove(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    # stdin=DEVNULL reproduces the non-TTY EOF that made the old interactive
+    # ``read -p`` fallback trip ``set -e``. ``timeout`` guards against a
+    # regression that reintroduces a blocking prompt (it would hang forever).
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=30,
+    )
+
+
+def _repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A main repo on ``main`` plus a linked worktree on branch ``feature``."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-q", "-b", "main")
+    (main / "base.txt").write_text("base\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-qm", "base")
+    wt = main / ".claude" / "worktrees" / "wt"
+    _git(main, "worktree", "add", "-q", str(wt), "-b", "feature")
+    return main, wt
+
+
+def _branch_exists(repo: Path, name: str) -> bool:
+    out = _git(repo, "branch", "--list", name)
+    return name in out
+
+
+@requires_git
+def test_squash_merged_branch_removed_cleanly(tmp_path: Path) -> None:
+    """The core bug: a squash-merged branch must be removed with exit 0."""
+    main, wt = _repo_with_worktree(tmp_path)
+    # Work on the feature branch (in its worktree).
+    (wt / "feat.txt").write_text("feature work\n")
+    _git(wt, "add", "-A")
+    _git(wt, "commit", "-qm", "feature work")
+    # Simulate a SQUASH merge: main gains an independent commit carrying the
+    # work, so ``feature`` is no longer an ancestor of main and ``branch -d``
+    # refuses - exactly the squash-merge shape.
+    (main / "feat.txt").write_text("feature work\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-qm", "squashed feature (#566)")
+
+    res = _run_remove(main, str(wt), "--force", "--delete-branch")
+
+    assert res.returncode == 0, f"false failure on squash-merged branch:\n{res.stderr}"
+    assert not wt.exists(), "worktree directory was not removed"
+    assert not _branch_exists(main, "feature"), "squash-merged branch was not deleted"
+    # Non-interactive: it must never have asked for confirmation.
+    assert "[y/N]" not in res.stdout and "[y/N]" not in res.stderr
+    assert "force-deleted" in res.stdout.lower()
+
+
+@requires_git
+def test_fully_merged_branch_reported_and_deleted(tmp_path: Path) -> None:
+    """A genuinely fully-merged (fast-forwardable) branch still deletes cleanly
+    and is reported as fully merged (the safe ``-d`` path)."""
+    main, wt = _repo_with_worktree(tmp_path)
+    (wt / "feat.txt").write_text("feature work\n")
+    _git(wt, "add", "-A")
+    _git(wt, "commit", "-qm", "feature work")
+    # Fast-forward main to feature: now feature IS an ancestor of main.
+    _git(main, "merge", "--ff-only", "feature")
+
+    res = _run_remove(main, str(wt), "--force", "--delete-branch")
+
+    assert res.returncode == 0, res.stderr
+    assert not _branch_exists(main, "feature"), "fully-merged branch was not deleted"
+    assert "fully merged" in res.stdout.lower()
+
+
+@requires_git
+def test_removal_without_delete_branch_keeps_branch(tmp_path: Path) -> None:
+    """Without --delete-branch the worktree goes but the branch is left intact."""
+    main, wt = _repo_with_worktree(tmp_path)
+    (wt / "feat.txt").write_text("feature work\n")
+    _git(wt, "add", "-A")
+    _git(wt, "commit", "-qm", "feature work")
+
+    res = _run_remove(main, str(wt), "--force")
+
+    assert res.returncode == 0, res.stderr
+    assert not wt.exists(), "worktree directory was not removed"
+    assert _branch_exists(main, "feature"), "branch should be kept without --delete-branch"
+
+
+@requires_git
+def test_real_removal_failure_still_surfaces_nonzero(tmp_path: Path) -> None:
+    """Only a genuine failure surfaces non-zero: a path that is not a worktree
+    is rejected with a non-zero exit (the removal itself failed)."""
+    main, _wt = _repo_with_worktree(tmp_path)
+    res = _run_remove(main, str(main), "--force", "--delete-branch")
+    assert res.returncode != 0, "a non-worktree path must be rejected non-zero"


### PR DESCRIPTION
## Summary
`scripts/worktree-remove.sh` (the git-fallback cleanup path used by `/flow:auto` and `/flow:merge`) **removed the worktree successfully but exited non-zero on a squash-merged branch**, narrating the run as a cleanup failure.

**Root cause:** under `set -euo pipefail`, `git branch -d` refuses a squash-merged branch (*"not fully merged"* — a squash rewrites the branch's commits into one new commit on `main`, so the branch tip is no longer an ancestor of `main` even though the PR is MERGED). The old fallback was an interactive `read -p` confirmation. Non-interactive callers have no TTY: `read` hit EOF and returned non-zero, tripping `set -e` so the whole script exited non-zero **and** left the branch undeleted. This is consistently the single most frequent `red-output` friction signal (~9 records).

## Fix
- Try `git branch -d` first (clean report for the genuinely fully-merged case), then fall back to `git branch -D` **non-interactively** — the `read -p` prompt is gone.
- Branch-delete outcome never fails the script: only a worktree-removal failure surfaces non-zero (issue AC).
- `--delete-branch` is an explicit deletion request made only after a merged PR, so the force fallback is safe; `-d` is tried first, and reflog recovery remains.
- Updated the `--delete-branch` help text.

## Changes
1. `scripts/worktree-remove.sh` — deterministic `-d` → `-D` fallback; drop interactive prompt; help text.
2. `tests/test_worktree_remove_squash.py` (new) — real git+bash regression tests (squash-merged, fully-merged, no-`--delete-branch`, genuine-removal-failure), invoked with **stdin closed** to reproduce the non-TTY EOF that caused the false failure; `skipif`-guarded for git/bash (CI validate container).
3. `codex/skills/{flow-auto,flow-doctor,flow-merge}/scripts/worktree-remove.sh` — re-synced byte-identical (`codex-skills-check` gate).

## Test plan
- `python -m lib.cicd run --plan finish` → lint + 878 tests (incl. 4 new) + security gate all green.
- `scripts/codex-skill-sync.py --check` → in sync.

Refs: sibling #461 (closed) was the different `gh pr merge --delete-branch` linked-worktree case, not this `git branch -d` ancestry check.

Closes #566