### PR TITLE
fix(second-opinion): don't auto-register MCP server on plugin install (Closes #569)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
     {
       "name": "second-opinion",
       "source": "./plugins/second-opinion",
-      "description": "Cross-vendor second-opinion code review client commands (/second-opinion:start, /second-opinion:models); ships the .mcp.json client pointer (default http://127.0.0.1:8080/mcp) to the external mcp-second-opinion server."
+      "description": "Cross-vendor second-opinion code review client commands (/second-opinion:start, /second-opinion:models). Does not auto-register an MCP server on install; the external mcp-second-opinion server is opt-in - register it with `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp` once it is running."
     },
     {
       "name": "secrets",

--- a/.claude/commands/second-opinion/help.md
+++ b/.claude/commands/second-opinion/help.md
@@ -51,16 +51,20 @@ You can also invoke the MCP tools directly without commands:
 
 ## Requirements
 
-- The external Second Opinion server running: clone and start `cooneycw/mcp-second-opinion`.
-- This project's root `.mcp.json` pointing at it: the `second-opinion` entry is a streamable-http server at `http://127.0.0.1:8080/mcp` (localhost) or a Tailscale URL (remote host).
+- The external Second Opinion server running: clone and start `cooneycw/mcp-second-opinion`. It is opt-in and is not started or auto-registered by CPP.
+- The `second-opinion` MCP server registered in Claude Code, pointing at it. Installing via the plugin does NOT auto-register it, so register it yourself once the server is up:
+  - **Plugin install:** `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user` (use your Tailscale URL for a remote host).
+  - **CPP repo checkout:** the repo-root `.mcp.json` already registers `second-opinion` at project scope (`http://127.0.0.1:8080/mcp` for localhost, or a Tailscale URL).
 - At least one API key configured on the server side (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY). All three recommended for cross-provider comparison.
 
 ## Troubleshooting
 
-**Error `-32602: Invalid request parameters`** usually means the server isn't running or the root `.mcp.json` is not pointing at it, not that parameters are wrong.
+**`second-opinion ... Failed to connect` or "1 error during load"** on a fresh plugin install is expected until you opt in: the external server is not running and the plugin does not auto-register it. It is benign, the other commands are unaffected. Start the server and register it (below) to clear it.
 
-**Fix:** Make sure the external server is up and `.mcp.json` targets it:
+**Error `-32602: Invalid request parameters`** usually means the server isn't running or `second-opinion` is not registered/pointing at it, not that parameters are wrong.
+
+**Fix:** Make sure the external server is up and `second-opinion` is registered against it:
 
 1. Start the external server from the `cooneycw/mcp-second-opinion` checkout (see that repo's README).
-2. Confirm this project's root `.mcp.json` registers `second-opinion` as a streamable-http server at the right URL (`http://127.0.0.1:8080/mcp` for localhost, or your Tailscale URL for a remote host).
-3. Reload MCP servers in Claude Code (or restart the session) so the updated `.mcp.json` is picked up.
+2. Register `second-opinion` as a streamable-http server at the right URL. Plugin install: `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user`. CPP repo checkout: confirm the repo-root `.mcp.json` `second-opinion` entry targets the same URL (`http://127.0.0.1:8080/mcp` for localhost, or your Tailscale URL for a remote host).
+3. Reload MCP servers in Claude Code (or restart the session) so the registration is picked up.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ CPP ships as a **plugin marketplace** (ADR [0001](docs/decisions/0001-plugin-mar
 #     help-only cpp plugin.
 ```
 
-`/plugin` handles versioning and updates for the installed surfaces. The `secrets` plugin bundles the PostToolUse secret-masking hook and the `second-opinion` plugin bundles its `.mcp.json` client pointer, so a plugin-only install gets masking and MCP wiring with no host setup.
+`/plugin` handles versioning and updates for the installed surfaces. The `secrets` plugin bundles the PostToolUse secret-masking hook, so a plugin-only install gets masking with no host setup. The `second-opinion` plugin ships the review *commands* only and deliberately does NOT auto-register an MCP server (the external server is opt-in and not running on a fresh box, so auto-registration would surface as "1 error during load"); register it yourself once the server is up (see below).
 
 ### Non-plugin setup (the fallback `/plugin` cannot cover)
 
-A plugin install delivers commands, skills, hooks, and the MCP *client pointer* - but not the out-of-band infrastructure some families reach. Run `/cpp:init` in a target project for those steps (it is now the non-plugin infra installer, not the primary way to get commands):
+A plugin install delivers commands, skills, and hooks - but not the out-of-band infrastructure some families reach, and not an auto-registered MCP server. Run `/cpp:init` in a target project for those steps (it is now the non-plugin infra installer, not the primary way to get commands):
 
-- **External Second Opinion server** - the multi-model review server lives in its own repo ([cooneycw/mcp-second-opinion](https://github.com/cooneycw/mcp-second-opinion)). The `second-opinion` plugin ships a `.mcp.json` pointer at `http://127.0.0.1:8080/mcp`; start that server, or re-point the URL at a Tailscale host with `claude mcp add second-opinion --transport http --url <url> --scope user`.
+- **External Second Opinion server** - the multi-model review server lives in its own repo ([cooneycw/mcp-second-opinion](https://github.com/cooneycw/mcp-second-opinion)). The `second-opinion` plugin ships the review commands only and does NOT auto-register the server; start the external server, then register it with `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user` (use your Tailscale URL for a remote host).
 - **Browser automation** - registers the upstream `@playwright/mcp` npx/stdio server (no container).
 - **Secrets provisioning** - AWS Secrets Manager access for Woodpecker CI keys (`essent-ai`) and the `CPP_MEMORIES_DSN` common-memory DSN; fetched directly via the AWS SDK/CLI.
 - **Bootstrap prerequisites** - `jq`, and the optional spec-kit CLI (`specify`, the engine behind `/spec:adopt`).

--- a/codex/skills/second-opinion-help/SKILL.md
+++ b/codex/skills/second-opinion-help/SKILL.md
@@ -59,16 +59,20 @@ You can also invoke the MCP tools directly without commands:
 
 ## Requirements
 
-- The external Second Opinion server running: clone and start `cooneycw/mcp-second-opinion`.
-- This project's root `.mcp.json` pointing at it: the `second-opinion` entry is a streamable-http server at `http://127.0.0.1:8080/mcp` (localhost) or a Tailscale URL (remote host).
+- The external Second Opinion server running: clone and start `cooneycw/mcp-second-opinion`. It is opt-in and is not started or auto-registered by CPP.
+- The `second-opinion` MCP server registered in Claude Code, pointing at it. Installing via the plugin does NOT auto-register it, so register it yourself once the server is up:
+  - **Plugin install:** `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user` (use your Tailscale URL for a remote host).
+  - **CPP repo checkout:** the repo-root `.mcp.json` already registers `second-opinion` at project scope (`http://127.0.0.1:8080/mcp` for localhost, or a Tailscale URL).
 - At least one API key configured on the server side (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY). All three recommended for cross-provider comparison.
 
 ## Troubleshooting
 
-**Error `-32602: Invalid request parameters`** usually means the server isn't running or the root `.mcp.json` is not pointing at it, not that parameters are wrong.
+**`second-opinion ... Failed to connect` or "1 error during load"** on a fresh plugin install is expected until you opt in: the external server is not running and the plugin does not auto-register it. It is benign, the other commands are unaffected. Start the server and register it (below) to clear it.
 
-**Fix:** Make sure the external server is up and `.mcp.json` targets it:
+**Error `-32602: Invalid request parameters`** usually means the server isn't running or `second-opinion` is not registered/pointing at it, not that parameters are wrong.
+
+**Fix:** Make sure the external server is up and `second-opinion` is registered against it:
 
 1. Start the external server from the `cooneycw/mcp-second-opinion` checkout (see that repo's README).
-2. Confirm this project's root `.mcp.json` registers `second-opinion` as a streamable-http server at the right URL (`http://127.0.0.1:8080/mcp` for localhost, or your Tailscale URL for a remote host).
-3. Reload MCP servers in Claude Code (or restart the session) so the updated `.mcp.json` is picked up.
+2. Register `second-opinion` as a streamable-http server at the right URL. Plugin install: `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user`. CPP repo checkout: confirm the repo-root `.mcp.json` `second-opinion` entry targets the same URL (`http://127.0.0.1:8080/mcp` for localhost, or your Tailscale URL for a remote host).
+3. Reload MCP servers in Claude Code (or restart the session) so the registration is picked up.

--- a/plugins/second-opinion/.claude-plugin/plugin.json
+++ b/plugins/second-opinion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "second-opinion",
-  "description": "Cross-vendor second-opinion code review client: /second-opinion:start quick reviews with sensible defaults, /second-opinion:models model/depth selection. Ships the .mcp.json streamable-http client pointer (default http://127.0.0.1:8080/mcp) to the external mcp-second-opinion server (github.com/cooneycw/mcp-second-opinion); run the server from that repo and re-register the URL at user scope if it lives elsewhere.",
-  "version": "1.1.0",
+  "description": "Cross-vendor second-opinion code review client: /second-opinion:start quick reviews with sensible defaults, /second-opinion:models model/depth selection. Does NOT auto-register an MCP server on install - the external mcp-second-opinion server (github.com/cooneycw/mcp-second-opinion) is opt-in. When you want reviews, run that server, then register it at user scope: claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user (edit the URL for a Tailscale host).",
+  "version": "1.2.0",
   "author": {
     "name": "cooneycw",
     "url": "https://github.com/cooneycw"
@@ -9,6 +9,5 @@
   "homepage": "https://github.com/cooneycw/claude-power-pack",
   "repository": "https://github.com/cooneycw/claude-power-pack",
   "license": "MIT",
-  "keywords": ["code-review", "second-opinion", "cross-vendor", "mcp"],
-  "mcpServers": "./.mcp.json"
+  "keywords": ["code-review", "second-opinion", "cross-vendor", "mcp"]
 }

--- a/plugins/second-opinion/.mcp.json
+++ b/plugins/second-opinion/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "second-opinion": {
-      "type": "http",
-      "url": "http://127.0.0.1:8080/mcp"
-    }
-  }
-}

--- a/plugins/second-opinion/commands/help.md
+++ b/plugins/second-opinion/commands/help.md
@@ -51,16 +51,20 @@ You can also invoke the MCP tools directly without commands:
 
 ## Requirements
 
-- The external Second Opinion server running: clone and start `cooneycw/mcp-second-opinion`.
-- This project's root `.mcp.json` pointing at it: the `second-opinion` entry is a streamable-http server at `http://127.0.0.1:8080/mcp` (localhost) or a Tailscale URL (remote host).
+- The external Second Opinion server running: clone and start `cooneycw/mcp-second-opinion`. It is opt-in and is not started or auto-registered by CPP.
+- The `second-opinion` MCP server registered in Claude Code, pointing at it. Installing via the plugin does NOT auto-register it, so register it yourself once the server is up:
+  - **Plugin install:** `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user` (use your Tailscale URL for a remote host).
+  - **CPP repo checkout:** the repo-root `.mcp.json` already registers `second-opinion` at project scope (`http://127.0.0.1:8080/mcp` for localhost, or a Tailscale URL).
 - At least one API key configured on the server side (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY). All three recommended for cross-provider comparison.
 
 ## Troubleshooting
 
-**Error `-32602: Invalid request parameters`** usually means the server isn't running or the root `.mcp.json` is not pointing at it, not that parameters are wrong.
+**`second-opinion ... Failed to connect` or "1 error during load"** on a fresh plugin install is expected until you opt in: the external server is not running and the plugin does not auto-register it. It is benign, the other commands are unaffected. Start the server and register it (below) to clear it.
 
-**Fix:** Make sure the external server is up and `.mcp.json` targets it:
+**Error `-32602: Invalid request parameters`** usually means the server isn't running or `second-opinion` is not registered/pointing at it, not that parameters are wrong.
+
+**Fix:** Make sure the external server is up and `second-opinion` is registered against it:
 
 1. Start the external server from the `cooneycw/mcp-second-opinion` checkout (see that repo's README).
-2. Confirm this project's root `.mcp.json` registers `second-opinion` as a streamable-http server at the right URL (`http://127.0.0.1:8080/mcp` for localhost, or your Tailscale URL for a remote host).
-3. Reload MCP servers in Claude Code (or restart the session) so the updated `.mcp.json` is picked up.
+2. Register `second-opinion` as a streamable-http server at the right URL. Plugin install: `claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user`. CPP repo checkout: confirm the repo-root `.mcp.json` `second-opinion` entry targets the same URL (`http://127.0.0.1:8080/mcp` for localhost, or your Tailscale URL for a remote host).
+3. Reload MCP servers in Claude Code (or restart the session) so the registration is picked up.

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -20,9 +20,10 @@ The hazards these pin:
     would ship the legacy installer B4 retired;
   * the Phase B3 (#479) bundled artifacts must stay coherent: the secrets
     plugin's masking-hook script is a byte-identical copy resolved via
-    ${CLAUDE_PLUGIN_ROOT} (never a host path), and the second-opinion plugin's
-    .mcp.json client pointer must match the repo-root one (#469) or a plugin
-    install and a repo checkout would talk to different servers.
+    ${CLAUDE_PLUGIN_ROOT} (never a host path), and the second-opinion plugin
+    must NOT auto-register an MCP server on install (#569): the external
+    mcp-second-opinion server is opt-in and not running on a fresh box, so a
+    bundled/auto-registered pointer surfaces as "1 error during load".
 
 Hermetic and git-free: reads the REAL repo manifests + command sources and shells
 only to the git-free sync guard, so it runs in CI's git-less validate container
@@ -180,8 +181,8 @@ def test_cpp_plugin_is_help_only():
 SECRETS_HOOKS = PLUGINS_DIR / "secrets" / "hooks" / "hooks.json"
 SECRETS_HOOK_SCRIPT = PLUGINS_DIR / "secrets" / "scripts" / "hook-mask-output.sh"
 HOOK_SCRIPT_SOURCE = ROOT / "scripts" / "hook-mask-output.sh"
-SO_PLUGIN_MCP = PLUGINS_DIR / "second-opinion" / ".mcp.json"
-ROOT_MCP = ROOT / ".mcp.json"
+SO_PLUGIN_DIR = PLUGINS_DIR / "second-opinion"
+SO_PLUGIN_MANIFEST = SO_PLUGIN_DIR / ".claude-plugin" / "plugin.json"
 
 
 def test_secrets_plugin_bundles_posttooluse_masking_hook():
@@ -215,15 +216,22 @@ def test_secrets_hook_script_is_executable():
     )
 
 
-def test_second_opinion_plugin_mcp_pointer_matches_root():
-    assert SO_PLUGIN_MCP.is_file(), f"missing {SO_PLUGIN_MCP}"
-    plugin_ptr = json.loads(SO_PLUGIN_MCP.read_text())["mcpServers"]["second-opinion"]
-    assert plugin_ptr.get("type") == "http", "pointer must be the streamable-http client stanza"
-    assert plugin_ptr.get("url"), "pointer needs a url"
-    # The plugin pointer and the repo-root pointer (#469) must never diverge.
-    root_ptr = json.loads(ROOT_MCP.read_text())["mcpServers"]["second-opinion"]
-    assert plugin_ptr == root_ptr, (
-        f"plugin pointer {plugin_ptr} != repo-root .mcp.json pointer {root_ptr}"
+def test_second_opinion_plugin_does_not_autoregister_mcp_server():
+    # #569: the external mcp-second-opinion server is opt-in and not running on a
+    # fresh box. A plugin that auto-registers an http MCP pointer on install makes
+    # Claude Code try to connect on every fresh install, fail, and surface a scary
+    # "1 error during load". The plugin must ship the review COMMANDS only and let
+    # the user register the server (claude mcp add ...) when they opt in.
+    manifest = json.loads(SO_PLUGIN_MANIFEST.read_text())
+    assert "mcpServers" not in manifest, (
+        "second-opinion plugin.json must NOT declare mcpServers - that auto-registers "
+        "the external server on install and fails to connect on a fresh box (#569). "
+        "The server is opt-in via `claude mcp add second-opinion ...`."
+    )
+    assert not (SO_PLUGIN_DIR / ".mcp.json").exists(), (
+        "second-opinion plugin must not bundle a .mcp.json client pointer (#569); "
+        "with mcpServers removed it is dead weight, and any bundled pointer risks "
+        "reintroducing an active-on-install registration."
     )
 
 


### PR DESCRIPTION
## Summary

Fixes the fresh-install papercut where installing the CPP plugins showed **"1 error during load"** for the `second-opinion` MCP server.

**Root cause:** `plugins/second-opinion/.claude-plugin/plugin.json` declared `"mcpServers": "./.mcp.json"`, so Claude Code auto-registered the external `mcp-second-opinion` http server (`127.0.0.1:8080`) on every install. That server is external and opt-in and is not running on a fresh box, so the reload failed to connect and reported a load error even though nothing was actually broken.

**Fix:** the plugin now ships the review **commands only** and does NOT auto-register an MCP server. Users register it when they opt in, with the same command `/cpp:init` already prints:

```
claude mcp add second-opinion --transport http --url http://127.0.0.1:8080/mcp --scope user
```

## Changes

- `plugin.json`: drop the `mcpServers` auto-registration; bump `1.1.0` -> `1.2.0`; rewrite the description to document opt-in registration.
- Delete the now-unreferenced `plugins/second-opinion/.mcp.json`.
- `help.md` (source of truth + byte-identical plugin copy + Codex skill copy): document opt-in registration for both a plugin install (`claude mcp add`) and a CPP repo checkout (root `.mcp.json`); note the benign `Failed to connect` / "1 error during load" until the server is up.
- `marketplace.json` + `README.md`: correct the now-stale "plugin ships/bundles the `.mcp.json` pointer" statements.
- `tests/test_plugin_marketplace.py`: replace `test_second_opinion_plugin_mcp_pointer_matches_root` with a #569 regression guard asserting the plugin declares no `mcpServers` and bundles no `.mcp.json`.

The repo-root `.mcp.json` (the CPP-repo dogfooding surface for maintainers) is intentionally left unchanged.

## Test plan

- `lib.cicd run --plan finish`: lint (ruff) clean, **883 tests pass**, security scan passed.
- New regression test fails on a reintroduced `mcpServers`/bundled `.mcp.json`.
- All three generated surfaces (`plugins/`, `codex/skills/`) re-synced and drift-clean.

Closes #569