### PR TITLE
fix(woodpecker): tolerate slow forge config fetches

### DIFF
--- a/templates/woodpecker/docker-compose.server.yml.example
+++ b/templates/woodpecker/docker-compose.server.yml.example
@@ -28,6 +28,10 @@ services:
       # WOODPECKER_<FORGE> block per https://woodpecker-ci.org/docs/administration/forges
       - WOODPECKER_GITHUB=true
       - WOODPECKER_ADMIN=CHANGE_ME   # <- your forge username
+      # Give multi-workflow repositories enough time to fetch configuration
+      # during transient forge latency before pipeline creation fails.
+      - WOODPECKER_FORGE_TIMEOUT=15s
+      - WOODPECKER_FORGE_RETRY=5
       # Privileged plugins are an allowlist - list ONLY what you use. buildx is
       # needed only if you build/scan container images in CI.
       - WOODPECKER_PLUGINS_PRIVILEGED=woodpeckerci/plugin-docker-buildx,plugins/docker

--- a/tests/test_woodpecker_server_config.py
+++ b/tests/test_woodpecker_server_config.py
@@ -1,0 +1,22 @@
+"""Contracts for resilient Woodpecker server configuration fetches."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).parent.parent
+SERVER_COMPOSE_FILES = [
+    ROOT / "woodpecker" / "docker-compose.yml",
+    ROOT / "templates" / "woodpecker" / "docker-compose.server.yml.example",
+]
+
+
+@pytest.mark.parametrize("compose_path", SERVER_COMPOSE_FILES, ids=lambda path: path.name)
+def test_server_retries_slow_forge_config_fetches(compose_path: Path) -> None:
+    """Live and scaffolded servers tolerate transient forge latency."""
+    compose = yaml.safe_load(compose_path.read_text())
+    environment = compose["services"]["woodpecker-server"]["environment"]
+
+    assert "WOODPECKER_FORGE_TIMEOUT=15s" in environment
+    assert "WOODPECKER_FORGE_RETRY=5" in environment

--- a/woodpecker/docker-compose.yml
+++ b/woodpecker/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - WOODPECKER_OPEN=true
       - WOODPECKER_GITHUB=true
       - WOODPECKER_ADMIN=cooneycw
+      - WOODPECKER_FORGE_TIMEOUT=15s
+      - WOODPECKER_FORGE_RETRY=5
       - WOODPECKER_PLUGINS_PRIVILEGED=woodpeckerci/plugin-docker-buildx,plugins/docker
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

- raise the Woodpecker forge configuration fetch timeout from the 5s default to 15s
- raise forge fetch retries from the default of 3 to 5
- apply the resilient defaults to both the live server compose source and reusable template
- add a regression contract for both compose files

## Test plan

- `make lint`
- deterministic finish runner: lint, 885 tests, security scan
- after merge: deploy during a quiet window and verify the effective container environment

Refs cooneycw/insurance-pricing-simulation#2375

The linked issue remains open for its two-week post-rollout observation criterion.