### PR TITLE
feat(flow): FLOW_WORKTREE_BASE - configurable worktree base location (Closes #584)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -117,18 +117,32 @@ SESSION_REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 CROSS_REPO=0
 [ "$TARGET_REPO" != "$SESSION_REPO" ] && CROSS_REPO=1
 [ "$CROSS_REPO" -eq 1 ] && cd "$TARGET_REPO"
-echo "Target repo: $TARGET_REPO (cross-repo: $CROSS_REPO)"
+
+# Worktree base override (issue #584, ADR 0003 Option A). Unset (the shipped
+# default) is byte-identical to today: worktrees live in-repo under
+# .claude/worktrees/<branch>. When FLOW_WORKTREE_BASE is set (host config, e.g.
+# ~/.bashrc), worktrees are created OUT of the repo at
+# $FLOW_WORKTREE_BASE/<repo>-<branch> and the run rides the git lane
+# end-to-end - never EnterWorktree(path=...) to an out-of-repo path, whose
+# approval prompt permission rules cannot suppress (ADR 0003 constraint 2).
+GIT_LANE=$CROSS_REPO
+[ -n "$FLOW_WORKTREE_BASE" ] && GIT_LANE=1
+echo "Target repo: $TARGET_REPO (cross-repo: $CROSS_REPO, git lane: $GIT_LANE)"
+echo "Worktree base: ${FLOW_WORKTREE_BASE:-<in-repo default .claude/worktrees/>}"
 ```
 
-- **`CROSS_REPO=1` commits this run to the git lane end-to-end.** Do NOT call
-  `EnterWorktree` on ANY Step-1 path, fresh included - create with
-  `git -C "$TARGET_REPO" worktree add` and `cd` into the worktree (each lane
-  below states its cross-repo form). Step 7 uses the git cleanup fallback. The
-  worktree still lives under the TARGET repo's `.claude/worktrees/`, so the
-  #473/#486 guards and the friction-log durable buffer resolve exactly as in a
-  native run; resolve `Write`/`Edit` paths from `git rev-parse --show-toplevel`
-  run inside the worktree (the #486 rule, which already covers this lane).
-- **`CROSS_REPO=0`:** proceed with the lanes below unchanged - native
+- **`GIT_LANE=1` (cross-repo run, or `FLOW_WORKTREE_BASE` set) commits this run
+  to the git lane end-to-end.** Do NOT call `EnterWorktree` on ANY Step-1 path,
+  fresh included - create with `git -C "$TARGET_REPO" worktree add` and `cd`
+  into the worktree (each lane below states its git-lane form). Step 7 uses the
+  git cleanup fallback. The worktree lives under the TARGET repo's
+  `.claude/worktrees/` (or at `$FLOW_WORKTREE_BASE/<repo>-<branch>` when the
+  base is overridden); either way the #473/#486 guards and the friction-log
+  durable buffer resolve via git plumbing exactly as in a native run (verified
+  in ADR 0003); resolve `Write`/`Edit` paths from `git rev-parse
+  --show-toplevel` run inside the worktree (the #486 rule, which already covers
+  this lane).
+- **`GIT_LANE=0`:** proceed with the lanes below unchanged - native
   `EnterWorktree` for the fresh path.
 
 ```bash
@@ -185,20 +199,26 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   user confirmation that no other live session owns this worktree before calling
   `EnterWorktree(path="$WT_PATH")`. If both are clear, switch in with
   `EnterWorktree(path="<path from git worktree list>")` - or, when
-  `CROSS_REPO=1`, `cd "$WT_PATH"` instead (issue #578). Resumed run - Step 7 uses
-  the git cleanup fallback.
+  `GIT_LANE=1` OR the listed path lies outside `$TARGET_REPO` (a base-override
+  worktree from a prior run), `cd "$WT_PATH"` instead (issues #578, #584).
+  Resumed run - Step 7 uses the git cleanup fallback.
 - **Remote branch exists, no local worktree** (cross-machine pickup): the native
   tool cannot check out an existing remote branch, so add it with git, then switch
   in:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$TARGET_REPO")-${LOCAL_BRANCH}"
+  else
+      WT_PATH=".claude/worktrees/${LOCAL_BRANCH}"
+  fi
+  git worktree add -b "$LOCAL_BRANCH" "$WT_PATH" "$REMOTE_BRANCH"
   ```
-  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")` - or, when
-  `CROSS_REPO=1`, `cd ".claude/worktrees/${LOCAL_BRANCH}"` instead (issue #578).
-  Step 7 uses the git cleanup fallback (a `path`-entered worktree is not removed
-  by `ExitWorktree`).
+  then call `EnterWorktree(path="$WT_PATH")` - or, when `GIT_LANE=1`,
+  `cd "$WT_PATH"` instead (issues #578, #584). Step 7 uses the git cleanup
+  fallback (a `path`-entered worktree is not removed by `ExitWorktree`).
 - **Neither exists** (fresh start): create and enter natively by calling the
   `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
   `origin/<default-branch>` (default `worktree.baseRef: fresh`) and switches the
@@ -206,15 +226,24 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   add` for the fresh path. This is a session-created worktree - Step 7 removes it
   with `ExitWorktree`.
 
-  **Cross-repo exception (issue #578):** when `CROSS_REPO=1`, `EnterWorktree`
-  cannot reach the target repo, so the fresh path is the git lane instead:
+  **Git-lane exception (issues #578, #584):** when `GIT_LANE=1` - a cross-repo
+  run (`EnterWorktree` cannot reach the target repo) or `FLOW_WORKTREE_BASE`
+  set (the native tool's base dir is not configurable, and
+  `EnterWorktree(path=...)` outside the repo triggers an unsuppressable
+  approval prompt) - the fresh path is the git lane instead:
   ```bash
   git -C "$TARGET_REPO" fetch origin --quiet
   DEFAULT_BRANCH=$(git -C "$TARGET_REPO" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
   DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
   DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
-  git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$TARGET_REPO/.claude/worktrees/${BRANCH}" "origin/${DEFAULT_BRANCH}"
-  cd "$TARGET_REPO/.claude/worktrees/${BRANCH}"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$TARGET_REPO")-${BRANCH}"
+  else
+      WT_PATH="$TARGET_REPO/.claude/worktrees/${BRANCH}"
+  fi
+  git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$WT_PATH" "origin/${DEFAULT_BRANCH}"
+  cd "$WT_PATH"
   ```
   This is NOT a session-created native worktree - Step 7 uses the git cleanup
   fallback, same as a resumed run.
@@ -696,9 +725,9 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    correct. After this the session cwd is back in the main repo.
 
    **Otherwise** (Step 1 resumed an existing worktree, entered via
-   `EnterWorktree(path=...)`, ran the cross-repo git lane (`CROSS_REPO=1`,
-   issue #578), or you are on a feature branch in the main repo)
-   `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
+   `EnterWorktree(path=...)`, ran the git lane (`GIT_LANE=1` - cross-repo
+   #578, or `FLOW_WORKTREE_BASE` set #584), or you are on a feature branch in
+   the main repo) `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
    the main repo BEFORE removing the worktree - never remove a worktree while your
    cwd is inside it. Execute as SEPARATE Bash calls.**
 
@@ -1049,6 +1078,7 @@ Key failure scenarios:
 - Each step builds on the previous one; there's no skipping
 - Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - Cross-repo invocations (`/flow:auto <ISSUE> <PROJECT>`, or a session cwd outside any git repo) are first-class (issue #578): Step 1 resolves the target checkout (path, else `~/Projects/<PROJECT>`), detects the mismatch, and rides the deterministic git lane end-to-end - `git -C` worktree create, `cd` instead of `EnterWorktree`, git cleanup at Step 7 - with the worktree still under the target repo's `.claude/worktrees/` so every guard resolves unchanged
+- The worktree base is configurable (issue #584, ADR 0003 Option A): `FLOW_WORKTREE_BASE`, when set in host config, relocates worktrees to `$FLOW_WORKTREE_BASE/<repo>-<branch>` and commits the run to the same git lane (`GIT_LANE=1`); unset, shipped behavior is byte-identical to the in-repo default. The guard/merge/remove/friction scripts resolve via git plumbing and need no awareness of the base
 - The deploy step is always optional - it only runs if a deploy target exists
 - After completion, the user is in the main repo on the main branch
 - For step-by-step control, use individual commands: `/flow:start`, `/flow:eli5`, `/flow:finish`, `/flow:merge`, `/flow:deploy`

--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -44,6 +44,16 @@ git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/orig
 # User identity
 git config user.name 2>/dev/null || echo "NOT_SET"
 git config user.email 2>/dev/null || echo "NOT_SET"
+
+# Effective worktree base (issue #584, ADR 0003): unset = in-repo default.
+# When set, /flow:start + /flow:auto create worktrees at
+# $FLOW_WORKTREE_BASE/<repo>-<branch> via the git lane (never EnterWorktree).
+if [ -n "$FLOW_WORKTREE_BASE" ]; then
+    echo "Worktree base: $FLOW_WORKTREE_BASE (override; git-lane worktrees)"
+    [ -d "$FLOW_WORKTREE_BASE" ] || echo "WARN worktree base dir does not exist yet (created on first use)"
+else
+    echo "Worktree base: .claude/worktrees/ (in-repo default)"
+fi
 ```
 
 ### Step 3: Makefile Targets

--- a/.claude/commands/flow/start.md
+++ b/.claude/commands/flow/start.md
@@ -57,6 +57,16 @@ The native worktree lives under `.claude/worktrees/${BRANCH}` - you do not choos
 a sibling directory; pass `${BRANCH}` as the worktree `name` and the tool places
 and names it.
 
+**Worktree base override (issue #584, ADR 0003 Option A):** when
+`FLOW_WORKTREE_BASE` is set (host config, e.g. `~/.bashrc`), worktrees are
+created OUT of the repo at `$FLOW_WORKTREE_BASE/<repo>-<branch>` via plain
+`git worktree add` + `cd` instead of `EnterWorktree` - the native tool's base
+dir is not configurable, and `EnterWorktree(path=...)` outside the repo
+triggers an approval prompt permission rules cannot suppress. Unset (the
+shipped default), behavior below is byte-identical to today. Cleanup of a
+base-override worktree is the git fallback (`/flow:merge` / `/flow:cleanup` /
+`scripts/worktree-remove.sh` - all already layout-aware).
+
 ### Step 4: Check for Existing Work
 
 ```bash
@@ -84,15 +94,36 @@ Pick exactly one path:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$(git rev-parse --show-toplevel)")-${LOCAL_BRANCH}"
+  else
+      WT_PATH=".claude/worktrees/${LOCAL_BRANCH}"
+  fi
+  git worktree add -b "$LOCAL_BRANCH" "$WT_PATH" "$REMOTE_BRANCH"
   ```
-  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`.
+  then call `EnterWorktree(path="$WT_PATH")` - or, when `FLOW_WORKTREE_BASE` is
+  set, `cd "$WT_PATH"` instead (out-of-repo `EnterWorktree(path=...)` prompts;
+  see the base-override note in Step 3).
 - **Neither exists** (fresh start): create and enter the worktree natively by
   calling the `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
   `origin/<default-branch>` (under the default `worktree.baseRef: fresh`) and
   switches the session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to
   `git worktree add` for the fresh path. If your `worktree.baseRef` is set to
   `head`, sync `main` first so the branch does not start from a stale local HEAD.
+
+  **Base-override exception (issue #584):** when `FLOW_WORKTREE_BASE` is set,
+  the fresh path is the git lane instead of `EnterWorktree`:
+  ```bash
+  git fetch origin --quiet
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+  DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
+  DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+  mkdir -p "$FLOW_WORKTREE_BASE"
+  WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$(git rev-parse --show-toplevel)")-${BRANCH}"
+  git worktree add -b "$BRANCH" "$WT_PATH" "origin/${DEFAULT_BRANCH}"
+  cd "$WT_PATH"
+  ```
 
 ### Step 5: Verify, Normalize Branch, Output
 

--- a/.claude/commands/project-lite.md
+++ b/.claude/commands/project-lite.md
@@ -26,6 +26,11 @@ Run these commands to detect the current repository:
 ```bash
 # Get basic repo info
 gh repo view --json owner,name,defaultBranchRef --jq '{owner: .owner.login, name: .name, branch: .defaultBranchRef.name}' 2>/dev/null || echo "Not a GitHub repo"
+
+# Interleaved flow worktrees (FLOW_WORKTREE_BASE, ADR 0003 / #584) look like
+# projects under ~/Projects; a linked worktree's .git is a FILE. Say so rather
+# than presenting the worktree as the project.
+[ -f .git ] && echo "NOTE: current dir is a linked flow worktree of the repo above, not a standalone project."
 ```
 
 If not a GitHub repo, output a simple message and stop.

--- a/.claude/commands/project-next.md
+++ b/.claude/commands/project-next.md
@@ -37,6 +37,13 @@ if [ -n "$TARGET" ] && [ -d "$HOME/Projects/$TARGET" ]; then
 elif [ -n "$CLAUDE_PROJECT" ] && ! git rev-parse --git-dir >/dev/null 2>&1; then
   [ -d "$HOME/Projects/$CLAUDE_PROJECT" ] && cd "$HOME/Projects/$CLAUDE_PROJECT"
 fi
+# Interleaved flow worktrees (FLOW_WORKTREE_BASE, ADR 0003 / #584) can sit at
+# ~/Projects/<repo>-<branch> beside real projects; a linked worktree's .git is
+# a FILE, not a directory. Analyzing one as a "project" double-reports its
+# parent repo - flag it and analyze the parent instead.
+if [ -f .git ]; then
+  echo "NOTE: '$PWD' is a linked flow worktree, not a project - its issues belong to the parent repo. Re-run against the parent (worktrees appear in its in-flight table)."
+fi
 gh repo view --json owner,name,defaultBranchRef \
   --jq '{owner: .owner.login, name: .name, default_branch: .defaultBranchRef.name}'
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Core components and their locations:
 ## Environment Variables
 
 - `CLAUDE_PROJECT` - Default project for `/project-next` from `~/Projects`. Set in `~/.bashrc`.
+- `FLOW_WORKTREE_BASE` - Optional worktree base override (issue #584, ADR 0003 Option A): when set (host config, e.g. `~/.bashrc`), `/flow:start` + `/flow:auto` create worktrees at `$FLOW_WORKTREE_BASE/<repo>-<branch>` via the git lane instead of in-repo `.claude/worktrees/<branch>` via `EnterWorktree`. Unset = shipped default, byte-identical to today. Never set in shipped config (PR #527 norm).
 
 ## MCP Servers and Secrets
 
@@ -105,7 +106,13 @@ name (enforced after `EnterWorktree`), the `/flow:eli5` necessity gate, the
 quality gates, and merge/cleanup discipline are unchanged. Because native
 `ExitWorktree` only removes worktrees created in the current session, cross-session
 and cross-machine cleanup (`/flow:merge`, `/flow:cleanup`) keep `git worktree
-remove` / `scripts/worktree-remove.sh` as the fallback. The `/flow:*` commands
+remove` / `scripts/worktree-remove.sh` as the fallback. The base location is
+configurable via `FLOW_WORKTREE_BASE` (issue #584, ADR 0003 Option A): when set,
+worktrees are created at `$FLOW_WORKTREE_BASE/<repo>-<branch>` and the run rides
+the #578 git lane end-to-end (the native tool's base dir is not configurable,
+and out-of-repo `EnterWorktree(path=...)` triggers an unsuppressable approval
+prompt); the guard/merge/remove/friction scripts resolve via git plumbing and
+work unchanged at any base. The `/flow:*` commands
 ship as the `flow` plugin (`/plugin install flow@cpp`): `.claude/commands/flow/*`
 is the permanent source of truth and `plugins/flow/commands/*` holds
 byte-identical copies kept in sync by `scripts/plugin-sync.sh`. The legacy

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -119,18 +119,32 @@ SESSION_REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 CROSS_REPO=0
 [ "$TARGET_REPO" != "$SESSION_REPO" ] && CROSS_REPO=1
 [ "$CROSS_REPO" -eq 1 ] && cd "$TARGET_REPO"
-echo "Target repo: $TARGET_REPO (cross-repo: $CROSS_REPO)"
+
+# Worktree base override (issue #584, ADR 0003 Option A). Unset (the shipped
+# default) is byte-identical to today: worktrees live in-repo under
+# .claude/worktrees/<branch>. When FLOW_WORKTREE_BASE is set (host config, e.g.
+# ~/.bashrc), worktrees are created OUT of the repo at
+# $FLOW_WORKTREE_BASE/<repo>-<branch> and the run rides the git lane
+# end-to-end - never EnterWorktree(path=...) to an out-of-repo path, whose
+# approval prompt permission rules cannot suppress (ADR 0003 constraint 2).
+GIT_LANE=$CROSS_REPO
+[ -n "$FLOW_WORKTREE_BASE" ] && GIT_LANE=1
+echo "Target repo: $TARGET_REPO (cross-repo: $CROSS_REPO, git lane: $GIT_LANE)"
+echo "Worktree base: ${FLOW_WORKTREE_BASE:-<in-repo default .claude/worktrees/>}"
 ```
 
-- **`CROSS_REPO=1` commits this run to the git lane end-to-end.** Do NOT call
-  `EnterWorktree` on ANY Step-1 path, fresh included - create with
-  `git -C "$TARGET_REPO" worktree add` and `cd` into the worktree (each lane
-  below states its cross-repo form). Step 7 uses the git cleanup fallback. The
-  worktree still lives under the TARGET repo's `.claude/worktrees/`, so the
-  #473/#486 guards and the friction-log durable buffer resolve exactly as in a
-  native run; resolve `Write`/`Edit` paths from `git rev-parse --show-toplevel`
-  run inside the worktree (the #486 rule, which already covers this lane).
-- **`CROSS_REPO=0`:** proceed with the lanes below unchanged - native
+- **`GIT_LANE=1` (cross-repo run, or `FLOW_WORKTREE_BASE` set) commits this run
+  to the git lane end-to-end.** Do NOT call `EnterWorktree` on ANY Step-1 path,
+  fresh included - create with `git -C "$TARGET_REPO" worktree add` and `cd`
+  into the worktree (each lane below states its git-lane form). Step 7 uses the
+  git cleanup fallback. The worktree lives under the TARGET repo's
+  `.claude/worktrees/` (or at `$FLOW_WORKTREE_BASE/<repo>-<branch>` when the
+  base is overridden); either way the #473/#486 guards and the friction-log
+  durable buffer resolve via git plumbing exactly as in a native run (verified
+  in ADR 0003); resolve `Write`/`Edit` paths from `git rev-parse
+  --show-toplevel` run inside the worktree (the #486 rule, which already covers
+  this lane).
+- **`GIT_LANE=0`:** proceed with the lanes below unchanged - native
   `EnterWorktree` for the fresh path.
 
 ```bash
@@ -187,20 +201,26 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   user confirmation that no other live session owns this worktree before calling
   `EnterWorktree(path="$WT_PATH")`. If both are clear, switch in with
   `EnterWorktree(path="<path from git worktree list>")` - or, when
-  `CROSS_REPO=1`, `cd "$WT_PATH"` instead (issue #578). Resumed run - Step 7 uses
-  the git cleanup fallback.
+  `GIT_LANE=1` OR the listed path lies outside `$TARGET_REPO` (a base-override
+  worktree from a prior run), `cd "$WT_PATH"` instead (issues #578, #584).
+  Resumed run - Step 7 uses the git cleanup fallback.
 - **Remote branch exists, no local worktree** (cross-machine pickup): the native
   tool cannot check out an existing remote branch, so add it with git, then switch
   in:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$TARGET_REPO")-${LOCAL_BRANCH}"
+  else
+      WT_PATH=".claude/worktrees/${LOCAL_BRANCH}"
+  fi
+  git worktree add -b "$LOCAL_BRANCH" "$WT_PATH" "$REMOTE_BRANCH"
   ```
-  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")` - or, when
-  `CROSS_REPO=1`, `cd ".claude/worktrees/${LOCAL_BRANCH}"` instead (issue #578).
-  Step 7 uses the git cleanup fallback (a `path`-entered worktree is not removed
-  by `ExitWorktree`).
+  then call `EnterWorktree(path="$WT_PATH")` - or, when `GIT_LANE=1`,
+  `cd "$WT_PATH"` instead (issues #578, #584). Step 7 uses the git cleanup
+  fallback (a `path`-entered worktree is not removed by `ExitWorktree`).
 - **Neither exists** (fresh start): create and enter natively by calling the
   `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
   `origin/<default-branch>` (default `worktree.baseRef: fresh`) and switches the
@@ -208,15 +228,24 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   add` for the fresh path. This is a session-created worktree - Step 7 removes it
   with `ExitWorktree`.
 
-  **Cross-repo exception (issue #578):** when `CROSS_REPO=1`, `EnterWorktree`
-  cannot reach the target repo, so the fresh path is the git lane instead:
+  **Git-lane exception (issues #578, #584):** when `GIT_LANE=1` - a cross-repo
+  run (`EnterWorktree` cannot reach the target repo) or `FLOW_WORKTREE_BASE`
+  set (the native tool's base dir is not configurable, and
+  `EnterWorktree(path=...)` outside the repo triggers an unsuppressable
+  approval prompt) - the fresh path is the git lane instead:
   ```bash
   git -C "$TARGET_REPO" fetch origin --quiet
   DEFAULT_BRANCH=$(git -C "$TARGET_REPO" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
   DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
   DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
-  git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$TARGET_REPO/.claude/worktrees/${BRANCH}" "origin/${DEFAULT_BRANCH}"
-  cd "$TARGET_REPO/.claude/worktrees/${BRANCH}"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$TARGET_REPO")-${BRANCH}"
+  else
+      WT_PATH="$TARGET_REPO/.claude/worktrees/${BRANCH}"
+  fi
+  git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$WT_PATH" "origin/${DEFAULT_BRANCH}"
+  cd "$WT_PATH"
   ```
   This is NOT a session-created native worktree - Step 7 uses the git cleanup
   fallback, same as a resumed run.
@@ -698,9 +727,9 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    correct. After this the session cwd is back in the main repo.
 
    **Otherwise** (Step 1 resumed an existing worktree, entered via
-   `EnterWorktree(path=...)`, ran the cross-repo git lane (`CROSS_REPO=1`,
-   issue #578), or you are on a feature branch in the main repo)
-   `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
+   `EnterWorktree(path=...)`, ran the git lane (`GIT_LANE=1` - cross-repo
+   #578, or `FLOW_WORKTREE_BASE` set #584), or you are on a feature branch in
+   the main repo) `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
    the main repo BEFORE removing the worktree - never remove a worktree while your
    cwd is inside it. Execute as SEPARATE Bash calls.**
 
@@ -1051,6 +1080,7 @@ Key failure scenarios:
 - Each step builds on the previous one; there's no skipping
 - Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - Cross-repo invocations (`/flow-auto <ISSUE> <PROJECT>`, or a session cwd outside any git repo) are first-class (issue #578): Step 1 resolves the target checkout (path, else `~/Projects/<PROJECT>`), detects the mismatch, and rides the deterministic git lane end-to-end - `git -C` worktree create, `cd` instead of `EnterWorktree`, git cleanup at Step 7 - with the worktree still under the target repo's `.claude/worktrees/` so every guard resolves unchanged
+- The worktree base is configurable (issue #584, ADR 0003 Option A): `FLOW_WORKTREE_BASE`, when set in host config, relocates worktrees to `$FLOW_WORKTREE_BASE/<repo>-<branch>` and commits the run to the same git lane (`GIT_LANE=1`); unset, shipped behavior is byte-identical to the in-repo default. The guard/merge/remove/friction scripts resolve via git plumbing and need no awareness of the base
 - The deploy step is always optional - it only runs if a deploy target exists
 - After completion, the user is in the main repo on the main branch
 - For step-by-step control, use individual commands: `/flow-start`, `/flow-eli5`, `/flow-finish`, `/flow-merge`, `/flow-deploy`

--- a/codex/skills/flow-doctor/reference.md
+++ b/codex/skills/flow-doctor/reference.md
@@ -41,6 +41,16 @@ git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/orig
 # User identity
 git config user.name 2>/dev/null || echo "NOT_SET"
 git config user.email 2>/dev/null || echo "NOT_SET"
+
+# Effective worktree base (issue #584, ADR 0003): unset = in-repo default.
+# When set, /flow-start + /flow-auto create worktrees at
+# $FLOW_WORKTREE_BASE/<repo>-<branch> via the git lane (never EnterWorktree).
+if [ -n "$FLOW_WORKTREE_BASE" ]; then
+    echo "Worktree base: $FLOW_WORKTREE_BASE (override; git-lane worktrees)"
+    [ -d "$FLOW_WORKTREE_BASE" ] || echo "WARN worktree base dir does not exist yet (created on first use)"
+else
+    echo "Worktree base: .claude/worktrees/ (in-repo default)"
+fi
 ```
 
 ### Step 3: Makefile Targets

--- a/codex/skills/flow-start/reference.md
+++ b/codex/skills/flow-start/reference.md
@@ -59,6 +59,16 @@ The native worktree lives under `.claude/worktrees/${BRANCH}` - you do not choos
 a sibling directory; pass `${BRANCH}` as the worktree `name` and the tool places
 and names it.
 
+**Worktree base override (issue #584, ADR 0003 Option A):** when
+`FLOW_WORKTREE_BASE` is set (host config, e.g. `~/.bashrc`), worktrees are
+created OUT of the repo at `$FLOW_WORKTREE_BASE/<repo>-<branch>` via plain
+`git worktree add` + `cd` instead of `EnterWorktree` - the native tool's base
+dir is not configurable, and `EnterWorktree(path=...)` outside the repo
+triggers an approval prompt permission rules cannot suppress. Unset (the
+shipped default), behavior below is byte-identical to today. Cleanup of a
+base-override worktree is the git fallback (`/flow-merge` / `/flow-cleanup` /
+`scripts/worktree-remove.sh` - all already layout-aware).
+
 ### Step 4: Check for Existing Work
 
 ```bash
@@ -86,15 +96,36 @@ Pick exactly one path:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$(git rev-parse --show-toplevel)")-${LOCAL_BRANCH}"
+  else
+      WT_PATH=".claude/worktrees/${LOCAL_BRANCH}"
+  fi
+  git worktree add -b "$LOCAL_BRANCH" "$WT_PATH" "$REMOTE_BRANCH"
   ```
-  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`.
+  then call `EnterWorktree(path="$WT_PATH")` - or, when `FLOW_WORKTREE_BASE` is
+  set, `cd "$WT_PATH"` instead (out-of-repo `EnterWorktree(path=...)` prompts;
+  see the base-override note in Step 3).
 - **Neither exists** (fresh start): create and enter the worktree natively by
   calling the `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
   `origin/<default-branch>` (under the default `worktree.baseRef: fresh`) and
   switches the session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to
   `git worktree add` for the fresh path. If your `worktree.baseRef` is set to
   `head`, sync `main` first so the branch does not start from a stale local HEAD.
+
+  **Base-override exception (issue #584):** when `FLOW_WORKTREE_BASE` is set,
+  the fresh path is the git lane instead of `EnterWorktree`:
+  ```bash
+  git fetch origin --quiet
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+  DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
+  DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+  mkdir -p "$FLOW_WORKTREE_BASE"
+  WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$(git rev-parse --show-toplevel)")-${BRANCH}"
+  git worktree add -b "$BRANCH" "$WT_PATH" "origin/${DEFAULT_BRANCH}"
+  cd "$WT_PATH"
+  ```
 
 ### Step 5: Verify, Normalize Branch, Output
 

--- a/codex/skills/flow-start/scripts/worktree-remove.sh
+++ b/codex/skills/flow-start/scripts/worktree-remove.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# worktree-remove.sh - Safely remove git worktrees
+#
+# If you're inside the worktree being removed, the script automatically
+# changes to the main repository first (determined from the worktree's
+# .git file) to prevent breaking your shell session.
+#
+# Usage:
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#
+# Options:
+#   --force          Remove even if worktree has uncommitted changes
+#   --delete-branch  Also delete the associated branch after removal
+#
+# Examples:
+#   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
+#   worktree-remove.sh ../nhl-api-issue-42 --delete-branch
+#   worktree-remove.sh /home/user/Projects/nhl-api-issue-42 --force --delete-branch
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+WORKTREE_PATH=""
+FORCE=""
+DELETE_BRANCH=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force)
+            FORCE="--force"
+            shift
+            ;;
+        --delete-branch)
+            DELETE_BRANCH=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: worktree-remove.sh <worktree-path> [--force] [--delete-branch]"
+            echo ""
+            echo "Safely remove git worktrees. If you're currently inside the worktree"
+            echo "being removed, the script automatically changes to the main repository"
+            echo "first to prevent breaking your shell session."
+            echo ""
+            echo "Options:"
+            echo "  --force          Remove even if worktree has uncommitted changes"
+            echo "  --delete-branch  Also delete the associated branch after removal"
+            echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo ""
+            echo "Examples:"
+            echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
+            echo "  worktree-remove.sh ../nhl-api-issue-42 --delete-branch"
+            exit 0
+            ;;
+        *)
+            if [[ -z "$WORKTREE_PATH" ]]; then
+                WORKTREE_PATH="$1"
+            else
+                echo -e "${RED}Error: Unknown argument: $1${NC}" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$WORKTREE_PATH" ]]; then
+    echo -e "${RED}Error: Worktree path is required${NC}" >&2
+    echo "Usage: worktree-remove.sh <worktree-path> [--force] [--delete-branch]"
+    exit 1
+fi
+
+# Resolve to absolute path
+if [[ "$WORKTREE_PATH" != /* ]]; then
+    WORKTREE_PATH="$(cd "$(dirname "$WORKTREE_PATH")" 2>/dev/null && pwd)/$(basename "$WORKTREE_PATH")"
+fi
+
+# Normalize path (remove trailing slash)
+WORKTREE_PATH="${WORKTREE_PATH%/}"
+
+# Get current working directory
+CWD="$(pwd 2>/dev/null || echo "")"
+CWD="${CWD%/}"
+
+# Check if we're inside the worktree being removed
+INSIDE_WORKTREE=false
+if [[ -n "$CWD" && "$CWD" == "$WORKTREE_PATH"* ]]; then
+    INSIDE_WORKTREE=true
+fi
+
+# Check if worktree exists
+if [[ ! -d "$WORKTREE_PATH" ]]; then
+    echo -e "${YELLOW}Warning: Worktree directory does not exist: ${WORKTREE_PATH}${NC}"
+    echo "It may have already been removed. Running 'git worktree prune'..."
+
+    # Find the main repo (a directory whose .git is a real directory, not a
+    # worktree's .git file). Two layouts to cover:
+    #   1. Legacy sibling worktrees:  ../repo-issue-N  (main repo is a sibling)
+    #   2. Native worktrees:          .claude/worktrees/<name>  (main repo is an ancestor)
+    PRUNE_REPO=""
+    # (1) Scan siblings of the worktree path.
+    for parent in "$(dirname "$WORKTREE_PATH")"/*; do
+        if [[ -d "$parent/.git" ]]; then
+            PRUNE_REPO="$parent"
+            break
+        fi
+    done
+    # (2) Walk up ancestors (covers .claude/worktrees/<name> nested under the repo).
+    if [[ -z "$PRUNE_REPO" ]]; then
+        ancestor="$(dirname "$WORKTREE_PATH")"
+        while [[ "$ancestor" != "/" && -n "$ancestor" ]]; do
+            if [[ -d "$ancestor/.git" ]]; then
+                PRUNE_REPO="$ancestor"
+                break
+            fi
+            ancestor="$(dirname "$ancestor")"
+        done
+    fi
+    if [[ -n "$PRUNE_REPO" ]]; then
+        git -C "$PRUNE_REPO" worktree prune
+        echo -e "${GREEN}Pruned stale worktree references.${NC}"
+    else
+        echo -e "${YELLOW}Could not locate the main repository to prune; run 'git worktree prune' from it manually.${NC}"
+    fi
+    exit 0
+fi
+
+# Check if it's actually a worktree (has .git file, not directory)
+if [[ ! -f "$WORKTREE_PATH/.git" ]]; then
+    echo -e "${RED}Error: ${WORKTREE_PATH} is not a git worktree${NC}" >&2
+    echo "(Worktrees have a .git file, not a .git directory)" >&2
+    exit 1
+fi
+
+# Get the main repository path from the worktree's .git file
+MAIN_REPO=$(cat "$WORKTREE_PATH/.git" | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+
+if [[ ! -d "$MAIN_REPO/.git" ]]; then
+    echo -e "${RED}Error: Could not find main repository${NC}" >&2
+    exit 1
+fi
+
+# If we're inside the worktree, cd to main repo first
+if [[ "$INSIDE_WORKTREE" == true ]]; then
+    echo -e "${YELLOW}Currently inside worktree being removed.${NC}"
+    echo -e "${BLUE}Changing to main repository: ${MAIN_REPO}${NC}"
+    cd "$MAIN_REPO" || {
+        echo -e "${RED}Error: Failed to change to main repository${NC}" >&2
+        exit 1
+    }
+fi
+
+# Get the branch name before removing
+BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# Check for uncommitted changes (unless --force)
+if [[ -z "$FORCE" ]]; then
+    CHANGES=$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null || echo "")
+    if [[ -n "$CHANGES" ]]; then
+        echo -e "${RED}Error: Worktree has uncommitted changes${NC}" >&2
+        echo "" >&2
+        git -C "$WORKTREE_PATH" status --short >&2
+        echo "" >&2
+        echo "Use --force to remove anyway, or commit/stash changes first." >&2
+        exit 1
+    fi
+fi
+
+# Remove the worktree
+echo -e "${BLUE}Removing worktree: ${WORKTREE_PATH}${NC}"
+git -C "$MAIN_REPO" worktree remove "$WORKTREE_PATH" $FORCE
+
+echo -e "${GREEN}Worktree removed successfully.${NC}"
+
+# Optionally delete the branch.
+#
+# --delete-branch is an explicit deletion request, and by this point the worktree
+# has already been removed. Try the safe `git branch -d` first so a genuinely
+# fully-merged branch is reported as such. When it refuses with "not fully
+# merged", that is the EXPECTED squash-merge case: a squash rewrites the branch's
+# commits into one new commit on main, so the branch tip is no longer an ancestor
+# of main even though the PR is MERGED and the work is safely on main. Fall back
+# to `git branch -D` non-interactively rather than prompting.
+#
+# The old interactive `read -p` confirmation broke every non-interactive caller
+# (/flow:auto, /flow:merge): with stdin not a TTY, `read` hit EOF and returned
+# non-zero, tripping `set -e` so the whole script exited non-zero AND left the
+# branch undeleted - a false "cleanup failed" even though the worktree removal
+# succeeded (issue #566). Branch-delete outcome never fails the script now: the
+# worktree removal (above) is the only step whose failure surfaces non-zero.
+if [[ "$DELETE_BRANCH" == true && -n "$BRANCH_NAME" && "$BRANCH_NAME" != "main" && "$BRANCH_NAME" != "master" ]]; then
+    echo -e "${BLUE}Deleting branch: ${BRANCH_NAME}${NC}"
+
+    if git -C "$MAIN_REPO" branch -d "$BRANCH_NAME" 2>/dev/null; then
+        echo -e "${GREEN}Branch deleted (was fully merged).${NC}"
+    elif git -C "$MAIN_REPO" branch -D "$BRANCH_NAME" 2>/dev/null; then
+        # Expected for squash-merged PRs: the branch is not an ancestor of main,
+        # so -d refuses; --delete-branch already authorized the deletion.
+        echo -e "${GREEN}Branch force-deleted (squash-merged; not an ancestor of main).${NC}"
+    else
+        # Branch removal genuinely failed (e.g. already gone) - warn, do NOT fail
+        # the run: the worktree was removed, which is this script's job.
+        echo -e "${YELLOW}Could not delete branch '${BRANCH_NAME}' (may already be gone). Worktree removal still succeeded.${NC}"
+    fi
+fi
+
+echo ""
+echo -e "${GREEN}Done.${NC}"

--- a/docs/decisions/0003-worktree-base-location.md
+++ b/docs/decisions/0003-worktree-base-location.md
@@ -1,6 +1,6 @@
 # ADR 0003: Configurable worktree base location (CPP + CxPP)
 
-- Status: Proposed (awaiting owner decisions 1-3 below)
+- Status: Accepted (owner decisions recorded 2026-07-18; see "Decision record" below. Implementation: #584; CxPP twin: cooneycw/codex-power-pack#136)
 - Date: 2026-07-18
 - Deciders: cooneycw (owner)
 - Issue: #572 (exploration/design; Phase 0 per the security-first-before-scaffolding norm)
@@ -206,6 +206,29 @@ Worktrees stay exactly where they are; visibility is a projection:
   via git plumbing and keep working under both options (verified in the
   sweep); no guard needs a compensating change, so neither option weakens an
   existing protection.
+
+## Decision record (2026-07-18)
+
+The owner answered the three decisions the same day, interactively:
+
+1. **Scope: real feature in both packs.** The corrected blast radius made the
+   shipped knob the cheap path; the owner's box only sets the env var.
+2. **Mechanism: Option A** - real checkouts, work-from. The symlink farm
+   (Option D) was declined.
+3. **Layout: INTERLEAVED, deviating from this ADR's dedicated-subdir
+   recommendation.** The owner sets `FLOW_WORKTREE_BASE=$HOME/Projects`
+   directly, so worktrees sit at `~/Projects/<repo>-<branch>` beside real
+   projects - maximum visibility was the point. The phantom-project concern
+   that motivated the `_worktrees/` subdir is mitigated in tooling instead:
+   `project-next` / `project-lite` detect a linked worktree at resolution time
+   (its `.git` is a FILE, not a directory) and flag it rather than analyzing
+   it as a project. Nothing else enumerates `~/Projects` blindly (verified:
+   both commands resolve NAMED directories only).
+
+Knob semantics as shipped (#584): `FLOW_WORKTREE_BASE` unset -> in-repo
+default, byte-identical behavior; set -> worktrees at
+`$FLOW_WORKTREE_BASE/<repo>-<branch>`, run committed to the #578 git lane
+end-to-end (`GIT_LANE=1`), guards unchanged.
 
 ## Open decisions for owner (restated with this pass's findings weighed in)
 

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -117,18 +117,32 @@ SESSION_REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 CROSS_REPO=0
 [ "$TARGET_REPO" != "$SESSION_REPO" ] && CROSS_REPO=1
 [ "$CROSS_REPO" -eq 1 ] && cd "$TARGET_REPO"
-echo "Target repo: $TARGET_REPO (cross-repo: $CROSS_REPO)"
+
+# Worktree base override (issue #584, ADR 0003 Option A). Unset (the shipped
+# default) is byte-identical to today: worktrees live in-repo under
+# .claude/worktrees/<branch>. When FLOW_WORKTREE_BASE is set (host config, e.g.
+# ~/.bashrc), worktrees are created OUT of the repo at
+# $FLOW_WORKTREE_BASE/<repo>-<branch> and the run rides the git lane
+# end-to-end - never EnterWorktree(path=...) to an out-of-repo path, whose
+# approval prompt permission rules cannot suppress (ADR 0003 constraint 2).
+GIT_LANE=$CROSS_REPO
+[ -n "$FLOW_WORKTREE_BASE" ] && GIT_LANE=1
+echo "Target repo: $TARGET_REPO (cross-repo: $CROSS_REPO, git lane: $GIT_LANE)"
+echo "Worktree base: ${FLOW_WORKTREE_BASE:-<in-repo default .claude/worktrees/>}"
 ```
 
-- **`CROSS_REPO=1` commits this run to the git lane end-to-end.** Do NOT call
-  `EnterWorktree` on ANY Step-1 path, fresh included - create with
-  `git -C "$TARGET_REPO" worktree add` and `cd` into the worktree (each lane
-  below states its cross-repo form). Step 7 uses the git cleanup fallback. The
-  worktree still lives under the TARGET repo's `.claude/worktrees/`, so the
-  #473/#486 guards and the friction-log durable buffer resolve exactly as in a
-  native run; resolve `Write`/`Edit` paths from `git rev-parse --show-toplevel`
-  run inside the worktree (the #486 rule, which already covers this lane).
-- **`CROSS_REPO=0`:** proceed with the lanes below unchanged - native
+- **`GIT_LANE=1` (cross-repo run, or `FLOW_WORKTREE_BASE` set) commits this run
+  to the git lane end-to-end.** Do NOT call `EnterWorktree` on ANY Step-1 path,
+  fresh included - create with `git -C "$TARGET_REPO" worktree add` and `cd`
+  into the worktree (each lane below states its git-lane form). Step 7 uses the
+  git cleanup fallback. The worktree lives under the TARGET repo's
+  `.claude/worktrees/` (or at `$FLOW_WORKTREE_BASE/<repo>-<branch>` when the
+  base is overridden); either way the #473/#486 guards and the friction-log
+  durable buffer resolve via git plumbing exactly as in a native run (verified
+  in ADR 0003); resolve `Write`/`Edit` paths from `git rev-parse
+  --show-toplevel` run inside the worktree (the #486 rule, which already covers
+  this lane).
+- **`GIT_LANE=0`:** proceed with the lanes below unchanged - native
   `EnterWorktree` for the fresh path.
 
 ```bash
@@ -185,20 +199,26 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   user confirmation that no other live session owns this worktree before calling
   `EnterWorktree(path="$WT_PATH")`. If both are clear, switch in with
   `EnterWorktree(path="<path from git worktree list>")` - or, when
-  `CROSS_REPO=1`, `cd "$WT_PATH"` instead (issue #578). Resumed run - Step 7 uses
-  the git cleanup fallback.
+  `GIT_LANE=1` OR the listed path lies outside `$TARGET_REPO` (a base-override
+  worktree from a prior run), `cd "$WT_PATH"` instead (issues #578, #584).
+  Resumed run - Step 7 uses the git cleanup fallback.
 - **Remote branch exists, no local worktree** (cross-machine pickup): the native
   tool cannot check out an existing remote branch, so add it with git, then switch
   in:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$TARGET_REPO")-${LOCAL_BRANCH}"
+  else
+      WT_PATH=".claude/worktrees/${LOCAL_BRANCH}"
+  fi
+  git worktree add -b "$LOCAL_BRANCH" "$WT_PATH" "$REMOTE_BRANCH"
   ```
-  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")` - or, when
-  `CROSS_REPO=1`, `cd ".claude/worktrees/${LOCAL_BRANCH}"` instead (issue #578).
-  Step 7 uses the git cleanup fallback (a `path`-entered worktree is not removed
-  by `ExitWorktree`).
+  then call `EnterWorktree(path="$WT_PATH")` - or, when `GIT_LANE=1`,
+  `cd "$WT_PATH"` instead (issues #578, #584). Step 7 uses the git cleanup
+  fallback (a `path`-entered worktree is not removed by `ExitWorktree`).
 - **Neither exists** (fresh start): create and enter natively by calling the
   `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
   `origin/<default-branch>` (default `worktree.baseRef: fresh`) and switches the
@@ -206,15 +226,24 @@ git branch -r | grep "issue-${ISSUE_NUM}-"
   add` for the fresh path. This is a session-created worktree - Step 7 removes it
   with `ExitWorktree`.
 
-  **Cross-repo exception (issue #578):** when `CROSS_REPO=1`, `EnterWorktree`
-  cannot reach the target repo, so the fresh path is the git lane instead:
+  **Git-lane exception (issues #578, #584):** when `GIT_LANE=1` - a cross-repo
+  run (`EnterWorktree` cannot reach the target repo) or `FLOW_WORKTREE_BASE`
+  set (the native tool's base dir is not configurable, and
+  `EnterWorktree(path=...)` outside the repo triggers an unsuppressable
+  approval prompt) - the fresh path is the git lane instead:
   ```bash
   git -C "$TARGET_REPO" fetch origin --quiet
   DEFAULT_BRANCH=$(git -C "$TARGET_REPO" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
   DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
   DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
-  git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$TARGET_REPO/.claude/worktrees/${BRANCH}" "origin/${DEFAULT_BRANCH}"
-  cd "$TARGET_REPO/.claude/worktrees/${BRANCH}"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$TARGET_REPO")-${BRANCH}"
+  else
+      WT_PATH="$TARGET_REPO/.claude/worktrees/${BRANCH}"
+  fi
+  git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$WT_PATH" "origin/${DEFAULT_BRANCH}"
+  cd "$WT_PATH"
   ```
   This is NOT a session-created native worktree - Step 7 uses the git cleanup
   fallback, same as a resumed run.
@@ -696,9 +725,9 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    correct. After this the session cwd is back in the main repo.
 
    **Otherwise** (Step 1 resumed an existing worktree, entered via
-   `EnterWorktree(path=...)`, ran the cross-repo git lane (`CROSS_REPO=1`,
-   issue #578), or you are on a feature branch in the main repo)
-   `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
+   `EnterWorktree(path=...)`, ran the git lane (`GIT_LANE=1` - cross-repo
+   #578, or `FLOW_WORKTREE_BASE` set #584), or you are on a feature branch in
+   the main repo) `ExitWorktree` will not remove it, so use the git fallback. **CRITICAL: `cd` to
    the main repo BEFORE removing the worktree - never remove a worktree while your
    cwd is inside it. Execute as SEPARATE Bash calls.**
 
@@ -1049,6 +1078,7 @@ Key failure scenarios:
 - Each step builds on the previous one; there's no skipping
 - Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - Cross-repo invocations (`/flow:auto <ISSUE> <PROJECT>`, or a session cwd outside any git repo) are first-class (issue #578): Step 1 resolves the target checkout (path, else `~/Projects/<PROJECT>`), detects the mismatch, and rides the deterministic git lane end-to-end - `git -C` worktree create, `cd` instead of `EnterWorktree`, git cleanup at Step 7 - with the worktree still under the target repo's `.claude/worktrees/` so every guard resolves unchanged
+- The worktree base is configurable (issue #584, ADR 0003 Option A): `FLOW_WORKTREE_BASE`, when set in host config, relocates worktrees to `$FLOW_WORKTREE_BASE/<repo>-<branch>` and commits the run to the same git lane (`GIT_LANE=1`); unset, shipped behavior is byte-identical to the in-repo default. The guard/merge/remove/friction scripts resolve via git plumbing and need no awareness of the base
 - The deploy step is always optional - it only runs if a deploy target exists
 - After completion, the user is in the main repo on the main branch
 - For step-by-step control, use individual commands: `/flow:start`, `/flow:eli5`, `/flow:finish`, `/flow:merge`, `/flow:deploy`

--- a/plugins/flow/commands/doctor.md
+++ b/plugins/flow/commands/doctor.md
@@ -44,6 +44,16 @@ git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/orig
 # User identity
 git config user.name 2>/dev/null || echo "NOT_SET"
 git config user.email 2>/dev/null || echo "NOT_SET"
+
+# Effective worktree base (issue #584, ADR 0003): unset = in-repo default.
+# When set, /flow:start + /flow:auto create worktrees at
+# $FLOW_WORKTREE_BASE/<repo>-<branch> via the git lane (never EnterWorktree).
+if [ -n "$FLOW_WORKTREE_BASE" ]; then
+    echo "Worktree base: $FLOW_WORKTREE_BASE (override; git-lane worktrees)"
+    [ -d "$FLOW_WORKTREE_BASE" ] || echo "WARN worktree base dir does not exist yet (created on first use)"
+else
+    echo "Worktree base: .claude/worktrees/ (in-repo default)"
+fi
 ```
 
 ### Step 3: Makefile Targets

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -57,6 +57,16 @@ The native worktree lives under `.claude/worktrees/${BRANCH}` - you do not choos
 a sibling directory; pass `${BRANCH}` as the worktree `name` and the tool places
 and names it.
 
+**Worktree base override (issue #584, ADR 0003 Option A):** when
+`FLOW_WORKTREE_BASE` is set (host config, e.g. `~/.bashrc`), worktrees are
+created OUT of the repo at `$FLOW_WORKTREE_BASE/<repo>-<branch>` via plain
+`git worktree add` + `cd` instead of `EnterWorktree` - the native tool's base
+dir is not configurable, and `EnterWorktree(path=...)` outside the repo
+triggers an approval prompt permission rules cannot suppress. Unset (the
+shipped default), behavior below is byte-identical to today. Cleanup of a
+base-override worktree is the git fallback (`/flow:merge` / `/flow:cleanup` /
+`scripts/worktree-remove.sh` - all already layout-aware).
+
 ### Step 4: Check for Existing Work
 
 ```bash
@@ -84,15 +94,36 @@ Pick exactly one path:
   ```bash
   REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
   LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
-  git worktree add -b "$LOCAL_BRANCH" ".claude/worktrees/${LOCAL_BRANCH}" "$REMOTE_BRANCH"
+  if [ -n "$FLOW_WORKTREE_BASE" ]; then
+      mkdir -p "$FLOW_WORKTREE_BASE"
+      WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$(git rev-parse --show-toplevel)")-${LOCAL_BRANCH}"
+  else
+      WT_PATH=".claude/worktrees/${LOCAL_BRANCH}"
+  fi
+  git worktree add -b "$LOCAL_BRANCH" "$WT_PATH" "$REMOTE_BRANCH"
   ```
-  then call `EnterWorktree(path=".claude/worktrees/${LOCAL_BRANCH}")`.
+  then call `EnterWorktree(path="$WT_PATH")` - or, when `FLOW_WORKTREE_BASE` is
+  set, `cd "$WT_PATH"` instead (out-of-repo `EnterWorktree(path=...)` prompts;
+  see the base-override note in Step 3).
 - **Neither exists** (fresh start): create and enter the worktree natively by
   calling the `EnterWorktree` tool with `name="${BRANCH}"`. This branches from
   `origin/<default-branch>` (under the default `worktree.baseRef: fresh`) and
   switches the session into `.claude/worktrees/${BRANCH}`. Do NOT shell out to
   `git worktree add` for the fresh path. If your `worktree.baseRef` is set to
   `head`, sync `main` first so the branch does not start from a stale local HEAD.
+
+  **Base-override exception (issue #584):** when `FLOW_WORKTREE_BASE` is set,
+  the fresh path is the git lane instead of `EnterWorktree`:
+  ```bash
+  git fetch origin --quiet
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+  DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
+  DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+  mkdir -p "$FLOW_WORKTREE_BASE"
+  WT_PATH="${FLOW_WORKTREE_BASE}/$(basename "$(git rev-parse --show-toplevel)")-${BRANCH}"
+  git worktree add -b "$BRANCH" "$WT_PATH" "origin/${DEFAULT_BRANCH}"
+  cd "$WT_PATH"
+  ```
 
 ### Step 5: Verify, Normalize Branch, Output
 

--- a/tests/test_flow_worktree_native.py
+++ b/tests/test_flow_worktree_native.py
@@ -10,6 +10,7 @@ discipline, and the cross-session ``git worktree`` cleanup fallback.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -40,13 +41,18 @@ def test_auto_uses_native_enter_and_exit_worktree() -> None:
 def test_fresh_path_drops_sibling_worktree_dir() -> None:
     # The old plumbing created ../<repo>-issue-<N> and branched it with git; the
     # native fresh path must not reintroduce that create mechanic. The
-    # cross-machine path (which git-adds "$LOCAL_BRANCH") and the cross-repo lane
-    # (which git-adds via `git -C "$TARGET_REPO"`, issue #578) are intentionally
-    # kept - only the bare same-repo fresh path must stay native.
+    # cross-machine path (which git-adds "$LOCAL_BRANCH"), the cross-repo lane
+    # (which git-adds via `git -C "$TARGET_REPO"`, issue #578), and the
+    # FLOW_WORKTREE_BASE override lane (which git-adds "$WT_PATH", issue #584 /
+    # ADR 0003) are intentionally kept - only the bare same-repo default fresh
+    # path must stay native.
     for rel in (".claude/commands/flow/start.md", ".claude/commands/flow/auto.md"):
         text = _read(rel)
         assert 'WORKTREE_DIR="../' not in text, f"{rel} still creates a sibling worktree dir"
-        assert 'git worktree add -b "$BRANCH"' not in text, f"{rel} still git-adds the fresh path"
+        for match in re.findall(r'git worktree add -b "\$BRANCH" \S+', text):
+            assert '"$WT_PATH"' in match, (
+                f"{rel} git-adds the fresh path outside the #584 override lane: {match}"
+            )
 
 
 def test_auto_cross_repo_lane() -> None:


### PR DESCRIPTION
## Summary

Implements ADR 0003 **Option A** with the owner's decisions recorded 2026-07-18 (real feature both packs; real checkouts; **interleaved layout** - owner box sets `FLOW_WORKTREE_BASE=$HOME/Projects`, worktrees land at `~/Projects/<repo>-<branch>`).

- **`flow/auto.md`**: `GIT_LANE` generalizes the #578 cross-repo lane (`GIT_LANE = CROSS_REPO || FLOW_WORKTREE_BASE set`); all three path-producer sites (fresh, cross-machine pickup, resume entry) honor the base; Step 7 cleanup enumerates the lane. Never `EnterWorktree(path=...)` out-of-repo (unsuppressable approval prompt, ADR 0003 constraint 2).
- **`flow/start.md`**: base-override exception on the fresh and pickup lanes (git lane + `cd`).
- **`flow/doctor.md`**: effective-base report line.
- **`project-next.md` / `project-lite.md`**: interleaved-layout mitigation - a linked worktree (`.git` is a FILE) is flagged at resolution instead of analyzed as a project. Verified nothing enumerates `~/Projects` blindly.
- **`CLAUDE.md`**: `FLOW_WORKTREE_BASE` env-var entry + native-worktrees section update.
- **ADR 0003**: Status -> Accepted with the decision record (CxPP twin: cooneycw/codex-power-pack#136).
- **Tests**: `test_fresh_path_drops_sibling_worktree_dir` pin updated - fresh-path `git worktree add` is sanctioned only in the `$WT_PATH` override form; native-default guard intact.
- **Generated surfaces**: `plugins/` + `codex/skills/` regenerated; both parity gates green. `codex/skills/flow-start/scripts/worktree-remove.sh` is newly bundled (start.md now references it).

Shipped default (env var unset) is byte-identical to today. No guard/merge/remove/friction script changes (verified layout-aware in ADR 0003).

## Test plan

- `python -m lib.cicd run --plan finish` green: lint + 889 tests + security scan (1 pin updated after a first-attempt failure, logged to friction ledger)
- `plugin-sync.sh --check` + `codex-skill-sync.py --check` clean
- Em/en-dash ban + ignored-additions + worktree-leak guards clean

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)