### PR TITLE
feat(flow): wire the eli5 vendor link into CI + declare the session cwd (Closes #591, Closes #592)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -103,9 +103,25 @@ result. This rule applies to every flow helper in this file (see also Steps 4,
 number (and project, when `/flow:auto` was given a PROJECT arg):
 
 ```bash
-~/.claude/scripts/flow-start-resolve.sh 42
-~/.claude/scripts/flow-start-resolve.sh 42 my-project
+~/.claude/scripts/flow-start-resolve.sh 42 --session-cwd /home/user/Projects/my-repo
+~/.claude/scripts/flow-start-resolve.sh 42 my-project --session-cwd /home/user/Projects/my-repo
 ```
+
+**`--session-cwd` is not optional in practice (issue #592).** The helper cannot
+observe the Claude session's working directory - it sees only the cwd this Bash
+call inherited, and that cwd persists across calls and drifts the moment any
+earlier step `cd`s somewhere. `EnterWorktree` always acts on the SESSION cwd,
+which never moves. When the two diverge, the contract's central decision
+(`EnterWorktree` vs `cd`) is made against the wrong repo and a faithful reading
+of this contract does the wrong thing. So pass the session's working directory
+VERBATIM as a literal path - the directory this session reports as its cwd,
+never `$(pwd)` and never wherever a previous step left the shell.
+
+Omitting it does not break the run: the helper falls back to the process cwd,
+reports `SESSION_CWD_INFERRED=1`, and fails closed to `GIT_LANE=1`. The git
+lane is correct in every case, just slightly less ergonomic than the native
+one - the asymmetry is deliberate, since a wrong `GIT_LANE=0` sends
+`EnterWorktree` at a directory that may not be a repo at all.
 
 If the stable path is missing (exit 127), fall back in this order - the first
 that exists (issue #590):
@@ -129,8 +145,13 @@ Contract keys: `LANE` (`current-branch|fresh|resume|remote-pickup|cross-repo`),
 `EnterWorktree`, git cleanup at Step 7 - set for cross-repo runs, when
 `FLOW_WORKTREE_BASE` relocates worktrees out of the repo (issue #584, ADR 0003:
 the native tool's base dir is not configurable, and out-of-repo
-`EnterWorktree(path=...)` triggers an unsuppressable approval prompt), and when
-a resumed worktree lies outside the target repo), `TARGET_REPO`, `ISSUE_STATE`,
+`EnterWorktree(path=...)` triggers an unsuppressable approval prompt), when
+a resumed worktree lies outside the target repo, and whenever the session cwd
+was inferred rather than declared (issue #592)), `SESSION_CWD` (the directory
+the lane decision was made against), `SESSION_CWD_INFERRED` (1 = no
+`--session-cwd` was passed; the decision rests on a possibly drifted process
+cwd, so `GIT_LANE` was forced to 1 - if you see this, you forgot to pass it),
+`TARGET_REPO`, `ISSUE_STATE`,
 `ISSUE_TITLE`, `BRANCH` (the enforced issue-anchored name), `WT_PATH` (honors
 `FLOW_WORKTREE_BASE`: `$FLOW_WORKTREE_BASE/<repo>-<branch>` when set, else
 in-repo `.claude/worktrees/<branch>`), `DEFAULT_BRANCH`, `REMOTE_BRANCH`
@@ -1007,6 +1028,7 @@ Key failure scenarios:
 - Each step builds on the previous one; there's no skipping
 - Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - Step 1's plumbing is deterministic (issue #581): `scripts/flow-start-resolve.sh` owns target-repo resolution, issue fetch, branch derivation, existing-work triage, the #503 guard, and git-lane creation, emitting a `key=value` contract; the model's only decision is `EnterWorktree` vs `cd`. Helpers are invoked bare at their stable `~/.claude/scripts/` paths so the shipped allowlist rules match (`templates/claude-settings-permissions.json`) and Phase 1 runs prompt-free
+- The session cwd is DECLARED, not inferred (issue #592): Step 1a passes `--session-cwd <path>` so the resolver decides `CROSS_REPO`/`GIT_LANE` (and, with no PROJECT arg, `TARGET_REPO` itself) against the session's working directory rather than the Bash tool's cwd, which drifts on any earlier `cd`. Without it the resolver reports `SESSION_CWD_INFERRED=1` and fails closed to `GIT_LANE=1` - the residual #578 left behind
 - Cross-repo invocations (`/flow:auto <ISSUE> <PROJECT>`, or a session cwd outside any git repo) are first-class (issue #578): the resolver detects the mismatch (path, else `~/Projects/<PROJECT>`) and the run rides the deterministic git lane end-to-end - helper-created worktree, `cd` instead of `EnterWorktree`, git cleanup at Step 7 - with the worktree still under the target repo's `.claude/worktrees/` so every guard resolves unchanged
 - The worktree base is configurable (issue #584, ADR 0003 Option A): `FLOW_WORKTREE_BASE`, when set in host config, relocates worktrees to `$FLOW_WORKTREE_BASE/<repo>-<branch>` and commits the run to the same git lane (`GIT_LANE=1`); unset, shipped behavior is byte-identical to the in-repo default. The guard/merge/remove/friction scripts resolve via git plumbing and need no awareness of the base
 - The deploy step is always optional - it only runs if a deploy target exists

--- a/.claude/commands/flow/eli5.md
+++ b/.claude/commands/flow/eli5.md
@@ -67,7 +67,25 @@ Emit all three sections every time. Do not skip a section even if it is short.
 
 **Section A - ELI5 overview of intent.** A plain-language restatement of what the
 issue is trying to accomplish and why, free of implementation jargon. Two to four
-sentences a non-author reviewer can sanity-check for a misread of intent.
+sentences minimum - a short paragraph is fine - that a non-author reviewer can
+sanity-check for a misread of intent.
+
+**Section A depth floor (applies regardless of how concise the model is tuned to
+be):** this is the section the gate is named for, and the one concision pressure
+squeezes hardest, so it carries an explicit floor too:
+
+- **Motivation before mechanics.** Explain what is wrong or missing today, and
+  why that matters, *before* describing what will change. Misread intent almost
+  always hides in the motivation, not in the file list - Section C already covers
+  the mechanics.
+- **No unexplained jargon.** Any technical term the issue cannot avoid gets a
+  plain-language gloss on first use - "the worktree (a scratch copy of the repo)",
+  "idempotent (safe to run twice)". A term left unglossed is jargon, however
+  ordinary it looks to the implementer.
+- **The explain-like-I'm-five bar.** Someone who has never seen this codebase
+  should finish Section A understanding what is wrong today and what will be
+  better afterward. A restatement of the issue title, or sentences that only parse
+  for a reader who already read the issue body, does not satisfy the gate.
 
 **Section B - Necessity / staleness analysis.** Assess whether the issue is still
 necessary given the current code and anything merged *after* it was filed. Inspect
@@ -142,7 +160,8 @@ The verdict drives what happens next:
 ELI5 Gate: Issue #398
 
 == A. What this issue actually wants (ELI5) ==
-{plain-language intent, 2-4 sentences}
+{plain-language intent: what is wrong today and why it matters, then what will
+ be better - 2-4 sentences minimum, every technical term glossed on first use}
 
 == B. Is it still needed? ==
 Verdict: Still needed | Partially addressed | No longer needed | Needs reframing

--- a/.claude/commands/flow/start.md
+++ b/.claude/commands/flow/start.md
@@ -38,9 +38,21 @@ issue number - never wrapped in `if [ -x ... ]`, never chained with `&&` or
 `;`, never followed by `echo $?`. A compound invocation defeats the allowlist
 prefix rule; the helper prints its own status markers.
 
+**Always pass `--session-cwd` (issue #592).** The helper cannot observe the
+Claude session's working directory; it can only see the cwd the Bash tool call
+inherited, and that cwd drifts whenever any earlier command in the session
+`cd`s somewhere. `EnterWorktree`, meanwhile, always acts on the session cwd,
+which never moves. So supply the session's working directory VERBATIM as a
+literal path - the same directory the session reports as its cwd, not `$(pwd)`
+and not the directory a previous step left you in:
+
 ```bash
-~/.claude/scripts/flow-start-resolve.sh 42
+~/.claude/scripts/flow-start-resolve.sh 42 --session-cwd /home/user/Projects/my-repo
 ```
+
+If it is omitted the helper still works, but it says so
+(`SESSION_CWD_INFERRED=1`) and fails closed to `GIT_LANE=1`, because a wrong
+`GIT_LANE=0` would point `EnterWorktree` at the wrong repo - or at no repo.
 
 If the stable path is missing (exit 127), fall back in this order - the first
 that exists (issue #590):
@@ -60,9 +72,11 @@ The helper fetches the issue, derives the `issue-<N>-<slug>` branch (slug cut
 to keep the name within the EnterWorktree 64-char limit), triages existing
 work, and prints a `key=value` contract ending in `FLOW_START_RESOLVE: ok`. On
 `FLOW_START_RESOLVE: error` (with an `ERROR=` line): **STOP** and report it.
-Keys: `LANE`, `CROSS_REPO`, `GIT_LANE`, `TARGET_REPO`, `ISSUE_STATE`,
-`ISSUE_TITLE`, `BRANCH`, `WT_PATH`, `DEFAULT_BRANCH`, `REMOTE_BRANCH`,
-`WT_CREATED`, `LIVE_DRIVER` (the helper wraps its sibling
+Keys: `LANE`, `CROSS_REPO`, `GIT_LANE`, `SESSION_CWD`, `SESSION_CWD_INFERRED`
+(1 = no `--session-cwd` was passed, so the lane decision rests on a possibly
+drifted process cwd and `GIT_LANE` was forced to 1, issue #592), `TARGET_REPO`,
+`ISSUE_STATE`, `ISSUE_TITLE`, `BRANCH`, `WT_PATH`, `DEFAULT_BRANCH`,
+`REMOTE_BRANCH`, `WT_CREATED`, `LIVE_DRIVER` (the helper wraps its sibling
 `scripts/flow-live-driver-guard.sh`, #503), `PR_HEAD`, `CONFIRM_REQUIRED` -
 the same contract `/flow:auto` Step 1 documents.
 

--- a/.claude/eli5-vendor.json
+++ b/.claude/eli5-vendor.json
@@ -1,0 +1,28 @@
+{
+  "_comment": [
+    "Pinned-SHA vendor manifest for the eli5 necessity-gate core (issue #591).",
+    "The core between the eli5-core markers in vendored.file is copied verbatim",
+    "from the canonical repo below. This manifest pins WHAT WAS VENDORED so an",
+    "offline, network-free CI gate can verify the local copy was not edited out",
+    "of band (scripts/eli5-vendor.py, `make eli5-check`). It cannot detect that",
+    "UPSTREAM moved - that is `make eli5-drift`, the advisory live-fetch check.",
+    "Re-vendor with `make eli5-revendor`, which rewrites both together."
+  ],
+  "source": {
+    "repo": "cooneycw/eli5-gate",
+    "path": "commands/eli5.md",
+    "raw_url": "https://raw.githubusercontent.com/cooneycw/eli5-gate/main/commands/eli5.md",
+    "commits_api": "https://api.github.com/repos/cooneycw/eli5-gate/commits?path=commands/eli5.md&per_page=1",
+    "upstream_commit": "4e9431afa16fd07d83143b41affb3c2607b834be"
+  },
+  "vendored": {
+    "file": ".claude/commands/flow/eli5.md",
+    "markers": [
+      "eli5-core:begin",
+      "eli5-core:end"
+    ],
+    "core_sha256": "1bd933a256e7aea65e310c555f469098d1b8121dd856ea5a4d933e7e62cc4bf2",
+    "core_lines": 164,
+    "vendored_at": "2026-07-19"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ desktop.ini
 !renovate.json
 !.mcp.json
 !templates/claude-settings-permissions.json
+# Pinned-SHA manifest for the vendored eli5-gate core (#591) - checked in by
+# design: it IS the offline gate's source of truth, so the blanket *.json rule
+# must not swallow it.
+!.claude/eli5-vendor.json
 !templates/playwright-pool.example.json
 !templates/sandbox/settings-bash-sandbox.json
 # Plugin marketplace manifests (issue #477, ADR 0001) - tracked despite *.json

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,7 +2,8 @@
 # Runs quality gates and Dockerfile lint.
 #
 # Pipeline:
-#   PR/push -> secret-scan -> validate (lint+test+typecheck) + codex-skills-check -> Dockerfile lint
+#   PR/push -> secret-scan -> validate (lint+test+typecheck) + codex-skills-check
+#              + eli5-vendor-check + eli5-upstream-drift (advisory) -> Dockerfile lint
 #
 # The Docker MCP runtime (second-opinion + aws-secrets-agent images, compose
 # policy checks, image CVE/SBOM scans, and the runtime smoke stage) was retired
@@ -37,6 +38,36 @@ steps:
     depends_on: [secret-scan]
     commands:
       - python3 scripts/codex-skill-sync.py --check
+
+  # Vendored eli5-gate core gates (issue #591). The canonical home of the
+  # /flow:eli5 necessity gate is cooneycw/eli5-gate; CPP vendors its core
+  # between the eli5-core markers. The drift script for that link existed and
+  # worked but was invoked by NOTHING - no step, no target, no test - so a stale
+  # core was invisible. Two steps, because they catch different failures:
+  #
+  #   eli5-vendor-check   HARD gate, offline. Verifies the checked-in core still
+  #                       matches the hash pinned in .claude/eli5-vendor.json,
+  #                       i.e. nobody edited the vendored copy instead of the
+  #                       canonical repo. Stdlib-only and network-free, so it
+  #                       runs directly under the slim image (no curl, no git -
+  #                       the #451/#489 trap).
+  #   eli5-upstream-drift ADVISORY, network. The manifest pins what WAS vendored
+  #                       and therefore cannot notice that upstream MOVED; only
+  #                       a live fetch can. `failure: ignore` plus the script's
+  #                       own fail-open behavior means neither drift nor an
+  #                       offline runner can redden the pipeline - it reports.
+  eli5-vendor-check:
+    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim@sha256:4f5d923c9dcea037f57bda425dd209f3ec643da2f0b74227f68d09dab0b3bb36
+    depends_on: [secret-scan]
+    commands:
+      - python3 scripts/eli5-vendor.py
+
+  eli5-upstream-drift:
+    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim@sha256:4f5d923c9dcea037f57bda425dd209f3ec643da2f0b74227f68d09dab0b3bb36
+    depends_on: [secret-scan]
+    failure: ignore
+    commands:
+      - python3 scripts/eli5-vendor.py --upstream
 
   dockerfile-lint:
     image: ghcr.io/hadolint/hadolint:v2.14.0-debian

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,15 @@ Core components and their locations:
   - flow-stale-check - advisory early stale-base detector for `/flow:auto` Step 4/6 + `/flow:finish` (#473)
   - flow-worktree-guard - advisory leaked-edit detector: warns when a `/flow:auto` edit landed in the MAIN tree instead of the worktree (#486)
   - flow-start-resolve - deterministic `/flow` Step-1 resolver + `--verify` gate (#581): target-repo resolution (#578), issue fetch + state check, issue-anchored branch derivation, existing-work triage (`current-branch|fresh|resume|remote-pickup|cross-repo`), wraps the #503 live-driver guard + shipped-PR hazard, performs git-lane worktree creation (honoring `FLOW_WORKTREE_BASE`, #584), and emits a `key=value` contract - extracts the compound Step-1 bash the permission matcher could never auto-allow
+  - flow-start-resolve `--session-cwd` - the session cwd is DECLARED, not inferred (#592): the Bash tool's cwd persists across calls and drifts on any earlier `cd`, while `EnterWorktree` acts on the session cwd, which never moves - so `CROSS_REPO`/`GIT_LANE` (and, with no PROJECT arg, `TARGET_REPO` itself) are resolved from the path `auto.md`/`start.md` pass verbatim. Omitting it emits `SESSION_CWD_INFERRED=1` and fails closed to `GIT_LANE=1`, since the git lane is correct in every case while a wrong `GIT_LANE=0` points `EnterWorktree` at the wrong repo - or at none
   - flow-live-driver-guard - advisory concurrent-session guard (#503): warns when a worktree's dirty files were modified within the freshness window, the signature of another live session mid-implementation; wrapped by flow-start-resolve on the resume lane
   - hooks
   - drift-detect
   - mcp-drift
   - plugin-sync - byte-identical drift guard keeping every packaged family plugin in sync with its command source (#477/#478) plus per-family extra artifacts such as the secrets masking-hook script (#479); the B1 plugin-flow-sync shim was retired in B4 (#480)
   - codex-skill-sync - single-source -> per-harness SKILL.md generator (#555, CxPP epic cooneycw/codex-power-pack#64 story B1): emits checked-in per-command Codex skill dirs under `codex/skills/<family>-<cmd>/` (frontmatter name/description with front-loaded trigger words, Codex harness-adaptations block for detected Claude-only constructs, long bodies split to `reference.md`, referenced helper scripts bundled byte-identical); `--check` drift gate (pinned by tests/test_codex_skill_sync.py AND an explicit `codex-skills-check` step in `.woodpecker.yml`, #556), `--write` regen, `--install` copies to `~/.codex/skills/`; editing any bundled `scripts/*` requires a `--write` re-run. Superseded the deprecated flat `codex/prompts/` surface + its `codex-prompt-sync.py` generator, both retired at the #556 cutover
+  - eli5-vendor - guard for the canonical->vendored eli5-core link (#591): `check` (default) verifies the vendored core against the sha256 pinned in `.claude/eli5-vendor.json` - offline, stdlib-only, a HARD gate (`make eli5-check`, `eli5-vendor-check` step in `.woodpecker.yml`); `--upstream` live-fetches cooneycw/eli5-gate and diffs - advisory + fail-open (`make eli5-drift`, `eli5-upstream-drift` step, `failure: ignore`); `--revendor` re-fetches the core, replaces it in place and re-pins the manifest (`make eli5-revendor`). The two halves are complementary: a manifest cannot notice that UPSTREAM moved, and a live fetch cannot run offline
+  - eli5-core-drift - thin shim onto `eli5-vendor.py --upstream`, kept so existing references resolve to one implementation (#591)
   - speckit-tasks-to-issues
   - playwright-desk - lease-desk ledger
   - check-ignored-additions - advisory guard warning when a blanket-ignore rule silently swallowed a file the repo should track; skips a short allow-list of files git-ignored by design (env-only `.claude/` runtime state such as `settings.local.json`/`friction.jsonl`) so it never cries wolf on them (#504)
@@ -61,7 +64,7 @@ Core components and their locations:
 - `plugins/` - Per-family Claude Code plugins. Phase B2 (#478) packages every surviving family (15 plugins, `browser` through `self-improvement`): byte-identical copies of `.claude/commands/<family>/*.md` (the single source of truth, ADR 0001 section 5), kept honest by `scripts/plugin-sync.sh --check` and regenerated with `--write` after any command edit. Phase B3 (#479) adds bundled hooks + MCP pointers: `secrets` ships the PostToolUse masking hook (plugin-local script via `${CLAUDE_PLUGIN_ROOT}`) and `second-opinion` ships its `.mcp.json` client pointer (matches the repo-root one). The `flow` plugin bundles its helper family (`plugins/flow/scripts/`, #590) and `/flow:repair` installs it to `~/.claude/scripts/` so the #581 allowlist rules keep matching. The `cpp` plugin ships help/meta plus the cross-cutting utilities folded in from the loose top-level commands (`/cpp:dockers`, `/cpp:happy-check`, `/cpp:load-best-practices` with the bundled 25K guide, `/cpp:load-mcp-docs`; issue #582, ADR 0001 amendment) - the init/update/status installer stays repo-local. Phase B4 (#480) proved parity and retired the dual surface: the global-skill mirror, `flow-skill-sync.py`, `skill-drift.py`, and `.claude/deprecated-skills.yaml` are gone. Phase B5 (#481) cut the docs over to the `/plugin` install path (`/plugin marketplace add cooneycw/claude-power-pack` then `/plugin install <family>@cpp`); `/cpp:init` / `/cpp:update` remain only for the non-plugin infra a plugin cannot deliver.
 - `codex/skills/` - Codex SKILL.md skills, the second harness surface (issue #555, companion to codex-power-pack epic cooneycw/codex-power-pack#64): generated `<family>-<cmd>/` skill dirs emitted from the same `.claude/commands/<family>/` single source by `scripts/codex-skill-sync.py`; codex-power-pack vendors this source (pull model, issue #556 / codex-power-pack#75) rather than receiving a push, and CPP's own currency is guarded by the explicit `codex-skills-check` step in `.woodpecker.yml`. Regenerate with `make codex-skills` after any command or referenced-script edit; `make codex-init` installs to `~/.codex/skills/`. Hand-curated skill dirs (no GENERATED marker) are never touched.
 - `codex/cpp-memory.md` - Hand-curated Codex `/cpp-memory` prompt (#433) for the common-memory harness, installed to `~/.codex/prompts/cpp-memory.md` by `scripts/install-memory-harness.sh`. Relocated here when the deprecated generated `codex/prompts/` flat surface (#446) was retired at the #556 cutover (superseded by `codex/skills/`, #555).
-- `.woodpecker.yml` - Woodpecker CI pipeline (secret-scan, lint, test, typecheck, Dockerfile lint)
+- `.woodpecker.yml` - Woodpecker CI pipeline (secret-scan, lint, test, typecheck, codex-skills-check, eli5-vendor-check, eli5-upstream-drift (advisory), Dockerfile lint)
 
 ## Environment Variables
 
@@ -149,9 +152,17 @@ stays a consumer: it vendors the extracted skill's canonical core between
 marker comments and layers its /flow wiring outside them; an advisory drift
 script warns when the vendored copy falls behind. First extraction: the
 `/flow:eli5` necessity gate -> https://github.com/cooneycw/eli5-gate
-(core markers `eli5-core:begin`/`end` in `.claude/commands/flow/eli5.md`,
-checked by `scripts/eli5-core-drift.sh`; reconcile drift by editing the
-canonical repo first, then re-vendoring).
+(core markers `eli5-core:begin`/`end` in `.claude/commands/flow/eli5.md`).
+That link is guarded on both sides (issue #591 - before it, the drift script
+was invoked by nothing at all): `.claude/eli5-vendor.json` pins the vendored
+core's sha256 plus the upstream commit, enforced offline by
+`scripts/eli5-vendor.py` (`make eli5-check`, the `eli5-vendor-check` CI step
+and `tests/test_eli5_vendor.py`), while `scripts/eli5-core-drift.sh` ->
+`eli5-vendor.py --upstream` live-fetches the canonical copy as a fail-open
+advisory (`make eli5-drift`, the `eli5-upstream-drift` CI step). Neither
+subsumes the other: the manifest cannot see upstream move, the fetch cannot run
+offline. Reconcile drift by editing the canonical repo first, then
+`make eli5-revendor` (which re-pins the manifest in the same step).
 
 ### Project
 - `/project:init <name>` - Full project scaffolding (zero to GitHub repo)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test lint format typecheck verify secret-scan update_docs clean \
        bootstrap-check drift-check deploy setup-woodpecker-cli \
-       codex-init codex-skills codex-skills-check
+       codex-init codex-skills codex-skills-check \
+       eli5-check eli5-drift eli5-revendor
 
 ## Quality gates (used by /flow:finish)
 
@@ -76,6 +77,22 @@ codex-skills:
 
 codex-init:
 	@python3 scripts/codex-skill-sync.py --write --install
+
+## Vendored eli5-gate core (issue #591)
+## The canonical home of the /flow:eli5 necessity gate is cooneycw/eli5-gate;
+## CPP vendors its core between the eli5-core markers. Two complementary checks:
+## eli5-check is OFFLINE and a hard gate (did the local core get edited out of
+## band?); eli5-drift is a NETWORK, fail-open advisory (did upstream move?).
+## Neither subsumes the other - a manifest cannot notice upstream moving.
+
+eli5-check:
+	@python3 scripts/eli5-vendor.py
+
+eli5-drift:
+	@python3 scripts/eli5-vendor.py --upstream
+
+eli5-revendor:
+	@python3 scripts/eli5-vendor.py --revendor
 
 ## Utilities
 

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -105,9 +105,25 @@ result. This rule applies to every flow helper in this file (see also Steps 4,
 number (and project, when `/flow-auto` was given a PROJECT arg):
 
 ```bash
-~/.claude/scripts/flow-start-resolve.sh 42
-~/.claude/scripts/flow-start-resolve.sh 42 my-project
+~/.claude/scripts/flow-start-resolve.sh 42 --session-cwd /home/user/Projects/my-repo
+~/.claude/scripts/flow-start-resolve.sh 42 my-project --session-cwd /home/user/Projects/my-repo
 ```
+
+**`--session-cwd` is not optional in practice (issue #592).** The helper cannot
+observe the Claude session's working directory - it sees only the cwd this Bash
+call inherited, and that cwd persists across calls and drifts the moment any
+earlier step `cd`s somewhere. `EnterWorktree` always acts on the SESSION cwd,
+which never moves. When the two diverge, the contract's central decision
+(`EnterWorktree` vs `cd`) is made against the wrong repo and a faithful reading
+of this contract does the wrong thing. So pass the session's working directory
+VERBATIM as a literal path - the directory this session reports as its cwd,
+never `$(pwd)` and never wherever a previous step left the shell.
+
+Omitting it does not break the run: the helper falls back to the process cwd,
+reports `SESSION_CWD_INFERRED=1`, and fails closed to `GIT_LANE=1`. The git
+lane is correct in every case, just slightly less ergonomic than the native
+one - the asymmetry is deliberate, since a wrong `GIT_LANE=0` sends
+`EnterWorktree` at a directory that may not be a repo at all.
 
 If the stable path is missing (exit 127), fall back in this order - the first
 that exists (issue #590):
@@ -131,8 +147,13 @@ Contract keys: `LANE` (`current-branch|fresh|resume|remote-pickup|cross-repo`),
 `EnterWorktree`, git cleanup at Step 7 - set for cross-repo runs, when
 `FLOW_WORKTREE_BASE` relocates worktrees out of the repo (issue #584, ADR 0003:
 the native tool's base dir is not configurable, and out-of-repo
-`EnterWorktree(path=...)` triggers an unsuppressable approval prompt), and when
-a resumed worktree lies outside the target repo), `TARGET_REPO`, `ISSUE_STATE`,
+`EnterWorktree(path=...)` triggers an unsuppressable approval prompt), when
+a resumed worktree lies outside the target repo, and whenever the session cwd
+was inferred rather than declared (issue #592)), `SESSION_CWD` (the directory
+the lane decision was made against), `SESSION_CWD_INFERRED` (1 = no
+`--session-cwd` was passed; the decision rests on a possibly drifted process
+cwd, so `GIT_LANE` was forced to 1 - if you see this, you forgot to pass it),
+`TARGET_REPO`, `ISSUE_STATE`,
 `ISSUE_TITLE`, `BRANCH` (the enforced issue-anchored name), `WT_PATH` (honors
 `FLOW_WORKTREE_BASE`: `$FLOW_WORKTREE_BASE/<repo>-<branch>` when set, else
 in-repo `.claude/worktrees/<branch>`), `DEFAULT_BRANCH`, `REMOTE_BRANCH`
@@ -1009,6 +1030,7 @@ Key failure scenarios:
 - Each step builds on the previous one; there's no skipping
 - Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - Step 1's plumbing is deterministic (issue #581): `scripts/flow-start-resolve.sh` owns target-repo resolution, issue fetch, branch derivation, existing-work triage, the #503 guard, and git-lane creation, emitting a `key=value` contract; the model's only decision is `EnterWorktree` vs `cd`. Helpers are invoked bare at their stable `~/.claude/scripts/` paths so the shipped allowlist rules match (`templates/claude-settings-permissions.json`) and Phase 1 runs prompt-free
+- The session cwd is DECLARED, not inferred (issue #592): Step 1a passes `--session-cwd <path>` so the resolver decides `CROSS_REPO`/`GIT_LANE` (and, with no PROJECT arg, `TARGET_REPO` itself) against the session's working directory rather than the Bash tool's cwd, which drifts on any earlier `cd`. Without it the resolver reports `SESSION_CWD_INFERRED=1` and fails closed to `GIT_LANE=1` - the residual #578 left behind
 - Cross-repo invocations (`/flow-auto <ISSUE> <PROJECT>`, or a session cwd outside any git repo) are first-class (issue #578): the resolver detects the mismatch (path, else `~/Projects/<PROJECT>`) and the run rides the deterministic git lane end-to-end - helper-created worktree, `cd` instead of `EnterWorktree`, git cleanup at Step 7 - with the worktree still under the target repo's `.claude/worktrees/` so every guard resolves unchanged
 - The worktree base is configurable (issue #584, ADR 0003 Option A): `FLOW_WORKTREE_BASE`, when set in host config, relocates worktrees to `$FLOW_WORKTREE_BASE/<repo>-<branch>` and commits the run to the same git lane (`GIT_LANE=1`); unset, shipped behavior is byte-identical to the in-repo default. The guard/merge/remove/friction scripts resolve via git plumbing and need no awareness of the base
 - The deploy step is always optional - it only runs if a deploy target exists

--- a/codex/skills/flow-auto/scripts/flow-start-resolve.sh
+++ b/codex/skills/flow-auto/scripts/flow-start-resolve.sh
@@ -15,11 +15,24 @@
 # call EnterWorktree, or ride the git lane (cd).
 #
 # Resolve mode:
-#   flow-start-resolve.sh <ISSUE> [PROJECT] [--allow-closed]
+#   flow-start-resolve.sh <ISSUE> [PROJECT] [--session-cwd PATH] [--allow-closed]
 #
 #   PROJECT        target repo when the session cwd is not the issue's repo
 #                  (issue #578): tried as a path first, else
 #                  $HOME/Projects/<PROJECT>.
+#   --session-cwd  the CLAUDE SESSION's working directory, passed verbatim by
+#                  auto.md / start.md (issue #592). This is NOT the same thing
+#                  as the process cwd: the Bash tool's cwd persists across calls
+#                  and drifts whenever any earlier command `cd`s somewhere,
+#                  while EnterWorktree always acts on the session cwd, which
+#                  never moves. Inferring the session repo from `.` therefore
+#                  decides GIT_LANE against whatever repo the last `cd` landed
+#                  in. May also be supplied as FLOW_SESSION_CWD.
+#                  When ABSENT the resolver falls back to `.` (nothing
+#                  regresses) but says so - SESSION_CWD_INFERRED=1 - and fails
+#                  closed to GIT_LANE=1, because the git lane is correct in
+#                  every case while a wrong GIT_LANE=0 points EnterWorktree at
+#                  a directory that may not be a repo at all.
 #   --allow-closed proceed with worktree creation although the issue is not
 #                  OPEN (pass only after the user has confirmed).
 #
@@ -29,8 +42,16 @@
 #     GIT_LANE=0|1          1 = ride the git lane end-to-end: enter with `cd`,
 #                           never EnterWorktree, git cleanup at Step 7. Set for
 #                           cross-repo runs, when FLOW_WORKTREE_BASE is set
-#                           (issue #584, ADR 0003), and when a resumed worktree
-#                           lies outside the target repo
+#                           (issue #584, ADR 0003), when a resumed worktree
+#                           lies outside the target repo, and whenever the
+#                           session cwd was inferred rather than declared
+#                           (issue #592 - fail closed toward the safe lane)
+#     SESSION_CWD=<path>    the session cwd this resolution was decided against
+#     SESSION_CWD_INFERRED=0|1
+#                           1 = no --session-cwd/FLOW_SESSION_CWD was supplied,
+#                           so the process cwd was used as a stand-in and the
+#                           run may be resolving against a drifted directory
+#                           (issue #592); GIT_LANE is forced to 1 in this case
 #     TARGET_REPO=<abs path of the primary checkout>
 #     ISSUE_STATE=OPEN|CLOSED|MERGED
 #     ISSUE_TITLE=<title, whitespace flattened>
@@ -61,6 +82,7 @@
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
 #                                    0003 Option A; host config, never shipped)
+#   FLOW_SESSION_CWD                 session cwd (issue #592); --session-cwd wins
 # Env (test hooks - unset in normal use):
 #   FLOW_START_RESOLVE_GH            override the `gh` binary
 #   FLOW_START_RESOLVE_PROJECTS_DIR  override $HOME/Projects for name lookup
@@ -107,13 +129,20 @@ ALLOW_CLOSED=0
 ISSUE_NUM=""
 PROJECT=""
 EXPECTED_BRANCH=""
+SESSION_CWD_ARG=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --verify) MODE=verify ;;
     --allow-closed) ALLOW_CLOSED=1 ;;
+    --session-cwd)
+      [ "$#" -ge 2 ] || usage_fail "--session-cwd requires a path argument"
+      SESSION_CWD_ARG="$2"
+      shift
+      ;;
+    --session-cwd=*) SESSION_CWD_ARG="${1#--session-cwd=}" ;;
     --help|-h)
-      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*) usage_fail "unknown option: $1" ;;
@@ -171,6 +200,28 @@ if [ "$MODE" = verify ]; then
   exit 0
 fi
 
+# ---- session cwd (issue #592) -----------------------------------------------
+# The process cwd is NOT the session cwd. In Claude Code the Bash tool's working
+# directory persists across calls and drifts on any earlier `cd`, while
+# EnterWorktree always acts on the session's working directory, which never
+# moves. Resolving the session repo from `.` therefore decides the contract's
+# central question against whatever repo the last `cd` happened to land in.
+# Prefer the value the caller declares; fall back to `.` so nothing regresses,
+# but mark the fallback as inferred and fail closed below.
+SESSION_CWD_INFERRED=0
+if [ -n "$SESSION_CWD_ARG" ]; then
+  SESSION_CWD="$SESSION_CWD_ARG"
+elif [ -n "${FLOW_SESSION_CWD:-}" ]; then
+  SESSION_CWD="$FLOW_SESSION_CWD"
+else
+  SESSION_CWD="."
+  SESSION_CWD_INFERRED=1
+fi
+if [ "$SESSION_CWD_INFERRED" -eq 0 ] && [ ! -d "$SESSION_CWD" ]; then
+  fail "--session-cwd '$SESSION_CWD' is not a directory"
+fi
+SESSION_CWD_ABS=$(cd "$SESSION_CWD" 2>/dev/null && pwd) || SESSION_CWD_ABS="$SESSION_CWD"
+
 # ---- target-repo resolution (issue #578) ------------------------------------
 TARGET_REPO=""
 if [ -n "$PROJECT" ]; then
@@ -182,11 +233,14 @@ if [ -n "$PROJECT" ]; then
   done
   [ -n "$TARGET_REPO" ] || fail "PROJECT '$PROJECT' is not a git checkout (tried '$PROJECT' and '$PROJECTS_DIR/$PROJECT')"
 else
-  TARGET_REPO=$(resolve_primary . || true)
-  [ -n "$TARGET_REPO" ] || fail "session cwd is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
+  # No PROJECT: the target repo comes from the SESSION cwd, never from the
+  # process cwd - a bare `/flow:start 42` after any earlier `cd` would otherwise
+  # branch and create a worktree in a surprise repository (issue #592, facet 2).
+  TARGET_REPO=$(resolve_primary "$SESSION_CWD" || true)
+  [ -n "$TARGET_REPO" ] || fail "session cwd '$SESSION_CWD_ABS' is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
 fi
 
-SESSION_PRIMARY=$(resolve_primary . 2>/dev/null || true)
+SESSION_PRIMARY=$(resolve_primary "$SESSION_CWD" 2>/dev/null || true)
 CROSS_REPO=1
 [ -n "$SESSION_PRIMARY" ] && [ "$SESSION_PRIMARY" = "$TARGET_REPO" ] && CROSS_REPO=0
 
@@ -196,6 +250,15 @@ CROSS_REPO=1
 # unsuppressable approval prompt (ADR 0003 constraint 2).
 GIT_LANE=$CROSS_REPO
 [ -n "${FLOW_WORKTREE_BASE:-}" ] && GIT_LANE=1
+# Fail closed (issue #592): GIT_LANE=1 is safe in every case - the git lane
+# works whether or not the session sits in the target repo - while a wrong
+# GIT_LANE=0 tells the model to call EnterWorktree on a directory that may be
+# another repo or no repo at all. So an UNVERIFIED session cwd never earns the
+# native lane.
+if [ "$SESSION_CWD_INFERRED" -eq 1 ]; then
+  GIT_LANE=1
+  echo "flow-start-resolve: no --session-cwd given - resolving against the process cwd '$SESSION_CWD_ABS', which may have drifted from the session cwd; riding the git lane (issue #592)." >&2
+fi
 
 # Worktree path for a branch, honoring the #584 base override.
 wt_path_for() {
@@ -255,14 +318,15 @@ WT_CREATED=0
 LIVE_DRIVER=skipped
 PR_HEAD=none
 
-# 1. Already on the issue's branch in the session cwd (same repo only).
-SESSION_BRANCH=$("$GIT" branch --show-current 2>/dev/null || true)
+# 1. Already on the issue's branch in the session cwd (same repo only). Read
+#    the branch and toplevel from the SESSION cwd, not the process cwd (#592).
+SESSION_BRANCH=$("$GIT" -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)
 case "$SESSION_BRANCH" in
   issue-"$ISSUE_NUM"-*)
     if [ "$CROSS_REPO" -eq 0 ]; then
       LANE=current-branch
       BRANCH="$SESSION_BRANCH"
-      WT_PATH=$("$GIT" rev-parse --show-toplevel)
+      WT_PATH=$("$GIT" -C "$SESSION_CWD" rev-parse --show-toplevel)
     fi
     ;;
 esac
@@ -354,6 +418,8 @@ fi
 echo "LANE=$LANE"
 echo "CROSS_REPO=$CROSS_REPO"
 echo "GIT_LANE=$GIT_LANE"
+echo "SESSION_CWD=$SESSION_CWD_ABS"
+echo "SESSION_CWD_INFERRED=$SESSION_CWD_INFERRED"
 echo "TARGET_REPO=$TARGET_REPO"
 echo "ISSUE_STATE=$ISSUE_STATE"
 echo "ISSUE_TITLE=$ISSUE_TITLE"

--- a/codex/skills/flow-eli5/reference.md
+++ b/codex/skills/flow-eli5/reference.md
@@ -69,7 +69,25 @@ Emit all three sections every time. Do not skip a section even if it is short.
 
 **Section A - ELI5 overview of intent.** A plain-language restatement of what the
 issue is trying to accomplish and why, free of implementation jargon. Two to four
-sentences a non-author reviewer can sanity-check for a misread of intent.
+sentences minimum - a short paragraph is fine - that a non-author reviewer can
+sanity-check for a misread of intent.
+
+**Section A depth floor (applies regardless of how concise the model is tuned to
+be):** this is the section the gate is named for, and the one concision pressure
+squeezes hardest, so it carries an explicit floor too:
+
+- **Motivation before mechanics.** Explain what is wrong or missing today, and
+  why that matters, *before* describing what will change. Misread intent almost
+  always hides in the motivation, not in the file list - Section C already covers
+  the mechanics.
+- **No unexplained jargon.** Any technical term the issue cannot avoid gets a
+  plain-language gloss on first use - "the worktree (a scratch copy of the repo)",
+  "idempotent (safe to run twice)". A term left unglossed is jargon, however
+  ordinary it looks to the implementer.
+- **The explain-like-I'm-five bar.** Someone who has never seen this codebase
+  should finish Section A understanding what is wrong today and what will be
+  better afterward. A restatement of the issue title, or sentences that only parse
+  for a reader who already read the issue body, does not satisfy the gate.
 
 **Section B - Necessity / staleness analysis.** Assess whether the issue is still
 necessary given the current code and anything merged *after* it was filed. Inspect
@@ -144,7 +162,8 @@ The verdict drives what happens next:
 ELI5 Gate: Issue #398
 
 == A. What this issue actually wants (ELI5) ==
-{plain-language intent, 2-4 sentences}
+{plain-language intent: what is wrong today and why it matters, then what will
+ be better - 2-4 sentences minimum, every technical term glossed on first use}
 
 == B. Is it still needed? ==
 Verdict: Still needed | Partially addressed | No longer needed | Needs reframing

--- a/codex/skills/flow-eli5/scripts/eli5-core-drift.sh
+++ b/codex/skills/flow-eli5/scripts/eli5-core-drift.sh
@@ -1,55 +1,20 @@
 #!/usr/bin/env bash
 # eli5-core-drift.sh - advisory drift check for the vendored eli5 necessity gate.
 #
-# CPP's /flow:eli5 vendors its core (the section between the eli5-core:begin /
-# eli5-core:end markers) verbatim from the canonical standalone repo
-# https://github.com/cooneycw/eli5-gate (extracted in issue #443). This script
-# fetches the canonical copy and diffs the marker-delimited core against the
-# local vendored copy.
+# Thin shim onto scripts/eli5-vendor.py --upstream (issue #591). The check moved
+# to Python so it can run in the Woodpecker validate container, which ships
+# neither curl nor git (the recurring #451/#489 trap); this entry point stays so
+# every existing reference - CLAUDE.md, CHANGELOG, eli5.md's Notes, ADR 0001 -
+# keeps working, and so there is exactly ONE implementation behind them.
 #
 # Advisory and fail-open by design: network down or canonical unreachable ->
-# exit 0 with a note; drift found -> warn with the diff and exit 1 so a CI step
-# or /flow gate CAN choose to surface it, but nothing in the flow hard-fails on
-# it. Reconcile drift by editing the CANONICAL repo first, then re-vendoring.
+# exit 0 with a note; drift found -> warn with the diff and exit 1. Reconcile
+# drift by editing the CANONICAL repo (cooneycw/eli5-gate) first, then
+# re-vendoring: make eli5-revendor
+#
+# See also `make eli5-check` - the OFFLINE half, which verifies the vendored
+# core against the pinned hash in .claude/eli5-vendor.json and is a hard CI gate.
 set -uo pipefail
 
-CANON_URL="${ELI5_GATE_CANON_URL:-https://raw.githubusercontent.com/cooneycw/eli5-gate/main/commands/eli5.md}"
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-LOCAL_FILE="$REPO_ROOT/.claude/commands/flow/eli5.md"
-
-if [[ ! -f "$LOCAL_FILE" ]]; then
-    echo "eli5-core-drift: $LOCAL_FILE not found (nothing to check)" >&2
-    exit 0
-fi
-
-# Anchored to comment-line starts so prose that merely MENTIONS the markers
-# (e.g. a Notes bullet) cannot re-trigger the state machine.
-extract_core() {
-    awk '/^<!-- eli5-core:begin/{f=1; next} /^<!-- eli5-core:end/{f=0} f' "$1"
-}
-
-TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
-
-if ! curl -fsSL --max-time 15 "$CANON_URL" -o "$TMP"; then
-    echo "eli5-core-drift: canonical source unreachable ($CANON_URL) - skipping (fail-open)" >&2
-    exit 0
-fi
-
-if [[ ! -s "$TMP" ]] || ! grep -q "eli5-core:begin" "$TMP"; then
-    echo "eli5-core-drift: canonical copy has no eli5-core markers - skipping (fail-open)" >&2
-    exit 0
-fi
-
-if diff -u <(extract_core "$TMP") <(extract_core "$LOCAL_FILE"); then
-    echo "eli5-core-drift: vendored core is in sync with canonical eli5-gate"
-    exit 0
-fi
-
-echo "" >&2
-echo "WARNING: the vendored eli5 core has drifted from the canonical copy at" >&2
-echo "  $CANON_URL" >&2
-echo "Reconcile by updating the canonical cooneycw/eli5-gate repo first, then" >&2
-echo "re-vendoring the marker section into .claude/commands/flow/eli5.md" >&2
-echo "(then run scripts/plugin-sync.sh --write flow to refresh the packaged copies)." >&2
-exit 1
+SELF_DIR=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+exec python3 "$SELF_DIR/eli5-vendor.py" --upstream "$@"

--- a/codex/skills/flow-repair/scripts/flow-start-resolve.sh
+++ b/codex/skills/flow-repair/scripts/flow-start-resolve.sh
@@ -15,11 +15,24 @@
 # call EnterWorktree, or ride the git lane (cd).
 #
 # Resolve mode:
-#   flow-start-resolve.sh <ISSUE> [PROJECT] [--allow-closed]
+#   flow-start-resolve.sh <ISSUE> [PROJECT] [--session-cwd PATH] [--allow-closed]
 #
 #   PROJECT        target repo when the session cwd is not the issue's repo
 #                  (issue #578): tried as a path first, else
 #                  $HOME/Projects/<PROJECT>.
+#   --session-cwd  the CLAUDE SESSION's working directory, passed verbatim by
+#                  auto.md / start.md (issue #592). This is NOT the same thing
+#                  as the process cwd: the Bash tool's cwd persists across calls
+#                  and drifts whenever any earlier command `cd`s somewhere,
+#                  while EnterWorktree always acts on the session cwd, which
+#                  never moves. Inferring the session repo from `.` therefore
+#                  decides GIT_LANE against whatever repo the last `cd` landed
+#                  in. May also be supplied as FLOW_SESSION_CWD.
+#                  When ABSENT the resolver falls back to `.` (nothing
+#                  regresses) but says so - SESSION_CWD_INFERRED=1 - and fails
+#                  closed to GIT_LANE=1, because the git lane is correct in
+#                  every case while a wrong GIT_LANE=0 points EnterWorktree at
+#                  a directory that may not be a repo at all.
 #   --allow-closed proceed with worktree creation although the issue is not
 #                  OPEN (pass only after the user has confirmed).
 #
@@ -29,8 +42,16 @@
 #     GIT_LANE=0|1          1 = ride the git lane end-to-end: enter with `cd`,
 #                           never EnterWorktree, git cleanup at Step 7. Set for
 #                           cross-repo runs, when FLOW_WORKTREE_BASE is set
-#                           (issue #584, ADR 0003), and when a resumed worktree
-#                           lies outside the target repo
+#                           (issue #584, ADR 0003), when a resumed worktree
+#                           lies outside the target repo, and whenever the
+#                           session cwd was inferred rather than declared
+#                           (issue #592 - fail closed toward the safe lane)
+#     SESSION_CWD=<path>    the session cwd this resolution was decided against
+#     SESSION_CWD_INFERRED=0|1
+#                           1 = no --session-cwd/FLOW_SESSION_CWD was supplied,
+#                           so the process cwd was used as a stand-in and the
+#                           run may be resolving against a drifted directory
+#                           (issue #592); GIT_LANE is forced to 1 in this case
 #     TARGET_REPO=<abs path of the primary checkout>
 #     ISSUE_STATE=OPEN|CLOSED|MERGED
 #     ISSUE_TITLE=<title, whitespace flattened>
@@ -61,6 +82,7 @@
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
 #                                    0003 Option A; host config, never shipped)
+#   FLOW_SESSION_CWD                 session cwd (issue #592); --session-cwd wins
 # Env (test hooks - unset in normal use):
 #   FLOW_START_RESOLVE_GH            override the `gh` binary
 #   FLOW_START_RESOLVE_PROJECTS_DIR  override $HOME/Projects for name lookup
@@ -107,13 +129,20 @@ ALLOW_CLOSED=0
 ISSUE_NUM=""
 PROJECT=""
 EXPECTED_BRANCH=""
+SESSION_CWD_ARG=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --verify) MODE=verify ;;
     --allow-closed) ALLOW_CLOSED=1 ;;
+    --session-cwd)
+      [ "$#" -ge 2 ] || usage_fail "--session-cwd requires a path argument"
+      SESSION_CWD_ARG="$2"
+      shift
+      ;;
+    --session-cwd=*) SESSION_CWD_ARG="${1#--session-cwd=}" ;;
     --help|-h)
-      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*) usage_fail "unknown option: $1" ;;
@@ -171,6 +200,28 @@ if [ "$MODE" = verify ]; then
   exit 0
 fi
 
+# ---- session cwd (issue #592) -----------------------------------------------
+# The process cwd is NOT the session cwd. In Claude Code the Bash tool's working
+# directory persists across calls and drifts on any earlier `cd`, while
+# EnterWorktree always acts on the session's working directory, which never
+# moves. Resolving the session repo from `.` therefore decides the contract's
+# central question against whatever repo the last `cd` happened to land in.
+# Prefer the value the caller declares; fall back to `.` so nothing regresses,
+# but mark the fallback as inferred and fail closed below.
+SESSION_CWD_INFERRED=0
+if [ -n "$SESSION_CWD_ARG" ]; then
+  SESSION_CWD="$SESSION_CWD_ARG"
+elif [ -n "${FLOW_SESSION_CWD:-}" ]; then
+  SESSION_CWD="$FLOW_SESSION_CWD"
+else
+  SESSION_CWD="."
+  SESSION_CWD_INFERRED=1
+fi
+if [ "$SESSION_CWD_INFERRED" -eq 0 ] && [ ! -d "$SESSION_CWD" ]; then
+  fail "--session-cwd '$SESSION_CWD' is not a directory"
+fi
+SESSION_CWD_ABS=$(cd "$SESSION_CWD" 2>/dev/null && pwd) || SESSION_CWD_ABS="$SESSION_CWD"
+
 # ---- target-repo resolution (issue #578) ------------------------------------
 TARGET_REPO=""
 if [ -n "$PROJECT" ]; then
@@ -182,11 +233,14 @@ if [ -n "$PROJECT" ]; then
   done
   [ -n "$TARGET_REPO" ] || fail "PROJECT '$PROJECT' is not a git checkout (tried '$PROJECT' and '$PROJECTS_DIR/$PROJECT')"
 else
-  TARGET_REPO=$(resolve_primary . || true)
-  [ -n "$TARGET_REPO" ] || fail "session cwd is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
+  # No PROJECT: the target repo comes from the SESSION cwd, never from the
+  # process cwd - a bare `/flow:start 42` after any earlier `cd` would otherwise
+  # branch and create a worktree in a surprise repository (issue #592, facet 2).
+  TARGET_REPO=$(resolve_primary "$SESSION_CWD" || true)
+  [ -n "$TARGET_REPO" ] || fail "session cwd '$SESSION_CWD_ABS' is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
 fi
 
-SESSION_PRIMARY=$(resolve_primary . 2>/dev/null || true)
+SESSION_PRIMARY=$(resolve_primary "$SESSION_CWD" 2>/dev/null || true)
 CROSS_REPO=1
 [ -n "$SESSION_PRIMARY" ] && [ "$SESSION_PRIMARY" = "$TARGET_REPO" ] && CROSS_REPO=0
 
@@ -196,6 +250,15 @@ CROSS_REPO=1
 # unsuppressable approval prompt (ADR 0003 constraint 2).
 GIT_LANE=$CROSS_REPO
 [ -n "${FLOW_WORKTREE_BASE:-}" ] && GIT_LANE=1
+# Fail closed (issue #592): GIT_LANE=1 is safe in every case - the git lane
+# works whether or not the session sits in the target repo - while a wrong
+# GIT_LANE=0 tells the model to call EnterWorktree on a directory that may be
+# another repo or no repo at all. So an UNVERIFIED session cwd never earns the
+# native lane.
+if [ "$SESSION_CWD_INFERRED" -eq 1 ]; then
+  GIT_LANE=1
+  echo "flow-start-resolve: no --session-cwd given - resolving against the process cwd '$SESSION_CWD_ABS', which may have drifted from the session cwd; riding the git lane (issue #592)." >&2
+fi
 
 # Worktree path for a branch, honoring the #584 base override.
 wt_path_for() {
@@ -255,14 +318,15 @@ WT_CREATED=0
 LIVE_DRIVER=skipped
 PR_HEAD=none
 
-# 1. Already on the issue's branch in the session cwd (same repo only).
-SESSION_BRANCH=$("$GIT" branch --show-current 2>/dev/null || true)
+# 1. Already on the issue's branch in the session cwd (same repo only). Read
+#    the branch and toplevel from the SESSION cwd, not the process cwd (#592).
+SESSION_BRANCH=$("$GIT" -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)
 case "$SESSION_BRANCH" in
   issue-"$ISSUE_NUM"-*)
     if [ "$CROSS_REPO" -eq 0 ]; then
       LANE=current-branch
       BRANCH="$SESSION_BRANCH"
-      WT_PATH=$("$GIT" rev-parse --show-toplevel)
+      WT_PATH=$("$GIT" -C "$SESSION_CWD" rev-parse --show-toplevel)
     fi
     ;;
 esac
@@ -354,6 +418,8 @@ fi
 echo "LANE=$LANE"
 echo "CROSS_REPO=$CROSS_REPO"
 echo "GIT_LANE=$GIT_LANE"
+echo "SESSION_CWD=$SESSION_CWD_ABS"
+echo "SESSION_CWD_INFERRED=$SESSION_CWD_INFERRED"
 echo "TARGET_REPO=$TARGET_REPO"
 echo "ISSUE_STATE=$ISSUE_STATE"
 echo "ISSUE_TITLE=$ISSUE_TITLE"

--- a/codex/skills/flow-start/reference.md
+++ b/codex/skills/flow-start/reference.md
@@ -40,9 +40,21 @@ issue number - never wrapped in `if [ -x ... ]`, never chained with `&&` or
 `;`, never followed by `echo $?`. A compound invocation defeats the allowlist
 prefix rule; the helper prints its own status markers.
 
+**Always pass `--session-cwd` (issue #592).** The helper cannot observe the
+Claude session's working directory; it can only see the cwd the Bash tool call
+inherited, and that cwd drifts whenever any earlier command in the session
+`cd`s somewhere. `EnterWorktree`, meanwhile, always acts on the session cwd,
+which never moves. So supply the session's working directory VERBATIM as a
+literal path - the same directory the session reports as its cwd, not `$(pwd)`
+and not the directory a previous step left you in:
+
 ```bash
-~/.claude/scripts/flow-start-resolve.sh 42
+~/.claude/scripts/flow-start-resolve.sh 42 --session-cwd /home/user/Projects/my-repo
 ```
+
+If it is omitted the helper still works, but it says so
+(`SESSION_CWD_INFERRED=1`) and fails closed to `GIT_LANE=1`, because a wrong
+`GIT_LANE=0` would point `EnterWorktree` at the wrong repo - or at no repo.
 
 If the stable path is missing (exit 127), fall back in this order - the first
 that exists (issue #590):
@@ -62,9 +74,11 @@ The helper fetches the issue, derives the `issue-<N>-<slug>` branch (slug cut
 to keep the name within the EnterWorktree 64-char limit), triages existing
 work, and prints a `key=value` contract ending in `FLOW_START_RESOLVE: ok`. On
 `FLOW_START_RESOLVE: error` (with an `ERROR=` line): **STOP** and report it.
-Keys: `LANE`, `CROSS_REPO`, `GIT_LANE`, `TARGET_REPO`, `ISSUE_STATE`,
-`ISSUE_TITLE`, `BRANCH`, `WT_PATH`, `DEFAULT_BRANCH`, `REMOTE_BRANCH`,
-`WT_CREATED`, `LIVE_DRIVER` (the helper wraps its sibling
+Keys: `LANE`, `CROSS_REPO`, `GIT_LANE`, `SESSION_CWD`, `SESSION_CWD_INFERRED`
+(1 = no `--session-cwd` was passed, so the lane decision rests on a possibly
+drifted process cwd and `GIT_LANE` was forced to 1, issue #592), `TARGET_REPO`,
+`ISSUE_STATE`, `ISSUE_TITLE`, `BRANCH`, `WT_PATH`, `DEFAULT_BRANCH`,
+`REMOTE_BRANCH`, `WT_CREATED`, `LIVE_DRIVER` (the helper wraps its sibling
 `scripts/flow-live-driver-guard.sh`, #503), `PR_HEAD`, `CONFIRM_REQUIRED` -
 the same contract `/flow-auto` Step 1 documents.
 

--- a/codex/skills/flow-start/scripts/flow-start-resolve.sh
+++ b/codex/skills/flow-start/scripts/flow-start-resolve.sh
@@ -15,11 +15,24 @@
 # call EnterWorktree, or ride the git lane (cd).
 #
 # Resolve mode:
-#   flow-start-resolve.sh <ISSUE> [PROJECT] [--allow-closed]
+#   flow-start-resolve.sh <ISSUE> [PROJECT] [--session-cwd PATH] [--allow-closed]
 #
 #   PROJECT        target repo when the session cwd is not the issue's repo
 #                  (issue #578): tried as a path first, else
 #                  $HOME/Projects/<PROJECT>.
+#   --session-cwd  the CLAUDE SESSION's working directory, passed verbatim by
+#                  auto.md / start.md (issue #592). This is NOT the same thing
+#                  as the process cwd: the Bash tool's cwd persists across calls
+#                  and drifts whenever any earlier command `cd`s somewhere,
+#                  while EnterWorktree always acts on the session cwd, which
+#                  never moves. Inferring the session repo from `.` therefore
+#                  decides GIT_LANE against whatever repo the last `cd` landed
+#                  in. May also be supplied as FLOW_SESSION_CWD.
+#                  When ABSENT the resolver falls back to `.` (nothing
+#                  regresses) but says so - SESSION_CWD_INFERRED=1 - and fails
+#                  closed to GIT_LANE=1, because the git lane is correct in
+#                  every case while a wrong GIT_LANE=0 points EnterWorktree at
+#                  a directory that may not be a repo at all.
 #   --allow-closed proceed with worktree creation although the issue is not
 #                  OPEN (pass only after the user has confirmed).
 #
@@ -29,8 +42,16 @@
 #     GIT_LANE=0|1          1 = ride the git lane end-to-end: enter with `cd`,
 #                           never EnterWorktree, git cleanup at Step 7. Set for
 #                           cross-repo runs, when FLOW_WORKTREE_BASE is set
-#                           (issue #584, ADR 0003), and when a resumed worktree
-#                           lies outside the target repo
+#                           (issue #584, ADR 0003), when a resumed worktree
+#                           lies outside the target repo, and whenever the
+#                           session cwd was inferred rather than declared
+#                           (issue #592 - fail closed toward the safe lane)
+#     SESSION_CWD=<path>    the session cwd this resolution was decided against
+#     SESSION_CWD_INFERRED=0|1
+#                           1 = no --session-cwd/FLOW_SESSION_CWD was supplied,
+#                           so the process cwd was used as a stand-in and the
+#                           run may be resolving against a drifted directory
+#                           (issue #592); GIT_LANE is forced to 1 in this case
 #     TARGET_REPO=<abs path of the primary checkout>
 #     ISSUE_STATE=OPEN|CLOSED|MERGED
 #     ISSUE_TITLE=<title, whitespace flattened>
@@ -61,6 +82,7 @@
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
 #                                    0003 Option A; host config, never shipped)
+#   FLOW_SESSION_CWD                 session cwd (issue #592); --session-cwd wins
 # Env (test hooks - unset in normal use):
 #   FLOW_START_RESOLVE_GH            override the `gh` binary
 #   FLOW_START_RESOLVE_PROJECTS_DIR  override $HOME/Projects for name lookup
@@ -107,13 +129,20 @@ ALLOW_CLOSED=0
 ISSUE_NUM=""
 PROJECT=""
 EXPECTED_BRANCH=""
+SESSION_CWD_ARG=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --verify) MODE=verify ;;
     --allow-closed) ALLOW_CLOSED=1 ;;
+    --session-cwd)
+      [ "$#" -ge 2 ] || usage_fail "--session-cwd requires a path argument"
+      SESSION_CWD_ARG="$2"
+      shift
+      ;;
+    --session-cwd=*) SESSION_CWD_ARG="${1#--session-cwd=}" ;;
     --help|-h)
-      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*) usage_fail "unknown option: $1" ;;
@@ -171,6 +200,28 @@ if [ "$MODE" = verify ]; then
   exit 0
 fi
 
+# ---- session cwd (issue #592) -----------------------------------------------
+# The process cwd is NOT the session cwd. In Claude Code the Bash tool's working
+# directory persists across calls and drifts on any earlier `cd`, while
+# EnterWorktree always acts on the session's working directory, which never
+# moves. Resolving the session repo from `.` therefore decides the contract's
+# central question against whatever repo the last `cd` happened to land in.
+# Prefer the value the caller declares; fall back to `.` so nothing regresses,
+# but mark the fallback as inferred and fail closed below.
+SESSION_CWD_INFERRED=0
+if [ -n "$SESSION_CWD_ARG" ]; then
+  SESSION_CWD="$SESSION_CWD_ARG"
+elif [ -n "${FLOW_SESSION_CWD:-}" ]; then
+  SESSION_CWD="$FLOW_SESSION_CWD"
+else
+  SESSION_CWD="."
+  SESSION_CWD_INFERRED=1
+fi
+if [ "$SESSION_CWD_INFERRED" -eq 0 ] && [ ! -d "$SESSION_CWD" ]; then
+  fail "--session-cwd '$SESSION_CWD' is not a directory"
+fi
+SESSION_CWD_ABS=$(cd "$SESSION_CWD" 2>/dev/null && pwd) || SESSION_CWD_ABS="$SESSION_CWD"
+
 # ---- target-repo resolution (issue #578) ------------------------------------
 TARGET_REPO=""
 if [ -n "$PROJECT" ]; then
@@ -182,11 +233,14 @@ if [ -n "$PROJECT" ]; then
   done
   [ -n "$TARGET_REPO" ] || fail "PROJECT '$PROJECT' is not a git checkout (tried '$PROJECT' and '$PROJECTS_DIR/$PROJECT')"
 else
-  TARGET_REPO=$(resolve_primary . || true)
-  [ -n "$TARGET_REPO" ] || fail "session cwd is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
+  # No PROJECT: the target repo comes from the SESSION cwd, never from the
+  # process cwd - a bare `/flow:start 42` after any earlier `cd` would otherwise
+  # branch and create a worktree in a surprise repository (issue #592, facet 2).
+  TARGET_REPO=$(resolve_primary "$SESSION_CWD" || true)
+  [ -n "$TARGET_REPO" ] || fail "session cwd '$SESSION_CWD_ABS' is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
 fi
 
-SESSION_PRIMARY=$(resolve_primary . 2>/dev/null || true)
+SESSION_PRIMARY=$(resolve_primary "$SESSION_CWD" 2>/dev/null || true)
 CROSS_REPO=1
 [ -n "$SESSION_PRIMARY" ] && [ "$SESSION_PRIMARY" = "$TARGET_REPO" ] && CROSS_REPO=0
 
@@ -196,6 +250,15 @@ CROSS_REPO=1
 # unsuppressable approval prompt (ADR 0003 constraint 2).
 GIT_LANE=$CROSS_REPO
 [ -n "${FLOW_WORKTREE_BASE:-}" ] && GIT_LANE=1
+# Fail closed (issue #592): GIT_LANE=1 is safe in every case - the git lane
+# works whether or not the session sits in the target repo - while a wrong
+# GIT_LANE=0 tells the model to call EnterWorktree on a directory that may be
+# another repo or no repo at all. So an UNVERIFIED session cwd never earns the
+# native lane.
+if [ "$SESSION_CWD_INFERRED" -eq 1 ]; then
+  GIT_LANE=1
+  echo "flow-start-resolve: no --session-cwd given - resolving against the process cwd '$SESSION_CWD_ABS', which may have drifted from the session cwd; riding the git lane (issue #592)." >&2
+fi
 
 # Worktree path for a branch, honoring the #584 base override.
 wt_path_for() {
@@ -255,14 +318,15 @@ WT_CREATED=0
 LIVE_DRIVER=skipped
 PR_HEAD=none
 
-# 1. Already on the issue's branch in the session cwd (same repo only).
-SESSION_BRANCH=$("$GIT" branch --show-current 2>/dev/null || true)
+# 1. Already on the issue's branch in the session cwd (same repo only). Read
+#    the branch and toplevel from the SESSION cwd, not the process cwd (#592).
+SESSION_BRANCH=$("$GIT" -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)
 case "$SESSION_BRANCH" in
   issue-"$ISSUE_NUM"-*)
     if [ "$CROSS_REPO" -eq 0 ]; then
       LANE=current-branch
       BRANCH="$SESSION_BRANCH"
-      WT_PATH=$("$GIT" rev-parse --show-toplevel)
+      WT_PATH=$("$GIT" -C "$SESSION_CWD" rev-parse --show-toplevel)
     fi
     ;;
 esac
@@ -354,6 +418,8 @@ fi
 echo "LANE=$LANE"
 echo "CROSS_REPO=$CROSS_REPO"
 echo "GIT_LANE=$GIT_LANE"
+echo "SESSION_CWD=$SESSION_CWD_ABS"
+echo "SESSION_CWD_INFERRED=$SESSION_CWD_INFERRED"
 echo "TARGET_REPO=$TARGET_REPO"
 echo "ISSUE_STATE=$ISSUE_STATE"
 echo "ISSUE_TITLE=$ISSUE_TITLE"

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -103,9 +103,25 @@ result. This rule applies to every flow helper in this file (see also Steps 4,
 number (and project, when `/flow:auto` was given a PROJECT arg):
 
 ```bash
-~/.claude/scripts/flow-start-resolve.sh 42
-~/.claude/scripts/flow-start-resolve.sh 42 my-project
+~/.claude/scripts/flow-start-resolve.sh 42 --session-cwd /home/user/Projects/my-repo
+~/.claude/scripts/flow-start-resolve.sh 42 my-project --session-cwd /home/user/Projects/my-repo
 ```
+
+**`--session-cwd` is not optional in practice (issue #592).** The helper cannot
+observe the Claude session's working directory - it sees only the cwd this Bash
+call inherited, and that cwd persists across calls and drifts the moment any
+earlier step `cd`s somewhere. `EnterWorktree` always acts on the SESSION cwd,
+which never moves. When the two diverge, the contract's central decision
+(`EnterWorktree` vs `cd`) is made against the wrong repo and a faithful reading
+of this contract does the wrong thing. So pass the session's working directory
+VERBATIM as a literal path - the directory this session reports as its cwd,
+never `$(pwd)` and never wherever a previous step left the shell.
+
+Omitting it does not break the run: the helper falls back to the process cwd,
+reports `SESSION_CWD_INFERRED=1`, and fails closed to `GIT_LANE=1`. The git
+lane is correct in every case, just slightly less ergonomic than the native
+one - the asymmetry is deliberate, since a wrong `GIT_LANE=0` sends
+`EnterWorktree` at a directory that may not be a repo at all.
 
 If the stable path is missing (exit 127), fall back in this order - the first
 that exists (issue #590):
@@ -129,8 +145,13 @@ Contract keys: `LANE` (`current-branch|fresh|resume|remote-pickup|cross-repo`),
 `EnterWorktree`, git cleanup at Step 7 - set for cross-repo runs, when
 `FLOW_WORKTREE_BASE` relocates worktrees out of the repo (issue #584, ADR 0003:
 the native tool's base dir is not configurable, and out-of-repo
-`EnterWorktree(path=...)` triggers an unsuppressable approval prompt), and when
-a resumed worktree lies outside the target repo), `TARGET_REPO`, `ISSUE_STATE`,
+`EnterWorktree(path=...)` triggers an unsuppressable approval prompt), when
+a resumed worktree lies outside the target repo, and whenever the session cwd
+was inferred rather than declared (issue #592)), `SESSION_CWD` (the directory
+the lane decision was made against), `SESSION_CWD_INFERRED` (1 = no
+`--session-cwd` was passed; the decision rests on a possibly drifted process
+cwd, so `GIT_LANE` was forced to 1 - if you see this, you forgot to pass it),
+`TARGET_REPO`, `ISSUE_STATE`,
 `ISSUE_TITLE`, `BRANCH` (the enforced issue-anchored name), `WT_PATH` (honors
 `FLOW_WORKTREE_BASE`: `$FLOW_WORKTREE_BASE/<repo>-<branch>` when set, else
 in-repo `.claude/worktrees/<branch>`), `DEFAULT_BRANCH`, `REMOTE_BRANCH`
@@ -1007,6 +1028,7 @@ Key failure scenarios:
 - Each step builds on the previous one; there's no skipping
 - Worktrees are native: Step 1 uses the `EnterWorktree` tool (checkout under `.claude/worktrees/`, branched from `origin/<default-branch>`) and Step 7 uses `ExitWorktree` for session-created worktrees, with a `git worktree` fallback for resumed or cross-machine worktrees. The issue-anchored `issue-<N>-<slug>` branch name, the ELI5 gate, and quality gates are CPP policy layered on top of the native mechanics
 - Step 1's plumbing is deterministic (issue #581): `scripts/flow-start-resolve.sh` owns target-repo resolution, issue fetch, branch derivation, existing-work triage, the #503 guard, and git-lane creation, emitting a `key=value` contract; the model's only decision is `EnterWorktree` vs `cd`. Helpers are invoked bare at their stable `~/.claude/scripts/` paths so the shipped allowlist rules match (`templates/claude-settings-permissions.json`) and Phase 1 runs prompt-free
+- The session cwd is DECLARED, not inferred (issue #592): Step 1a passes `--session-cwd <path>` so the resolver decides `CROSS_REPO`/`GIT_LANE` (and, with no PROJECT arg, `TARGET_REPO` itself) against the session's working directory rather than the Bash tool's cwd, which drifts on any earlier `cd`. Without it the resolver reports `SESSION_CWD_INFERRED=1` and fails closed to `GIT_LANE=1` - the residual #578 left behind
 - Cross-repo invocations (`/flow:auto <ISSUE> <PROJECT>`, or a session cwd outside any git repo) are first-class (issue #578): the resolver detects the mismatch (path, else `~/Projects/<PROJECT>`) and the run rides the deterministic git lane end-to-end - helper-created worktree, `cd` instead of `EnterWorktree`, git cleanup at Step 7 - with the worktree still under the target repo's `.claude/worktrees/` so every guard resolves unchanged
 - The worktree base is configurable (issue #584, ADR 0003 Option A): `FLOW_WORKTREE_BASE`, when set in host config, relocates worktrees to `$FLOW_WORKTREE_BASE/<repo>-<branch>` and commits the run to the same git lane (`GIT_LANE=1`); unset, shipped behavior is byte-identical to the in-repo default. The guard/merge/remove/friction scripts resolve via git plumbing and need no awareness of the base
 - The deploy step is always optional - it only runs if a deploy target exists

--- a/plugins/flow/commands/eli5.md
+++ b/plugins/flow/commands/eli5.md
@@ -67,7 +67,25 @@ Emit all three sections every time. Do not skip a section even if it is short.
 
 **Section A - ELI5 overview of intent.** A plain-language restatement of what the
 issue is trying to accomplish and why, free of implementation jargon. Two to four
-sentences a non-author reviewer can sanity-check for a misread of intent.
+sentences minimum - a short paragraph is fine - that a non-author reviewer can
+sanity-check for a misread of intent.
+
+**Section A depth floor (applies regardless of how concise the model is tuned to
+be):** this is the section the gate is named for, and the one concision pressure
+squeezes hardest, so it carries an explicit floor too:
+
+- **Motivation before mechanics.** Explain what is wrong or missing today, and
+  why that matters, *before* describing what will change. Misread intent almost
+  always hides in the motivation, not in the file list - Section C already covers
+  the mechanics.
+- **No unexplained jargon.** Any technical term the issue cannot avoid gets a
+  plain-language gloss on first use - "the worktree (a scratch copy of the repo)",
+  "idempotent (safe to run twice)". A term left unglossed is jargon, however
+  ordinary it looks to the implementer.
+- **The explain-like-I'm-five bar.** Someone who has never seen this codebase
+  should finish Section A understanding what is wrong today and what will be
+  better afterward. A restatement of the issue title, or sentences that only parse
+  for a reader who already read the issue body, does not satisfy the gate.
 
 **Section B - Necessity / staleness analysis.** Assess whether the issue is still
 necessary given the current code and anything merged *after* it was filed. Inspect
@@ -142,7 +160,8 @@ The verdict drives what happens next:
 ELI5 Gate: Issue #398
 
 == A. What this issue actually wants (ELI5) ==
-{plain-language intent, 2-4 sentences}
+{plain-language intent: what is wrong today and why it matters, then what will
+ be better - 2-4 sentences minimum, every technical term glossed on first use}
 
 == B. Is it still needed? ==
 Verdict: Still needed | Partially addressed | No longer needed | Needs reframing

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -38,9 +38,21 @@ issue number - never wrapped in `if [ -x ... ]`, never chained with `&&` or
 `;`, never followed by `echo $?`. A compound invocation defeats the allowlist
 prefix rule; the helper prints its own status markers.
 
+**Always pass `--session-cwd` (issue #592).** The helper cannot observe the
+Claude session's working directory; it can only see the cwd the Bash tool call
+inherited, and that cwd drifts whenever any earlier command in the session
+`cd`s somewhere. `EnterWorktree`, meanwhile, always acts on the session cwd,
+which never moves. So supply the session's working directory VERBATIM as a
+literal path - the same directory the session reports as its cwd, not `$(pwd)`
+and not the directory a previous step left you in:
+
 ```bash
-~/.claude/scripts/flow-start-resolve.sh 42
+~/.claude/scripts/flow-start-resolve.sh 42 --session-cwd /home/user/Projects/my-repo
 ```
+
+If it is omitted the helper still works, but it says so
+(`SESSION_CWD_INFERRED=1`) and fails closed to `GIT_LANE=1`, because a wrong
+`GIT_LANE=0` would point `EnterWorktree` at the wrong repo - or at no repo.
 
 If the stable path is missing (exit 127), fall back in this order - the first
 that exists (issue #590):
@@ -60,9 +72,11 @@ The helper fetches the issue, derives the `issue-<N>-<slug>` branch (slug cut
 to keep the name within the EnterWorktree 64-char limit), triages existing
 work, and prints a `key=value` contract ending in `FLOW_START_RESOLVE: ok`. On
 `FLOW_START_RESOLVE: error` (with an `ERROR=` line): **STOP** and report it.
-Keys: `LANE`, `CROSS_REPO`, `GIT_LANE`, `TARGET_REPO`, `ISSUE_STATE`,
-`ISSUE_TITLE`, `BRANCH`, `WT_PATH`, `DEFAULT_BRANCH`, `REMOTE_BRANCH`,
-`WT_CREATED`, `LIVE_DRIVER` (the helper wraps its sibling
+Keys: `LANE`, `CROSS_REPO`, `GIT_LANE`, `SESSION_CWD`, `SESSION_CWD_INFERRED`
+(1 = no `--session-cwd` was passed, so the lane decision rests on a possibly
+drifted process cwd and `GIT_LANE` was forced to 1, issue #592), `TARGET_REPO`,
+`ISSUE_STATE`, `ISSUE_TITLE`, `BRANCH`, `WT_PATH`, `DEFAULT_BRANCH`,
+`REMOTE_BRANCH`, `WT_CREATED`, `LIVE_DRIVER` (the helper wraps its sibling
 `scripts/flow-live-driver-guard.sh`, #503), `PR_HEAD`, `CONFIRM_REQUIRED` -
 the same contract `/flow:auto` Step 1 documents.
 

--- a/plugins/flow/scripts/flow-start-resolve.sh
+++ b/plugins/flow/scripts/flow-start-resolve.sh
@@ -15,11 +15,24 @@
 # call EnterWorktree, or ride the git lane (cd).
 #
 # Resolve mode:
-#   flow-start-resolve.sh <ISSUE> [PROJECT] [--allow-closed]
+#   flow-start-resolve.sh <ISSUE> [PROJECT] [--session-cwd PATH] [--allow-closed]
 #
 #   PROJECT        target repo when the session cwd is not the issue's repo
 #                  (issue #578): tried as a path first, else
 #                  $HOME/Projects/<PROJECT>.
+#   --session-cwd  the CLAUDE SESSION's working directory, passed verbatim by
+#                  auto.md / start.md (issue #592). This is NOT the same thing
+#                  as the process cwd: the Bash tool's cwd persists across calls
+#                  and drifts whenever any earlier command `cd`s somewhere,
+#                  while EnterWorktree always acts on the session cwd, which
+#                  never moves. Inferring the session repo from `.` therefore
+#                  decides GIT_LANE against whatever repo the last `cd` landed
+#                  in. May also be supplied as FLOW_SESSION_CWD.
+#                  When ABSENT the resolver falls back to `.` (nothing
+#                  regresses) but says so - SESSION_CWD_INFERRED=1 - and fails
+#                  closed to GIT_LANE=1, because the git lane is correct in
+#                  every case while a wrong GIT_LANE=0 points EnterWorktree at
+#                  a directory that may not be a repo at all.
 #   --allow-closed proceed with worktree creation although the issue is not
 #                  OPEN (pass only after the user has confirmed).
 #
@@ -29,8 +42,16 @@
 #     GIT_LANE=0|1          1 = ride the git lane end-to-end: enter with `cd`,
 #                           never EnterWorktree, git cleanup at Step 7. Set for
 #                           cross-repo runs, when FLOW_WORKTREE_BASE is set
-#                           (issue #584, ADR 0003), and when a resumed worktree
-#                           lies outside the target repo
+#                           (issue #584, ADR 0003), when a resumed worktree
+#                           lies outside the target repo, and whenever the
+#                           session cwd was inferred rather than declared
+#                           (issue #592 - fail closed toward the safe lane)
+#     SESSION_CWD=<path>    the session cwd this resolution was decided against
+#     SESSION_CWD_INFERRED=0|1
+#                           1 = no --session-cwd/FLOW_SESSION_CWD was supplied,
+#                           so the process cwd was used as a stand-in and the
+#                           run may be resolving against a drifted directory
+#                           (issue #592); GIT_LANE is forced to 1 in this case
 #     TARGET_REPO=<abs path of the primary checkout>
 #     ISSUE_STATE=OPEN|CLOSED|MERGED
 #     ISSUE_TITLE=<title, whitespace flattened>
@@ -61,6 +82,7 @@
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
 #                                    0003 Option A; host config, never shipped)
+#   FLOW_SESSION_CWD                 session cwd (issue #592); --session-cwd wins
 # Env (test hooks - unset in normal use):
 #   FLOW_START_RESOLVE_GH            override the `gh` binary
 #   FLOW_START_RESOLVE_PROJECTS_DIR  override $HOME/Projects for name lookup
@@ -107,13 +129,20 @@ ALLOW_CLOSED=0
 ISSUE_NUM=""
 PROJECT=""
 EXPECTED_BRANCH=""
+SESSION_CWD_ARG=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --verify) MODE=verify ;;
     --allow-closed) ALLOW_CLOSED=1 ;;
+    --session-cwd)
+      [ "$#" -ge 2 ] || usage_fail "--session-cwd requires a path argument"
+      SESSION_CWD_ARG="$2"
+      shift
+      ;;
+    --session-cwd=*) SESSION_CWD_ARG="${1#--session-cwd=}" ;;
     --help|-h)
-      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*) usage_fail "unknown option: $1" ;;
@@ -171,6 +200,28 @@ if [ "$MODE" = verify ]; then
   exit 0
 fi
 
+# ---- session cwd (issue #592) -----------------------------------------------
+# The process cwd is NOT the session cwd. In Claude Code the Bash tool's working
+# directory persists across calls and drifts on any earlier `cd`, while
+# EnterWorktree always acts on the session's working directory, which never
+# moves. Resolving the session repo from `.` therefore decides the contract's
+# central question against whatever repo the last `cd` happened to land in.
+# Prefer the value the caller declares; fall back to `.` so nothing regresses,
+# but mark the fallback as inferred and fail closed below.
+SESSION_CWD_INFERRED=0
+if [ -n "$SESSION_CWD_ARG" ]; then
+  SESSION_CWD="$SESSION_CWD_ARG"
+elif [ -n "${FLOW_SESSION_CWD:-}" ]; then
+  SESSION_CWD="$FLOW_SESSION_CWD"
+else
+  SESSION_CWD="."
+  SESSION_CWD_INFERRED=1
+fi
+if [ "$SESSION_CWD_INFERRED" -eq 0 ] && [ ! -d "$SESSION_CWD" ]; then
+  fail "--session-cwd '$SESSION_CWD' is not a directory"
+fi
+SESSION_CWD_ABS=$(cd "$SESSION_CWD" 2>/dev/null && pwd) || SESSION_CWD_ABS="$SESSION_CWD"
+
 # ---- target-repo resolution (issue #578) ------------------------------------
 TARGET_REPO=""
 if [ -n "$PROJECT" ]; then
@@ -182,11 +233,14 @@ if [ -n "$PROJECT" ]; then
   done
   [ -n "$TARGET_REPO" ] || fail "PROJECT '$PROJECT' is not a git checkout (tried '$PROJECT' and '$PROJECTS_DIR/$PROJECT')"
 else
-  TARGET_REPO=$(resolve_primary . || true)
-  [ -n "$TARGET_REPO" ] || fail "session cwd is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
+  # No PROJECT: the target repo comes from the SESSION cwd, never from the
+  # process cwd - a bare `/flow:start 42` after any earlier `cd` would otherwise
+  # branch and create a worktree in a surprise repository (issue #592, facet 2).
+  TARGET_REPO=$(resolve_primary "$SESSION_CWD" || true)
+  [ -n "$TARGET_REPO" ] || fail "session cwd '$SESSION_CWD_ABS' is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
 fi
 
-SESSION_PRIMARY=$(resolve_primary . 2>/dev/null || true)
+SESSION_PRIMARY=$(resolve_primary "$SESSION_CWD" 2>/dev/null || true)
 CROSS_REPO=1
 [ -n "$SESSION_PRIMARY" ] && [ "$SESSION_PRIMARY" = "$TARGET_REPO" ] && CROSS_REPO=0
 
@@ -196,6 +250,15 @@ CROSS_REPO=1
 # unsuppressable approval prompt (ADR 0003 constraint 2).
 GIT_LANE=$CROSS_REPO
 [ -n "${FLOW_WORKTREE_BASE:-}" ] && GIT_LANE=1
+# Fail closed (issue #592): GIT_LANE=1 is safe in every case - the git lane
+# works whether or not the session sits in the target repo - while a wrong
+# GIT_LANE=0 tells the model to call EnterWorktree on a directory that may be
+# another repo or no repo at all. So an UNVERIFIED session cwd never earns the
+# native lane.
+if [ "$SESSION_CWD_INFERRED" -eq 1 ]; then
+  GIT_LANE=1
+  echo "flow-start-resolve: no --session-cwd given - resolving against the process cwd '$SESSION_CWD_ABS', which may have drifted from the session cwd; riding the git lane (issue #592)." >&2
+fi
 
 # Worktree path for a branch, honoring the #584 base override.
 wt_path_for() {
@@ -255,14 +318,15 @@ WT_CREATED=0
 LIVE_DRIVER=skipped
 PR_HEAD=none
 
-# 1. Already on the issue's branch in the session cwd (same repo only).
-SESSION_BRANCH=$("$GIT" branch --show-current 2>/dev/null || true)
+# 1. Already on the issue's branch in the session cwd (same repo only). Read
+#    the branch and toplevel from the SESSION cwd, not the process cwd (#592).
+SESSION_BRANCH=$("$GIT" -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)
 case "$SESSION_BRANCH" in
   issue-"$ISSUE_NUM"-*)
     if [ "$CROSS_REPO" -eq 0 ]; then
       LANE=current-branch
       BRANCH="$SESSION_BRANCH"
-      WT_PATH=$("$GIT" rev-parse --show-toplevel)
+      WT_PATH=$("$GIT" -C "$SESSION_CWD" rev-parse --show-toplevel)
     fi
     ;;
 esac
@@ -354,6 +418,8 @@ fi
 echo "LANE=$LANE"
 echo "CROSS_REPO=$CROSS_REPO"
 echo "GIT_LANE=$GIT_LANE"
+echo "SESSION_CWD=$SESSION_CWD_ABS"
+echo "SESSION_CWD_INFERRED=$SESSION_CWD_INFERRED"
 echo "TARGET_REPO=$TARGET_REPO"
 echo "ISSUE_STATE=$ISSUE_STATE"
 echo "ISSUE_TITLE=$ISSUE_TITLE"

--- a/scripts/eli5-core-drift.sh
+++ b/scripts/eli5-core-drift.sh
@@ -1,55 +1,20 @@
 #!/usr/bin/env bash
 # eli5-core-drift.sh - advisory drift check for the vendored eli5 necessity gate.
 #
-# CPP's /flow:eli5 vendors its core (the section between the eli5-core:begin /
-# eli5-core:end markers) verbatim from the canonical standalone repo
-# https://github.com/cooneycw/eli5-gate (extracted in issue #443). This script
-# fetches the canonical copy and diffs the marker-delimited core against the
-# local vendored copy.
+# Thin shim onto scripts/eli5-vendor.py --upstream (issue #591). The check moved
+# to Python so it can run in the Woodpecker validate container, which ships
+# neither curl nor git (the recurring #451/#489 trap); this entry point stays so
+# every existing reference - CLAUDE.md, CHANGELOG, eli5.md's Notes, ADR 0001 -
+# keeps working, and so there is exactly ONE implementation behind them.
 #
 # Advisory and fail-open by design: network down or canonical unreachable ->
-# exit 0 with a note; drift found -> warn with the diff and exit 1 so a CI step
-# or /flow gate CAN choose to surface it, but nothing in the flow hard-fails on
-# it. Reconcile drift by editing the CANONICAL repo first, then re-vendoring.
+# exit 0 with a note; drift found -> warn with the diff and exit 1. Reconcile
+# drift by editing the CANONICAL repo (cooneycw/eli5-gate) first, then
+# re-vendoring: make eli5-revendor
+#
+# See also `make eli5-check` - the OFFLINE half, which verifies the vendored
+# core against the pinned hash in .claude/eli5-vendor.json and is a hard CI gate.
 set -uo pipefail
 
-CANON_URL="${ELI5_GATE_CANON_URL:-https://raw.githubusercontent.com/cooneycw/eli5-gate/main/commands/eli5.md}"
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-LOCAL_FILE="$REPO_ROOT/.claude/commands/flow/eli5.md"
-
-if [[ ! -f "$LOCAL_FILE" ]]; then
-    echo "eli5-core-drift: $LOCAL_FILE not found (nothing to check)" >&2
-    exit 0
-fi
-
-# Anchored to comment-line starts so prose that merely MENTIONS the markers
-# (e.g. a Notes bullet) cannot re-trigger the state machine.
-extract_core() {
-    awk '/^<!-- eli5-core:begin/{f=1; next} /^<!-- eli5-core:end/{f=0} f' "$1"
-}
-
-TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
-
-if ! curl -fsSL --max-time 15 "$CANON_URL" -o "$TMP"; then
-    echo "eli5-core-drift: canonical source unreachable ($CANON_URL) - skipping (fail-open)" >&2
-    exit 0
-fi
-
-if [[ ! -s "$TMP" ]] || ! grep -q "eli5-core:begin" "$TMP"; then
-    echo "eli5-core-drift: canonical copy has no eli5-core markers - skipping (fail-open)" >&2
-    exit 0
-fi
-
-if diff -u <(extract_core "$TMP") <(extract_core "$LOCAL_FILE"); then
-    echo "eli5-core-drift: vendored core is in sync with canonical eli5-gate"
-    exit 0
-fi
-
-echo "" >&2
-echo "WARNING: the vendored eli5 core has drifted from the canonical copy at" >&2
-echo "  $CANON_URL" >&2
-echo "Reconcile by updating the canonical cooneycw/eli5-gate repo first, then" >&2
-echo "re-vendoring the marker section into .claude/commands/flow/eli5.md" >&2
-echo "(then run scripts/plugin-sync.sh --write flow to refresh the packaged copies)." >&2
-exit 1
+SELF_DIR=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+exec python3 "$SELF_DIR/eli5-vendor.py" --upstream "$@"

--- a/scripts/eli5-vendor.py
+++ b/scripts/eli5-vendor.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""eli5-vendor.py - guard the canonical -> vendored link for the eli5 gate core.
+
+CPP's ``/flow:eli5`` vendors its core - the section between the
+``eli5-core:begin`` / ``eli5-core:end`` markers - verbatim from the canonical
+standalone repo https://github.com/cooneycw/eli5-gate (extracted in #443). That
+link had a drift script but no automation of any kind: no CI step, no Makefile
+target, no test (issue #591). Advisory-by-design is fine; advisory-and-never-run
+is decoration.
+
+Two checks, because they catch different failures and neither subsumes the
+other:
+
+``check`` (offline, the CI gate)
+    Recompute the vendored core's sha256 and compare it to the pinned value in
+    the manifest (``.claude/eli5-vendor.json``). Deterministic, stdlib-only, no
+    network and no git - so it runs inside the uv:python3.11-slim validate
+    container that ships neither curl nor git (the recurring #451/#489 trap).
+    Catches a local edit of the vendored core that bypassed re-vendoring.
+
+``--upstream`` (network, advisory)
+    Fetch the canonical copy and diff it against the vendored one. This is the
+    check that notices UPSTREAM MOVED - the manifest cannot, since it pins what
+    was vendored, not what is now canonical. Fail-open: any network trouble
+    exits 0 with a note, so an offline runner never reddens the pipeline.
+
+``--revendor`` (network, writes)
+    Re-vendor: fetch the canonical core, replace the marker section in place,
+    and rewrite the manifest (content hash + upstream commit SHA + date) so the
+    offline gate goes green on the new content. This keeps the core and its
+    pin in lockstep - the whole point of the manifest.
+
+Reconcile drift by editing the CANONICAL repo first, then re-vendoring here.
+After a re-vendor, refresh the generated surfaces:
+    scripts/plugin-sync.sh --write flow
+    python3 scripts/codex-skill-sync.py --write flow
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / ".claude" / "eli5-vendor.json"
+DEFAULT_VENDORED = ".claude/commands/flow/eli5.md"
+DEFAULT_RAW_URL = "https://raw.githubusercontent.com/cooneycw/eli5-gate/main/commands/eli5.md"
+DEFAULT_COMMITS_API = "https://api.github.com/repos/cooneycw/eli5-gate/commits?path=commands/eli5.md&per_page=1"
+
+BEGIN_MARKER = "<!-- eli5-core:begin"
+END_MARKER = "<!-- eli5-core:end"
+
+NETWORK_TIMEOUT = 15
+
+
+class CoreNotFound(Exception):
+    """The marker-delimited core is missing or malformed."""
+
+
+def extract_core(text: str) -> str:
+    """Return the text between the eli5-core markers.
+
+    Marker detection is anchored to the START of a line, so prose that merely
+    MENTIONS a marker (the Notes bullet in eli5.md does) cannot re-trigger the
+    state machine - the same anchoring the shell implementation used.
+    """
+    lines = text.splitlines(keepends=True)
+    start = end = None
+    for i, line in enumerate(lines):
+        if start is None and line.startswith(BEGIN_MARKER):
+            start = i + 1
+        elif start is not None and line.startswith(END_MARKER):
+            end = i
+            break
+    if start is None:
+        raise CoreNotFound(f"no line starting with '{BEGIN_MARKER}'")
+    if end is None:
+        raise CoreNotFound(f"'{BEGIN_MARKER}' has no matching '{END_MARKER}'")
+    return "".join(lines[start:end])
+
+
+def core_sha256(core: str) -> str:
+    return hashlib.sha256(core.encode("utf-8")).hexdigest()
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict:
+    if not path.is_file():
+        raise FileNotFoundError(f"manifest not found: {path}")
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"manifest is not a JSON object: {path}")
+    return data
+
+
+def vendored_path(manifest: dict) -> Path:
+    rel = manifest.get("vendored", {}).get("file", DEFAULT_VENDORED)
+    return REPO_ROOT / rel
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "cpp-eli5-vendor"})
+    with urllib.request.urlopen(req, timeout=NETWORK_TIMEOUT) as resp:  # noqa: S310 - fixed https URL
+        return resp.read().decode("utf-8")
+
+
+# --- check (offline) ---------------------------------------------------------
+
+
+def cmd_check(manifest: dict) -> int:
+    """Vendored core must match the hash the manifest pins. Offline, hard gate."""
+    local = vendored_path(manifest)
+    if not local.is_file():
+        print(f"eli5-vendor: {local} not found", file=sys.stderr)
+        return 1
+    try:
+        core = extract_core(local.read_text(encoding="utf-8"))
+    except CoreNotFound as exc:
+        print(f"eli5-vendor: {local}: {exc}", file=sys.stderr)
+        return 1
+
+    pinned = manifest.get("vendored", {}).get("core_sha256", "")
+    actual = core_sha256(core)
+    if actual == pinned:
+        upstream = manifest.get("source", {}).get("upstream_commit") or "unpinned"
+        print(f"eli5-vendor: vendored core matches the manifest (sha256 {actual[:12]}, upstream {upstream[:12]})")
+        return 0
+
+    print("", file=sys.stderr)
+    print("DRIFT: the vendored eli5 core does not match the manifest pin.", file=sys.stderr)
+    print(f"  manifest: {MANIFEST_PATH}", file=sys.stderr)
+    print(f"  expected: {pinned or '(missing)'}", file=sys.stderr)
+    print(f"  actual:   {actual}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("The core between the eli5-core markers was edited locally. That core is", file=sys.stderr)
+    print("vendored from https://github.com/cooneycw/eli5-gate - edit it THERE first,", file=sys.stderr)
+    print("then re-vendor here:  make eli5-revendor", file=sys.stderr)
+    print("If the local edit is the intended new content, the same target re-pins it.", file=sys.stderr)
+    return 1
+
+
+# --- upstream (network, advisory) --------------------------------------------
+
+
+def cmd_upstream(manifest: dict) -> int:
+    """Diff the vendored core against the live canonical copy. Fail-open."""
+    local = vendored_path(manifest)
+    url = manifest.get("source", {}).get("raw_url", DEFAULT_RAW_URL)
+
+    if not local.is_file():
+        print(f"eli5-vendor: {local} not found (nothing to check)", file=sys.stderr)
+        return 0
+    try:
+        local_core = extract_core(local.read_text(encoding="utf-8"))
+    except CoreNotFound as exc:
+        print(f"eli5-vendor: {local}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        remote_text = fetch(url)
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        print(f"eli5-vendor: canonical source unreachable ({url}): {exc} - skipping (fail-open)", file=sys.stderr)
+        return 0
+
+    try:
+        remote_core = extract_core(remote_text)
+    except CoreNotFound as exc:
+        print(f"eli5-vendor: canonical copy has no usable core ({exc}) - skipping (fail-open)", file=sys.stderr)
+        return 0
+
+    if remote_core == local_core:
+        print("eli5-vendor: vendored core is in sync with canonical eli5-gate")
+        return 0
+
+    diff = difflib.unified_diff(
+        remote_core.splitlines(keepends=True),
+        local_core.splitlines(keepends=True),
+        fromfile="canonical/eli5-gate",
+        tofile="vendored/cpp",
+    )
+    sys.stderr.writelines(diff)
+    print("", file=sys.stderr)
+    print("WARNING: the vendored eli5 core has drifted from the canonical copy at", file=sys.stderr)
+    print(f"  {url}", file=sys.stderr)
+    print("Reconcile by updating cooneycw/eli5-gate first, then re-vendoring:", file=sys.stderr)
+    print("  make eli5-revendor", file=sys.stderr)
+    return 1
+
+
+# --- revendor (network, writes) ----------------------------------------------
+
+
+def latest_upstream_commit(manifest: dict) -> str | None:
+    api = manifest.get("source", {}).get("commits_api", DEFAULT_COMMITS_API)
+    try:
+        payload = json.loads(fetch(api))
+    except (urllib.error.URLError, OSError, TimeoutError, ValueError) as exc:
+        print(f"eli5-vendor: could not resolve the upstream commit SHA ({exc}) - leaving it unpinned", file=sys.stderr)
+        return None
+    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        sha = payload[0].get("sha")
+        return sha if isinstance(sha, str) else None
+    return None
+
+
+def cmd_revendor(manifest: dict) -> int:
+    local = vendored_path(manifest)
+    url = manifest.get("source", {}).get("raw_url", DEFAULT_RAW_URL)
+
+    try:
+        remote_core = extract_core(fetch(url))
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        print(f"eli5-vendor: cannot re-vendor - canonical source unreachable ({url}): {exc}", file=sys.stderr)
+        return 1
+    except CoreNotFound as exc:
+        print(f"eli5-vendor: cannot re-vendor - canonical copy has no usable core: {exc}", file=sys.stderr)
+        return 1
+
+    text = local.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    start = end = None
+    for i, line in enumerate(lines):
+        if start is None and line.startswith(BEGIN_MARKER):
+            start = i + 1
+        elif start is not None and line.startswith(END_MARKER):
+            end = i
+            break
+    if start is None or end is None:
+        print(f"eli5-vendor: {local} has no usable marker pair - cannot re-vendor", file=sys.stderr)
+        return 1
+
+    changed = "".join(lines[start:end]) != remote_core
+    if changed:
+        local.write_text("".join(lines[:start]) + remote_core + "".join(lines[end:]), encoding="utf-8")
+
+    manifest.setdefault("source", {})["upstream_commit"] = latest_upstream_commit(manifest)
+    manifest.setdefault("vendored", {})["core_sha256"] = core_sha256(remote_core)
+    manifest["vendored"]["core_lines"] = len(remote_core.splitlines())
+    manifest["vendored"]["vendored_at"] = date.today().isoformat()
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    print(f"eli5-vendor: {'re-vendored core and' if changed else 'core already current;'} updated the manifest")
+    print("Next: scripts/plugin-sync.sh --write flow && python3 scripts/codex-skill-sync.py --write flow")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Guard the vendored eli5 gate core (issue #591).")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--upstream",
+        action="store_true",
+        help="diff the vendored core against the live canonical copy (network, fail-open)",
+    )
+    mode.add_argument(
+        "--revendor",
+        action="store_true",
+        help="re-fetch the canonical core, replace it in place, and re-pin the manifest",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = load_manifest()
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"eli5-vendor: {exc}", file=sys.stderr)
+        return 1
+
+    if args.revendor:
+        return cmd_revendor(manifest)
+    if args.upstream:
+        return cmd_upstream(manifest)
+    return cmd_check(manifest)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/flow-start-resolve.sh
+++ b/scripts/flow-start-resolve.sh
@@ -15,11 +15,24 @@
 # call EnterWorktree, or ride the git lane (cd).
 #
 # Resolve mode:
-#   flow-start-resolve.sh <ISSUE> [PROJECT] [--allow-closed]
+#   flow-start-resolve.sh <ISSUE> [PROJECT] [--session-cwd PATH] [--allow-closed]
 #
 #   PROJECT        target repo when the session cwd is not the issue's repo
 #                  (issue #578): tried as a path first, else
 #                  $HOME/Projects/<PROJECT>.
+#   --session-cwd  the CLAUDE SESSION's working directory, passed verbatim by
+#                  auto.md / start.md (issue #592). This is NOT the same thing
+#                  as the process cwd: the Bash tool's cwd persists across calls
+#                  and drifts whenever any earlier command `cd`s somewhere,
+#                  while EnterWorktree always acts on the session cwd, which
+#                  never moves. Inferring the session repo from `.` therefore
+#                  decides GIT_LANE against whatever repo the last `cd` landed
+#                  in. May also be supplied as FLOW_SESSION_CWD.
+#                  When ABSENT the resolver falls back to `.` (nothing
+#                  regresses) but says so - SESSION_CWD_INFERRED=1 - and fails
+#                  closed to GIT_LANE=1, because the git lane is correct in
+#                  every case while a wrong GIT_LANE=0 points EnterWorktree at
+#                  a directory that may not be a repo at all.
 #   --allow-closed proceed with worktree creation although the issue is not
 #                  OPEN (pass only after the user has confirmed).
 #
@@ -29,8 +42,16 @@
 #     GIT_LANE=0|1          1 = ride the git lane end-to-end: enter with `cd`,
 #                           never EnterWorktree, git cleanup at Step 7. Set for
 #                           cross-repo runs, when FLOW_WORKTREE_BASE is set
-#                           (issue #584, ADR 0003), and when a resumed worktree
-#                           lies outside the target repo
+#                           (issue #584, ADR 0003), when a resumed worktree
+#                           lies outside the target repo, and whenever the
+#                           session cwd was inferred rather than declared
+#                           (issue #592 - fail closed toward the safe lane)
+#     SESSION_CWD=<path>    the session cwd this resolution was decided against
+#     SESSION_CWD_INFERRED=0|1
+#                           1 = no --session-cwd/FLOW_SESSION_CWD was supplied,
+#                           so the process cwd was used as a stand-in and the
+#                           run may be resolving against a drifted directory
+#                           (issue #592); GIT_LANE is forced to 1 in this case
 #     TARGET_REPO=<abs path of the primary checkout>
 #     ISSUE_STATE=OPEN|CLOSED|MERGED
 #     ISSUE_TITLE=<title, whitespace flattened>
@@ -61,6 +82,7 @@
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
 #                                    0003 Option A; host config, never shipped)
+#   FLOW_SESSION_CWD                 session cwd (issue #592); --session-cwd wins
 # Env (test hooks - unset in normal use):
 #   FLOW_START_RESOLVE_GH            override the `gh` binary
 #   FLOW_START_RESOLVE_PROJECTS_DIR  override $HOME/Projects for name lookup
@@ -107,13 +129,20 @@ ALLOW_CLOSED=0
 ISSUE_NUM=""
 PROJECT=""
 EXPECTED_BRANCH=""
+SESSION_CWD_ARG=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --verify) MODE=verify ;;
     --allow-closed) ALLOW_CLOSED=1 ;;
+    --session-cwd)
+      [ "$#" -ge 2 ] || usage_fail "--session-cwd requires a path argument"
+      SESSION_CWD_ARG="$2"
+      shift
+      ;;
+    --session-cwd=*) SESSION_CWD_ARG="${1#--session-cwd=}" ;;
     --help|-h)
-      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*) usage_fail "unknown option: $1" ;;
@@ -171,6 +200,28 @@ if [ "$MODE" = verify ]; then
   exit 0
 fi
 
+# ---- session cwd (issue #592) -----------------------------------------------
+# The process cwd is NOT the session cwd. In Claude Code the Bash tool's working
+# directory persists across calls and drifts on any earlier `cd`, while
+# EnterWorktree always acts on the session's working directory, which never
+# moves. Resolving the session repo from `.` therefore decides the contract's
+# central question against whatever repo the last `cd` happened to land in.
+# Prefer the value the caller declares; fall back to `.` so nothing regresses,
+# but mark the fallback as inferred and fail closed below.
+SESSION_CWD_INFERRED=0
+if [ -n "$SESSION_CWD_ARG" ]; then
+  SESSION_CWD="$SESSION_CWD_ARG"
+elif [ -n "${FLOW_SESSION_CWD:-}" ]; then
+  SESSION_CWD="$FLOW_SESSION_CWD"
+else
+  SESSION_CWD="."
+  SESSION_CWD_INFERRED=1
+fi
+if [ "$SESSION_CWD_INFERRED" -eq 0 ] && [ ! -d "$SESSION_CWD" ]; then
+  fail "--session-cwd '$SESSION_CWD' is not a directory"
+fi
+SESSION_CWD_ABS=$(cd "$SESSION_CWD" 2>/dev/null && pwd) || SESSION_CWD_ABS="$SESSION_CWD"
+
 # ---- target-repo resolution (issue #578) ------------------------------------
 TARGET_REPO=""
 if [ -n "$PROJECT" ]; then
@@ -182,11 +233,14 @@ if [ -n "$PROJECT" ]; then
   done
   [ -n "$TARGET_REPO" ] || fail "PROJECT '$PROJECT' is not a git checkout (tried '$PROJECT' and '$PROJECTS_DIR/$PROJECT')"
 else
-  TARGET_REPO=$(resolve_primary . || true)
-  [ -n "$TARGET_REPO" ] || fail "session cwd is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
+  # No PROJECT: the target repo comes from the SESSION cwd, never from the
+  # process cwd - a bare `/flow:start 42` after any earlier `cd` would otherwise
+  # branch and create a worktree in a surprise repository (issue #592, facet 2).
+  TARGET_REPO=$(resolve_primary "$SESSION_CWD" || true)
+  [ -n "$TARGET_REPO" ] || fail "session cwd '$SESSION_CWD_ABS' is not inside a git repo and no PROJECT was given - re-run as: flow-start-resolve.sh $ISSUE_NUM <PROJECT>"
 fi
 
-SESSION_PRIMARY=$(resolve_primary . 2>/dev/null || true)
+SESSION_PRIMARY=$(resolve_primary "$SESSION_CWD" 2>/dev/null || true)
 CROSS_REPO=1
 [ -n "$SESSION_PRIMARY" ] && [ "$SESSION_PRIMARY" = "$TARGET_REPO" ] && CROSS_REPO=0
 
@@ -196,6 +250,15 @@ CROSS_REPO=1
 # unsuppressable approval prompt (ADR 0003 constraint 2).
 GIT_LANE=$CROSS_REPO
 [ -n "${FLOW_WORKTREE_BASE:-}" ] && GIT_LANE=1
+# Fail closed (issue #592): GIT_LANE=1 is safe in every case - the git lane
+# works whether or not the session sits in the target repo - while a wrong
+# GIT_LANE=0 tells the model to call EnterWorktree on a directory that may be
+# another repo or no repo at all. So an UNVERIFIED session cwd never earns the
+# native lane.
+if [ "$SESSION_CWD_INFERRED" -eq 1 ]; then
+  GIT_LANE=1
+  echo "flow-start-resolve: no --session-cwd given - resolving against the process cwd '$SESSION_CWD_ABS', which may have drifted from the session cwd; riding the git lane (issue #592)." >&2
+fi
 
 # Worktree path for a branch, honoring the #584 base override.
 wt_path_for() {
@@ -255,14 +318,15 @@ WT_CREATED=0
 LIVE_DRIVER=skipped
 PR_HEAD=none
 
-# 1. Already on the issue's branch in the session cwd (same repo only).
-SESSION_BRANCH=$("$GIT" branch --show-current 2>/dev/null || true)
+# 1. Already on the issue's branch in the session cwd (same repo only). Read
+#    the branch and toplevel from the SESSION cwd, not the process cwd (#592).
+SESSION_BRANCH=$("$GIT" -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)
 case "$SESSION_BRANCH" in
   issue-"$ISSUE_NUM"-*)
     if [ "$CROSS_REPO" -eq 0 ]; then
       LANE=current-branch
       BRANCH="$SESSION_BRANCH"
-      WT_PATH=$("$GIT" rev-parse --show-toplevel)
+      WT_PATH=$("$GIT" -C "$SESSION_CWD" rev-parse --show-toplevel)
     fi
     ;;
 esac
@@ -354,6 +418,8 @@ fi
 echo "LANE=$LANE"
 echo "CROSS_REPO=$CROSS_REPO"
 echo "GIT_LANE=$GIT_LANE"
+echo "SESSION_CWD=$SESSION_CWD_ABS"
+echo "SESSION_CWD_INFERRED=$SESSION_CWD_INFERRED"
 echo "TARGET_REPO=$TARGET_REPO"
 echo "ISSUE_STATE=$ISSUE_STATE"
 echo "ISSUE_TITLE=$ISSUE_TITLE"

--- a/tests/test_eli5_vendor.py
+++ b/tests/test_eli5_vendor.py
@@ -1,0 +1,177 @@
+"""Tests for scripts/eli5-vendor.py - the vendored eli5-core guard (issue #591).
+
+The link these protect: CPP vendors the eli5 necessity-gate core verbatim from
+cooneycw/eli5-gate between the ``eli5-core`` markers. Before #591 the drift
+script for that link was invoked by nothing at all - no CI step, no Makefile
+target, no test - so a stale or locally-edited core was invisible.
+
+Everything here is OFFLINE and stdlib-only on purpose: no network, no git, no
+external binaries. The Woodpecker ``validate`` container (uv:python3.11-slim)
+ships neither curl nor git, and an unguarded shell-out turns CI red even though
+it passes locally (the recurring #451/#489 trap). The live-fetch half of the
+guard (``--upstream``) is deliberately NOT exercised here - it is advisory and
+fail-open by design, and a test that reaches the network would be flaky.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "eli5-vendor.py"
+MANIFEST = ROOT / ".claude" / "eli5-vendor.json"
+
+
+def _load_module():
+    """Import the hyphenated script by path (not importable as a module name)."""
+    spec = importlib.util.spec_from_file_location("eli5_vendor", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["eli5_vendor"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ev = _load_module()
+
+
+# --- wiring ------------------------------------------------------------------
+
+
+def test_script_exists_and_executable():
+    assert SCRIPT.is_file(), f"missing {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), "eli5-vendor.py must be executable"
+
+
+def test_manifest_is_present_and_well_formed():
+    assert MANIFEST.is_file(), f"missing {MANIFEST} - the offline gate has nothing to pin against"
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert data["source"]["repo"] == "cooneycw/eli5-gate"
+    assert data["source"]["raw_url"].startswith("https://")
+    assert data["vendored"]["file"] == ".claude/commands/flow/eli5.md"
+    sha = data["vendored"]["core_sha256"]
+    assert isinstance(sha, str) and len(sha) == 64, "core_sha256 must be a full sha256 hex digest"
+
+
+def test_manifest_pins_an_upstream_commit():
+    """A manifest without an upstream SHA still guards content, but loses the
+    provenance half - you cannot tell WHICH canonical revision was vendored."""
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    commit = data["source"].get("upstream_commit")
+    assert isinstance(commit, str) and len(commit) >= 7, "re-vendor with `make eli5-revendor` to pin the upstream SHA"
+
+
+# --- the gate itself ---------------------------------------------------------
+
+
+def test_vendored_core_matches_the_manifest_pin():
+    """THE gate: the checked-in core must be exactly what the manifest pins.
+
+    Fails when someone edits the core between the markers directly instead of
+    editing cooneycw/eli5-gate and re-vendoring.
+    """
+    manifest = ev.load_manifest()
+    core = ev.extract_core(ev.vendored_path(manifest).read_text(encoding="utf-8"))
+    assert ev.core_sha256(core) == manifest["vendored"]["core_sha256"], (
+        "vendored eli5 core does not match .claude/eli5-vendor.json. Edit the core "
+        "UPSTREAM (cooneycw/eli5-gate) first, then run `make eli5-revendor`."
+    )
+
+
+def test_check_command_passes_on_the_real_repo():
+    assert ev.main([]) == 0
+
+
+def test_manifest_line_count_matches():
+    manifest = ev.load_manifest()
+    core = ev.extract_core(ev.vendored_path(manifest).read_text(encoding="utf-8"))
+    assert len(core.splitlines()) == manifest["vendored"]["core_lines"]
+
+
+# --- marker extraction -------------------------------------------------------
+
+
+def test_extract_core_returns_only_the_marker_section():
+    text = "before\n<!-- eli5-core:begin (canonical: x) -->\ncore line\n<!-- eli5-core:end -->\nafter\n"
+    assert ev.extract_core(text) == "core line\n"
+
+
+def test_extract_core_ignores_markers_mentioned_mid_line():
+    """The Notes bullet in eli5.md mentions the markers in prose; anchoring to
+    line starts is what keeps that from re-triggering the state machine."""
+    text = (
+        "see the <!-- eli5-core:begin --> marker in prose\n"
+        "<!-- eli5-core:begin -->\n"
+        "real core\n"
+        "<!-- eli5-core:end -->\n"
+    )
+    assert ev.extract_core(text) == "real core\n"
+
+
+def test_extract_core_rejects_a_missing_begin_marker():
+    with pytest.raises(ev.CoreNotFound):
+        ev.extract_core("no markers here\n")
+
+
+def test_extract_core_rejects_an_unterminated_core():
+    with pytest.raises(ev.CoreNotFound):
+        ev.extract_core("<!-- eli5-core:begin -->\ndangling\n")
+
+
+# --- failure surfacing -------------------------------------------------------
+
+
+def test_check_reports_drift_when_the_core_is_edited(tmp_path: Path, capsys, monkeypatch):
+    """A tampered core must FAIL, not warn - this half of the guard is the hard
+    gate; the live-fetch half is the advisory one."""
+    vendored = tmp_path / "eli5.md"
+    vendored.write_text("<!-- eli5-core:begin -->\ntampered\n<!-- eli5-core:end -->\n", encoding="utf-8")
+    manifest = {
+        "source": {"raw_url": "https://example.invalid/x.md", "upstream_commit": "deadbeef"},
+        "vendored": {"file": vendored.name, "core_sha256": ev.core_sha256("original\n")},
+    }
+    monkeypatch.setattr(ev, "REPO_ROOT", tmp_path)
+    assert ev.cmd_check(manifest) == 1
+    assert "DRIFT" in capsys.readouterr().err
+
+
+def test_upstream_check_fails_open_when_the_network_is_down(tmp_path: Path, capsys, monkeypatch):
+    """Advisory means advisory: an unreachable canonical source exits 0 so an
+    offline CI runner can never redden the pipeline on it."""
+    vendored = tmp_path / "eli5.md"
+    vendored.write_text("<!-- eli5-core:begin -->\ncore\n<!-- eli5-core:end -->\n", encoding="utf-8")
+
+    def _boom(url: str) -> str:
+        raise OSError("network is unreachable")
+
+    monkeypatch.setattr(ev, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(ev, "fetch", _boom)
+    manifest = {"source": {"raw_url": "https://example.invalid/x.md"}, "vendored": {"file": vendored.name}}
+    assert ev.cmd_upstream(manifest) == 0
+    assert "fail-open" in capsys.readouterr().err
+
+
+def test_upstream_check_reports_drift(tmp_path: Path, capsys, monkeypatch):
+    vendored = tmp_path / "eli5.md"
+    vendored.write_text("<!-- eli5-core:begin -->\nlocal\n<!-- eli5-core:end -->\n", encoding="utf-8")
+    monkeypatch.setattr(ev, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(ev, "fetch", lambda url: "<!-- eli5-core:begin -->\nupstream\n<!-- eli5-core:end -->\n")
+    manifest = {"source": {"raw_url": "https://example.invalid/x.md"}, "vendored": {"file": vendored.name}}
+    assert ev.cmd_upstream(manifest) == 1
+    assert "drifted" in capsys.readouterr().err
+
+
+def test_upstream_check_is_in_sync_when_cores_match(tmp_path: Path, monkeypatch):
+    vendored = tmp_path / "eli5.md"
+    body = "<!-- eli5-core:begin -->\nsame\n<!-- eli5-core:end -->\n"
+    vendored.write_text(body, encoding="utf-8")
+    monkeypatch.setattr(ev, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(ev, "fetch", lambda url: body)
+    manifest = {"source": {"raw_url": "https://example.invalid/x.md"}, "vendored": {"file": vendored.name}}
+    assert ev.cmd_upstream(manifest) == 0

--- a/tests/test_flow_start_resolve.py
+++ b/tests/test_flow_start_resolve.py
@@ -149,13 +149,14 @@ def test_script_exists_and_executable():
 @requires_git
 def test_fresh_lane_in_session_repo(tmp_path: Path):
     _, clone = _make_origin_and_clone(tmp_path)
-    res = _run("42", cwd=clone, gh=_fake_gh(tmp_path))
+    res = _run("42", "--session-cwd", str(clone), cwd=clone, gh=_fake_gh(tmp_path))
     assert res.returncode == 0, res.stderr
     assert "FLOW_START_RESOLVE: ok" in res.stdout
     c = _contract(res)
     assert c["LANE"] == "fresh"
     assert c["CROSS_REPO"] == "0"
     assert c["GIT_LANE"] == "0"
+    assert c["SESSION_CWD_INFERRED"] == "0"
     assert c["BRANCH"] == "issue-42-fix-the-frobnicator"
     assert c["WT_PATH"].endswith(".claude/worktrees/issue-42-fix-the-frobnicator")
     # The native lane creates nothing - EnterWorktree owns fresh creation.
@@ -215,6 +216,122 @@ def test_error_when_gh_unavailable(tmp_path: Path):
     assert "FLOW_START_RESOLVE: error" in res.stdout
 
 
+# --- resolve: session cwd is declared, not inferred (issue #592) -------------
+#
+# The regression these pin: in Claude Code the Bash tool's cwd persists across
+# calls and drifts on any earlier `cd`, while EnterWorktree always acts on the
+# session cwd, which never moves. Resolving from `.` therefore decided GIT_LANE
+# (and, with no PROJECT, TARGET_REPO itself) against whatever repo the last
+# `cd` landed in. Every test below runs the resolver with a process cwd
+# DELIBERATELY different from the declared session cwd.
+
+
+@requires_git
+def test_drifted_process_cwd_does_not_win_over_declared_session_cwd(tmp_path: Path):
+    """The #592 scenario verbatim: process cwd sits in the target repo while the
+    session cwd is elsewhere. GIT_LANE must stay 1 - EnterWorktree would act on
+    the session cwd, which is not this repo."""
+    _, clone = _make_origin_and_clone(tmp_path)
+    session = tmp_path / "session-elsewhere"
+    session.mkdir()
+    # cwd=clone is the drift; --session-cwd is the truth.
+    res = _run("42", str(clone), "--session-cwd", str(session), cwd=clone, gh=_fake_gh(tmp_path))
+    assert res.returncode == 0, res.stderr
+    c = _contract(res)
+    assert c["SESSION_CWD"] == str(session.resolve())
+    assert c["SESSION_CWD_INFERRED"] == "0"
+    assert c["CROSS_REPO"] == "1", "session cwd is not the target repo"
+    assert c["GIT_LANE"] == "1", "must not send EnterWorktree at a repo the session is not in"
+    assert c["LANE"] == "cross-repo"
+    assert c["WT_CREATED"] == "1"
+
+
+@requires_git
+def test_target_repo_comes_from_session_cwd_not_process_cwd(tmp_path: Path):
+    """Second facet: with no PROJECT arg, TARGET_REPO itself was resolved from
+    the drifted cwd - so a bare `/flow:start 42` could branch in a surprise
+    repository."""
+    _, session_repo = _make_origin_and_clone(tmp_path)
+    other = tmp_path / "other-origin"
+    other.mkdir()
+    _git(other, "init", "-q", "-b", "main")
+    (other / "b.txt").write_text("b\n")
+    _git(other, "add", "-A")
+    _git(other, "commit", "-q", "-m", "init")
+
+    res = _run("42", "--session-cwd", str(session_repo), cwd=other, gh=_fake_gh(tmp_path))
+    assert res.returncode == 0, res.stderr
+    c = _contract(res)
+    assert c["TARGET_REPO"] == str(session_repo.resolve()), "resolved the wrong repo"
+    assert c["CROSS_REPO"] == "0"
+    assert c["GIT_LANE"] == "0"
+
+
+@requires_git
+def test_session_cwd_env_var_is_honored(tmp_path: Path):
+    _, clone = _make_origin_and_clone(tmp_path)
+    session = tmp_path / "session-elsewhere"
+    session.mkdir()
+    res = _run(
+        "42",
+        str(clone),
+        cwd=clone,
+        gh=_fake_gh(tmp_path),
+        extra_env={"FLOW_SESSION_CWD": str(session)},
+    )
+    c = _contract(res)
+    assert c["SESSION_CWD_INFERRED"] == "0"
+    assert c["SESSION_CWD"] == str(session.resolve())
+    assert c["GIT_LANE"] == "1"
+
+
+@requires_git
+def test_inferred_session_cwd_fails_closed_to_git_lane(tmp_path: Path):
+    """No --session-cwd: the resolver must SAY so and pick the safe lane rather
+    than silently trusting a cwd it cannot vouch for."""
+    _, clone = _make_origin_and_clone(tmp_path)
+    res = _run("42", cwd=clone, gh=_fake_gh(tmp_path))
+    assert res.returncode == 0, res.stderr
+    c = _contract(res)
+    assert c["SESSION_CWD_INFERRED"] == "1"
+    assert c["CROSS_REPO"] == "0", "the process cwd IS this repo - only its provenance is unverified"
+    assert c["GIT_LANE"] == "1", "unverified session cwd never earns the native lane"
+    # Failing closed means the git lane must actually be usable: the helper
+    # creates the worktree itself, since EnterWorktree will not be called.
+    assert c["WT_CREATED"] == "1"
+    assert Path(c["WT_PATH"]).is_dir()
+
+
+@requires_git
+def test_session_cwd_must_be_a_directory(tmp_path: Path):
+    _, clone = _make_origin_and_clone(tmp_path)
+    res = _run("42", "--session-cwd", str(tmp_path / "nope"), cwd=clone, gh=_fake_gh(tmp_path))
+    assert res.returncode == 1
+    assert "FLOW_START_RESOLVE: error" in res.stdout
+    assert "not a directory" in res.stdout
+
+
+@requires_git
+def test_current_branch_lane_reads_the_session_cwd(tmp_path: Path):
+    """The current-branch lane asked `git branch --show-current` of the process
+    cwd; on a drifted cwd that reports another checkout's branch."""
+    _, clone = _make_origin_and_clone(tmp_path)
+    _git(clone, "switch", "-q", "-c", "issue-42-already-here")
+    drifted = tmp_path / "drifted"
+    drifted.mkdir()
+    _git(drifted, "init", "-q", "-b", "main")
+    (drifted / "c.txt").write_text("c\n")
+    _git(drifted, "add", "-A")
+    _git(drifted, "commit", "-q", "-m", "init")
+    _git(drifted, "switch", "-q", "-c", "issue-42-decoy-branch")
+
+    res = _run("42", "--session-cwd", str(clone), cwd=drifted, gh=_fake_gh(tmp_path))
+    c = _contract(res)
+    assert c["LANE"] == "current-branch"
+    assert c["BRANCH"] == "issue-42-already-here", "picked up the drifted checkout's branch"
+    assert c["WT_PATH"] == str(clone.resolve())
+
+
 # --- resolve: cross-repo lane (issue #578) -----------------------------------
 
 
@@ -223,7 +340,7 @@ def test_cross_repo_fresh_creates_worktree(tmp_path: Path):
     _, clone = _make_origin_and_clone(tmp_path)
     plain = tmp_path / "elsewhere"
     plain.mkdir()
-    res = _run("42", str(clone), cwd=plain, gh=_fake_gh(tmp_path))
+    res = _run("42", str(clone), "--session-cwd", str(plain), cwd=plain, gh=_fake_gh(tmp_path))
     assert res.returncode == 0, res.stderr
     c = _contract(res)
     assert c["LANE"] == "cross-repo"
@@ -350,6 +467,8 @@ def test_base_override_fresh_same_repo_rides_git_lane(tmp_path: Path):
     base = tmp_path / "wt-base"
     res = _run(
         "42",
+        "--session-cwd",
+        str(clone),
         cwd=clone,
         gh=_fake_gh(tmp_path),
         extra_env={"FLOW_WORKTREE_BASE": str(base)},
@@ -376,10 +495,11 @@ def test_resume_of_out_of_repo_worktree_forces_git_lane(tmp_path: Path):
     _git(clone, "worktree", "add", "-q", "-b", "issue-42-earlier-work", str(outside))
     # No FLOW_WORKTREE_BASE this run - the prior run's base-override worktree
     # still must not be entered via EnterWorktree(path=...).
-    res = _run("42", cwd=clone, gh=_fake_gh(tmp_path))
+    res = _run("42", "--session-cwd", str(clone), cwd=clone, gh=_fake_gh(tmp_path))
     c = _contract(res)
     assert c["LANE"] == "resume"
     assert c["GIT_LANE"] == "1"
+    assert c["SESSION_CWD_INFERRED"] == "0"
     assert c["WT_PATH"] == str(outside)
 
 


### PR DESCRIPTION
Two shipped guards that were never actually invoked. Compatible and disjoint in files, so landed together.

## #591 - the vendoring link had no automation

`scripts/eli5-core-drift.sh` existed and worked, but nothing ran it: no `.woodpecker.yml` step, no Makefile target, no test. Both halves are now wired, because **neither subsumes the other**:

| | offline | network |
|---|---|---|
| **hard gate** | `eli5-vendor-check` CI step / `make eli5-check` / `tests/test_eli5_vendor.py` - vendored core vs the sha256 pinned in `.claude/eli5-vendor.json`. Stdlib-only, no curl and no git, so it runs in the `uv:python3.11-slim` validate container (the recurring #451/#489 trap). Catches a local edit that bypassed re-vendoring. | - |
| **advisory** | - | `eli5-upstream-drift` CI step (`failure: ignore`) / `make eli5-drift` - live-fetches cooneycw/eli5-gate and diffs, fail-open. **This is the half that notices upstream moved** - a manifest pins what *was* vendored and structurally cannot. |

`make eli5-revendor` re-fetches the core, replaces it in place, and re-pins the manifest in one step. `scripts/eli5-core-drift.sh` is now a thin shim onto `--upstream`, so every existing reference (CLAUDE.md, CHANGELOG, eli5.md Notes, ADR 0001) resolves to one implementation.

**The check found real drift on its first run.** eli5-gate#3 - the Section A depth floor - had already landed upstream while CPP kept running the stale core, with nothing anywhere surfacing it. That is exactly the failure #591 predicted, observed live. Re-vendored to upstream `4e9431a`, so this PR also delivers the depth floor to every CPP and CxPP flow user.

## #592 - the resolver inferred the session repo from a drifting cwd

`flow-start-resolve.sh` decided `CROSS_REPO`/`GIT_LANE` - and, with no `PROJECT` arg, `TARGET_REPO` itself - by resolving the **process** cwd. That cwd persists across Bash calls and drifts on any earlier `cd`, while `EnterWorktree` always acts on the **session** cwd, which never moves.

- `--session-cwd <path>` / `FLOW_SESSION_CWD`; `auto.md` and `start.md` now pass the session's working directory verbatim.
- New contract keys `SESSION_CWD` and `SESSION_CWD_INFERRED`.
- **Fails closed:** an inferred session cwd never earns `GIT_LANE=0`. `GIT_LANE=1` is correct in every case, just less ergonomic; a wrong `GIT_LANE=0` points `EnterWorktree` at a directory that may not be a repo at all.
- The current-branch lane reads branch/toplevel via `-C "$SESSION_CWD"`.

**Reproduced live in this PR's own Step 1.** Running `/flow:auto 591 claude-power-pack` from session cwd `~/Projects` (not a git repo), an earlier `gh issue view` had left the Bash cwd inside the target repo, so the contract emitted `CROSS_REPO=0 / GIT_LANE=0` - an instruction to call `EnterWorktree` on `~/Projects`. Overridden by hand; the same invocation with `--session-cwd` returns `LANE=cross-repo / GIT_LANE=1`.

## Behavior change

A caller that does **not** pass `--session-cwd` now gets `GIT_LANE=1` where it previously got `0`. The git lane works in every case, so nothing breaks - but users on a stale installed flow plugin will see worktrees created by `git worktree add` rather than natively until they update. Deliberate, per the issue's stated safety asymmetry; documented in CLAUDE.md.

## Test plan

- `make lint` / `make typecheck` / `make test` - **965 passed**, ruff and mypy clean
- `python -m lib.cicd run --plan finish` - 3/3 SUCCESS (lint, test, security_scan)
- `tests/test_flow_start_resolve.py`: 19 -> 25 tests; the six new ones run the resolver with a process cwd deliberately different from the declared session cwd
- `tests/test_eli5_vendor.py`: 14 new tests, all offline (no network, git, or external binaries)
- `make eli5-check` and `make eli5-drift` both green against the re-vendored core
- `scripts/check-ignored-additions.sh` clean after adding a `.gitignore` negation for `.claude/eli5-vendor.json`, which the blanket `*.json` rule silently swallowed (#430 trap)

## Related

- #576 item 2 is subsumed by this PR; items 1 (`tool-risk-drift --strict`) and 3 (`worktree-guard --strict` promotion) remain open there.
- The manifest pattern is reusable for the other unguarded link in the chain, cooneycw/codex-power-pack#139.
- #578 is the ancestor of #592; #590 landed mid-run and was merged in.

Closes #591
Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKCFHPnVpwRMZMgAv8DMLd