### PR TITLE
fix(flow): run deploy verification through uv with PYTHONPATH at the lib parent (Closes #595)

### DIFF
--- a/.claude/commands/cicd/verify.md
+++ b/.claude/commands/cicd/verify.md
@@ -30,7 +30,19 @@ if [ -z "$CPP_DIR" ]; then
   echo "ERROR: claude-power-pack not found"
   exit 1
 fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: 'uv' not found - lib/cicd runs through it so its deps (pydantic)"
+  echo "resolve and the interpreter is pinned >= 3.11. Install uv, then re-run."
+  exit 1
+fi
 ```
+
+Every `lib.cicd` invocation below runs through `uv run --project "$CPP_DIR"`
+with `PYTHONPATH` pointed at `$CPP_DIR` - the **parent** of `lib/`, so
+`-m lib.cicd` resolves. Pointing it inside `lib/` instead, and running the
+system interpreter rather than uv, fails on both counts: that was the long-lived
+defect fixed in issue #595.
 
 ---
 
@@ -67,7 +79,7 @@ fi
 **Before deploying**, snapshot the currently-running system:
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline
 ```
 
 This runs every health check and smoke test once and writes the result to
@@ -84,7 +96,7 @@ baseline is the "before" picture the post-deploy run is compared against.
 **After `make deploy`**, re-run the probes and diff against the baseline:
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
 ```
 
 Add `--summary` for a one-line verdict, or `--json` for machine-readable output.

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -868,9 +868,19 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
     break
   fi
 done
+# Verification runs through `uv`, exactly as the Step 6 gate does (issue #595):
+# bare `python3 -m lib.cicd` uses the system interpreter (often 3.10, no venv),
+# so lib/cicd's deps (pydantic) are absent and the module dies on import. If
+# `uv` is missing, verification is skipped with a NOTE rather than attempted -
+# it is a fail-open confidence gate, and there is no Makefile fallback for it
+# the way `make lint` / `make test` back the Step 6 runner.
 VERIFY_ENABLED=0
 if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
-    VERIFY_ENABLED=1
+    if command -v uv >/dev/null 2>&1; then
+        VERIFY_ENABLED=1
+    else
+        echo "NOTE: deploy verification configured but 'uv' is not installed; skipping baseline + verdict." >&2
+    fi
 fi
 
 # Out-of-band deploy opt-out (issue #535): a repo whose real deploy path is a host
@@ -910,7 +920,9 @@ elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     # verify can detect regressions.
     if [ "$VERIFY_ENABLED" -eq 1 ]; then
         echo "Capturing pre-deploy baseline..."
-        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+        # PYTHONPATH points at CPP_DIR (the PARENT of lib/), not at lib/ itself,
+        # or `-m lib.cicd` cannot resolve the package - same contract as Step 6.
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline --summary
     fi
 
     echo "Running: make deploy"
@@ -921,7 +933,7 @@ elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     VERDICT="none"
     if [ "$VERIFY_ENABLED" -eq 1 ]; then
         echo "Running deploy verification..."
-        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
         VERIFY_EXIT=$?
         VERDICT=$( [ "$VERIFY_EXIT" -eq 1 ] && echo "rollback" || echo "proceed/review" )
         if [ "$VERIFY_EXIT" -eq 1 ]; then

--- a/.claude/commands/flow/deploy.md
+++ b/.claude/commands/flow/deploy.md
@@ -121,14 +121,22 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
 done
 
 if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
-    echo "Capturing pre-deploy baseline..."
-    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+    if command -v uv >/dev/null 2>&1; then
+        echo "Capturing pre-deploy baseline..."
+        # Invoke through uv, and point PYTHONPATH at CPP_DIR (the PARENT of
+        # lib/) - bare `python3 -m lib.cicd` with PYTHONPATH inside lib/ cannot
+        # resolve the package and has no pydantic (issue #595, same contract as
+        # the Step-6 quality-gate runner).
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline --summary
+    else
+        echo "NOTE: deploy verification configured but 'uv' is not installed; skipping baseline capture." >&2
+    fi
 fi
 ```
 
 - Captures health + smoke probes into `.claude/deploy-baseline.json`.
-- Fail-open: if `lib/cicd` is unavailable or no probes are configured, skip -
-  the deploy is never blocked by baseline capture.
+- Fail-open: if `lib/cicd` is unavailable, `uv` is missing, or no probes are
+  configured, skip - the deploy is never blocked by baseline capture.
 
 ### Step 4b: Run Deploy via Deterministic Runner (primary path)
 
@@ -263,9 +271,12 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
 
    ```bash
    echo "Running deploy verification..."
-   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+   PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
    VERIFY_EXIT=$?
    ```
+
+   Skips when `uv` is unavailable, exactly as the Step 4c baseline capture does
+   - with no baseline there is nothing to diff against anyway (issue #595).
 
    - `VERIFY_EXIT == 0` (PROCEED or REVIEW): keep the deployment. On REVIEW,
      surface the flagged probes to the user.
@@ -286,7 +297,7 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
    ```bash
    HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
    SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
-   VERDICT=$( PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
+   VERDICT=$( PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
    echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS} | verify:${VERDICT:-none}" >> .claude/deploy.log
    ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ mirrors the `/security` #438 and hooks #439 defer-the-commodity-half moves).
 - `python -m lib.cicd run --plan <name>` - Execute CI/CD plan deterministically (finish, check, deploy)
 - `python -m lib.cicd verify --baseline` - Capture pre-deploy health/smoke baseline
 - `python -m lib.cicd verify` - Verify post-deploy against baseline (exit 1 = ROLLBACK)
+  - Invocation contract for every `lib.cicd` call in a command doc: `PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd ...` - `PYTHONPATH` names the PARENT of `lib/` (or `-m lib.cicd` cannot resolve) and `uv` supplies the pinned 3.11+ interpreter plus pydantic. Bare `python3` with `PYTHONPATH` pointed inside `lib/` fails on both counts; it silently disabled deploy verification for months (#430 fixed Step 6, #595 fixed the Step 9 / `/flow:deploy` / `/cicd:verify` verify calls, pinned by `tests/test_cicd_verify_invocation.py`). The same broken shape still rides ~40 non-`verify` `lib.cicd` lines in the `cicd`/`cpp`/`codex`/`project` families - a known latent bug awaiting its own sweep, not a covered case
 - `python -m lib.cicd.bootstrap check` - Check admin-only bootstrap dependencies (config: `.claude/bootstrap.yaml`)
 
 ### Codex Orchestration

--- a/codex/skills/cicd-verify/reference.md
+++ b/codex/skills/cicd-verify/reference.md
@@ -27,7 +27,19 @@ if [ -z "$CPP_DIR" ]; then
   echo "ERROR: claude-power-pack not found"
   exit 1
 fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: 'uv' not found - lib/cicd runs through it so its deps (pydantic)"
+  echo "resolve and the interpreter is pinned >= 3.11. Install uv, then re-run."
+  exit 1
+fi
 ```
+
+Every `lib.cicd` invocation below runs through `uv run --project "$CPP_DIR"`
+with `PYTHONPATH` pointed at `$CPP_DIR` - the **parent** of `lib/`, so
+`-m lib.cicd` resolves. Pointing it inside `lib/` instead, and running the
+system interpreter rather than uv, fails on both counts: that was the long-lived
+defect fixed in issue #595.
 
 ---
 
@@ -64,7 +76,7 @@ fi
 **Before deploying**, snapshot the currently-running system:
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline
 ```
 
 This runs every health check and smoke test once and writes the result to
@@ -81,7 +93,7 @@ baseline is the "before" picture the post-deploy run is compared against.
 **After `make deploy`**, re-run the probes and diff against the baseline:
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
 ```
 
 Add `--summary` for a one-line verdict, or `--json` for machine-readable output.

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -870,9 +870,19 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
     break
   fi
 done
+# Verification runs through `uv`, exactly as the Step 6 gate does (issue #595):
+# bare `python3 -m lib.cicd` uses the system interpreter (often 3.10, no venv),
+# so lib/cicd's deps (pydantic) are absent and the module dies on import. If
+# `uv` is missing, verification is skipped with a NOTE rather than attempted -
+# it is a fail-open confidence gate, and there is no Makefile fallback for it
+# the way `make lint` / `make test` back the Step 6 runner.
 VERIFY_ENABLED=0
 if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
-    VERIFY_ENABLED=1
+    if command -v uv >/dev/null 2>&1; then
+        VERIFY_ENABLED=1
+    else
+        echo "NOTE: deploy verification configured but 'uv' is not installed; skipping baseline + verdict." >&2
+    fi
 fi
 
 # Out-of-band deploy opt-out (issue #535): a repo whose real deploy path is a host
@@ -912,7 +922,9 @@ elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     # verify can detect regressions.
     if [ "$VERIFY_ENABLED" -eq 1 ]; then
         echo "Capturing pre-deploy baseline..."
-        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+        # PYTHONPATH points at CPP_DIR (the PARENT of lib/), not at lib/ itself,
+        # or `-m lib.cicd` cannot resolve the package - same contract as Step 6.
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline --summary
     fi
 
     echo "Running: make deploy"
@@ -923,7 +935,7 @@ elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     VERDICT="none"
     if [ "$VERIFY_ENABLED" -eq 1 ]; then
         echo "Running deploy verification..."
-        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
         VERIFY_EXIT=$?
         VERDICT=$( [ "$VERIFY_EXIT" -eq 1 ] && echo "rollback" || echo "proceed/review" )
         if [ "$VERIFY_EXIT" -eq 1 ]; then

--- a/codex/skills/flow-deploy/reference.md
+++ b/codex/skills/flow-deploy/reference.md
@@ -123,14 +123,22 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
 done
 
 if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
-    echo "Capturing pre-deploy baseline..."
-    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+    if command -v uv >/dev/null 2>&1; then
+        echo "Capturing pre-deploy baseline..."
+        # Invoke through uv, and point PYTHONPATH at CPP_DIR (the PARENT of
+        # lib/) - bare `python3 -m lib.cicd` with PYTHONPATH inside lib/ cannot
+        # resolve the package and has no pydantic (issue #595, same contract as
+        # the Step-6 quality-gate runner).
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline --summary
+    else
+        echo "NOTE: deploy verification configured but 'uv' is not installed; skipping baseline capture." >&2
+    fi
 fi
 ```
 
 - Captures health + smoke probes into `.claude/deploy-baseline.json`.
-- Fail-open: if `lib/cicd` is unavailable or no probes are configured, skip -
-  the deploy is never blocked by baseline capture.
+- Fail-open: if `lib/cicd` is unavailable, `uv` is missing, or no probes are
+  configured, skip - the deploy is never blocked by baseline capture.
 
 ### Step 4b: Run Deploy via Deterministic Runner (primary path)
 
@@ -265,9 +273,12 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
 
    ```bash
    echo "Running deploy verification..."
-   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+   PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
    VERIFY_EXIT=$?
    ```
+
+   Skips when `uv` is unavailable, exactly as the Step 4c baseline capture does
+   - with no baseline there is nothing to diff against anyway (issue #595).
 
    - `VERIFY_EXIT == 0` (PROCEED or REVIEW): keep the deployment. On REVIEW,
      surface the flagged probes to the user.
@@ -288,7 +299,7 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
    ```bash
    HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
    SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
-   VERDICT=$( PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
+   VERDICT=$( PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
    echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS} | verify:${VERDICT:-none}" >> .claude/deploy.log
    ```
 

--- a/plugins/cicd/commands/verify.md
+++ b/plugins/cicd/commands/verify.md
@@ -30,7 +30,19 @@ if [ -z "$CPP_DIR" ]; then
   echo "ERROR: claude-power-pack not found"
   exit 1
 fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: 'uv' not found - lib/cicd runs through it so its deps (pydantic)"
+  echo "resolve and the interpreter is pinned >= 3.11. Install uv, then re-run."
+  exit 1
+fi
 ```
+
+Every `lib.cicd` invocation below runs through `uv run --project "$CPP_DIR"`
+with `PYTHONPATH` pointed at `$CPP_DIR` - the **parent** of `lib/`, so
+`-m lib.cicd` resolves. Pointing it inside `lib/` instead, and running the
+system interpreter rather than uv, fails on both counts: that was the long-lived
+defect fixed in issue #595.
 
 ---
 
@@ -67,7 +79,7 @@ fi
 **Before deploying**, snapshot the currently-running system:
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline
 ```
 
 This runs every health check and smoke test once and writes the result to
@@ -84,7 +96,7 @@ baseline is the "before" picture the post-deploy run is compared against.
 **After `make deploy`**, re-run the probes and diff against the baseline:
 
 ```bash
-PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
 ```
 
 Add `--summary` for a one-line verdict, or `--json` for machine-readable output.

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -868,9 +868,19 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
     break
   fi
 done
+# Verification runs through `uv`, exactly as the Step 6 gate does (issue #595):
+# bare `python3 -m lib.cicd` uses the system interpreter (often 3.10, no venv),
+# so lib/cicd's deps (pydantic) are absent and the module dies on import. If
+# `uv` is missing, verification is skipped with a NOTE rather than attempted -
+# it is a fail-open confidence gate, and there is no Makefile fallback for it
+# the way `make lint` / `make test` back the Step 6 runner.
 VERIFY_ENABLED=0
 if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
-    VERIFY_ENABLED=1
+    if command -v uv >/dev/null 2>&1; then
+        VERIFY_ENABLED=1
+    else
+        echo "NOTE: deploy verification configured but 'uv' is not installed; skipping baseline + verdict." >&2
+    fi
 fi
 
 # Out-of-band deploy opt-out (issue #535): a repo whose real deploy path is a host
@@ -910,7 +920,9 @@ elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     # verify can detect regressions.
     if [ "$VERIFY_ENABLED" -eq 1 ]; then
         echo "Capturing pre-deploy baseline..."
-        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+        # PYTHONPATH points at CPP_DIR (the PARENT of lib/), not at lib/ itself,
+        # or `-m lib.cicd` cannot resolve the package - same contract as Step 6.
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline --summary
     fi
 
     echo "Running: make deploy"
@@ -921,7 +933,7 @@ elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     VERDICT="none"
     if [ "$VERIFY_ENABLED" -eq 1 ]; then
         echo "Running deploy verification..."
-        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
         VERIFY_EXIT=$?
         VERDICT=$( [ "$VERIFY_EXIT" -eq 1 ] && echo "rollback" || echo "proceed/review" )
         if [ "$VERIFY_EXIT" -eq 1 ]; then

--- a/plugins/flow/commands/deploy.md
+++ b/plugins/flow/commands/deploy.md
@@ -121,14 +121,22 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
 done
 
 if [ -n "$CPP_DIR" ] && grep -q "deploy_verification:" .claude/cicd.yml 2>/dev/null; then
-    echo "Capturing pre-deploy baseline..."
-    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --baseline --summary
+    if command -v uv >/dev/null 2>&1; then
+        echo "Capturing pre-deploy baseline..."
+        # Invoke through uv, and point PYTHONPATH at CPP_DIR (the PARENT of
+        # lib/) - bare `python3 -m lib.cicd` with PYTHONPATH inside lib/ cannot
+        # resolve the package and has no pydantic (issue #595, same contract as
+        # the Step-6 quality-gate runner).
+        PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --baseline --summary
+    else
+        echo "NOTE: deploy verification configured but 'uv' is not installed; skipping baseline capture." >&2
+    fi
 fi
 ```
 
 - Captures health + smoke probes into `.claude/deploy-baseline.json`.
-- Fail-open: if `lib/cicd` is unavailable or no probes are configured, skip -
-  the deploy is never blocked by baseline capture.
+- Fail-open: if `lib/cicd` is unavailable, `uv` is missing, or no probes are
+  configured, skip - the deploy is never blocked by baseline capture.
 
 ### Step 4b: Run Deploy via Deterministic Runner (primary path)
 
@@ -263,9 +271,12 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
 
    ```bash
    echo "Running deploy verification..."
-   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify
+   PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify
    VERIFY_EXIT=$?
    ```
+
+   Skips when `uv` is unavailable, exactly as the Step 4c baseline capture does
+   - with no baseline there is nothing to diff against anyway (issue #595).
 
    - `VERIFY_EXIT == 0` (PROCEED or REVIEW): keep the deployment. On REVIEW,
      surface the flagged probes to the user.
@@ -286,7 +297,7 @@ If `CPP_DIR` is found and `.claude/cicd.yml` exists:
    ```bash
    HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
    SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
-   VERDICT=$( PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
+   VERDICT=$( PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify --summary 2>/dev/null | grep -oiE 'proceed|review|rollback' | head -1 | tr 'A-Z' 'a-z' )
    echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS} | verify:${VERDICT:-none}" >> .claude/deploy.log
    ```
 

--- a/tests/test_cicd_verify_invocation.py
+++ b/tests/test_cicd_verify_invocation.py
@@ -1,0 +1,109 @@
+"""Guard the documented ``lib.cicd verify`` invocation on every command surface (issue #595).
+
+``lib/cicd`` is a package inside the CPP checkout, not an installed
+distribution, so a documented invocation has exactly two ways to be wrong - and
+both shipped for months in the deploy-verification path:
+
+1. ``PYTHONPATH`` pointed INSIDE ``lib/`` instead of at its parent, so
+   ``-m lib.cicd`` cannot resolve the package at all.
+2. bare ``python3`` instead of ``uv run --project "$CPP_DIR"``, so the system
+   interpreter (often 3.10, no venv) runs it and ``pydantic`` is missing.
+
+Issue #430 fixed both in the ``/flow:auto`` Step 6 quality gate; Step 9's
+``verify`` calls - and their ``/flow:deploy`` and ``/cicd:verify`` siblings -
+were never updated alongside it. The failure prints to stderr mid-deploy and is
+easy to narrate past, so it was captured in the friction buffer twice, months
+apart, before anyone applied the recorded fix. This test is the gate that stops
+a third recurrence: the invocation contract is asserted, not remembered.
+
+SCOPE - deliberately narrow, and narrower than the defect. Only ``lib.cicd
+verify`` lines are checked, because that is the deploy-verification gate #595
+covers. The SAME broken ``PYTHONPATH="$CPP_DIR/lib"`` + bare-``python3`` shape
+still appears on ~40 other ``lib.cicd`` lines across the ``cicd``, ``cpp``,
+``codex`` and ``project`` command families (``detect``, ``check``, ``health``,
+``smoke``, ``pipeline``, ``infra-*``, ``run --plan``). Those are a real latent
+bug, not an oversight of this test - fixing them is a repo-wide sweep that
+belongs in its own issue. Widening the patterns below is the intended way to
+land that sweep.
+
+Offline and stdlib-only by design: this reads markdown and shells out to
+nothing. The Woodpecker ``validate`` container ships no git/docker/curl, and an
+unguarded shell-out turns CI red even when it passes locally (#451/#489).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The surfaces that document how to run lib/cicd. `.claude/commands/` is the
+# single source of truth; `plugins/` and `codex/skills/` are generated from it
+# and are included so a stale regenerated copy is caught too. CHANGELOG.md is
+# deliberately excluded - it quotes historical commands as a record of what
+# changed, and editing history to satisfy a lint is the wrong fix.
+SURFACES = (".claude/commands", "plugins", "codex/skills")
+
+# Only lines that actually invoke the verify subcommand (see SCOPE above).
+VERIFY_LINE = re.compile(r"-m lib\.cicd verify\b")
+BARE_PYTHON = re.compile(r"\bpython3\b")
+PYTHONPATH_INTO_LIB = re.compile(r'PYTHONPATH="\$CPP_DIR/lib')
+CORRECT_UV = re.compile(r'uv run --project "\$CPP_DIR" python -m lib\.cicd verify\b')
+
+
+def _markdown_files() -> list[Path]:
+    files: list[Path] = []
+    for surface in SURFACES:
+        base = ROOT / surface
+        if base.is_dir():
+            files.extend(sorted(base.rglob("*.md")))
+    return files
+
+
+def _verify_lines() -> list[tuple[str, str]]:
+    """Every (location, text) pair that invokes `-m lib.cicd verify`."""
+    found = []
+    for path in _markdown_files():
+        rel = path.relative_to(ROOT)
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if VERIFY_LINE.search(line):
+                found.append((f"{rel}:{lineno}", line.strip()))
+    return found
+
+
+VERIFY_LINES = _verify_lines()
+_IDS = [loc for loc, _ in VERIFY_LINES]
+
+
+def test_scan_found_verify_invocations():
+    """An empty sweep proves nothing - fail loudly if the surfaces moved."""
+    assert VERIFY_LINES, (
+        f"no `-m lib.cicd verify` lines found under {SURFACES} - either the command "
+        "surfaces moved or the pattern went stale; this guard would pass vacuously"
+    )
+
+
+@pytest.mark.parametrize(("location", "line"), VERIFY_LINES, ids=_IDS)
+def test_pythonpath_points_at_cpp_dir_not_lib(location: str, line: str):
+    """PYTHONPATH must be the PARENT of lib/, or `-m lib.cicd` cannot resolve."""
+    assert not PYTHONPATH_INTO_LIB.search(line), (
+        'PYTHONPATH must be "$CPP_DIR:$PYTHONPATH" (the parent of lib/), not '
+        f'"$CPP_DIR/lib" (issue #595):\n  {location}: {line}'
+    )
+
+
+@pytest.mark.parametrize(("location", "line"), VERIFY_LINES, ids=_IDS)
+def test_verify_runs_through_uv(location: str, line: str):
+    """`lib.cicd verify` must run through uv, not the bare system interpreter."""
+    assert not BARE_PYTHON.search(line), (
+        'run verify via `uv run --project "$CPP_DIR" python -m lib.cicd verify`, not '
+        f"bare python3 - the system interpreter has no pydantic (issue #595):\n  {location}: {line}"
+    )
+    assert CORRECT_UV.search(line), (
+        "expected the canonical invocation "
+        '`uv run --project "$CPP_DIR" python -m lib.cicd verify` (issue #595):\n  '
+        f"{location}: {line}"
+    )


### PR DESCRIPTION
## Summary

`/flow:auto` Step 9's deploy-verification calls used `PYTHONPATH="$CPP_DIR/lib" python3 -m lib.cicd verify`, which fails two ways at once: `PYTHONPATH` names `lib/` itself so `-m lib.cicd` cannot resolve the package, and the bare system interpreter (often 3.10, no venv) has no `pydantic`. Deploy verification therefore **never ran** - the flagship "one command to ship" path deployed with neither a pre-deploy baseline nor a post-deploy proceed/rollback verdict, printing a `ModuleNotFoundError` mid-deploy that is easy to narrate past.

Issue #430 fixed the identical defect in the Step 6 quality gate months ago; Step 9 was never updated alongside it.

## Changes

1. `.claude/commands/flow/auto.md` - Step 9's two `verify` calls now use the Step 6 contract: `PYTHONPATH="$CPP_DIR:$PYTHONPATH" uv run --project "$CPP_DIR" python -m lib.cicd verify`. `VERIFY_ENABLED` additionally requires `uv`, skipping with a NOTE when it is absent.
2. `.claude/commands/flow/deploy.md` - same three occurrences. Beyond the issue's checkboxes, but `/flow:deploy` is the standalone path with the identical defect.
3. `.claude/commands/cicd/verify.md` - same two occurrences, plus an explicit `uv` precondition. This is the doc users copy the command from, so it is the root of the propagation.
4. `tests/test_cicd_verify_invocation.py` (new) - asserts the invocation contract on every `lib.cicd verify` line across `.claude/commands/`, `plugins/`, and `codex/skills/`.
5. `CLAUDE.md` - records the invocation contract and the remaining out-of-scope surface.
6. Generated mirrors (`plugins/`, `codex/skills/`) re-synced via `scripts/plugin-sync.sh --write` + `scripts/codex-skill-sync.py --write` - not hand-edited.

## Why a test, not just a fix

The first friction capture of this bug **recorded the correct fix and it was never applied**, so a second run hit it verbatim months later. Memory was the failing control, so the contract is now asserted rather than remembered.

## Known scope limit

Deliberately narrower than the defect: ~40 non-`verify` `lib.cicd` lines in the `cicd`/`cpp`/`codex`/`project` families still carry the same broken `PYTHONPATH` + bare-`python3` shape. That repo-wide sweep belongs in its own issue; it is documented as out of scope in both the test docstring and CLAUDE.md rather than left implicit as "covered".

## Test plan

- [x] Reproduced both failure modes on this checkout (`ModuleNotFoundError: No module named 'pydantic'`) and confirmed the corrected invocation prints a verdict
- [x] **Mutation-verified** the new guard: reintroducing either defect fails it (2 failed, 41 passed); restored and green
- [x] `lib.cicd run --plan finish` on the post-merge tree: lint + 1055 tests + security gate all pass
- [x] `check-ignored-additions.sh` and `flow-worktree-guard.sh` clean

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)