### PR TITLE
docs(retro): never wrap read-only commands in 'cd X && ...' - it defeats the allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 - After any fix, verify through the full pipeline: `make verify`.
 - Use `/cpp:dockers` to check container status, health, and project linkages.
 - **Use single dashes (-) not em dashes (-)** in all markdown, comments, and documentation. Never generate Unicode em dashes (U+2014) or en dashes (U+2013).
+- **Never wrap a read-only command in `cd X && ...`.** Name the path instead of moving to it: `git -C <path> status`, an absolute path, or the tool's own path argument. A permission allow rule matches a command PREFIX, so `cd "$(git rev-parse --show-toplevel)" && grep -n foo bar.md` prompts even though `Bash(grep:*)` is allowlisted - the 2026-07-19 retro found EVERY safe-tier prompt in a 138-record census firing this way, with the matching rule already installed. This generalizes #581's bare-invocation discipline from the flow helpers to ordinary commands. The `cd` habit is a defense against the Bash tool's cwd drifting between calls, and that same drift caused the #590/#592 lane bugs and the #595 stale-grep trap - so prefer an explicit path there too, rather than trusting where the shell happens to be.
 - **One inventory item per line in CLAUDE.md.** When adding to an inventory entry (the `scripts/` list, component feature lists, CI behavior lists), add a new sub-bullet - never append to an existing line. Git merges at line granularity, so packed single-line lists make every concurrent PR that touches them a manual merge conflict (#501).
 
 ## Project Map

--- a/templates/claude-settings-permissions.md
+++ b/templates/claude-settings-permissions.md
@@ -61,6 +61,17 @@ installed at the stable `~/.claude/scripts/` path by `/cpp:init` /
   compound command and prompts. The flow docs (auto.md Steps 1/4/6/7,
   start.md) encode this invocation discipline; helpers print their own status
   markers so no wrapper is ever needed.
+- **The `cd X && <cmd>` habit defeats the whole allowlist.** The rule generalizes
+  past the helper family to ORDINARY read-only commands: `grep -n foo bar.md` is
+  auto-allowed, `cd "$(git rev-parse --show-toplevel)" && grep -n foo bar.md` is a
+  compound command and prompts. A 2026-07-19 retro found every safe-tier prompt in
+  a 138-record census - `pwd`, `grep`, `sed`, `git log`, `git worktree` - fired
+  this way, with the matching allow rule already present and simply unmatchable.
+  The habit exists because the Bash tool's cwd persists across calls and drifts,
+  so `cd` reads as defensive; the fix is to name the path instead of moving to it
+  (`git -C <path> ...`, an absolute path, or the tool's own path argument). Same
+  root cause as the cwd-drift lane bugs (#590, #592) and the stale-grep
+  verification trap (#595).
 
 ## Known caveat: `sed`
 


### PR DESCRIPTION
## Summary

Codified fix from the 2026-07-19 friction retro (`/self-improvement:retro` over a 138-record census drained after `/flow:auto` #577).

**Finding:** every safe-tier permission prompt in the census - `pwd`, `grep`, `sed`, `git log`, `git worktree`, `git rev-parse` - fired on a compound command:

```
Bash: cd "$(git rev-parse --show-toplevel)" && grep -n "VERIFY_ENABLED" .claude/commands/flow/auto.md
Bash: pwd && git status --short | head -3
```

All 11 derived allow rules were **already present** in `~/.claude/settings.json`. A permission rule matches a command *prefix*, so none of them could ever match. The rule set was fine; the invocation shape was not - so this PR codifies the shape rather than adding rules.

## Changes

- `CLAUDE.md` - new core directive: name the path (`git -C <path>`, an absolute path, the tool's own path argument) instead of moving to it.
- `templates/claude-settings-permissions.md` - the same point in the "Rules only match BARE invocations" section, with the census evidence.

This generalizes #581's bare-invocation discipline from the flow helper family to ordinary read-only commands.

## Why the `cd` habit exists

It is a defense against the Bash tool's cwd persisting and drifting between calls - the same drift behind the #590 / #592 lane bugs and the #595 stale-grep verification trap. The directive therefore points at explicit paths in those cases too, rather than trusting where the shell happens to be.

## Test plan

Documentation only - no code paths touched. Quality gates run in CI.

Also from this retro: #602 (gate the guarded-binary test rule - third recurrence), #603 (CPP cannot dogfood its own deploy-verification path), and #596 closed as fixed by #592 with evidence.