### PR TITLE
feat(flow): claim a worktree so concurrent sessions stop destroying each other's work (Closes #597)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -157,10 +157,20 @@ cwd, so `GIT_LANE` was forced to 1 - if you see this, you forgot to pass it),
 in-repo `.claude/worktrees/<branch>`), `DEFAULT_BRANCH`, `REMOTE_BRANCH`
 (pickup lane), `WT_CREATED` (1 = the helper already ran `git worktree add`),
 `LIVE_DRIVER` / `PR_HEAD` (the #503 resume hazards - the helper wraps its
-sibling `scripts/flow-live-driver-guard.sh`), `CONFIRM_REQUIRED`.
+sibling `scripts/flow-live-driver-guard.sh`), `CLAIM` / `CLAIM_PID` /
+`CLAIM_SESSION` (the #597 cross-session claim on issue-N, read BEFORE any
+worktree is created), `CONFIRM_REQUIRED`.
 
 **1b. Act on the contract** - the only decision left to you:
 
+- `CLAIM=held` (`CONFIRM_REQUIRED=1`): another LIVE session is driving this
+  issue right now (issue #597). **STOP.** Do not create or enter anything -
+  proceeding duplicates that session's work, and whichever run reaches Step 7
+  first deletes the other's worktree. Report the owner (`CLAIM_PID`,
+  `CLAIM_SESSION`) and let the user decide: wait for that session, pick a
+  different issue, or - only if they confirm the other session is genuinely
+  gone - take it over. `CLAIM=stale` (owner process no longer exists) is taken
+  over automatically and needs no confirmation.
 - `ISSUE_STATE` not `OPEN` (`CONFIRM_REQUIRED=1`): warn the user and ask
   whether to proceed. On yes, re-run the same resolve command with
   `--allow-closed` appended (the helper is idempotent) and continue with its
@@ -211,7 +221,15 @@ This enforces the moat every later step relies on: it fails
 (`FLOW_START_VERIFY: fail`, exit 1) when the checkout is still on main/master,
 and renames a non-conforming branch to the issue-anchored `issue-<N>-<slug>`
 name so downstream steps can parse the issue number. On success it prints the
-final `BRANCH=` and `WT_ROOT=`.
+final `BRANCH=`, `WT_ROOT=` and `CLAIM=`.
+
+The verify gate also STAKES this run's claim on the worktree (issue #597) - it
+is the only hook point that runs inside the checkout on every lane, since the
+native `EnterWorktree` lane creates it only after 1a has already returned. A
+`CLAIM=self` line means the worktree is locked to this session and a sibling
+run's cleanup will refuse to remove it. Claiming is advisory: `unsupported` or
+`unknown` (git too old, or the current-branch lane, where the primary checkout
+cannot be locked) is normal and never blocks the run.
 
 **If this verification fails, STOP immediately. Report the failure using the error template at the bottom of this file. Do NOT proceed to Step 2.**
 
@@ -307,6 +325,28 @@ Report: `Step 3/9: ELI5 complete - verdict: {Still needed|Partially addressed|No
 ---
 
 ### Step 4: Implement - Write the Code
+
+**Re-check for a second driver (issue #597) - run BEFORE the first edit.** The
+#503 live-driver guard fires once, in Step 1. Everything between Step 1 and here
+- analysis, the ELI5 gate, the approval pause - is wall-clock time in which
+another session can enter this checkout, and one did: on `flow:auto #13` a
+concurrent session wrote a file into this worktree between the Step-1 clear
+verdict and the Step-4 merge, which then aborted on their dirty tree. A guard
+that runs only at Step 1 cannot see that. Re-run it bare, against the worktree
+(#581 invocation discipline; advisory, fail-open):
+
+```bash
+~/.claude/scripts/flow-live-driver-guard.sh
+```
+
+- `FLOW_LIVE_DRIVER: clear` - proceed.
+- `FLOW_LIVE_DRIVER: suspected` - dirty files here were modified in the last
+  30m and you have not written anything yet, so they are NOT yours. **STOP** and
+  ask the user before editing: another session is mid-implementation in this
+  checkout. Editing now means two drivers fighting over one tree.
+- Confirm the claim is still ours if anything looks off:
+  `~/.claude/scripts/flow-worktree-claim.sh check .` - `FLOW_CLAIM: self` is the
+  healthy answer; `held` means someone took the checkout over.
 
 **Early stale-base check (issue #473) - run BEFORE editing.** A sibling PR that
 merges during implementation moves `origin/main` under you; discovering it only
@@ -672,6 +712,20 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 
 4. **Clean up worktree and branch:**
 
+   **Release this run's claim FIRST (issue #597), whichever path follows.** The
+   claim is a real `git worktree lock`, and git refuses to remove a locked
+   worktree - including via the native tool, which does not know about the
+   claim. Drop it before removing, bare (#581 discipline; fail-open, never
+   blocks):
+
+   ```bash
+   ~/.claude/scripts/flow-worktree-claim.sh release /path/to/worktree
+   ```
+
+   It only releases a claim owned by THIS session (or an abandoned one); a
+   sibling's live claim is left intact and reported, which is the signal that
+   you are about to remove the wrong checkout.
+
    **If Step 1 created the worktree this session via `EnterWorktree(name=...)`**
    (the fresh-start path), remove it natively - a single tool call that deletes the
    worktree and its branch and restores the session to the main repo, with no
@@ -703,6 +757,16 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    ```bash
    ~/.claude/scripts/worktree-remove.sh /path/to/worktree --force --delete-branch
    ```
+   The helper checks the #597 claim before removing and **exits 4** when the
+   worktree is claimed by another LIVE session, printing the owner. That is a
+   correct refusal, not a flow failure: it means the path you were about to
+   delete belongs to a run that is still working in it (the failure that
+   destroyed uncommitted work on `flow:auto #5`). Do NOT retry with `--steal` -
+   report it and stop, so the user can decide. Almost always it means Step 1
+   resumed someone else's checkout; the claim caught it late but correctly.
+   A claim owned by THIS session, or left by a dead one, is released
+   automatically and the removal proceeds normally.
+
    If the helper is not installed (exit 127), fall back to:
    ```bash
    git worktree remove "$WORKTREE_PATH" --force
@@ -899,7 +963,23 @@ fi
 # fixed prod container_name values and leaks orphaned volumes/networks.
 DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
 
-if [ "$DEPLOY_MODE" = "external" ]; then
+# Deploy idempotence (issue #597): with several sessions merging to the same
+# main, a sibling run can have deployed THIS exact sha minutes ago - on
+# flow:auto #49 the deploy.log showed the same sha 2 minutes earlier and the
+# duplicate deploy was skipped only because the model happened to notice. Make
+# it a guard: a successful deploy of the current HEAD already on record means
+# there is nothing to do. Only an exit-0 record counts, so a failed deploy is
+# still retried. Fail-open - no log, no skip.
+HEAD_SHA=$(git rev-parse --short HEAD)
+ALREADY_DEPLOYED=0
+if [ -f .claude/deploy.log ] && awk -F'|' -v sha="$HEAD_SHA" '$2 ~ /deploy/ && $3 ~ ("^[[:space:]]*" sha "[[:space:]]*$") && $5 ~ /^[[:space:]]*0[[:space:]]*$/ { found = 1 } END { exit !found }' .claude/deploy.log; then
+    ALREADY_DEPLOYED=1
+fi
+
+if [ "$ALREADY_DEPLOYED" -eq 1 ]; then
+    echo "Deploy skipped: $HEAD_SHA is already recorded as successfully deployed in .claude/deploy.log"
+    echo "(issue #597 - a concurrent session deployed this same commit; re-running would be a duplicate deploy)."
+elif [ "$DEPLOY_MODE" = "external" ]; then
     echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main). Skipping inline 'make deploy'."
 elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     # Compose-project safety (issue #535): when COMPOSE_PROJECT_NAME is unset,
@@ -963,7 +1043,8 @@ fi
   never rolls back automatically - it is an actionable signal, not an action.
 
 Report: `Step 9/9: Deploy complete (verify: {proceed|review|rollback|none})` or
-`Step 9/9: Deploy skipped (no Makefile target)`
+`Step 9/9: Deploy skipped (no Makefile target)` or
+`Step 9/9: Deploy skipped ({sha} already deployed by a concurrent session)`
 
 ---
 

--- a/.claude/commands/flow/cleanup.md
+++ b/.claude/commands/flow/cleanup.md
@@ -47,6 +47,13 @@ git -C "$MAIN_REPO" worktree prune
 
 Report what was pruned (or "No stale worktree references found").
 
+Note: `git worktree prune` deliberately skips a LOCKED entry, so a worktree
+still carrying a live `/flow` claim (issue #597) is never pruned even if its
+directory is gone. That is the intended asymmetry - a claim outranks cleanup.
+Inspect one with `~/.claude/scripts/flow-worktree-claim.sh check --issue <N>`;
+a claim whose owning process is gone reports `stale` and is released by the
+next run that needs the worktree.
+
 ### Step 3: Find and Delete Merged Local Branches
 
 Delete local `issue-*` branches that have been merged to main. Protect `main`, `master`, and any branch with an active worktree.

--- a/.claude/commands/flow/doctor.md
+++ b/.claude/commands/flow/doctor.md
@@ -151,7 +151,7 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
   if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then CPP_DIR="$dir"; break; fi
 done
 
-for script in flow-start-resolve.sh flow-stale-check.sh flow-worktree-guard.sh flow-live-driver-guard.sh gh-pr-merge.sh; do
+for script in flow-start-resolve.sh flow-stale-check.sh flow-worktree-guard.sh flow-live-driver-guard.sh flow-worktree-claim.sh gh-pr-merge.sh; do
   if [ -x "$HOME/.claude/scripts/$script" ]; then
     echo "PASS $script (flow helper)"
   elif [ -f "$HOME/.claude/scripts/$script" ]; then
@@ -333,7 +333,7 @@ Output a single diagnostic report in this format:
 | prompt-context.sh | ✅/❌ | Shell prompt context |
 | worktree-remove.sh | ✅/⚠️ | Optional fallback (native ExitWorktree is primary) |
 | secrets-mask.sh | ✅/❌ | Output masking filter |
-| Flow helper family | ✅/⚠️/❌ | flow-start-resolve, flow-stale-check, flow-worktree-guard, flow-live-driver-guard, gh-pr-merge at ~/.claude/scripts/ (zero-prompt lane, #581). ❌ when missing with no CPP checkout to fall back to (#590) |
+| Flow helper family | ✅/⚠️/❌ | flow-start-resolve, flow-stale-check, flow-worktree-guard, flow-live-driver-guard, flow-worktree-claim, gh-pr-merge at ~/.claude/scripts/ (zero-prompt lane, #581). ❌ when missing with no CPP checkout to fall back to (#590) |
 | Helper freshness | ✅/⚠️ | `flow-helpers-install.sh --check`: ok / stale (plugin upgraded, installed copies behind) |
 | Flow allowlist | ✅/⚠️/❌ | 38/38 rules in ~/.claude/settings.json / N missing / settings.json missing |
 

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -11,6 +11,20 @@ cross-session cleanup therefore stays on `git worktree remove` /
 same session with `EnterWorktree(name=...)`, prefer the native
 `ExitWorktree(action="remove", discard_changes=true)` instead of Steps 5a-5c.
 
+**Release the #597 claim before ANY removal path.** A `/flow` run stakes a real
+`git worktree lock` on its checkout, and git refuses to remove a locked worktree
+- including via the native tool, which knows nothing about the claim. Run this
+bare first (fail-open; it releases only a claim owned by this session or an
+abandoned one):
+
+```bash
+~/.claude/scripts/flow-worktree-claim.sh release /path/to/worktree
+```
+
+`worktree-remove.sh` does this itself, and **exits 4** rather than removing a
+worktree another LIVE session claims - a correct refusal, not a failure. Report
+it and stop instead of reaching for `--steal`.
+
 ## Instructions
 
 When the user invokes `/flow:merge`, perform these steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ Core components and their locations:
   - tool-risk-drift - shared permission-risk taxonomy guard (#495, wired in #576): checks that the safety-critical `DESTRUCTIVE_TOKENS` and `CODE_EXEC` sets are identical between the canonical `scripts/classify-tool-risk.py` and the copy vendored inline in `scripts/hook-permission-census.sh`, so a command one classifier calls dangerous can never be emitted as an allow-rule candidate by the other. Advisory by default; `--strict` exits 1 on drift and is a HARD gate (`make tool-risk-check`, the `tool-risk-drift` step in `.woodpecker.yml`, pinned by `tests/test_tool_risk_drift.py`). Non-safety sets (task-runner, dual-use-net) may differ benignly and are deliberately not guarded
   - flow-start-resolve - deterministic `/flow` Step-1 resolver + `--verify` gate (#581): target-repo resolution (#578), issue fetch + state check, issue-anchored branch derivation, existing-work triage (`current-branch|fresh|resume|remote-pickup|cross-repo`), wraps the #503 live-driver guard + shipped-PR hazard, performs git-lane worktree creation (honoring `FLOW_WORKTREE_BASE`, #584), and emits a `key=value` contract - extracts the compound Step-1 bash the permission matcher could never auto-allow
   - flow-start-resolve `--session-cwd` - the session cwd is DECLARED, not inferred (#592): the Bash tool's cwd persists across calls and drifts on any earlier `cd`, while `EnterWorktree` acts on the session cwd, which never moves - so `CROSS_REPO`/`GIT_LANE` (and, with no PROJECT arg, `TARGET_REPO` itself) are resolved from the path `auto.md`/`start.md` pass verbatim. Omitting it emits `SESSION_CWD_INFERRED=1` and fails closed to `GIT_LANE=1`, since the git lane is correct in every case while a wrong `GIT_LANE=0` points `EnterWorktree` at the wrong repo - or at none
-  - flow-live-driver-guard - advisory concurrent-session guard (#503): warns when a worktree's dirty files were modified within the freshness window, the signature of another live session mid-implementation; wrapped by flow-start-resolve on the resume lane
+  - flow-live-driver-guard - advisory concurrent-session guard (#503): warns when a worktree's dirty files were modified within the freshness window, the signature of another live session mid-implementation; wrapped by flow-start-resolve on the resume lane, and re-run at `/flow:auto` Step 4 before the first edit (#597) because a single Step-1 check goes stale across the analysis + ELI5 pause
+  - flow-worktree-claim - cross-session OWNERSHIP claim on a flow worktree (#597), the half #503 could not cover: the live-driver guard protects a session ENTERING a worktree, but nothing protected an active worktree from being REMOVED by a sibling session, whose Step-7 cleanup deleted an issue-N checkout by name and destroyed uncommitted work with no signal but the user noticing. Rides git's own `git worktree lock --reason "flow-claim issue=N pid=... session=... host=... ts=..."`, so the claim is a real barrier (`git worktree remove --force` refuses a locked worktree) rather than an advisory note, and is readable from `git worktree list --porcelain`. `claim`/`check`/`release` verbs; ownership is pid + session, liveness is `kill -0` trusted only when the recorded host matches, and a claim whose owner is gone is STALE and auto-taken-over so the mechanism can never wedge a repo. A lock this family did not write is FOREIGN and never stolen. Staked in `flow-start-resolve.sh --verify` - the only hook point running INSIDE the worktree on every lane, since the native EnterWorktree lane creates the checkout after resolve mode returns - and read by resolve mode via `check --issue N` BEFORE any worktree is created, so two sessions handed the same issue stop instead of racing. Fail-open everywhere except the case it exists for: claiming against a live owner exits 1
+  - worktree-remove `--steal` + claim owner check (#597) - refuses with exit 4 to remove a worktree claimed by another LIVE session (printing the owning pid/session), releases a self-owned or stale claim and proceeds otherwise, and takes `--steal` as the deliberate override. One change covers `/flow:auto` Step 7, `/flow:merge` and `/flow:cleanup`, since all three route removal through this script
   - hooks
   - drift-detect
   - mcp-drift
@@ -154,6 +156,27 @@ overlapping dirt whose main-side mtime predates the run's freshness window
 is someone else's uncommitted work on a shared file, not a leak from this run.
 A total leak (idle worktree + fresh main edits) is caught by the same freshness
 rule (#573).
+
+**Concurrent flow sessions (issue #597):** CPP encourages parallel `/flow`
+sessions, and nothing used to stop two of them from operating on one repo - or
+one worktree. Four failures were captured in a single friction buffer, the worst
+of them silent: a sibling session's Step-7 cleanup removed a live session's
+worktree by name, destroying uncommitted work. A run now stakes a **claim** on
+its checkout (`scripts/flow-worktree-claim.sh`, a real `git worktree lock`)
+during the Step-1 verify gate, and three guards read it: Step 1 refuses to start
+on an issue another LIVE session holds (`CLAIM=held` -> `CONFIRM_REQUIRED=1`),
+`worktree-remove.sh` refuses (exit 4) to delete a worktree claimed by a live
+sibling, and Step 4 re-runs the #503 live-driver guard immediately before the
+first edit, since the Step-1 check goes stale across the analysis and approval
+pause. Separately, Step 9 skips `make deploy` when `.claude/deploy.log` already
+records a SUCCESSFUL deploy of the current HEAD sha, so a commit a concurrent
+session just shipped is not deployed twice. Ownership is pid + session with
+host-scoped `kill -0` liveness; an owner that is gone reads as `stale` and is
+taken over automatically, so a claim can never permanently wedge a repo, and
+`--steal` is the documented break-glass. Repeated stale-base churn (the fourth
+captured failure - `origin/main` moving several times mid-run) is NOT addressed
+here: it needs serialized merges, not an ownership claim, and the #473
+stale-check plus the #462 Step-7 guard remain its only mitigations.
 
 **Standalone skill extractions (issue #443):** skills with standalone value are
 extracted to their own public plugin repos so users never have to clone CPP -

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -159,10 +159,20 @@ cwd, so `GIT_LANE` was forced to 1 - if you see this, you forgot to pass it),
 in-repo `.claude/worktrees/<branch>`), `DEFAULT_BRANCH`, `REMOTE_BRANCH`
 (pickup lane), `WT_CREATED` (1 = the helper already ran `git worktree add`),
 `LIVE_DRIVER` / `PR_HEAD` (the #503 resume hazards - the helper wraps its
-sibling `scripts/flow-live-driver-guard.sh`), `CONFIRM_REQUIRED`.
+sibling `scripts/flow-live-driver-guard.sh`), `CLAIM` / `CLAIM_PID` /
+`CLAIM_SESSION` (the #597 cross-session claim on issue-N, read BEFORE any
+worktree is created), `CONFIRM_REQUIRED`.
 
 **1b. Act on the contract** - the only decision left to you:
 
+- `CLAIM=held` (`CONFIRM_REQUIRED=1`): another LIVE session is driving this
+  issue right now (issue #597). **STOP.** Do not create or enter anything -
+  proceeding duplicates that session's work, and whichever run reaches Step 7
+  first deletes the other's worktree. Report the owner (`CLAIM_PID`,
+  `CLAIM_SESSION`) and let the user decide: wait for that session, pick a
+  different issue, or - only if they confirm the other session is genuinely
+  gone - take it over. `CLAIM=stale` (owner process no longer exists) is taken
+  over automatically and needs no confirmation.
 - `ISSUE_STATE` not `OPEN` (`CONFIRM_REQUIRED=1`): warn the user and ask
   whether to proceed. On yes, re-run the same resolve command with
   `--allow-closed` appended (the helper is idempotent) and continue with its
@@ -213,7 +223,15 @@ This enforces the moat every later step relies on: it fails
 (`FLOW_START_VERIFY: fail`, exit 1) when the checkout is still on main/master,
 and renames a non-conforming branch to the issue-anchored `issue-<N>-<slug>`
 name so downstream steps can parse the issue number. On success it prints the
-final `BRANCH=` and `WT_ROOT=`.
+final `BRANCH=`, `WT_ROOT=` and `CLAIM=`.
+
+The verify gate also STAKES this run's claim on the worktree (issue #597) - it
+is the only hook point that runs inside the checkout on every lane, since the
+native `EnterWorktree` lane creates it only after 1a has already returned. A
+`CLAIM=self` line means the worktree is locked to this session and a sibling
+run's cleanup will refuse to remove it. Claiming is advisory: `unsupported` or
+`unknown` (git too old, or the current-branch lane, where the primary checkout
+cannot be locked) is normal and never blocks the run.
 
 **If this verification fails, STOP immediately. Report the failure using the error template at the bottom of this file. Do NOT proceed to Step 2.**
 
@@ -309,6 +327,28 @@ Report: `Step 3/9: ELI5 complete - verdict: {Still needed|Partially addressed|No
 ---
 
 ### Step 4: Implement - Write the Code
+
+**Re-check for a second driver (issue #597) - run BEFORE the first edit.** The
+#503 live-driver guard fires once, in Step 1. Everything between Step 1 and here
+- analysis, the ELI5 gate, the approval pause - is wall-clock time in which
+another session can enter this checkout, and one did: on `flow:auto #13` a
+concurrent session wrote a file into this worktree between the Step-1 clear
+verdict and the Step-4 merge, which then aborted on their dirty tree. A guard
+that runs only at Step 1 cannot see that. Re-run it bare, against the worktree
+(#581 invocation discipline; advisory, fail-open):
+
+```bash
+~/.claude/scripts/flow-live-driver-guard.sh
+```
+
+- `FLOW_LIVE_DRIVER: clear` - proceed.
+- `FLOW_LIVE_DRIVER: suspected` - dirty files here were modified in the last
+  30m and you have not written anything yet, so they are NOT yours. **STOP** and
+  ask the user before editing: another session is mid-implementation in this
+  checkout. Editing now means two drivers fighting over one tree.
+- Confirm the claim is still ours if anything looks off:
+  `~/.claude/scripts/flow-worktree-claim.sh check .` - `FLOW_CLAIM: self` is the
+  healthy answer; `held` means someone took the checkout over.
 
 **Early stale-base check (issue #473) - run BEFORE editing.** A sibling PR that
 merges during implementation moves `origin/main` under you; discovering it only
@@ -674,6 +714,20 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 
 4. **Clean up worktree and branch:**
 
+   **Release this run's claim FIRST (issue #597), whichever path follows.** The
+   claim is a real `git worktree lock`, and git refuses to remove a locked
+   worktree - including via the native tool, which does not know about the
+   claim. Drop it before removing, bare (#581 discipline; fail-open, never
+   blocks):
+
+   ```bash
+   ~/.claude/scripts/flow-worktree-claim.sh release /path/to/worktree
+   ```
+
+   It only releases a claim owned by THIS session (or an abandoned one); a
+   sibling's live claim is left intact and reported, which is the signal that
+   you are about to remove the wrong checkout.
+
    **If Step 1 created the worktree this session via `EnterWorktree(name=...)`**
    (the fresh-start path), remove it natively - a single tool call that deletes the
    worktree and its branch and restores the session to the main repo, with no
@@ -705,6 +759,16 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    ```bash
    ~/.claude/scripts/worktree-remove.sh /path/to/worktree --force --delete-branch
    ```
+   The helper checks the #597 claim before removing and **exits 4** when the
+   worktree is claimed by another LIVE session, printing the owner. That is a
+   correct refusal, not a flow failure: it means the path you were about to
+   delete belongs to a run that is still working in it (the failure that
+   destroyed uncommitted work on `flow:auto #5`). Do NOT retry with `--steal` -
+   report it and stop, so the user can decide. Almost always it means Step 1
+   resumed someone else's checkout; the claim caught it late but correctly.
+   A claim owned by THIS session, or left by a dead one, is released
+   automatically and the removal proceeds normally.
+
    If the helper is not installed (exit 127), fall back to:
    ```bash
    git worktree remove "$WORKTREE_PATH" --force
@@ -901,7 +965,23 @@ fi
 # fixed prod container_name values and leaks orphaned volumes/networks.
 DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
 
-if [ "$DEPLOY_MODE" = "external" ]; then
+# Deploy idempotence (issue #597): with several sessions merging to the same
+# main, a sibling run can have deployed THIS exact sha minutes ago - on
+# flow:auto #49 the deploy.log showed the same sha 2 minutes earlier and the
+# duplicate deploy was skipped only because the model happened to notice. Make
+# it a guard: a successful deploy of the current HEAD already on record means
+# there is nothing to do. Only an exit-0 record counts, so a failed deploy is
+# still retried. Fail-open - no log, no skip.
+HEAD_SHA=$(git rev-parse --short HEAD)
+ALREADY_DEPLOYED=0
+if [ -f .claude/deploy.log ] && awk -F'|' -v sha="$HEAD_SHA" '$2 ~ /deploy/ && $3 ~ ("^[[:space:]]*" sha "[[:space:]]*$") && $5 ~ /^[[:space:]]*0[[:space:]]*$/ { found = 1 } END { exit !found }' .claude/deploy.log; then
+    ALREADY_DEPLOYED=1
+fi
+
+if [ "$ALREADY_DEPLOYED" -eq 1 ]; then
+    echo "Deploy skipped: $HEAD_SHA is already recorded as successfully deployed in .claude/deploy.log"
+    echo "(issue #597 - a concurrent session deployed this same commit; re-running would be a duplicate deploy)."
+elif [ "$DEPLOY_MODE" = "external" ]; then
     echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main). Skipping inline 'make deploy'."
 elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     # Compose-project safety (issue #535): when COMPOSE_PROJECT_NAME is unset,
@@ -965,7 +1045,8 @@ fi
   never rolls back automatically - it is an actionable signal, not an action.
 
 Report: `Step 9/9: Deploy complete (verify: {proceed|review|rollback|none})` or
-`Step 9/9: Deploy skipped (no Makefile target)`
+`Step 9/9: Deploy skipped (no Makefile target)` or
+`Step 9/9: Deploy skipped ({sha} already deployed by a concurrent session)`
 
 ---
 

--- a/codex/skills/flow-auto/scripts/flow-start-resolve.sh
+++ b/codex/skills/flow-auto/scripts/flow-start-resolve.sh
@@ -64,10 +64,17 @@
 #     REMOTE_BRANCH=origin/<...>       (remote-pickup lane only)
 #     WT_CREATED=0|1        1 = this run already ran `git worktree add`
 #     LIVE_DRIVER=clear|suspected|unknown|skipped  (#503 guard, resume lane)
+#     CLAIM=none|free|self|held|stale|foreign|unsupported|unknown
+#                           cross-session ownership of issue-N (issue #597),
+#                           read before any worktree is created. `held` = another
+#                           LIVE session is driving this issue right now
+#     CLAIM_PID=<pid|->     owning process id when CLAIM names an owner
+#     CLAIM_SESSION=<id|->  owning Claude session id
 #     PR_HEAD=none|<number>:<state>|unknown        (resume shipped-PR hazard)
 #     CONFIRM_REQUIRED=0|1  1 = STOP: explicit user confirmation needed
-#                           (suspected live driver, existing open/merged PR,
-#                           or non-OPEN issue without --allow-closed)
+#                           (suspected live driver, a live cross-session claim
+#                           on this issue, existing open/merged PR, or non-OPEN
+#                           issue without --allow-closed)
 #     FLOW_START_RESOLVE: ok
 #   On a hard error: ERROR=<reason> then `FLOW_START_RESOLVE: error`, exit 1.
 #
@@ -77,7 +84,12 @@
 #   Fails (FLOW_START_VERIFY: fail, exit 1) when the checkout is still on
 #   main/master or detached; renames a non-issue-anchored branch to
 #   EXPECTED_BRANCH so downstream steps can parse the issue number. On success
-#   prints BRANCH= and WT_ROOT= then `FLOW_START_VERIFY: ok`.
+#   prints BRANCH=, WT_ROOT= and CLAIM= then `FLOW_START_VERIFY: ok`.
+#
+#   Verify mode also STAKES the cross-session claim (issue #597) - it is the one
+#   hook point that runs inside the worktree on every lane, since the native
+#   EnterWorktree lane creates the checkout only after resolve mode has already
+#   returned. Claiming is advisory here and never fails the gate.
 #
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
@@ -100,6 +112,13 @@ fail() {
 }
 
 usage_fail() { echo "flow-start-resolve: $1" >&2; exit 2; }
+
+# Path to a sibling helper script (installed alongside this one).
+sibling() {
+  local self_dir
+  self_dir=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+  echo "$self_dir/$1"
+}
 
 # Given any checkout path, print the PRIMARY checkout's toplevel (a linked
 # worktree resolves to the main repo that owns it).
@@ -194,8 +213,27 @@ if [ "$MODE" = verify ]; then
       CURRENT="$EXPECTED_BRANCH"
       ;;
   esac
+  WT_ROOT=$("$GIT" rev-parse --show-toplevel)
+
+  # Stake the cross-session claim (issue #597). This is the only hook point that
+  # runs INSIDE the worktree on every lane: the native lane's worktree does not
+  # exist yet when resolve mode returns, so resolve cannot claim it. Advisory by
+  # design - the gate's job is to prove we are on the right branch, and a claim
+  # that cannot be taken must never turn a healthy Step 1 into a hard stop.
+  CLAIM=unknown
+  CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+  if [ -f "$CLAIM_HELPER" ]; then
+    claim_out=$(bash "$CLAIM_HELPER" claim "$WT_ROOT" --issue "$ISSUE_NUM" 2>&1) || true
+    CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM=${CLAIM:-unknown}
+    if [ "$CLAIM" = held ]; then
+      printf '%s\n' "$claim_out" | grep -v '^FLOW_CLAIM' >&2 || true
+    fi
+  fi
+
   echo "BRANCH=$CURRENT"
-  echo "WT_ROOT=$("$GIT" rev-parse --show-toplevel)"
+  echo "WT_ROOT=$WT_ROOT"
+  echo "CLAIM=$CLAIM"
   echo "FLOW_START_VERIFY: ok"
   exit 0
 fi
@@ -289,6 +327,33 @@ SLUG=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9
 SLUG=$(printf '%s' "$SLUG" | sed 's/-$//')
 [ -n "$SLUG" ] || SLUG=work
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+
+# ---- cross-session claim check (issue #597) ---------------------------------
+# Before triaging existing work, ask whether ANOTHER live session already holds
+# issue-N. Two sessions handed the same issue used to race silently: both
+# implemented it, and whichever cleaned up first deleted the other's worktree.
+# Run this BEFORE any worktree is created, so a fresh lane cannot find its own
+# brand-new checkout and report itself as the owner.
+CLAIM=none
+CLAIM_PID=-
+CLAIM_SESSION=-
+CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+if [ -f "$CLAIM_HELPER" ]; then
+  claim_out=$(bash "$CLAIM_HELPER" check --issue "$ISSUE_NUM" --repo "$TARGET_REPO" 2>/dev/null) || true
+  CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+  CLAIM=${CLAIM:-none}
+  CLAIM_PID=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+  CLAIM_SESSION=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+  CLAIM_PID=${CLAIM_PID:--}
+  CLAIM_SESSION=${CLAIM_SESSION:--}
+  if [ "$CLAIM" = held ]; then
+    CONFIRM_REQUIRED=1
+    echo "flow-start-resolve: issue #$ISSUE_NUM is CLAIMED by another live session (pid $CLAIM_PID, session $CLAIM_SESSION)." >&2
+    echo "  That session is working this issue right now. Proceeding would duplicate its work, and" >&2
+    echo "  whichever run cleans up first deletes the other's worktree (issue #597)." >&2
+    echo "  STOP and confirm with the user before continuing." >&2
+  fi
+fi
 
 # ---- remote sync + default branch -------------------------------------------
 if ! "$GIT" -C "$TARGET_REPO" fetch origin --quiet 2>/dev/null; then
@@ -431,6 +496,9 @@ if [ -n "$REMOTE_BRANCH" ]; then
 fi
 echo "WT_CREATED=$WT_CREATED"
 echo "LIVE_DRIVER=$LIVE_DRIVER"
+echo "CLAIM=$CLAIM"
+echo "CLAIM_PID=$CLAIM_PID"
+echo "CLAIM_SESSION=$CLAIM_SESSION"
 echo "PR_HEAD=$PR_HEAD"
 echo "CONFIRM_REQUIRED=$CONFIRM_REQUIRED"
 echo "FLOW_START_RESOLVE: ok"

--- a/codex/skills/flow-auto/scripts/flow-worktree-claim.sh
+++ b/codex/skills/flow-auto/scripts/flow-worktree-claim.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# flow-worktree-claim.sh - Cross-session ownership claim on a flow worktree
+# (issue #597).
+#
+# Motivation: nothing stopped two concurrent /flow sessions from operating on
+# the same repo, or the same worktree. The #503 live-driver guard protects
+# RESUMING into an active worktree; it does not protect an active worktree from
+# being REMOVED by someone else, and it has no notion of an owner, so it cannot
+# tell "another session is driving this" from "someone left files dirty". The
+# observed cost was silent data loss: a sibling session's Step-7 cleanup removed
+# a live session's worktree by name, destroying uncommitted work.
+#
+# This helper makes ownership explicit and machine-checkable by riding git's own
+# worktree lock. `git worktree lock --reason <text>` already makes
+# `git worktree remove --force` refuse (it demands `-f -f`), so a claim is a
+# real barrier rather than an advisory note, and the reason text is readable
+# from `git worktree list --porcelain`. The reason we write is a single line:
+#
+#   flow-claim issue=<N> pid=<PID> session=<SID> host=<HOST> ts=<EPOCH>
+#
+# Liveness: the owning session is alive when `kill -0 <pid>` succeeds AND the
+# recorded host matches this one (a pid from another machine says nothing about
+# a pid here). A claim whose owner is gone is STALE and may be taken over, so
+# the mechanism can never permanently wedge a repo. A lock this script did not
+# write (no `flow-claim` prefix) is FOREIGN and is never stolen - someone locked
+# that worktree deliberately.
+#
+# It is FAIL-OPEN by design: anything it cannot determine (not a worktree, git
+# too old, lock unsupported on the primary checkout) reports and exits 0 rather
+# than blocking a flow run. The one non-zero exit is the case it exists for -
+# `claim` losing to a LIVE foreign owner.
+#
+# Usage:
+#   flow-worktree-claim.sh claim   <WORKTREE_PATH> --issue <N> [--steal]
+#   flow-worktree-claim.sh check   <WORKTREE_PATH>
+#   flow-worktree-claim.sh check   --issue <N> [--repo <PATH>]
+#   flow-worktree-claim.sh release <WORKTREE_PATH> [--force]
+#
+#   claim    Acquire the claim. Re-claiming a self-owned worktree refreshes the
+#            timestamp (idempotent). A STALE claim is taken over automatically.
+#            A LIVE foreign claim exits 1 unless --steal is passed.
+#   check    Report the claim state without changing it. Always exits 0 unless
+#            --exit-code is passed, which returns 1 for a held claim.
+#   release  Drop a self-owned (or stale) claim. A foreign live claim is left
+#            alone unless --force. Never fails the caller.
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_CLAIM: free | self | held | stale | foreign | unsupported | unknown
+# preceded by owner detail lines (FLOW_CLAIM_OWNER_PID=, ..._SESSION=, ..._HOST=,
+# ..._TS=, ..._AGE_MIN=, FLOW_CLAIM_PATH=), each '-' when not applicable.
+#
+# Env:
+#   CLAUDE_PID              owning process id (Claude Code sets it); falls back
+#                           to $PPID
+#   CLAUDE_CODE_SESSION_ID  owning session id; falls back to '-'
+#   FLOW_CLAIM_MAX_AGE_HOURS  a claim from ANOTHER host older than this is
+#                           treated as stale (default 24) - cross-host liveness
+#                           cannot be probed, so age is the only safety valve
+# Env (test hooks - unset in normal use):
+#   FLOW_CLAIM_GIT          override the `git` binary
+#   FLOW_CLAIM_NOW          override "now" as epoch seconds
+#   FLOW_CLAIM_HOST         override this host's name
+#   FLOW_CLAIM_LIVE_PIDS    ':'-separated pids to treat as alive (bypasses
+#                           kill -0, so a test can simulate a live sibling)
+
+set -uo pipefail
+
+GIT="${FLOW_CLAIM_GIT:-git}"
+MAX_AGE_HOURS="${FLOW_CLAIM_MAX_AGE_HOURS:-24}"
+SELF_PID="${CLAUDE_PID:-$PPID}"
+SELF_SESSION="${CLAUDE_CODE_SESSION_ID:-}"
+SELF_HOST="${FLOW_CLAIM_HOST:-${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}}"
+NOW="${FLOW_CLAIM_NOW:-$(date +%s)}"
+
+CLAIM_PREFIX="flow-claim"
+
+usage_fail() { echo "flow-worktree-claim: $1" >&2; exit 2; }
+
+# Emit the owner detail block + verdict. All args default to '-'.
+emit() {
+  echo "FLOW_CLAIM_PATH=${O_PATH:--}"
+  echo "FLOW_CLAIM_OWNER_PID=${O_PID:--}"
+  echo "FLOW_CLAIM_OWNER_SESSION=${O_SESSION:--}"
+  echo "FLOW_CLAIM_OWNER_HOST=${O_HOST:--}"
+  echo "FLOW_CLAIM_TS=${O_TS:--}"
+  echo "FLOW_CLAIM_AGE_MIN=${O_AGE_MIN:--}"
+  echo "FLOW_CLAIM_ISSUE=${O_ISSUE:--}"
+  echo "FLOW_CLAIM: $1"
+}
+
+# Absolute, symlink-resolved path (git's porcelain prints resolved paths, so
+# both sides of the comparison must be normalized the same way).
+abspath() {
+  if [ -d "$1" ]; then (cd "$1" 2>/dev/null && pwd -P); else echo "$1"; fi
+}
+
+# is_alive PID HOST -> 0 when the owning session is still running here.
+is_alive() {
+  local pid="$1" host="$2"
+  [ -n "$pid" ] && [ "$pid" != "-" ] || return 1
+  # A pid only means something on the machine that recorded it.
+  [ "$host" = "$SELF_HOST" ] || return 1
+  if [ -n "${FLOW_CLAIM_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_CLAIM_LIVE_PIDS:" in
+      *":$pid:"*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Parse a claim reason string into the O_* globals. Returns 1 when the reason
+# is not one of ours (a foreign lock).
+O_PATH=""; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+parse_reason() {
+  local reason="$1" field
+  case "$reason" in
+    "$CLAIM_PREFIX "*) : ;;
+    *) return 1 ;;
+  esac
+  for field in $reason; do
+    case "$field" in
+      issue=*) O_ISSUE="${field#issue=}" ;;
+      pid=*) O_PID="${field#pid=}" ;;
+      session=*) O_SESSION="${field#session=}" ;;
+      host=*) O_HOST="${field#host=}" ;;
+      ts=*) O_TS="${field#ts=}" ;;
+    esac
+  done
+  if [ -n "$O_TS" ] && printf '%s' "$O_TS" | grep -qE '^[0-9]+$'; then
+    local age=$((NOW - O_TS))
+    [ "$age" -lt 0 ] && age=0
+    O_AGE_MIN=$((age / 60))
+  fi
+  return 0
+}
+
+# lock_reason_for PATH - print the lock reason for a worktree ('' when
+# unlocked). Locked-with-no-reason prints the sentinel '(no reason)'.
+lock_reason_for() {
+  local want cur="" locked_line=""
+  want="$(abspath "$1")"
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="$(abspath "${line#worktree }")"; locked_line="" ;;
+      "locked "*)
+        [ "$cur" = "$want" ] && { printf '%s' "${line#locked }"; return 0; }
+        ;;
+      "locked")
+        [ "$cur" = "$want" ] && { printf '%s' "(no reason)"; return 0; }
+        ;;
+    esac
+  done < <("$GIT" -C "$want" worktree list --porcelain 2>/dev/null)
+  return 0
+}
+
+# Classify the current state of WORKTREE_PATH, setting the O_* owner globals
+# and STATE. Deliberately NOT a value-returning function: the owner detail has
+# to survive into emit(), and command substitution would run this in a subshell
+# and discard every assignment.
+classify() {
+  local path="$1" reason
+  O_PATH="$path"; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+
+  if [ ! -d "$path" ]; then STATE=unknown; return 0; fi
+  if ! "$GIT" -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    STATE=unknown; return 0
+  fi
+  # The primary checkout cannot be locked by git at all; a run on the
+  # current-branch lane therefore has no claim to make.
+  if [ ! -f "$path/.git" ]; then STATE=unsupported; return 0; fi
+
+  reason="$(lock_reason_for "$path")"
+  if [ -z "$reason" ]; then STATE=free; return 0; fi
+  if ! parse_reason "$reason"; then STATE=foreign; return 0; fi
+
+  if [ -n "$SELF_SESSION" ] && [ "$O_SESSION" = "$SELF_SESSION" ]; then
+    STATE=self; return 0
+  fi
+  if [ "$O_HOST" = "$SELF_HOST" ] && [ "$O_PID" = "$SELF_PID" ]; then
+    STATE=self; return 0
+  fi
+  if is_alive "$O_PID" "$O_HOST"; then STATE=held; return 0; fi
+  # Not provably alive. Same host + dead pid is decisively stale; a claim from
+  # another host is only stale once it has aged out.
+  if [ "$O_HOST" = "$SELF_HOST" ]; then STATE=stale; return 0; fi
+  if [ -n "$O_AGE_MIN" ] && [ "$O_AGE_MIN" -gt $((MAX_AGE_HOURS * 60)) ]; then
+    STATE=stale; return 0
+  fi
+  STATE=held
+}
+
+# ---- argument parsing -------------------------------------------------------
+VERB="${1:-}"
+[ -n "$VERB" ] || usage_fail "usage: flow-worktree-claim.sh claim|check|release <WORKTREE_PATH> [options]"
+shift
+
+case "$VERB" in
+  claim | check | release) : ;;
+  --help | -h)
+    sed -n '2,70p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *) usage_fail "unknown verb: $VERB (expected claim, check or release)" ;;
+esac
+
+WT=""
+ISSUE_NUM=""
+REPO=""
+STEAL=0
+FORCE=0
+WANT_EXIT_CODE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue)
+      [ "$#" -ge 2 ] || usage_fail "--issue requires a number"
+      ISSUE_NUM="$2"; shift
+      ;;
+    --issue=*) ISSUE_NUM="${1#--issue=}" ;;
+    --repo)
+      [ "$#" -ge 2 ] || usage_fail "--repo requires a path"
+      REPO="$2"; shift
+      ;;
+    --repo=*) REPO="${1#--repo=}" ;;
+    --steal) STEAL=1 ;;
+    --force) FORCE=1 ;;
+    --exit-code) WANT_EXIT_CODE=1 ;;
+    --*) usage_fail "unknown option: $1" ;;
+    *)
+      [ -z "$WT" ] || usage_fail "unexpected argument: $1"
+      WT="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$ISSUE_NUM" ]; then
+  printf '%s' "$ISSUE_NUM" | grep -qE '^[0-9]+$' ||
+    usage_fail "--issue must be a number, got: $ISSUE_NUM"
+fi
+
+# `check --issue N` resolves the worktree by branch, so a session can ask
+# "does anyone hold issue N?" before it has a path of its own (issue #597,
+# the cross-session claim check).
+if [ -z "$WT" ] && [ -n "$ISSUE_NUM" ] && [ "$VERB" = check ]; then
+  REPO="${REPO:-.}"
+  cur=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="${line#worktree }" ;;
+      "branch refs/heads/issue-${ISSUE_NUM}-"*) WT="$cur" ;;
+    esac
+  done < <("$GIT" -C "$REPO" worktree list --porcelain 2>/dev/null)
+  if [ -z "$WT" ]; then
+    O_PATH="-"
+    emit free
+    exit 0
+  fi
+fi
+
+[ -n "$WT" ] || usage_fail "$VERB requires a worktree path"
+WT="$(abspath "$WT")"
+
+STATE=unknown
+classify "$WT"
+
+case "$VERB" in
+  check)
+    emit "$STATE"
+    if [ "$WANT_EXIT_CODE" -eq 1 ] && [ "$STATE" = held ]; then exit 1; fi
+    exit 0
+    ;;
+
+  release)
+    case "$STATE" in
+      self | stale)
+        if "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1; then
+          echo "flow-worktree-claim: released claim on '$WT'." >&2
+        fi
+        O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+        emit free
+        ;;
+      held | foreign)
+        if [ "$FORCE" -eq 1 ]; then
+          "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+          echo "flow-worktree-claim: FORCE-released a $STATE claim on '$WT' (owner pid ${O_PID:--})." >&2
+          emit free
+        else
+          echo "flow-worktree-claim: '$WT' is claimed by another session (pid ${O_PID:--}, session ${O_SESSION:--}) - not releasing. Pass --force to override." >&2
+          emit "$STATE"
+        fi
+        ;;
+      *) emit "$STATE" ;;
+    esac
+    exit 0
+    ;;
+
+  claim)
+    [ -n "$ISSUE_NUM" ] || usage_fail "claim requires --issue <N>"
+    case "$STATE" in
+      held)
+        if [ "$STEAL" -eq 0 ]; then
+          echo "flow-worktree-claim: '$WT' is CLAIMED by a live session (pid ${O_PID:--}, session ${O_SESSION:--}, host ${O_HOST:--}, ~${O_AGE_MIN:-?}m ago)." >&2
+          echo "  Another /flow run is driving this worktree right now (issue #597). Working here would race it:" >&2
+          echo "  its cleanup can delete this checkout, and yours can delete theirs." >&2
+          echo "  Either wait for that session to finish, or - if you are certain it is gone - re-run with --steal." >&2
+          emit held
+          exit 1
+        fi
+        echo "flow-worktree-claim: stealing a live claim on '$WT' (--steal; previous owner pid ${O_PID:--})." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      foreign)
+        # Someone locked this worktree for their own reasons. Never steal it,
+        # but do not fail the run either - report and move on (fail-open).
+        echo "flow-worktree-claim: '$WT' carries a non-flow lock; leaving it untouched and claiming nothing." >&2
+        emit foreign
+        exit 0
+        ;;
+      stale)
+        echo "flow-worktree-claim: taking over a stale claim on '$WT' (owner pid ${O_PID:--} is gone)." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      self)
+        # Idempotent refresh: drop our own lock so the new timestamp lands.
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      unsupported | unknown)
+        echo "flow-worktree-claim: '$WT' cannot hold a claim ($STATE) - continuing unclaimed (advisory)." >&2
+        emit "$STATE"
+        exit 0
+        ;;
+    esac
+
+    REASON="$CLAIM_PREFIX issue=$ISSUE_NUM pid=$SELF_PID session=${SELF_SESSION:--} host=$SELF_HOST ts=$NOW"
+    if ! "$GIT" -C "$WT" worktree lock --reason "$REASON" "$WT" >/dev/null 2>&1; then
+      echo "flow-worktree-claim: could not lock '$WT' (git too old, or lock unsupported) - continuing unclaimed (advisory)." >&2
+      O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+      emit unsupported
+      exit 0
+    fi
+    O_PID="$SELF_PID"; O_SESSION="${SELF_SESSION:--}"; O_HOST="$SELF_HOST"
+    O_TS="$NOW"; O_AGE_MIN=0; O_ISSUE="$ISSUE_NUM"
+    echo "flow-worktree-claim: claimed '$WT' for issue #$ISSUE_NUM (pid $SELF_PID)." >&2
+    emit self
+    exit 0
+    ;;
+esac

--- a/codex/skills/flow-auto/scripts/plugin-sync.sh
+++ b/codex/skills/flow-auto/scripts/plugin-sync.sh
@@ -65,7 +65,7 @@ declare -A EXTRA_FILES=(
     # allowlist rules match - by /flow:repair (flow-helpers-install.sh, itself
     # bundled so a plugin-only user can run it). flow-start-resolve.sh resolves
     # flow-live-driver-guard.sh via $SELF_DIR, so the two must travel together.
-    [flow]="scripts/flow-start-resolve.sh scripts/flow-live-driver-guard.sh scripts/flow-stale-check.sh scripts/flow-worktree-guard.sh scripts/gh-pr-merge.sh scripts/worktree-remove.sh scripts/friction-log.sh scripts/check-ignored-additions.sh scripts/flow-helpers-install.sh"
+    [flow]="scripts/flow-start-resolve.sh scripts/flow-live-driver-guard.sh scripts/flow-worktree-claim.sh scripts/flow-stale-check.sh scripts/flow-worktree-guard.sh scripts/gh-pr-merge.sh scripts/worktree-remove.sh scripts/friction-log.sh scripts/check-ignored-additions.sh scripts/flow-helpers-install.sh"
     # /cpp:load-best-practices reads this doc; a plugin-only install has no CPP
     # checkout, so the plugin bundles it (resolved via ${CLAUDE_PLUGIN_ROOT}).
     [cpp]="docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md"

--- a/codex/skills/flow-auto/scripts/worktree-remove.sh
+++ b/codex/skills/flow-auto/scripts/worktree-remove.sh
@@ -5,12 +5,19 @@
 # changes to the main repository first (determined from the worktree's
 # .git file) to prevent breaking your shell session.
 #
+# A worktree CLAIMED by another live /flow session (issue #597) is never
+# removed: the claim is checked first and a live foreign owner is a hard stop
+# (exit 4), because removing it is exactly the silent-data-loss failure that
+# motivated the claim. A self-owned or stale claim is released and removed as
+# usual, and --steal is the deliberate override.
+#
 # Usage:
-#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch] [--steal]
 #
 # Options:
 #   --force          Remove even if worktree has uncommitted changes
 #   --delete-branch  Also delete the associated branch after removal
+#   --steal          Remove even when another live session claims it (#597)
 #
 # Examples:
 #   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
@@ -30,6 +37,7 @@ NC='\033[0m' # No Color
 WORKTREE_PATH=""
 FORCE=""
 DELETE_BRANCH=false
+STEAL=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delete-branch)
             DELETE_BRANCH=true
+            shift
+            ;;
+        --steal)
+            STEAL=true
             shift
             ;;
         -h|--help)
@@ -52,6 +64,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
             echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo "  --steal          Remove even when another live /flow session claims it"
+            echo "                   (issue #597; without it a live claim is a hard stop)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -158,6 +172,53 @@ fi
 
 # Get the branch name before removing
 BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Cross-session claim check (issue #597) ----------------------------------
+# Another LIVE /flow session may be driving this checkout right now. Removing it
+# out from under that session is the silent-data-loss failure this guard exists
+# for, so a live foreign claim is a hard stop. A claim owned by THIS session, or
+# left behind by a session that has since died, is simply released first.
+#
+# Fail-open in both directions: a missing helper, an unreadable lock, or a git
+# too old to report one leaves the previous behavior exactly as it was.
+SELF_SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")"
+CLAIM_HELPER=""
+for cand in "$SELF_SCRIPT_DIR/flow-worktree-claim.sh" "$HOME/.claude/scripts/flow-worktree-claim.sh"; do
+    if [[ -f "$cand" ]]; then
+        CLAIM_HELPER="$cand"
+        break
+    fi
+done
+
+if [[ -n "$CLAIM_HELPER" ]]; then
+    CLAIM_OUT=$(bash "$CLAIM_HELPER" check "$WORKTREE_PATH" 2>/dev/null || true)
+    CLAIM_STATE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM_PID=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+    CLAIM_SESSION=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+    CLAIM_ISSUE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_ISSUE=//p' | tail -1)
+
+    case "${CLAIM_STATE:-unknown}" in
+        held | foreign)
+            if [[ "$STEAL" != true ]]; then
+                echo -e "${RED}Error: refusing to remove a worktree claimed by another session${NC}" >&2
+                echo "" >&2
+                echo "  Worktree: $WORKTREE_PATH" >&2
+                echo "  Claim:    ${CLAIM_STATE} (issue #${CLAIM_ISSUE:--}, pid ${CLAIM_PID:--}, session ${CLAIM_SESSION:--})" >&2
+                echo "" >&2
+                echo "  Another /flow session is driving this checkout. Removing it would destroy" >&2
+                echo "  its uncommitted work - the failure this claim exists to prevent (issue #597)." >&2
+                echo "  Wait for that session to finish, or pass --steal if you are certain it is gone." >&2
+                exit 4
+            fi
+            echo -e "${YELLOW}Warning: --steal given; removing a worktree claimed by pid ${CLAIM_PID:--}.${NC}" >&2
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" --force >/dev/null 2>&1 || true
+            ;;
+        self | stale)
+            # Ours, or abandoned - drop the lock so the removal below can proceed.
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" >/dev/null 2>&1 || true
+            ;;
+    esac
+fi
 
 # Check for uncommitted changes (unless --force)
 if [[ -z "$FORCE" ]]; then

--- a/codex/skills/flow-cleanup/SKILL.md
+++ b/codex/skills/flow-cleanup/SKILL.md
@@ -9,6 +9,7 @@ description: "Clean up stale worktree references and merged branches"
 Generated from a Claude Code command. Where the procedure references these Claude-only surfaces, adapt as follows:
 
 - Native worktrees (`EnterWorktree`/`ExitWorktree` tool calls, `.claude/worktrees/` paths): use plain git instead - `git worktree add <path> -b <branch>`, work inside it, then `git worktree remove <path>` when done.
+- Helper scripts referenced as `scripts/<name>` are bundled under `scripts/` in this skill directory (byte-identical copies from the claude-power-pack checkout); some expect sibling repo resources, so prefer a full checkout when one is available.
 
 # Flow: Cleanup - Prune Stale Worktrees and Branches
 

--- a/codex/skills/flow-cleanup/reference.md
+++ b/codex/skills/flow-cleanup/reference.md
@@ -44,6 +44,13 @@ git -C "$MAIN_REPO" worktree prune
 
 Report what was pruned (or "No stale worktree references found").
 
+Note: `git worktree prune` deliberately skips a LOCKED entry, so a worktree
+still carrying a live `/flow` claim (issue #597) is never pruned even if its
+directory is gone. That is the intended asymmetry - a claim outranks cleanup.
+Inspect one with `~/.claude/scripts/flow-worktree-claim.sh check --issue <N>`;
+a claim whose owning process is gone reports `stale` and is released by the
+next run that needs the worktree.
+
 ### Step 3: Find and Delete Merged Local Branches
 
 Delete local `issue-*` branches that have been merged to main. Protect `main`, `master`, and any branch with an active worktree.

--- a/codex/skills/flow-cleanup/scripts/flow-worktree-claim.sh
+++ b/codex/skills/flow-cleanup/scripts/flow-worktree-claim.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# flow-worktree-claim.sh - Cross-session ownership claim on a flow worktree
+# (issue #597).
+#
+# Motivation: nothing stopped two concurrent /flow sessions from operating on
+# the same repo, or the same worktree. The #503 live-driver guard protects
+# RESUMING into an active worktree; it does not protect an active worktree from
+# being REMOVED by someone else, and it has no notion of an owner, so it cannot
+# tell "another session is driving this" from "someone left files dirty". The
+# observed cost was silent data loss: a sibling session's Step-7 cleanup removed
+# a live session's worktree by name, destroying uncommitted work.
+#
+# This helper makes ownership explicit and machine-checkable by riding git's own
+# worktree lock. `git worktree lock --reason <text>` already makes
+# `git worktree remove --force` refuse (it demands `-f -f`), so a claim is a
+# real barrier rather than an advisory note, and the reason text is readable
+# from `git worktree list --porcelain`. The reason we write is a single line:
+#
+#   flow-claim issue=<N> pid=<PID> session=<SID> host=<HOST> ts=<EPOCH>
+#
+# Liveness: the owning session is alive when `kill -0 <pid>` succeeds AND the
+# recorded host matches this one (a pid from another machine says nothing about
+# a pid here). A claim whose owner is gone is STALE and may be taken over, so
+# the mechanism can never permanently wedge a repo. A lock this script did not
+# write (no `flow-claim` prefix) is FOREIGN and is never stolen - someone locked
+# that worktree deliberately.
+#
+# It is FAIL-OPEN by design: anything it cannot determine (not a worktree, git
+# too old, lock unsupported on the primary checkout) reports and exits 0 rather
+# than blocking a flow run. The one non-zero exit is the case it exists for -
+# `claim` losing to a LIVE foreign owner.
+#
+# Usage:
+#   flow-worktree-claim.sh claim   <WORKTREE_PATH> --issue <N> [--steal]
+#   flow-worktree-claim.sh check   <WORKTREE_PATH>
+#   flow-worktree-claim.sh check   --issue <N> [--repo <PATH>]
+#   flow-worktree-claim.sh release <WORKTREE_PATH> [--force]
+#
+#   claim    Acquire the claim. Re-claiming a self-owned worktree refreshes the
+#            timestamp (idempotent). A STALE claim is taken over automatically.
+#            A LIVE foreign claim exits 1 unless --steal is passed.
+#   check    Report the claim state without changing it. Always exits 0 unless
+#            --exit-code is passed, which returns 1 for a held claim.
+#   release  Drop a self-owned (or stale) claim. A foreign live claim is left
+#            alone unless --force. Never fails the caller.
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_CLAIM: free | self | held | stale | foreign | unsupported | unknown
+# preceded by owner detail lines (FLOW_CLAIM_OWNER_PID=, ..._SESSION=, ..._HOST=,
+# ..._TS=, ..._AGE_MIN=, FLOW_CLAIM_PATH=), each '-' when not applicable.
+#
+# Env:
+#   CLAUDE_PID              owning process id (Claude Code sets it); falls back
+#                           to $PPID
+#   CLAUDE_CODE_SESSION_ID  owning session id; falls back to '-'
+#   FLOW_CLAIM_MAX_AGE_HOURS  a claim from ANOTHER host older than this is
+#                           treated as stale (default 24) - cross-host liveness
+#                           cannot be probed, so age is the only safety valve
+# Env (test hooks - unset in normal use):
+#   FLOW_CLAIM_GIT          override the `git` binary
+#   FLOW_CLAIM_NOW          override "now" as epoch seconds
+#   FLOW_CLAIM_HOST         override this host's name
+#   FLOW_CLAIM_LIVE_PIDS    ':'-separated pids to treat as alive (bypasses
+#                           kill -0, so a test can simulate a live sibling)
+
+set -uo pipefail
+
+GIT="${FLOW_CLAIM_GIT:-git}"
+MAX_AGE_HOURS="${FLOW_CLAIM_MAX_AGE_HOURS:-24}"
+SELF_PID="${CLAUDE_PID:-$PPID}"
+SELF_SESSION="${CLAUDE_CODE_SESSION_ID:-}"
+SELF_HOST="${FLOW_CLAIM_HOST:-${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}}"
+NOW="${FLOW_CLAIM_NOW:-$(date +%s)}"
+
+CLAIM_PREFIX="flow-claim"
+
+usage_fail() { echo "flow-worktree-claim: $1" >&2; exit 2; }
+
+# Emit the owner detail block + verdict. All args default to '-'.
+emit() {
+  echo "FLOW_CLAIM_PATH=${O_PATH:--}"
+  echo "FLOW_CLAIM_OWNER_PID=${O_PID:--}"
+  echo "FLOW_CLAIM_OWNER_SESSION=${O_SESSION:--}"
+  echo "FLOW_CLAIM_OWNER_HOST=${O_HOST:--}"
+  echo "FLOW_CLAIM_TS=${O_TS:--}"
+  echo "FLOW_CLAIM_AGE_MIN=${O_AGE_MIN:--}"
+  echo "FLOW_CLAIM_ISSUE=${O_ISSUE:--}"
+  echo "FLOW_CLAIM: $1"
+}
+
+# Absolute, symlink-resolved path (git's porcelain prints resolved paths, so
+# both sides of the comparison must be normalized the same way).
+abspath() {
+  if [ -d "$1" ]; then (cd "$1" 2>/dev/null && pwd -P); else echo "$1"; fi
+}
+
+# is_alive PID HOST -> 0 when the owning session is still running here.
+is_alive() {
+  local pid="$1" host="$2"
+  [ -n "$pid" ] && [ "$pid" != "-" ] || return 1
+  # A pid only means something on the machine that recorded it.
+  [ "$host" = "$SELF_HOST" ] || return 1
+  if [ -n "${FLOW_CLAIM_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_CLAIM_LIVE_PIDS:" in
+      *":$pid:"*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Parse a claim reason string into the O_* globals. Returns 1 when the reason
+# is not one of ours (a foreign lock).
+O_PATH=""; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+parse_reason() {
+  local reason="$1" field
+  case "$reason" in
+    "$CLAIM_PREFIX "*) : ;;
+    *) return 1 ;;
+  esac
+  for field in $reason; do
+    case "$field" in
+      issue=*) O_ISSUE="${field#issue=}" ;;
+      pid=*) O_PID="${field#pid=}" ;;
+      session=*) O_SESSION="${field#session=}" ;;
+      host=*) O_HOST="${field#host=}" ;;
+      ts=*) O_TS="${field#ts=}" ;;
+    esac
+  done
+  if [ -n "$O_TS" ] && printf '%s' "$O_TS" | grep -qE '^[0-9]+$'; then
+    local age=$((NOW - O_TS))
+    [ "$age" -lt 0 ] && age=0
+    O_AGE_MIN=$((age / 60))
+  fi
+  return 0
+}
+
+# lock_reason_for PATH - print the lock reason for a worktree ('' when
+# unlocked). Locked-with-no-reason prints the sentinel '(no reason)'.
+lock_reason_for() {
+  local want cur="" locked_line=""
+  want="$(abspath "$1")"
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="$(abspath "${line#worktree }")"; locked_line="" ;;
+      "locked "*)
+        [ "$cur" = "$want" ] && { printf '%s' "${line#locked }"; return 0; }
+        ;;
+      "locked")
+        [ "$cur" = "$want" ] && { printf '%s' "(no reason)"; return 0; }
+        ;;
+    esac
+  done < <("$GIT" -C "$want" worktree list --porcelain 2>/dev/null)
+  return 0
+}
+
+# Classify the current state of WORKTREE_PATH, setting the O_* owner globals
+# and STATE. Deliberately NOT a value-returning function: the owner detail has
+# to survive into emit(), and command substitution would run this in a subshell
+# and discard every assignment.
+classify() {
+  local path="$1" reason
+  O_PATH="$path"; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+
+  if [ ! -d "$path" ]; then STATE=unknown; return 0; fi
+  if ! "$GIT" -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    STATE=unknown; return 0
+  fi
+  # The primary checkout cannot be locked by git at all; a run on the
+  # current-branch lane therefore has no claim to make.
+  if [ ! -f "$path/.git" ]; then STATE=unsupported; return 0; fi
+
+  reason="$(lock_reason_for "$path")"
+  if [ -z "$reason" ]; then STATE=free; return 0; fi
+  if ! parse_reason "$reason"; then STATE=foreign; return 0; fi
+
+  if [ -n "$SELF_SESSION" ] && [ "$O_SESSION" = "$SELF_SESSION" ]; then
+    STATE=self; return 0
+  fi
+  if [ "$O_HOST" = "$SELF_HOST" ] && [ "$O_PID" = "$SELF_PID" ]; then
+    STATE=self; return 0
+  fi
+  if is_alive "$O_PID" "$O_HOST"; then STATE=held; return 0; fi
+  # Not provably alive. Same host + dead pid is decisively stale; a claim from
+  # another host is only stale once it has aged out.
+  if [ "$O_HOST" = "$SELF_HOST" ]; then STATE=stale; return 0; fi
+  if [ -n "$O_AGE_MIN" ] && [ "$O_AGE_MIN" -gt $((MAX_AGE_HOURS * 60)) ]; then
+    STATE=stale; return 0
+  fi
+  STATE=held
+}
+
+# ---- argument parsing -------------------------------------------------------
+VERB="${1:-}"
+[ -n "$VERB" ] || usage_fail "usage: flow-worktree-claim.sh claim|check|release <WORKTREE_PATH> [options]"
+shift
+
+case "$VERB" in
+  claim | check | release) : ;;
+  --help | -h)
+    sed -n '2,70p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *) usage_fail "unknown verb: $VERB (expected claim, check or release)" ;;
+esac
+
+WT=""
+ISSUE_NUM=""
+REPO=""
+STEAL=0
+FORCE=0
+WANT_EXIT_CODE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue)
+      [ "$#" -ge 2 ] || usage_fail "--issue requires a number"
+      ISSUE_NUM="$2"; shift
+      ;;
+    --issue=*) ISSUE_NUM="${1#--issue=}" ;;
+    --repo)
+      [ "$#" -ge 2 ] || usage_fail "--repo requires a path"
+      REPO="$2"; shift
+      ;;
+    --repo=*) REPO="${1#--repo=}" ;;
+    --steal) STEAL=1 ;;
+    --force) FORCE=1 ;;
+    --exit-code) WANT_EXIT_CODE=1 ;;
+    --*) usage_fail "unknown option: $1" ;;
+    *)
+      [ -z "$WT" ] || usage_fail "unexpected argument: $1"
+      WT="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$ISSUE_NUM" ]; then
+  printf '%s' "$ISSUE_NUM" | grep -qE '^[0-9]+$' ||
+    usage_fail "--issue must be a number, got: $ISSUE_NUM"
+fi
+
+# `check --issue N` resolves the worktree by branch, so a session can ask
+# "does anyone hold issue N?" before it has a path of its own (issue #597,
+# the cross-session claim check).
+if [ -z "$WT" ] && [ -n "$ISSUE_NUM" ] && [ "$VERB" = check ]; then
+  REPO="${REPO:-.}"
+  cur=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="${line#worktree }" ;;
+      "branch refs/heads/issue-${ISSUE_NUM}-"*) WT="$cur" ;;
+    esac
+  done < <("$GIT" -C "$REPO" worktree list --porcelain 2>/dev/null)
+  if [ -z "$WT" ]; then
+    O_PATH="-"
+    emit free
+    exit 0
+  fi
+fi
+
+[ -n "$WT" ] || usage_fail "$VERB requires a worktree path"
+WT="$(abspath "$WT")"
+
+STATE=unknown
+classify "$WT"
+
+case "$VERB" in
+  check)
+    emit "$STATE"
+    if [ "$WANT_EXIT_CODE" -eq 1 ] && [ "$STATE" = held ]; then exit 1; fi
+    exit 0
+    ;;
+
+  release)
+    case "$STATE" in
+      self | stale)
+        if "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1; then
+          echo "flow-worktree-claim: released claim on '$WT'." >&2
+        fi
+        O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+        emit free
+        ;;
+      held | foreign)
+        if [ "$FORCE" -eq 1 ]; then
+          "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+          echo "flow-worktree-claim: FORCE-released a $STATE claim on '$WT' (owner pid ${O_PID:--})." >&2
+          emit free
+        else
+          echo "flow-worktree-claim: '$WT' is claimed by another session (pid ${O_PID:--}, session ${O_SESSION:--}) - not releasing. Pass --force to override." >&2
+          emit "$STATE"
+        fi
+        ;;
+      *) emit "$STATE" ;;
+    esac
+    exit 0
+    ;;
+
+  claim)
+    [ -n "$ISSUE_NUM" ] || usage_fail "claim requires --issue <N>"
+    case "$STATE" in
+      held)
+        if [ "$STEAL" -eq 0 ]; then
+          echo "flow-worktree-claim: '$WT' is CLAIMED by a live session (pid ${O_PID:--}, session ${O_SESSION:--}, host ${O_HOST:--}, ~${O_AGE_MIN:-?}m ago)." >&2
+          echo "  Another /flow run is driving this worktree right now (issue #597). Working here would race it:" >&2
+          echo "  its cleanup can delete this checkout, and yours can delete theirs." >&2
+          echo "  Either wait for that session to finish, or - if you are certain it is gone - re-run with --steal." >&2
+          emit held
+          exit 1
+        fi
+        echo "flow-worktree-claim: stealing a live claim on '$WT' (--steal; previous owner pid ${O_PID:--})." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      foreign)
+        # Someone locked this worktree for their own reasons. Never steal it,
+        # but do not fail the run either - report and move on (fail-open).
+        echo "flow-worktree-claim: '$WT' carries a non-flow lock; leaving it untouched and claiming nothing." >&2
+        emit foreign
+        exit 0
+        ;;
+      stale)
+        echo "flow-worktree-claim: taking over a stale claim on '$WT' (owner pid ${O_PID:--} is gone)." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      self)
+        # Idempotent refresh: drop our own lock so the new timestamp lands.
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      unsupported | unknown)
+        echo "flow-worktree-claim: '$WT' cannot hold a claim ($STATE) - continuing unclaimed (advisory)." >&2
+        emit "$STATE"
+        exit 0
+        ;;
+    esac
+
+    REASON="$CLAIM_PREFIX issue=$ISSUE_NUM pid=$SELF_PID session=${SELF_SESSION:--} host=$SELF_HOST ts=$NOW"
+    if ! "$GIT" -C "$WT" worktree lock --reason "$REASON" "$WT" >/dev/null 2>&1; then
+      echo "flow-worktree-claim: could not lock '$WT' (git too old, or lock unsupported) - continuing unclaimed (advisory)." >&2
+      O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+      emit unsupported
+      exit 0
+    fi
+    O_PID="$SELF_PID"; O_SESSION="${SELF_SESSION:--}"; O_HOST="$SELF_HOST"
+    O_TS="$NOW"; O_AGE_MIN=0; O_ISSUE="$ISSUE_NUM"
+    echo "flow-worktree-claim: claimed '$WT' for issue #$ISSUE_NUM (pid $SELF_PID)." >&2
+    emit self
+    exit 0
+    ;;
+esac

--- a/codex/skills/flow-doctor/reference.md
+++ b/codex/skills/flow-doctor/reference.md
@@ -148,7 +148,7 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
   if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then CPP_DIR="$dir"; break; fi
 done
 
-for script in flow-start-resolve.sh flow-stale-check.sh flow-worktree-guard.sh flow-live-driver-guard.sh gh-pr-merge.sh; do
+for script in flow-start-resolve.sh flow-stale-check.sh flow-worktree-guard.sh flow-live-driver-guard.sh flow-worktree-claim.sh gh-pr-merge.sh; do
   if [ -x "$HOME/.claude/scripts/$script" ]; then
     echo "PASS $script (flow helper)"
   elif [ -f "$HOME/.claude/scripts/$script" ]; then
@@ -330,7 +330,7 @@ Output a single diagnostic report in this format:
 | prompt-context.sh | ✅/❌ | Shell prompt context |
 | worktree-remove.sh | ✅/⚠️ | Optional fallback (native ExitWorktree is primary) |
 | secrets-mask.sh | ✅/❌ | Output masking filter |
-| Flow helper family | ✅/⚠️/❌ | flow-start-resolve, flow-stale-check, flow-worktree-guard, flow-live-driver-guard, gh-pr-merge at ~/.claude/scripts/ (zero-prompt lane, #581). ❌ when missing with no CPP checkout to fall back to (#590) |
+| Flow helper family | ✅/⚠️/❌ | flow-start-resolve, flow-stale-check, flow-worktree-guard, flow-live-driver-guard, flow-worktree-claim, gh-pr-merge at ~/.claude/scripts/ (zero-prompt lane, #581). ❌ when missing with no CPP checkout to fall back to (#590) |
 | Helper freshness | ✅/⚠️ | `flow-helpers-install.sh --check`: ok / stale (plugin upgraded, installed copies behind) |
 | Flow allowlist | ✅/⚠️/❌ | 38/38 rules in ~/.claude/settings.json / N missing / settings.json missing |
 

--- a/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
@@ -51,6 +51,7 @@ HELPERS=(
     flow-live-driver-guard.sh
     flow-stale-check.sh
     flow-worktree-guard.sh
+    flow-worktree-claim.sh
     gh-pr-merge.sh
     worktree-remove.sh
     friction-log.sh

--- a/codex/skills/flow-doctor/scripts/worktree-remove.sh
+++ b/codex/skills/flow-doctor/scripts/worktree-remove.sh
@@ -5,12 +5,19 @@
 # changes to the main repository first (determined from the worktree's
 # .git file) to prevent breaking your shell session.
 #
+# A worktree CLAIMED by another live /flow session (issue #597) is never
+# removed: the claim is checked first and a live foreign owner is a hard stop
+# (exit 4), because removing it is exactly the silent-data-loss failure that
+# motivated the claim. A self-owned or stale claim is released and removed as
+# usual, and --steal is the deliberate override.
+#
 # Usage:
-#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch] [--steal]
 #
 # Options:
 #   --force          Remove even if worktree has uncommitted changes
 #   --delete-branch  Also delete the associated branch after removal
+#   --steal          Remove even when another live session claims it (#597)
 #
 # Examples:
 #   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
@@ -30,6 +37,7 @@ NC='\033[0m' # No Color
 WORKTREE_PATH=""
 FORCE=""
 DELETE_BRANCH=false
+STEAL=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delete-branch)
             DELETE_BRANCH=true
+            shift
+            ;;
+        --steal)
+            STEAL=true
             shift
             ;;
         -h|--help)
@@ -52,6 +64,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
             echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo "  --steal          Remove even when another live /flow session claims it"
+            echo "                   (issue #597; without it a live claim is a hard stop)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -158,6 +172,53 @@ fi
 
 # Get the branch name before removing
 BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Cross-session claim check (issue #597) ----------------------------------
+# Another LIVE /flow session may be driving this checkout right now. Removing it
+# out from under that session is the silent-data-loss failure this guard exists
+# for, so a live foreign claim is a hard stop. A claim owned by THIS session, or
+# left behind by a session that has since died, is simply released first.
+#
+# Fail-open in both directions: a missing helper, an unreadable lock, or a git
+# too old to report one leaves the previous behavior exactly as it was.
+SELF_SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")"
+CLAIM_HELPER=""
+for cand in "$SELF_SCRIPT_DIR/flow-worktree-claim.sh" "$HOME/.claude/scripts/flow-worktree-claim.sh"; do
+    if [[ -f "$cand" ]]; then
+        CLAIM_HELPER="$cand"
+        break
+    fi
+done
+
+if [[ -n "$CLAIM_HELPER" ]]; then
+    CLAIM_OUT=$(bash "$CLAIM_HELPER" check "$WORKTREE_PATH" 2>/dev/null || true)
+    CLAIM_STATE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM_PID=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+    CLAIM_SESSION=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+    CLAIM_ISSUE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_ISSUE=//p' | tail -1)
+
+    case "${CLAIM_STATE:-unknown}" in
+        held | foreign)
+            if [[ "$STEAL" != true ]]; then
+                echo -e "${RED}Error: refusing to remove a worktree claimed by another session${NC}" >&2
+                echo "" >&2
+                echo "  Worktree: $WORKTREE_PATH" >&2
+                echo "  Claim:    ${CLAIM_STATE} (issue #${CLAIM_ISSUE:--}, pid ${CLAIM_PID:--}, session ${CLAIM_SESSION:--})" >&2
+                echo "" >&2
+                echo "  Another /flow session is driving this checkout. Removing it would destroy" >&2
+                echo "  its uncommitted work - the failure this claim exists to prevent (issue #597)." >&2
+                echo "  Wait for that session to finish, or pass --steal if you are certain it is gone." >&2
+                exit 4
+            fi
+            echo -e "${YELLOW}Warning: --steal given; removing a worktree claimed by pid ${CLAIM_PID:--}.${NC}" >&2
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" --force >/dev/null 2>&1 || true
+            ;;
+        self | stale)
+            # Ours, or abandoned - drop the lock so the removal below can proceed.
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" >/dev/null 2>&1 || true
+            ;;
+    esac
+fi
 
 # Check for uncommitted changes (unless --force)
 if [[ -z "$FORCE" ]]; then

--- a/codex/skills/flow-finish/scripts/plugin-sync.sh
+++ b/codex/skills/flow-finish/scripts/plugin-sync.sh
@@ -65,7 +65,7 @@ declare -A EXTRA_FILES=(
     # allowlist rules match - by /flow:repair (flow-helpers-install.sh, itself
     # bundled so a plugin-only user can run it). flow-start-resolve.sh resolves
     # flow-live-driver-guard.sh via $SELF_DIR, so the two must travel together.
-    [flow]="scripts/flow-start-resolve.sh scripts/flow-live-driver-guard.sh scripts/flow-stale-check.sh scripts/flow-worktree-guard.sh scripts/gh-pr-merge.sh scripts/worktree-remove.sh scripts/friction-log.sh scripts/check-ignored-additions.sh scripts/flow-helpers-install.sh"
+    [flow]="scripts/flow-start-resolve.sh scripts/flow-live-driver-guard.sh scripts/flow-worktree-claim.sh scripts/flow-stale-check.sh scripts/flow-worktree-guard.sh scripts/gh-pr-merge.sh scripts/worktree-remove.sh scripts/friction-log.sh scripts/check-ignored-additions.sh scripts/flow-helpers-install.sh"
     # /cpp:load-best-practices reads this doc; a plugin-only install has no CPP
     # checkout, so the plugin bundles it (resolved via ${CLAUDE_PLUGIN_ROOT}).
     [cpp]="docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md"

--- a/codex/skills/flow-merge/reference.md
+++ b/codex/skills/flow-merge/reference.md
@@ -13,6 +13,20 @@ cross-session cleanup therefore stays on `git worktree remove` /
 same session with `EnterWorktree(name=...)`, prefer the native
 `ExitWorktree(action="remove", discard_changes=true)` instead of Steps 5a-5c.
 
+**Release the #597 claim before ANY removal path.** A `/flow` run stakes a real
+`git worktree lock` on its checkout, and git refuses to remove a locked worktree
+- including via the native tool, which knows nothing about the claim. Run this
+bare first (fail-open; it releases only a claim owned by this session or an
+abandoned one):
+
+```bash
+~/.claude/scripts/flow-worktree-claim.sh release /path/to/worktree
+```
+
+`worktree-remove.sh` does this itself, and **exits 4** rather than removing a
+worktree another LIVE session claims - a correct refusal, not a failure. Report
+it and stop instead of reaching for `--steal`.
+
 ## Instructions
 
 When the user invokes `/flow-merge`, perform these steps:

--- a/codex/skills/flow-merge/scripts/flow-worktree-claim.sh
+++ b/codex/skills/flow-merge/scripts/flow-worktree-claim.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# flow-worktree-claim.sh - Cross-session ownership claim on a flow worktree
+# (issue #597).
+#
+# Motivation: nothing stopped two concurrent /flow sessions from operating on
+# the same repo, or the same worktree. The #503 live-driver guard protects
+# RESUMING into an active worktree; it does not protect an active worktree from
+# being REMOVED by someone else, and it has no notion of an owner, so it cannot
+# tell "another session is driving this" from "someone left files dirty". The
+# observed cost was silent data loss: a sibling session's Step-7 cleanup removed
+# a live session's worktree by name, destroying uncommitted work.
+#
+# This helper makes ownership explicit and machine-checkable by riding git's own
+# worktree lock. `git worktree lock --reason <text>` already makes
+# `git worktree remove --force` refuse (it demands `-f -f`), so a claim is a
+# real barrier rather than an advisory note, and the reason text is readable
+# from `git worktree list --porcelain`. The reason we write is a single line:
+#
+#   flow-claim issue=<N> pid=<PID> session=<SID> host=<HOST> ts=<EPOCH>
+#
+# Liveness: the owning session is alive when `kill -0 <pid>` succeeds AND the
+# recorded host matches this one (a pid from another machine says nothing about
+# a pid here). A claim whose owner is gone is STALE and may be taken over, so
+# the mechanism can never permanently wedge a repo. A lock this script did not
+# write (no `flow-claim` prefix) is FOREIGN and is never stolen - someone locked
+# that worktree deliberately.
+#
+# It is FAIL-OPEN by design: anything it cannot determine (not a worktree, git
+# too old, lock unsupported on the primary checkout) reports and exits 0 rather
+# than blocking a flow run. The one non-zero exit is the case it exists for -
+# `claim` losing to a LIVE foreign owner.
+#
+# Usage:
+#   flow-worktree-claim.sh claim   <WORKTREE_PATH> --issue <N> [--steal]
+#   flow-worktree-claim.sh check   <WORKTREE_PATH>
+#   flow-worktree-claim.sh check   --issue <N> [--repo <PATH>]
+#   flow-worktree-claim.sh release <WORKTREE_PATH> [--force]
+#
+#   claim    Acquire the claim. Re-claiming a self-owned worktree refreshes the
+#            timestamp (idempotent). A STALE claim is taken over automatically.
+#            A LIVE foreign claim exits 1 unless --steal is passed.
+#   check    Report the claim state without changing it. Always exits 0 unless
+#            --exit-code is passed, which returns 1 for a held claim.
+#   release  Drop a self-owned (or stale) claim. A foreign live claim is left
+#            alone unless --force. Never fails the caller.
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_CLAIM: free | self | held | stale | foreign | unsupported | unknown
+# preceded by owner detail lines (FLOW_CLAIM_OWNER_PID=, ..._SESSION=, ..._HOST=,
+# ..._TS=, ..._AGE_MIN=, FLOW_CLAIM_PATH=), each '-' when not applicable.
+#
+# Env:
+#   CLAUDE_PID              owning process id (Claude Code sets it); falls back
+#                           to $PPID
+#   CLAUDE_CODE_SESSION_ID  owning session id; falls back to '-'
+#   FLOW_CLAIM_MAX_AGE_HOURS  a claim from ANOTHER host older than this is
+#                           treated as stale (default 24) - cross-host liveness
+#                           cannot be probed, so age is the only safety valve
+# Env (test hooks - unset in normal use):
+#   FLOW_CLAIM_GIT          override the `git` binary
+#   FLOW_CLAIM_NOW          override "now" as epoch seconds
+#   FLOW_CLAIM_HOST         override this host's name
+#   FLOW_CLAIM_LIVE_PIDS    ':'-separated pids to treat as alive (bypasses
+#                           kill -0, so a test can simulate a live sibling)
+
+set -uo pipefail
+
+GIT="${FLOW_CLAIM_GIT:-git}"
+MAX_AGE_HOURS="${FLOW_CLAIM_MAX_AGE_HOURS:-24}"
+SELF_PID="${CLAUDE_PID:-$PPID}"
+SELF_SESSION="${CLAUDE_CODE_SESSION_ID:-}"
+SELF_HOST="${FLOW_CLAIM_HOST:-${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}}"
+NOW="${FLOW_CLAIM_NOW:-$(date +%s)}"
+
+CLAIM_PREFIX="flow-claim"
+
+usage_fail() { echo "flow-worktree-claim: $1" >&2; exit 2; }
+
+# Emit the owner detail block + verdict. All args default to '-'.
+emit() {
+  echo "FLOW_CLAIM_PATH=${O_PATH:--}"
+  echo "FLOW_CLAIM_OWNER_PID=${O_PID:--}"
+  echo "FLOW_CLAIM_OWNER_SESSION=${O_SESSION:--}"
+  echo "FLOW_CLAIM_OWNER_HOST=${O_HOST:--}"
+  echo "FLOW_CLAIM_TS=${O_TS:--}"
+  echo "FLOW_CLAIM_AGE_MIN=${O_AGE_MIN:--}"
+  echo "FLOW_CLAIM_ISSUE=${O_ISSUE:--}"
+  echo "FLOW_CLAIM: $1"
+}
+
+# Absolute, symlink-resolved path (git's porcelain prints resolved paths, so
+# both sides of the comparison must be normalized the same way).
+abspath() {
+  if [ -d "$1" ]; then (cd "$1" 2>/dev/null && pwd -P); else echo "$1"; fi
+}
+
+# is_alive PID HOST -> 0 when the owning session is still running here.
+is_alive() {
+  local pid="$1" host="$2"
+  [ -n "$pid" ] && [ "$pid" != "-" ] || return 1
+  # A pid only means something on the machine that recorded it.
+  [ "$host" = "$SELF_HOST" ] || return 1
+  if [ -n "${FLOW_CLAIM_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_CLAIM_LIVE_PIDS:" in
+      *":$pid:"*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Parse a claim reason string into the O_* globals. Returns 1 when the reason
+# is not one of ours (a foreign lock).
+O_PATH=""; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+parse_reason() {
+  local reason="$1" field
+  case "$reason" in
+    "$CLAIM_PREFIX "*) : ;;
+    *) return 1 ;;
+  esac
+  for field in $reason; do
+    case "$field" in
+      issue=*) O_ISSUE="${field#issue=}" ;;
+      pid=*) O_PID="${field#pid=}" ;;
+      session=*) O_SESSION="${field#session=}" ;;
+      host=*) O_HOST="${field#host=}" ;;
+      ts=*) O_TS="${field#ts=}" ;;
+    esac
+  done
+  if [ -n "$O_TS" ] && printf '%s' "$O_TS" | grep -qE '^[0-9]+$'; then
+    local age=$((NOW - O_TS))
+    [ "$age" -lt 0 ] && age=0
+    O_AGE_MIN=$((age / 60))
+  fi
+  return 0
+}
+
+# lock_reason_for PATH - print the lock reason for a worktree ('' when
+# unlocked). Locked-with-no-reason prints the sentinel '(no reason)'.
+lock_reason_for() {
+  local want cur="" locked_line=""
+  want="$(abspath "$1")"
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="$(abspath "${line#worktree }")"; locked_line="" ;;
+      "locked "*)
+        [ "$cur" = "$want" ] && { printf '%s' "${line#locked }"; return 0; }
+        ;;
+      "locked")
+        [ "$cur" = "$want" ] && { printf '%s' "(no reason)"; return 0; }
+        ;;
+    esac
+  done < <("$GIT" -C "$want" worktree list --porcelain 2>/dev/null)
+  return 0
+}
+
+# Classify the current state of WORKTREE_PATH, setting the O_* owner globals
+# and STATE. Deliberately NOT a value-returning function: the owner detail has
+# to survive into emit(), and command substitution would run this in a subshell
+# and discard every assignment.
+classify() {
+  local path="$1" reason
+  O_PATH="$path"; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+
+  if [ ! -d "$path" ]; then STATE=unknown; return 0; fi
+  if ! "$GIT" -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    STATE=unknown; return 0
+  fi
+  # The primary checkout cannot be locked by git at all; a run on the
+  # current-branch lane therefore has no claim to make.
+  if [ ! -f "$path/.git" ]; then STATE=unsupported; return 0; fi
+
+  reason="$(lock_reason_for "$path")"
+  if [ -z "$reason" ]; then STATE=free; return 0; fi
+  if ! parse_reason "$reason"; then STATE=foreign; return 0; fi
+
+  if [ -n "$SELF_SESSION" ] && [ "$O_SESSION" = "$SELF_SESSION" ]; then
+    STATE=self; return 0
+  fi
+  if [ "$O_HOST" = "$SELF_HOST" ] && [ "$O_PID" = "$SELF_PID" ]; then
+    STATE=self; return 0
+  fi
+  if is_alive "$O_PID" "$O_HOST"; then STATE=held; return 0; fi
+  # Not provably alive. Same host + dead pid is decisively stale; a claim from
+  # another host is only stale once it has aged out.
+  if [ "$O_HOST" = "$SELF_HOST" ]; then STATE=stale; return 0; fi
+  if [ -n "$O_AGE_MIN" ] && [ "$O_AGE_MIN" -gt $((MAX_AGE_HOURS * 60)) ]; then
+    STATE=stale; return 0
+  fi
+  STATE=held
+}
+
+# ---- argument parsing -------------------------------------------------------
+VERB="${1:-}"
+[ -n "$VERB" ] || usage_fail "usage: flow-worktree-claim.sh claim|check|release <WORKTREE_PATH> [options]"
+shift
+
+case "$VERB" in
+  claim | check | release) : ;;
+  --help | -h)
+    sed -n '2,70p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *) usage_fail "unknown verb: $VERB (expected claim, check or release)" ;;
+esac
+
+WT=""
+ISSUE_NUM=""
+REPO=""
+STEAL=0
+FORCE=0
+WANT_EXIT_CODE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue)
+      [ "$#" -ge 2 ] || usage_fail "--issue requires a number"
+      ISSUE_NUM="$2"; shift
+      ;;
+    --issue=*) ISSUE_NUM="${1#--issue=}" ;;
+    --repo)
+      [ "$#" -ge 2 ] || usage_fail "--repo requires a path"
+      REPO="$2"; shift
+      ;;
+    --repo=*) REPO="${1#--repo=}" ;;
+    --steal) STEAL=1 ;;
+    --force) FORCE=1 ;;
+    --exit-code) WANT_EXIT_CODE=1 ;;
+    --*) usage_fail "unknown option: $1" ;;
+    *)
+      [ -z "$WT" ] || usage_fail "unexpected argument: $1"
+      WT="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$ISSUE_NUM" ]; then
+  printf '%s' "$ISSUE_NUM" | grep -qE '^[0-9]+$' ||
+    usage_fail "--issue must be a number, got: $ISSUE_NUM"
+fi
+
+# `check --issue N` resolves the worktree by branch, so a session can ask
+# "does anyone hold issue N?" before it has a path of its own (issue #597,
+# the cross-session claim check).
+if [ -z "$WT" ] && [ -n "$ISSUE_NUM" ] && [ "$VERB" = check ]; then
+  REPO="${REPO:-.}"
+  cur=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="${line#worktree }" ;;
+      "branch refs/heads/issue-${ISSUE_NUM}-"*) WT="$cur" ;;
+    esac
+  done < <("$GIT" -C "$REPO" worktree list --porcelain 2>/dev/null)
+  if [ -z "$WT" ]; then
+    O_PATH="-"
+    emit free
+    exit 0
+  fi
+fi
+
+[ -n "$WT" ] || usage_fail "$VERB requires a worktree path"
+WT="$(abspath "$WT")"
+
+STATE=unknown
+classify "$WT"
+
+case "$VERB" in
+  check)
+    emit "$STATE"
+    if [ "$WANT_EXIT_CODE" -eq 1 ] && [ "$STATE" = held ]; then exit 1; fi
+    exit 0
+    ;;
+
+  release)
+    case "$STATE" in
+      self | stale)
+        if "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1; then
+          echo "flow-worktree-claim: released claim on '$WT'." >&2
+        fi
+        O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+        emit free
+        ;;
+      held | foreign)
+        if [ "$FORCE" -eq 1 ]; then
+          "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+          echo "flow-worktree-claim: FORCE-released a $STATE claim on '$WT' (owner pid ${O_PID:--})." >&2
+          emit free
+        else
+          echo "flow-worktree-claim: '$WT' is claimed by another session (pid ${O_PID:--}, session ${O_SESSION:--}) - not releasing. Pass --force to override." >&2
+          emit "$STATE"
+        fi
+        ;;
+      *) emit "$STATE" ;;
+    esac
+    exit 0
+    ;;
+
+  claim)
+    [ -n "$ISSUE_NUM" ] || usage_fail "claim requires --issue <N>"
+    case "$STATE" in
+      held)
+        if [ "$STEAL" -eq 0 ]; then
+          echo "flow-worktree-claim: '$WT' is CLAIMED by a live session (pid ${O_PID:--}, session ${O_SESSION:--}, host ${O_HOST:--}, ~${O_AGE_MIN:-?}m ago)." >&2
+          echo "  Another /flow run is driving this worktree right now (issue #597). Working here would race it:" >&2
+          echo "  its cleanup can delete this checkout, and yours can delete theirs." >&2
+          echo "  Either wait for that session to finish, or - if you are certain it is gone - re-run with --steal." >&2
+          emit held
+          exit 1
+        fi
+        echo "flow-worktree-claim: stealing a live claim on '$WT' (--steal; previous owner pid ${O_PID:--})." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      foreign)
+        # Someone locked this worktree for their own reasons. Never steal it,
+        # but do not fail the run either - report and move on (fail-open).
+        echo "flow-worktree-claim: '$WT' carries a non-flow lock; leaving it untouched and claiming nothing." >&2
+        emit foreign
+        exit 0
+        ;;
+      stale)
+        echo "flow-worktree-claim: taking over a stale claim on '$WT' (owner pid ${O_PID:--} is gone)." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      self)
+        # Idempotent refresh: drop our own lock so the new timestamp lands.
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      unsupported | unknown)
+        echo "flow-worktree-claim: '$WT' cannot hold a claim ($STATE) - continuing unclaimed (advisory)." >&2
+        emit "$STATE"
+        exit 0
+        ;;
+    esac
+
+    REASON="$CLAIM_PREFIX issue=$ISSUE_NUM pid=$SELF_PID session=${SELF_SESSION:--} host=$SELF_HOST ts=$NOW"
+    if ! "$GIT" -C "$WT" worktree lock --reason "$REASON" "$WT" >/dev/null 2>&1; then
+      echo "flow-worktree-claim: could not lock '$WT' (git too old, or lock unsupported) - continuing unclaimed (advisory)." >&2
+      O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+      emit unsupported
+      exit 0
+    fi
+    O_PID="$SELF_PID"; O_SESSION="${SELF_SESSION:--}"; O_HOST="$SELF_HOST"
+    O_TS="$NOW"; O_AGE_MIN=0; O_ISSUE="$ISSUE_NUM"
+    echo "flow-worktree-claim: claimed '$WT' for issue #$ISSUE_NUM (pid $SELF_PID)." >&2
+    emit self
+    exit 0
+    ;;
+esac

--- a/codex/skills/flow-merge/scripts/worktree-remove.sh
+++ b/codex/skills/flow-merge/scripts/worktree-remove.sh
@@ -5,12 +5,19 @@
 # changes to the main repository first (determined from the worktree's
 # .git file) to prevent breaking your shell session.
 #
+# A worktree CLAIMED by another live /flow session (issue #597) is never
+# removed: the claim is checked first and a live foreign owner is a hard stop
+# (exit 4), because removing it is exactly the silent-data-loss failure that
+# motivated the claim. A self-owned or stale claim is released and removed as
+# usual, and --steal is the deliberate override.
+#
 # Usage:
-#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch] [--steal]
 #
 # Options:
 #   --force          Remove even if worktree has uncommitted changes
 #   --delete-branch  Also delete the associated branch after removal
+#   --steal          Remove even when another live session claims it (#597)
 #
 # Examples:
 #   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
@@ -30,6 +37,7 @@ NC='\033[0m' # No Color
 WORKTREE_PATH=""
 FORCE=""
 DELETE_BRANCH=false
+STEAL=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delete-branch)
             DELETE_BRANCH=true
+            shift
+            ;;
+        --steal)
+            STEAL=true
             shift
             ;;
         -h|--help)
@@ -52,6 +64,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
             echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo "  --steal          Remove even when another live /flow session claims it"
+            echo "                   (issue #597; without it a live claim is a hard stop)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -158,6 +172,53 @@ fi
 
 # Get the branch name before removing
 BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Cross-session claim check (issue #597) ----------------------------------
+# Another LIVE /flow session may be driving this checkout right now. Removing it
+# out from under that session is the silent-data-loss failure this guard exists
+# for, so a live foreign claim is a hard stop. A claim owned by THIS session, or
+# left behind by a session that has since died, is simply released first.
+#
+# Fail-open in both directions: a missing helper, an unreadable lock, or a git
+# too old to report one leaves the previous behavior exactly as it was.
+SELF_SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")"
+CLAIM_HELPER=""
+for cand in "$SELF_SCRIPT_DIR/flow-worktree-claim.sh" "$HOME/.claude/scripts/flow-worktree-claim.sh"; do
+    if [[ -f "$cand" ]]; then
+        CLAIM_HELPER="$cand"
+        break
+    fi
+done
+
+if [[ -n "$CLAIM_HELPER" ]]; then
+    CLAIM_OUT=$(bash "$CLAIM_HELPER" check "$WORKTREE_PATH" 2>/dev/null || true)
+    CLAIM_STATE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM_PID=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+    CLAIM_SESSION=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+    CLAIM_ISSUE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_ISSUE=//p' | tail -1)
+
+    case "${CLAIM_STATE:-unknown}" in
+        held | foreign)
+            if [[ "$STEAL" != true ]]; then
+                echo -e "${RED}Error: refusing to remove a worktree claimed by another session${NC}" >&2
+                echo "" >&2
+                echo "  Worktree: $WORKTREE_PATH" >&2
+                echo "  Claim:    ${CLAIM_STATE} (issue #${CLAIM_ISSUE:--}, pid ${CLAIM_PID:--}, session ${CLAIM_SESSION:--})" >&2
+                echo "" >&2
+                echo "  Another /flow session is driving this checkout. Removing it would destroy" >&2
+                echo "  its uncommitted work - the failure this claim exists to prevent (issue #597)." >&2
+                echo "  Wait for that session to finish, or pass --steal if you are certain it is gone." >&2
+                exit 4
+            fi
+            echo -e "${YELLOW}Warning: --steal given; removing a worktree claimed by pid ${CLAIM_PID:--}.${NC}" >&2
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" --force >/dev/null 2>&1 || true
+            ;;
+        self | stale)
+            # Ours, or abandoned - drop the lock so the removal below can proceed.
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" >/dev/null 2>&1 || true
+            ;;
+    esac
+fi
 
 # Check for uncommitted changes (unless --force)
 if [[ -z "$FORCE" ]]; then

--- a/codex/skills/flow-repair/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-repair/scripts/flow-helpers-install.sh
@@ -51,6 +51,7 @@ HELPERS=(
     flow-live-driver-guard.sh
     flow-stale-check.sh
     flow-worktree-guard.sh
+    flow-worktree-claim.sh
     gh-pr-merge.sh
     worktree-remove.sh
     friction-log.sh

--- a/codex/skills/flow-repair/scripts/flow-start-resolve.sh
+++ b/codex/skills/flow-repair/scripts/flow-start-resolve.sh
@@ -64,10 +64,17 @@
 #     REMOTE_BRANCH=origin/<...>       (remote-pickup lane only)
 #     WT_CREATED=0|1        1 = this run already ran `git worktree add`
 #     LIVE_DRIVER=clear|suspected|unknown|skipped  (#503 guard, resume lane)
+#     CLAIM=none|free|self|held|stale|foreign|unsupported|unknown
+#                           cross-session ownership of issue-N (issue #597),
+#                           read before any worktree is created. `held` = another
+#                           LIVE session is driving this issue right now
+#     CLAIM_PID=<pid|->     owning process id when CLAIM names an owner
+#     CLAIM_SESSION=<id|->  owning Claude session id
 #     PR_HEAD=none|<number>:<state>|unknown        (resume shipped-PR hazard)
 #     CONFIRM_REQUIRED=0|1  1 = STOP: explicit user confirmation needed
-#                           (suspected live driver, existing open/merged PR,
-#                           or non-OPEN issue without --allow-closed)
+#                           (suspected live driver, a live cross-session claim
+#                           on this issue, existing open/merged PR, or non-OPEN
+#                           issue without --allow-closed)
 #     FLOW_START_RESOLVE: ok
 #   On a hard error: ERROR=<reason> then `FLOW_START_RESOLVE: error`, exit 1.
 #
@@ -77,7 +84,12 @@
 #   Fails (FLOW_START_VERIFY: fail, exit 1) when the checkout is still on
 #   main/master or detached; renames a non-issue-anchored branch to
 #   EXPECTED_BRANCH so downstream steps can parse the issue number. On success
-#   prints BRANCH= and WT_ROOT= then `FLOW_START_VERIFY: ok`.
+#   prints BRANCH=, WT_ROOT= and CLAIM= then `FLOW_START_VERIFY: ok`.
+#
+#   Verify mode also STAKES the cross-session claim (issue #597) - it is the one
+#   hook point that runs inside the worktree on every lane, since the native
+#   EnterWorktree lane creates the checkout only after resolve mode has already
+#   returned. Claiming is advisory here and never fails the gate.
 #
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
@@ -100,6 +112,13 @@ fail() {
 }
 
 usage_fail() { echo "flow-start-resolve: $1" >&2; exit 2; }
+
+# Path to a sibling helper script (installed alongside this one).
+sibling() {
+  local self_dir
+  self_dir=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+  echo "$self_dir/$1"
+}
 
 # Given any checkout path, print the PRIMARY checkout's toplevel (a linked
 # worktree resolves to the main repo that owns it).
@@ -194,8 +213,27 @@ if [ "$MODE" = verify ]; then
       CURRENT="$EXPECTED_BRANCH"
       ;;
   esac
+  WT_ROOT=$("$GIT" rev-parse --show-toplevel)
+
+  # Stake the cross-session claim (issue #597). This is the only hook point that
+  # runs INSIDE the worktree on every lane: the native lane's worktree does not
+  # exist yet when resolve mode returns, so resolve cannot claim it. Advisory by
+  # design - the gate's job is to prove we are on the right branch, and a claim
+  # that cannot be taken must never turn a healthy Step 1 into a hard stop.
+  CLAIM=unknown
+  CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+  if [ -f "$CLAIM_HELPER" ]; then
+    claim_out=$(bash "$CLAIM_HELPER" claim "$WT_ROOT" --issue "$ISSUE_NUM" 2>&1) || true
+    CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM=${CLAIM:-unknown}
+    if [ "$CLAIM" = held ]; then
+      printf '%s\n' "$claim_out" | grep -v '^FLOW_CLAIM' >&2 || true
+    fi
+  fi
+
   echo "BRANCH=$CURRENT"
-  echo "WT_ROOT=$("$GIT" rev-parse --show-toplevel)"
+  echo "WT_ROOT=$WT_ROOT"
+  echo "CLAIM=$CLAIM"
   echo "FLOW_START_VERIFY: ok"
   exit 0
 fi
@@ -289,6 +327,33 @@ SLUG=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9
 SLUG=$(printf '%s' "$SLUG" | sed 's/-$//')
 [ -n "$SLUG" ] || SLUG=work
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+
+# ---- cross-session claim check (issue #597) ---------------------------------
+# Before triaging existing work, ask whether ANOTHER live session already holds
+# issue-N. Two sessions handed the same issue used to race silently: both
+# implemented it, and whichever cleaned up first deleted the other's worktree.
+# Run this BEFORE any worktree is created, so a fresh lane cannot find its own
+# brand-new checkout and report itself as the owner.
+CLAIM=none
+CLAIM_PID=-
+CLAIM_SESSION=-
+CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+if [ -f "$CLAIM_HELPER" ]; then
+  claim_out=$(bash "$CLAIM_HELPER" check --issue "$ISSUE_NUM" --repo "$TARGET_REPO" 2>/dev/null) || true
+  CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+  CLAIM=${CLAIM:-none}
+  CLAIM_PID=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+  CLAIM_SESSION=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+  CLAIM_PID=${CLAIM_PID:--}
+  CLAIM_SESSION=${CLAIM_SESSION:--}
+  if [ "$CLAIM" = held ]; then
+    CONFIRM_REQUIRED=1
+    echo "flow-start-resolve: issue #$ISSUE_NUM is CLAIMED by another live session (pid $CLAIM_PID, session $CLAIM_SESSION)." >&2
+    echo "  That session is working this issue right now. Proceeding would duplicate its work, and" >&2
+    echo "  whichever run cleans up first deletes the other's worktree (issue #597)." >&2
+    echo "  STOP and confirm with the user before continuing." >&2
+  fi
+fi
 
 # ---- remote sync + default branch -------------------------------------------
 if ! "$GIT" -C "$TARGET_REPO" fetch origin --quiet 2>/dev/null; then
@@ -431,6 +496,9 @@ if [ -n "$REMOTE_BRANCH" ]; then
 fi
 echo "WT_CREATED=$WT_CREATED"
 echo "LIVE_DRIVER=$LIVE_DRIVER"
+echo "CLAIM=$CLAIM"
+echo "CLAIM_PID=$CLAIM_PID"
+echo "CLAIM_SESSION=$CLAIM_SESSION"
 echo "PR_HEAD=$PR_HEAD"
 echo "CONFIRM_REQUIRED=$CONFIRM_REQUIRED"
 echo "FLOW_START_RESOLVE: ok"

--- a/codex/skills/flow-start/scripts/flow-start-resolve.sh
+++ b/codex/skills/flow-start/scripts/flow-start-resolve.sh
@@ -64,10 +64,17 @@
 #     REMOTE_BRANCH=origin/<...>       (remote-pickup lane only)
 #     WT_CREATED=0|1        1 = this run already ran `git worktree add`
 #     LIVE_DRIVER=clear|suspected|unknown|skipped  (#503 guard, resume lane)
+#     CLAIM=none|free|self|held|stale|foreign|unsupported|unknown
+#                           cross-session ownership of issue-N (issue #597),
+#                           read before any worktree is created. `held` = another
+#                           LIVE session is driving this issue right now
+#     CLAIM_PID=<pid|->     owning process id when CLAIM names an owner
+#     CLAIM_SESSION=<id|->  owning Claude session id
 #     PR_HEAD=none|<number>:<state>|unknown        (resume shipped-PR hazard)
 #     CONFIRM_REQUIRED=0|1  1 = STOP: explicit user confirmation needed
-#                           (suspected live driver, existing open/merged PR,
-#                           or non-OPEN issue without --allow-closed)
+#                           (suspected live driver, a live cross-session claim
+#                           on this issue, existing open/merged PR, or non-OPEN
+#                           issue without --allow-closed)
 #     FLOW_START_RESOLVE: ok
 #   On a hard error: ERROR=<reason> then `FLOW_START_RESOLVE: error`, exit 1.
 #
@@ -77,7 +84,12 @@
 #   Fails (FLOW_START_VERIFY: fail, exit 1) when the checkout is still on
 #   main/master or detached; renames a non-issue-anchored branch to
 #   EXPECTED_BRANCH so downstream steps can parse the issue number. On success
-#   prints BRANCH= and WT_ROOT= then `FLOW_START_VERIFY: ok`.
+#   prints BRANCH=, WT_ROOT= and CLAIM= then `FLOW_START_VERIFY: ok`.
+#
+#   Verify mode also STAKES the cross-session claim (issue #597) - it is the one
+#   hook point that runs inside the worktree on every lane, since the native
+#   EnterWorktree lane creates the checkout only after resolve mode has already
+#   returned. Claiming is advisory here and never fails the gate.
 #
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
@@ -100,6 +112,13 @@ fail() {
 }
 
 usage_fail() { echo "flow-start-resolve: $1" >&2; exit 2; }
+
+# Path to a sibling helper script (installed alongside this one).
+sibling() {
+  local self_dir
+  self_dir=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+  echo "$self_dir/$1"
+}
 
 # Given any checkout path, print the PRIMARY checkout's toplevel (a linked
 # worktree resolves to the main repo that owns it).
@@ -194,8 +213,27 @@ if [ "$MODE" = verify ]; then
       CURRENT="$EXPECTED_BRANCH"
       ;;
   esac
+  WT_ROOT=$("$GIT" rev-parse --show-toplevel)
+
+  # Stake the cross-session claim (issue #597). This is the only hook point that
+  # runs INSIDE the worktree on every lane: the native lane's worktree does not
+  # exist yet when resolve mode returns, so resolve cannot claim it. Advisory by
+  # design - the gate's job is to prove we are on the right branch, and a claim
+  # that cannot be taken must never turn a healthy Step 1 into a hard stop.
+  CLAIM=unknown
+  CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+  if [ -f "$CLAIM_HELPER" ]; then
+    claim_out=$(bash "$CLAIM_HELPER" claim "$WT_ROOT" --issue "$ISSUE_NUM" 2>&1) || true
+    CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM=${CLAIM:-unknown}
+    if [ "$CLAIM" = held ]; then
+      printf '%s\n' "$claim_out" | grep -v '^FLOW_CLAIM' >&2 || true
+    fi
+  fi
+
   echo "BRANCH=$CURRENT"
-  echo "WT_ROOT=$("$GIT" rev-parse --show-toplevel)"
+  echo "WT_ROOT=$WT_ROOT"
+  echo "CLAIM=$CLAIM"
   echo "FLOW_START_VERIFY: ok"
   exit 0
 fi
@@ -289,6 +327,33 @@ SLUG=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9
 SLUG=$(printf '%s' "$SLUG" | sed 's/-$//')
 [ -n "$SLUG" ] || SLUG=work
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+
+# ---- cross-session claim check (issue #597) ---------------------------------
+# Before triaging existing work, ask whether ANOTHER live session already holds
+# issue-N. Two sessions handed the same issue used to race silently: both
+# implemented it, and whichever cleaned up first deleted the other's worktree.
+# Run this BEFORE any worktree is created, so a fresh lane cannot find its own
+# brand-new checkout and report itself as the owner.
+CLAIM=none
+CLAIM_PID=-
+CLAIM_SESSION=-
+CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+if [ -f "$CLAIM_HELPER" ]; then
+  claim_out=$(bash "$CLAIM_HELPER" check --issue "$ISSUE_NUM" --repo "$TARGET_REPO" 2>/dev/null) || true
+  CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+  CLAIM=${CLAIM:-none}
+  CLAIM_PID=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+  CLAIM_SESSION=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+  CLAIM_PID=${CLAIM_PID:--}
+  CLAIM_SESSION=${CLAIM_SESSION:--}
+  if [ "$CLAIM" = held ]; then
+    CONFIRM_REQUIRED=1
+    echo "flow-start-resolve: issue #$ISSUE_NUM is CLAIMED by another live session (pid $CLAIM_PID, session $CLAIM_SESSION)." >&2
+    echo "  That session is working this issue right now. Proceeding would duplicate its work, and" >&2
+    echo "  whichever run cleans up first deletes the other's worktree (issue #597)." >&2
+    echo "  STOP and confirm with the user before continuing." >&2
+  fi
+fi
 
 # ---- remote sync + default branch -------------------------------------------
 if ! "$GIT" -C "$TARGET_REPO" fetch origin --quiet 2>/dev/null; then
@@ -431,6 +496,9 @@ if [ -n "$REMOTE_BRANCH" ]; then
 fi
 echo "WT_CREATED=$WT_CREATED"
 echo "LIVE_DRIVER=$LIVE_DRIVER"
+echo "CLAIM=$CLAIM"
+echo "CLAIM_PID=$CLAIM_PID"
+echo "CLAIM_SESSION=$CLAIM_SESSION"
 echo "PR_HEAD=$PR_HEAD"
 echo "CONFIRM_REQUIRED=$CONFIRM_REQUIRED"
 echo "FLOW_START_RESOLVE: ok"

--- a/codex/skills/flow-start/scripts/worktree-remove.sh
+++ b/codex/skills/flow-start/scripts/worktree-remove.sh
@@ -5,12 +5,19 @@
 # changes to the main repository first (determined from the worktree's
 # .git file) to prevent breaking your shell session.
 #
+# A worktree CLAIMED by another live /flow session (issue #597) is never
+# removed: the claim is checked first and a live foreign owner is a hard stop
+# (exit 4), because removing it is exactly the silent-data-loss failure that
+# motivated the claim. A self-owned or stale claim is released and removed as
+# usual, and --steal is the deliberate override.
+#
 # Usage:
-#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch] [--steal]
 #
 # Options:
 #   --force          Remove even if worktree has uncommitted changes
 #   --delete-branch  Also delete the associated branch after removal
+#   --steal          Remove even when another live session claims it (#597)
 #
 # Examples:
 #   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
@@ -30,6 +37,7 @@ NC='\033[0m' # No Color
 WORKTREE_PATH=""
 FORCE=""
 DELETE_BRANCH=false
+STEAL=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delete-branch)
             DELETE_BRANCH=true
+            shift
+            ;;
+        --steal)
+            STEAL=true
             shift
             ;;
         -h|--help)
@@ -52,6 +64,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
             echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo "  --steal          Remove even when another live /flow session claims it"
+            echo "                   (issue #597; without it a live claim is a hard stop)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -158,6 +172,53 @@ fi
 
 # Get the branch name before removing
 BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Cross-session claim check (issue #597) ----------------------------------
+# Another LIVE /flow session may be driving this checkout right now. Removing it
+# out from under that session is the silent-data-loss failure this guard exists
+# for, so a live foreign claim is a hard stop. A claim owned by THIS session, or
+# left behind by a session that has since died, is simply released first.
+#
+# Fail-open in both directions: a missing helper, an unreadable lock, or a git
+# too old to report one leaves the previous behavior exactly as it was.
+SELF_SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")"
+CLAIM_HELPER=""
+for cand in "$SELF_SCRIPT_DIR/flow-worktree-claim.sh" "$HOME/.claude/scripts/flow-worktree-claim.sh"; do
+    if [[ -f "$cand" ]]; then
+        CLAIM_HELPER="$cand"
+        break
+    fi
+done
+
+if [[ -n "$CLAIM_HELPER" ]]; then
+    CLAIM_OUT=$(bash "$CLAIM_HELPER" check "$WORKTREE_PATH" 2>/dev/null || true)
+    CLAIM_STATE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM_PID=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+    CLAIM_SESSION=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+    CLAIM_ISSUE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_ISSUE=//p' | tail -1)
+
+    case "${CLAIM_STATE:-unknown}" in
+        held | foreign)
+            if [[ "$STEAL" != true ]]; then
+                echo -e "${RED}Error: refusing to remove a worktree claimed by another session${NC}" >&2
+                echo "" >&2
+                echo "  Worktree: $WORKTREE_PATH" >&2
+                echo "  Claim:    ${CLAIM_STATE} (issue #${CLAIM_ISSUE:--}, pid ${CLAIM_PID:--}, session ${CLAIM_SESSION:--})" >&2
+                echo "" >&2
+                echo "  Another /flow session is driving this checkout. Removing it would destroy" >&2
+                echo "  its uncommitted work - the failure this claim exists to prevent (issue #597)." >&2
+                echo "  Wait for that session to finish, or pass --steal if you are certain it is gone." >&2
+                exit 4
+            fi
+            echo -e "${YELLOW}Warning: --steal given; removing a worktree claimed by pid ${CLAIM_PID:--}.${NC}" >&2
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" --force >/dev/null 2>&1 || true
+            ;;
+        self | stale)
+            # Ours, or abandoned - drop the lock so the removal below can proceed.
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" >/dev/null 2>&1 || true
+            ;;
+    esac
+fi
 
 # Check for uncommitted changes (unless --force)
 if [[ -z "$FORCE" ]]; then

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -157,10 +157,20 @@ cwd, so `GIT_LANE` was forced to 1 - if you see this, you forgot to pass it),
 in-repo `.claude/worktrees/<branch>`), `DEFAULT_BRANCH`, `REMOTE_BRANCH`
 (pickup lane), `WT_CREATED` (1 = the helper already ran `git worktree add`),
 `LIVE_DRIVER` / `PR_HEAD` (the #503 resume hazards - the helper wraps its
-sibling `scripts/flow-live-driver-guard.sh`), `CONFIRM_REQUIRED`.
+sibling `scripts/flow-live-driver-guard.sh`), `CLAIM` / `CLAIM_PID` /
+`CLAIM_SESSION` (the #597 cross-session claim on issue-N, read BEFORE any
+worktree is created), `CONFIRM_REQUIRED`.
 
 **1b. Act on the contract** - the only decision left to you:
 
+- `CLAIM=held` (`CONFIRM_REQUIRED=1`): another LIVE session is driving this
+  issue right now (issue #597). **STOP.** Do not create or enter anything -
+  proceeding duplicates that session's work, and whichever run reaches Step 7
+  first deletes the other's worktree. Report the owner (`CLAIM_PID`,
+  `CLAIM_SESSION`) and let the user decide: wait for that session, pick a
+  different issue, or - only if they confirm the other session is genuinely
+  gone - take it over. `CLAIM=stale` (owner process no longer exists) is taken
+  over automatically and needs no confirmation.
 - `ISSUE_STATE` not `OPEN` (`CONFIRM_REQUIRED=1`): warn the user and ask
   whether to proceed. On yes, re-run the same resolve command with
   `--allow-closed` appended (the helper is idempotent) and continue with its
@@ -211,7 +221,15 @@ This enforces the moat every later step relies on: it fails
 (`FLOW_START_VERIFY: fail`, exit 1) when the checkout is still on main/master,
 and renames a non-conforming branch to the issue-anchored `issue-<N>-<slug>`
 name so downstream steps can parse the issue number. On success it prints the
-final `BRANCH=` and `WT_ROOT=`.
+final `BRANCH=`, `WT_ROOT=` and `CLAIM=`.
+
+The verify gate also STAKES this run's claim on the worktree (issue #597) - it
+is the only hook point that runs inside the checkout on every lane, since the
+native `EnterWorktree` lane creates it only after 1a has already returned. A
+`CLAIM=self` line means the worktree is locked to this session and a sibling
+run's cleanup will refuse to remove it. Claiming is advisory: `unsupported` or
+`unknown` (git too old, or the current-branch lane, where the primary checkout
+cannot be locked) is normal and never blocks the run.
 
 **If this verification fails, STOP immediately. Report the failure using the error template at the bottom of this file. Do NOT proceed to Step 2.**
 
@@ -307,6 +325,28 @@ Report: `Step 3/9: ELI5 complete - verdict: {Still needed|Partially addressed|No
 ---
 
 ### Step 4: Implement - Write the Code
+
+**Re-check for a second driver (issue #597) - run BEFORE the first edit.** The
+#503 live-driver guard fires once, in Step 1. Everything between Step 1 and here
+- analysis, the ELI5 gate, the approval pause - is wall-clock time in which
+another session can enter this checkout, and one did: on `flow:auto #13` a
+concurrent session wrote a file into this worktree between the Step-1 clear
+verdict and the Step-4 merge, which then aborted on their dirty tree. A guard
+that runs only at Step 1 cannot see that. Re-run it bare, against the worktree
+(#581 invocation discipline; advisory, fail-open):
+
+```bash
+~/.claude/scripts/flow-live-driver-guard.sh
+```
+
+- `FLOW_LIVE_DRIVER: clear` - proceed.
+- `FLOW_LIVE_DRIVER: suspected` - dirty files here were modified in the last
+  30m and you have not written anything yet, so they are NOT yours. **STOP** and
+  ask the user before editing: another session is mid-implementation in this
+  checkout. Editing now means two drivers fighting over one tree.
+- Confirm the claim is still ours if anything looks off:
+  `~/.claude/scripts/flow-worktree-claim.sh check .` - `FLOW_CLAIM: self` is the
+  healthy answer; `held` means someone took the checkout over.
 
 **Early stale-base check (issue #473) - run BEFORE editing.** A sibling PR that
 merges during implementation moves `origin/main` under you; discovering it only
@@ -672,6 +712,20 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 
 4. **Clean up worktree and branch:**
 
+   **Release this run's claim FIRST (issue #597), whichever path follows.** The
+   claim is a real `git worktree lock`, and git refuses to remove a locked
+   worktree - including via the native tool, which does not know about the
+   claim. Drop it before removing, bare (#581 discipline; fail-open, never
+   blocks):
+
+   ```bash
+   ~/.claude/scripts/flow-worktree-claim.sh release /path/to/worktree
+   ```
+
+   It only releases a claim owned by THIS session (or an abandoned one); a
+   sibling's live claim is left intact and reported, which is the signal that
+   you are about to remove the wrong checkout.
+
    **If Step 1 created the worktree this session via `EnterWorktree(name=...)`**
    (the fresh-start path), remove it natively - a single tool call that deletes the
    worktree and its branch and restores the session to the main repo, with no
@@ -703,6 +757,16 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    ```bash
    ~/.claude/scripts/worktree-remove.sh /path/to/worktree --force --delete-branch
    ```
+   The helper checks the #597 claim before removing and **exits 4** when the
+   worktree is claimed by another LIVE session, printing the owner. That is a
+   correct refusal, not a flow failure: it means the path you were about to
+   delete belongs to a run that is still working in it (the failure that
+   destroyed uncommitted work on `flow:auto #5`). Do NOT retry with `--steal` -
+   report it and stop, so the user can decide. Almost always it means Step 1
+   resumed someone else's checkout; the claim caught it late but correctly.
+   A claim owned by THIS session, or left by a dead one, is released
+   automatically and the removal proceeds normally.
+
    If the helper is not installed (exit 127), fall back to:
    ```bash
    git worktree remove "$WORKTREE_PATH" --force
@@ -899,7 +963,23 @@ fi
 # fixed prod container_name values and leaks orphaned volumes/networks.
 DEPLOY_MODE=$(grep -oP '^\s*mode:\s*\K\S+' .claude/deploy.yaml 2>/dev/null | head -1)
 
-if [ "$DEPLOY_MODE" = "external" ]; then
+# Deploy idempotence (issue #597): with several sessions merging to the same
+# main, a sibling run can have deployed THIS exact sha minutes ago - on
+# flow:auto #49 the deploy.log showed the same sha 2 minutes earlier and the
+# duplicate deploy was skipped only because the model happened to notice. Make
+# it a guard: a successful deploy of the current HEAD already on record means
+# there is nothing to do. Only an exit-0 record counts, so a failed deploy is
+# still retried. Fail-open - no log, no skip.
+HEAD_SHA=$(git rev-parse --short HEAD)
+ALREADY_DEPLOYED=0
+if [ -f .claude/deploy.log ] && awk -F'|' -v sha="$HEAD_SHA" '$2 ~ /deploy/ && $3 ~ ("^[[:space:]]*" sha "[[:space:]]*$") && $5 ~ /^[[:space:]]*0[[:space:]]*$/ { found = 1 } END { exit !found }' .claude/deploy.log; then
+    ALREADY_DEPLOYED=1
+fi
+
+if [ "$ALREADY_DEPLOYED" -eq 1 ]; then
+    echo "Deploy skipped: $HEAD_SHA is already recorded as successfully deployed in .claude/deploy.log"
+    echo "(issue #597 - a concurrent session deployed this same commit; re-running would be a duplicate deploy)."
+elif [ "$DEPLOY_MODE" = "external" ]; then
     echo "Deploy mode 'external' (.claude/deploy.yaml) - deploy runs out of band (host timer / CI on origin/main). Skipping inline 'make deploy'."
 elif [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
     # Compose-project safety (issue #535): when COMPOSE_PROJECT_NAME is unset,
@@ -963,7 +1043,8 @@ fi
   never rolls back automatically - it is an actionable signal, not an action.
 
 Report: `Step 9/9: Deploy complete (verify: {proceed|review|rollback|none})` or
-`Step 9/9: Deploy skipped (no Makefile target)`
+`Step 9/9: Deploy skipped (no Makefile target)` or
+`Step 9/9: Deploy skipped ({sha} already deployed by a concurrent session)`
 
 ---
 

--- a/plugins/flow/commands/cleanup.md
+++ b/plugins/flow/commands/cleanup.md
@@ -47,6 +47,13 @@ git -C "$MAIN_REPO" worktree prune
 
 Report what was pruned (or "No stale worktree references found").
 
+Note: `git worktree prune` deliberately skips a LOCKED entry, so a worktree
+still carrying a live `/flow` claim (issue #597) is never pruned even if its
+directory is gone. That is the intended asymmetry - a claim outranks cleanup.
+Inspect one with `~/.claude/scripts/flow-worktree-claim.sh check --issue <N>`;
+a claim whose owning process is gone reports `stale` and is released by the
+next run that needs the worktree.
+
 ### Step 3: Find and Delete Merged Local Branches
 
 Delete local `issue-*` branches that have been merged to main. Protect `main`, `master`, and any branch with an active worktree.

--- a/plugins/flow/commands/doctor.md
+++ b/plugins/flow/commands/doctor.md
@@ -151,7 +151,7 @@ for dir in ~/Projects/claude-power-pack /opt/claude-power-pack ~/.claude-power-p
   if [ -d "$dir" ] && [ -f "$dir/CLAUDE.md" ]; then CPP_DIR="$dir"; break; fi
 done
 
-for script in flow-start-resolve.sh flow-stale-check.sh flow-worktree-guard.sh flow-live-driver-guard.sh gh-pr-merge.sh; do
+for script in flow-start-resolve.sh flow-stale-check.sh flow-worktree-guard.sh flow-live-driver-guard.sh flow-worktree-claim.sh gh-pr-merge.sh; do
   if [ -x "$HOME/.claude/scripts/$script" ]; then
     echo "PASS $script (flow helper)"
   elif [ -f "$HOME/.claude/scripts/$script" ]; then
@@ -333,7 +333,7 @@ Output a single diagnostic report in this format:
 | prompt-context.sh | ✅/❌ | Shell prompt context |
 | worktree-remove.sh | ✅/⚠️ | Optional fallback (native ExitWorktree is primary) |
 | secrets-mask.sh | ✅/❌ | Output masking filter |
-| Flow helper family | ✅/⚠️/❌ | flow-start-resolve, flow-stale-check, flow-worktree-guard, flow-live-driver-guard, gh-pr-merge at ~/.claude/scripts/ (zero-prompt lane, #581). ❌ when missing with no CPP checkout to fall back to (#590) |
+| Flow helper family | ✅/⚠️/❌ | flow-start-resolve, flow-stale-check, flow-worktree-guard, flow-live-driver-guard, flow-worktree-claim, gh-pr-merge at ~/.claude/scripts/ (zero-prompt lane, #581). ❌ when missing with no CPP checkout to fall back to (#590) |
 | Helper freshness | ✅/⚠️ | `flow-helpers-install.sh --check`: ok / stale (plugin upgraded, installed copies behind) |
 | Flow allowlist | ✅/⚠️/❌ | 38/38 rules in ~/.claude/settings.json / N missing / settings.json missing |
 

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -11,6 +11,20 @@ cross-session cleanup therefore stays on `git worktree remove` /
 same session with `EnterWorktree(name=...)`, prefer the native
 `ExitWorktree(action="remove", discard_changes=true)` instead of Steps 5a-5c.
 
+**Release the #597 claim before ANY removal path.** A `/flow` run stakes a real
+`git worktree lock` on its checkout, and git refuses to remove a locked worktree
+- including via the native tool, which knows nothing about the claim. Run this
+bare first (fail-open; it releases only a claim owned by this session or an
+abandoned one):
+
+```bash
+~/.claude/scripts/flow-worktree-claim.sh release /path/to/worktree
+```
+
+`worktree-remove.sh` does this itself, and **exits 4** rather than removing a
+worktree another LIVE session claims - a correct refusal, not a failure. Report
+it and stop instead of reaching for `--steal`.
+
 ## Instructions
 
 When the user invokes `/flow:merge`, perform these steps:

--- a/plugins/flow/scripts/flow-helpers-install.sh
+++ b/plugins/flow/scripts/flow-helpers-install.sh
@@ -51,6 +51,7 @@ HELPERS=(
     flow-live-driver-guard.sh
     flow-stale-check.sh
     flow-worktree-guard.sh
+    flow-worktree-claim.sh
     gh-pr-merge.sh
     worktree-remove.sh
     friction-log.sh

--- a/plugins/flow/scripts/flow-start-resolve.sh
+++ b/plugins/flow/scripts/flow-start-resolve.sh
@@ -64,10 +64,17 @@
 #     REMOTE_BRANCH=origin/<...>       (remote-pickup lane only)
 #     WT_CREATED=0|1        1 = this run already ran `git worktree add`
 #     LIVE_DRIVER=clear|suspected|unknown|skipped  (#503 guard, resume lane)
+#     CLAIM=none|free|self|held|stale|foreign|unsupported|unknown
+#                           cross-session ownership of issue-N (issue #597),
+#                           read before any worktree is created. `held` = another
+#                           LIVE session is driving this issue right now
+#     CLAIM_PID=<pid|->     owning process id when CLAIM names an owner
+#     CLAIM_SESSION=<id|->  owning Claude session id
 #     PR_HEAD=none|<number>:<state>|unknown        (resume shipped-PR hazard)
 #     CONFIRM_REQUIRED=0|1  1 = STOP: explicit user confirmation needed
-#                           (suspected live driver, existing open/merged PR,
-#                           or non-OPEN issue without --allow-closed)
+#                           (suspected live driver, a live cross-session claim
+#                           on this issue, existing open/merged PR, or non-OPEN
+#                           issue without --allow-closed)
 #     FLOW_START_RESOLVE: ok
 #   On a hard error: ERROR=<reason> then `FLOW_START_RESOLVE: error`, exit 1.
 #
@@ -77,7 +84,12 @@
 #   Fails (FLOW_START_VERIFY: fail, exit 1) when the checkout is still on
 #   main/master or detached; renames a non-issue-anchored branch to
 #   EXPECTED_BRANCH so downstream steps can parse the issue number. On success
-#   prints BRANCH= and WT_ROOT= then `FLOW_START_VERIFY: ok`.
+#   prints BRANCH=, WT_ROOT= and CLAIM= then `FLOW_START_VERIFY: ok`.
+#
+#   Verify mode also STAKES the cross-session claim (issue #597) - it is the one
+#   hook point that runs inside the worktree on every lane, since the native
+#   EnterWorktree lane creates the checkout only after resolve mode has already
+#   returned. Claiming is advisory here and never fails the gate.
 #
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
@@ -100,6 +112,13 @@ fail() {
 }
 
 usage_fail() { echo "flow-start-resolve: $1" >&2; exit 2; }
+
+# Path to a sibling helper script (installed alongside this one).
+sibling() {
+  local self_dir
+  self_dir=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+  echo "$self_dir/$1"
+}
 
 # Given any checkout path, print the PRIMARY checkout's toplevel (a linked
 # worktree resolves to the main repo that owns it).
@@ -194,8 +213,27 @@ if [ "$MODE" = verify ]; then
       CURRENT="$EXPECTED_BRANCH"
       ;;
   esac
+  WT_ROOT=$("$GIT" rev-parse --show-toplevel)
+
+  # Stake the cross-session claim (issue #597). This is the only hook point that
+  # runs INSIDE the worktree on every lane: the native lane's worktree does not
+  # exist yet when resolve mode returns, so resolve cannot claim it. Advisory by
+  # design - the gate's job is to prove we are on the right branch, and a claim
+  # that cannot be taken must never turn a healthy Step 1 into a hard stop.
+  CLAIM=unknown
+  CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+  if [ -f "$CLAIM_HELPER" ]; then
+    claim_out=$(bash "$CLAIM_HELPER" claim "$WT_ROOT" --issue "$ISSUE_NUM" 2>&1) || true
+    CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM=${CLAIM:-unknown}
+    if [ "$CLAIM" = held ]; then
+      printf '%s\n' "$claim_out" | grep -v '^FLOW_CLAIM' >&2 || true
+    fi
+  fi
+
   echo "BRANCH=$CURRENT"
-  echo "WT_ROOT=$("$GIT" rev-parse --show-toplevel)"
+  echo "WT_ROOT=$WT_ROOT"
+  echo "CLAIM=$CLAIM"
   echo "FLOW_START_VERIFY: ok"
   exit 0
 fi
@@ -289,6 +327,33 @@ SLUG=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9
 SLUG=$(printf '%s' "$SLUG" | sed 's/-$//')
 [ -n "$SLUG" ] || SLUG=work
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+
+# ---- cross-session claim check (issue #597) ---------------------------------
+# Before triaging existing work, ask whether ANOTHER live session already holds
+# issue-N. Two sessions handed the same issue used to race silently: both
+# implemented it, and whichever cleaned up first deleted the other's worktree.
+# Run this BEFORE any worktree is created, so a fresh lane cannot find its own
+# brand-new checkout and report itself as the owner.
+CLAIM=none
+CLAIM_PID=-
+CLAIM_SESSION=-
+CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+if [ -f "$CLAIM_HELPER" ]; then
+  claim_out=$(bash "$CLAIM_HELPER" check --issue "$ISSUE_NUM" --repo "$TARGET_REPO" 2>/dev/null) || true
+  CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+  CLAIM=${CLAIM:-none}
+  CLAIM_PID=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+  CLAIM_SESSION=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+  CLAIM_PID=${CLAIM_PID:--}
+  CLAIM_SESSION=${CLAIM_SESSION:--}
+  if [ "$CLAIM" = held ]; then
+    CONFIRM_REQUIRED=1
+    echo "flow-start-resolve: issue #$ISSUE_NUM is CLAIMED by another live session (pid $CLAIM_PID, session $CLAIM_SESSION)." >&2
+    echo "  That session is working this issue right now. Proceeding would duplicate its work, and" >&2
+    echo "  whichever run cleans up first deletes the other's worktree (issue #597)." >&2
+    echo "  STOP and confirm with the user before continuing." >&2
+  fi
+fi
 
 # ---- remote sync + default branch -------------------------------------------
 if ! "$GIT" -C "$TARGET_REPO" fetch origin --quiet 2>/dev/null; then
@@ -431,6 +496,9 @@ if [ -n "$REMOTE_BRANCH" ]; then
 fi
 echo "WT_CREATED=$WT_CREATED"
 echo "LIVE_DRIVER=$LIVE_DRIVER"
+echo "CLAIM=$CLAIM"
+echo "CLAIM_PID=$CLAIM_PID"
+echo "CLAIM_SESSION=$CLAIM_SESSION"
 echo "PR_HEAD=$PR_HEAD"
 echo "CONFIRM_REQUIRED=$CONFIRM_REQUIRED"
 echo "FLOW_START_RESOLVE: ok"

--- a/plugins/flow/scripts/flow-worktree-claim.sh
+++ b/plugins/flow/scripts/flow-worktree-claim.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# flow-worktree-claim.sh - Cross-session ownership claim on a flow worktree
+# (issue #597).
+#
+# Motivation: nothing stopped two concurrent /flow sessions from operating on
+# the same repo, or the same worktree. The #503 live-driver guard protects
+# RESUMING into an active worktree; it does not protect an active worktree from
+# being REMOVED by someone else, and it has no notion of an owner, so it cannot
+# tell "another session is driving this" from "someone left files dirty". The
+# observed cost was silent data loss: a sibling session's Step-7 cleanup removed
+# a live session's worktree by name, destroying uncommitted work.
+#
+# This helper makes ownership explicit and machine-checkable by riding git's own
+# worktree lock. `git worktree lock --reason <text>` already makes
+# `git worktree remove --force` refuse (it demands `-f -f`), so a claim is a
+# real barrier rather than an advisory note, and the reason text is readable
+# from `git worktree list --porcelain`. The reason we write is a single line:
+#
+#   flow-claim issue=<N> pid=<PID> session=<SID> host=<HOST> ts=<EPOCH>
+#
+# Liveness: the owning session is alive when `kill -0 <pid>` succeeds AND the
+# recorded host matches this one (a pid from another machine says nothing about
+# a pid here). A claim whose owner is gone is STALE and may be taken over, so
+# the mechanism can never permanently wedge a repo. A lock this script did not
+# write (no `flow-claim` prefix) is FOREIGN and is never stolen - someone locked
+# that worktree deliberately.
+#
+# It is FAIL-OPEN by design: anything it cannot determine (not a worktree, git
+# too old, lock unsupported on the primary checkout) reports and exits 0 rather
+# than blocking a flow run. The one non-zero exit is the case it exists for -
+# `claim` losing to a LIVE foreign owner.
+#
+# Usage:
+#   flow-worktree-claim.sh claim   <WORKTREE_PATH> --issue <N> [--steal]
+#   flow-worktree-claim.sh check   <WORKTREE_PATH>
+#   flow-worktree-claim.sh check   --issue <N> [--repo <PATH>]
+#   flow-worktree-claim.sh release <WORKTREE_PATH> [--force]
+#
+#   claim    Acquire the claim. Re-claiming a self-owned worktree refreshes the
+#            timestamp (idempotent). A STALE claim is taken over automatically.
+#            A LIVE foreign claim exits 1 unless --steal is passed.
+#   check    Report the claim state without changing it. Always exits 0 unless
+#            --exit-code is passed, which returns 1 for a held claim.
+#   release  Drop a self-owned (or stale) claim. A foreign live claim is left
+#            alone unless --force. Never fails the caller.
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_CLAIM: free | self | held | stale | foreign | unsupported | unknown
+# preceded by owner detail lines (FLOW_CLAIM_OWNER_PID=, ..._SESSION=, ..._HOST=,
+# ..._TS=, ..._AGE_MIN=, FLOW_CLAIM_PATH=), each '-' when not applicable.
+#
+# Env:
+#   CLAUDE_PID              owning process id (Claude Code sets it); falls back
+#                           to $PPID
+#   CLAUDE_CODE_SESSION_ID  owning session id; falls back to '-'
+#   FLOW_CLAIM_MAX_AGE_HOURS  a claim from ANOTHER host older than this is
+#                           treated as stale (default 24) - cross-host liveness
+#                           cannot be probed, so age is the only safety valve
+# Env (test hooks - unset in normal use):
+#   FLOW_CLAIM_GIT          override the `git` binary
+#   FLOW_CLAIM_NOW          override "now" as epoch seconds
+#   FLOW_CLAIM_HOST         override this host's name
+#   FLOW_CLAIM_LIVE_PIDS    ':'-separated pids to treat as alive (bypasses
+#                           kill -0, so a test can simulate a live sibling)
+
+set -uo pipefail
+
+GIT="${FLOW_CLAIM_GIT:-git}"
+MAX_AGE_HOURS="${FLOW_CLAIM_MAX_AGE_HOURS:-24}"
+SELF_PID="${CLAUDE_PID:-$PPID}"
+SELF_SESSION="${CLAUDE_CODE_SESSION_ID:-}"
+SELF_HOST="${FLOW_CLAIM_HOST:-${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}}"
+NOW="${FLOW_CLAIM_NOW:-$(date +%s)}"
+
+CLAIM_PREFIX="flow-claim"
+
+usage_fail() { echo "flow-worktree-claim: $1" >&2; exit 2; }
+
+# Emit the owner detail block + verdict. All args default to '-'.
+emit() {
+  echo "FLOW_CLAIM_PATH=${O_PATH:--}"
+  echo "FLOW_CLAIM_OWNER_PID=${O_PID:--}"
+  echo "FLOW_CLAIM_OWNER_SESSION=${O_SESSION:--}"
+  echo "FLOW_CLAIM_OWNER_HOST=${O_HOST:--}"
+  echo "FLOW_CLAIM_TS=${O_TS:--}"
+  echo "FLOW_CLAIM_AGE_MIN=${O_AGE_MIN:--}"
+  echo "FLOW_CLAIM_ISSUE=${O_ISSUE:--}"
+  echo "FLOW_CLAIM: $1"
+}
+
+# Absolute, symlink-resolved path (git's porcelain prints resolved paths, so
+# both sides of the comparison must be normalized the same way).
+abspath() {
+  if [ -d "$1" ]; then (cd "$1" 2>/dev/null && pwd -P); else echo "$1"; fi
+}
+
+# is_alive PID HOST -> 0 when the owning session is still running here.
+is_alive() {
+  local pid="$1" host="$2"
+  [ -n "$pid" ] && [ "$pid" != "-" ] || return 1
+  # A pid only means something on the machine that recorded it.
+  [ "$host" = "$SELF_HOST" ] || return 1
+  if [ -n "${FLOW_CLAIM_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_CLAIM_LIVE_PIDS:" in
+      *":$pid:"*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Parse a claim reason string into the O_* globals. Returns 1 when the reason
+# is not one of ours (a foreign lock).
+O_PATH=""; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+parse_reason() {
+  local reason="$1" field
+  case "$reason" in
+    "$CLAIM_PREFIX "*) : ;;
+    *) return 1 ;;
+  esac
+  for field in $reason; do
+    case "$field" in
+      issue=*) O_ISSUE="${field#issue=}" ;;
+      pid=*) O_PID="${field#pid=}" ;;
+      session=*) O_SESSION="${field#session=}" ;;
+      host=*) O_HOST="${field#host=}" ;;
+      ts=*) O_TS="${field#ts=}" ;;
+    esac
+  done
+  if [ -n "$O_TS" ] && printf '%s' "$O_TS" | grep -qE '^[0-9]+$'; then
+    local age=$((NOW - O_TS))
+    [ "$age" -lt 0 ] && age=0
+    O_AGE_MIN=$((age / 60))
+  fi
+  return 0
+}
+
+# lock_reason_for PATH - print the lock reason for a worktree ('' when
+# unlocked). Locked-with-no-reason prints the sentinel '(no reason)'.
+lock_reason_for() {
+  local want cur="" locked_line=""
+  want="$(abspath "$1")"
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="$(abspath "${line#worktree }")"; locked_line="" ;;
+      "locked "*)
+        [ "$cur" = "$want" ] && { printf '%s' "${line#locked }"; return 0; }
+        ;;
+      "locked")
+        [ "$cur" = "$want" ] && { printf '%s' "(no reason)"; return 0; }
+        ;;
+    esac
+  done < <("$GIT" -C "$want" worktree list --porcelain 2>/dev/null)
+  return 0
+}
+
+# Classify the current state of WORKTREE_PATH, setting the O_* owner globals
+# and STATE. Deliberately NOT a value-returning function: the owner detail has
+# to survive into emit(), and command substitution would run this in a subshell
+# and discard every assignment.
+classify() {
+  local path="$1" reason
+  O_PATH="$path"; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+
+  if [ ! -d "$path" ]; then STATE=unknown; return 0; fi
+  if ! "$GIT" -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    STATE=unknown; return 0
+  fi
+  # The primary checkout cannot be locked by git at all; a run on the
+  # current-branch lane therefore has no claim to make.
+  if [ ! -f "$path/.git" ]; then STATE=unsupported; return 0; fi
+
+  reason="$(lock_reason_for "$path")"
+  if [ -z "$reason" ]; then STATE=free; return 0; fi
+  if ! parse_reason "$reason"; then STATE=foreign; return 0; fi
+
+  if [ -n "$SELF_SESSION" ] && [ "$O_SESSION" = "$SELF_SESSION" ]; then
+    STATE=self; return 0
+  fi
+  if [ "$O_HOST" = "$SELF_HOST" ] && [ "$O_PID" = "$SELF_PID" ]; then
+    STATE=self; return 0
+  fi
+  if is_alive "$O_PID" "$O_HOST"; then STATE=held; return 0; fi
+  # Not provably alive. Same host + dead pid is decisively stale; a claim from
+  # another host is only stale once it has aged out.
+  if [ "$O_HOST" = "$SELF_HOST" ]; then STATE=stale; return 0; fi
+  if [ -n "$O_AGE_MIN" ] && [ "$O_AGE_MIN" -gt $((MAX_AGE_HOURS * 60)) ]; then
+    STATE=stale; return 0
+  fi
+  STATE=held
+}
+
+# ---- argument parsing -------------------------------------------------------
+VERB="${1:-}"
+[ -n "$VERB" ] || usage_fail "usage: flow-worktree-claim.sh claim|check|release <WORKTREE_PATH> [options]"
+shift
+
+case "$VERB" in
+  claim | check | release) : ;;
+  --help | -h)
+    sed -n '2,70p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *) usage_fail "unknown verb: $VERB (expected claim, check or release)" ;;
+esac
+
+WT=""
+ISSUE_NUM=""
+REPO=""
+STEAL=0
+FORCE=0
+WANT_EXIT_CODE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue)
+      [ "$#" -ge 2 ] || usage_fail "--issue requires a number"
+      ISSUE_NUM="$2"; shift
+      ;;
+    --issue=*) ISSUE_NUM="${1#--issue=}" ;;
+    --repo)
+      [ "$#" -ge 2 ] || usage_fail "--repo requires a path"
+      REPO="$2"; shift
+      ;;
+    --repo=*) REPO="${1#--repo=}" ;;
+    --steal) STEAL=1 ;;
+    --force) FORCE=1 ;;
+    --exit-code) WANT_EXIT_CODE=1 ;;
+    --*) usage_fail "unknown option: $1" ;;
+    *)
+      [ -z "$WT" ] || usage_fail "unexpected argument: $1"
+      WT="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$ISSUE_NUM" ]; then
+  printf '%s' "$ISSUE_NUM" | grep -qE '^[0-9]+$' ||
+    usage_fail "--issue must be a number, got: $ISSUE_NUM"
+fi
+
+# `check --issue N` resolves the worktree by branch, so a session can ask
+# "does anyone hold issue N?" before it has a path of its own (issue #597,
+# the cross-session claim check).
+if [ -z "$WT" ] && [ -n "$ISSUE_NUM" ] && [ "$VERB" = check ]; then
+  REPO="${REPO:-.}"
+  cur=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="${line#worktree }" ;;
+      "branch refs/heads/issue-${ISSUE_NUM}-"*) WT="$cur" ;;
+    esac
+  done < <("$GIT" -C "$REPO" worktree list --porcelain 2>/dev/null)
+  if [ -z "$WT" ]; then
+    O_PATH="-"
+    emit free
+    exit 0
+  fi
+fi
+
+[ -n "$WT" ] || usage_fail "$VERB requires a worktree path"
+WT="$(abspath "$WT")"
+
+STATE=unknown
+classify "$WT"
+
+case "$VERB" in
+  check)
+    emit "$STATE"
+    if [ "$WANT_EXIT_CODE" -eq 1 ] && [ "$STATE" = held ]; then exit 1; fi
+    exit 0
+    ;;
+
+  release)
+    case "$STATE" in
+      self | stale)
+        if "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1; then
+          echo "flow-worktree-claim: released claim on '$WT'." >&2
+        fi
+        O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+        emit free
+        ;;
+      held | foreign)
+        if [ "$FORCE" -eq 1 ]; then
+          "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+          echo "flow-worktree-claim: FORCE-released a $STATE claim on '$WT' (owner pid ${O_PID:--})." >&2
+          emit free
+        else
+          echo "flow-worktree-claim: '$WT' is claimed by another session (pid ${O_PID:--}, session ${O_SESSION:--}) - not releasing. Pass --force to override." >&2
+          emit "$STATE"
+        fi
+        ;;
+      *) emit "$STATE" ;;
+    esac
+    exit 0
+    ;;
+
+  claim)
+    [ -n "$ISSUE_NUM" ] || usage_fail "claim requires --issue <N>"
+    case "$STATE" in
+      held)
+        if [ "$STEAL" -eq 0 ]; then
+          echo "flow-worktree-claim: '$WT' is CLAIMED by a live session (pid ${O_PID:--}, session ${O_SESSION:--}, host ${O_HOST:--}, ~${O_AGE_MIN:-?}m ago)." >&2
+          echo "  Another /flow run is driving this worktree right now (issue #597). Working here would race it:" >&2
+          echo "  its cleanup can delete this checkout, and yours can delete theirs." >&2
+          echo "  Either wait for that session to finish, or - if you are certain it is gone - re-run with --steal." >&2
+          emit held
+          exit 1
+        fi
+        echo "flow-worktree-claim: stealing a live claim on '$WT' (--steal; previous owner pid ${O_PID:--})." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      foreign)
+        # Someone locked this worktree for their own reasons. Never steal it,
+        # but do not fail the run either - report and move on (fail-open).
+        echo "flow-worktree-claim: '$WT' carries a non-flow lock; leaving it untouched and claiming nothing." >&2
+        emit foreign
+        exit 0
+        ;;
+      stale)
+        echo "flow-worktree-claim: taking over a stale claim on '$WT' (owner pid ${O_PID:--} is gone)." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      self)
+        # Idempotent refresh: drop our own lock so the new timestamp lands.
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      unsupported | unknown)
+        echo "flow-worktree-claim: '$WT' cannot hold a claim ($STATE) - continuing unclaimed (advisory)." >&2
+        emit "$STATE"
+        exit 0
+        ;;
+    esac
+
+    REASON="$CLAIM_PREFIX issue=$ISSUE_NUM pid=$SELF_PID session=${SELF_SESSION:--} host=$SELF_HOST ts=$NOW"
+    if ! "$GIT" -C "$WT" worktree lock --reason "$REASON" "$WT" >/dev/null 2>&1; then
+      echo "flow-worktree-claim: could not lock '$WT' (git too old, or lock unsupported) - continuing unclaimed (advisory)." >&2
+      O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+      emit unsupported
+      exit 0
+    fi
+    O_PID="$SELF_PID"; O_SESSION="${SELF_SESSION:--}"; O_HOST="$SELF_HOST"
+    O_TS="$NOW"; O_AGE_MIN=0; O_ISSUE="$ISSUE_NUM"
+    echo "flow-worktree-claim: claimed '$WT' for issue #$ISSUE_NUM (pid $SELF_PID)." >&2
+    emit self
+    exit 0
+    ;;
+esac

--- a/plugins/flow/scripts/worktree-remove.sh
+++ b/plugins/flow/scripts/worktree-remove.sh
@@ -5,12 +5,19 @@
 # changes to the main repository first (determined from the worktree's
 # .git file) to prevent breaking your shell session.
 #
+# A worktree CLAIMED by another live /flow session (issue #597) is never
+# removed: the claim is checked first and a live foreign owner is a hard stop
+# (exit 4), because removing it is exactly the silent-data-loss failure that
+# motivated the claim. A self-owned or stale claim is released and removed as
+# usual, and --steal is the deliberate override.
+#
 # Usage:
-#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch] [--steal]
 #
 # Options:
 #   --force          Remove even if worktree has uncommitted changes
 #   --delete-branch  Also delete the associated branch after removal
+#   --steal          Remove even when another live session claims it (#597)
 #
 # Examples:
 #   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
@@ -30,6 +37,7 @@ NC='\033[0m' # No Color
 WORKTREE_PATH=""
 FORCE=""
 DELETE_BRANCH=false
+STEAL=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delete-branch)
             DELETE_BRANCH=true
+            shift
+            ;;
+        --steal)
+            STEAL=true
             shift
             ;;
         -h|--help)
@@ -52,6 +64,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
             echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo "  --steal          Remove even when another live /flow session claims it"
+            echo "                   (issue #597; without it a live claim is a hard stop)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -158,6 +172,53 @@ fi
 
 # Get the branch name before removing
 BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Cross-session claim check (issue #597) ----------------------------------
+# Another LIVE /flow session may be driving this checkout right now. Removing it
+# out from under that session is the silent-data-loss failure this guard exists
+# for, so a live foreign claim is a hard stop. A claim owned by THIS session, or
+# left behind by a session that has since died, is simply released first.
+#
+# Fail-open in both directions: a missing helper, an unreadable lock, or a git
+# too old to report one leaves the previous behavior exactly as it was.
+SELF_SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")"
+CLAIM_HELPER=""
+for cand in "$SELF_SCRIPT_DIR/flow-worktree-claim.sh" "$HOME/.claude/scripts/flow-worktree-claim.sh"; do
+    if [[ -f "$cand" ]]; then
+        CLAIM_HELPER="$cand"
+        break
+    fi
+done
+
+if [[ -n "$CLAIM_HELPER" ]]; then
+    CLAIM_OUT=$(bash "$CLAIM_HELPER" check "$WORKTREE_PATH" 2>/dev/null || true)
+    CLAIM_STATE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM_PID=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+    CLAIM_SESSION=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+    CLAIM_ISSUE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_ISSUE=//p' | tail -1)
+
+    case "${CLAIM_STATE:-unknown}" in
+        held | foreign)
+            if [[ "$STEAL" != true ]]; then
+                echo -e "${RED}Error: refusing to remove a worktree claimed by another session${NC}" >&2
+                echo "" >&2
+                echo "  Worktree: $WORKTREE_PATH" >&2
+                echo "  Claim:    ${CLAIM_STATE} (issue #${CLAIM_ISSUE:--}, pid ${CLAIM_PID:--}, session ${CLAIM_SESSION:--})" >&2
+                echo "" >&2
+                echo "  Another /flow session is driving this checkout. Removing it would destroy" >&2
+                echo "  its uncommitted work - the failure this claim exists to prevent (issue #597)." >&2
+                echo "  Wait for that session to finish, or pass --steal if you are certain it is gone." >&2
+                exit 4
+            fi
+            echo -e "${YELLOW}Warning: --steal given; removing a worktree claimed by pid ${CLAIM_PID:--}.${NC}" >&2
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" --force >/dev/null 2>&1 || true
+            ;;
+        self | stale)
+            # Ours, or abandoned - drop the lock so the removal below can proceed.
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" >/dev/null 2>&1 || true
+            ;;
+    esac
+fi
 
 # Check for uncommitted changes (unless --force)
 if [[ -z "$FORCE" ]]; then

--- a/scripts/flow-helpers-install.sh
+++ b/scripts/flow-helpers-install.sh
@@ -51,6 +51,7 @@ HELPERS=(
     flow-live-driver-guard.sh
     flow-stale-check.sh
     flow-worktree-guard.sh
+    flow-worktree-claim.sh
     gh-pr-merge.sh
     worktree-remove.sh
     friction-log.sh

--- a/scripts/flow-start-resolve.sh
+++ b/scripts/flow-start-resolve.sh
@@ -64,10 +64,17 @@
 #     REMOTE_BRANCH=origin/<...>       (remote-pickup lane only)
 #     WT_CREATED=0|1        1 = this run already ran `git worktree add`
 #     LIVE_DRIVER=clear|suspected|unknown|skipped  (#503 guard, resume lane)
+#     CLAIM=none|free|self|held|stale|foreign|unsupported|unknown
+#                           cross-session ownership of issue-N (issue #597),
+#                           read before any worktree is created. `held` = another
+#                           LIVE session is driving this issue right now
+#     CLAIM_PID=<pid|->     owning process id when CLAIM names an owner
+#     CLAIM_SESSION=<id|->  owning Claude session id
 #     PR_HEAD=none|<number>:<state>|unknown        (resume shipped-PR hazard)
 #     CONFIRM_REQUIRED=0|1  1 = STOP: explicit user confirmation needed
-#                           (suspected live driver, existing open/merged PR,
-#                           or non-OPEN issue without --allow-closed)
+#                           (suspected live driver, a live cross-session claim
+#                           on this issue, existing open/merged PR, or non-OPEN
+#                           issue without --allow-closed)
 #     FLOW_START_RESOLVE: ok
 #   On a hard error: ERROR=<reason> then `FLOW_START_RESOLVE: error`, exit 1.
 #
@@ -77,7 +84,12 @@
 #   Fails (FLOW_START_VERIFY: fail, exit 1) when the checkout is still on
 #   main/master or detached; renames a non-issue-anchored branch to
 #   EXPECTED_BRANCH so downstream steps can parse the issue number. On success
-#   prints BRANCH= and WT_ROOT= then `FLOW_START_VERIFY: ok`.
+#   prints BRANCH=, WT_ROOT= and CLAIM= then `FLOW_START_VERIFY: ok`.
+#
+#   Verify mode also STAKES the cross-session claim (issue #597) - it is the one
+#   hook point that runs inside the worktree on every lane, since the native
+#   EnterWorktree lane creates the checkout only after resolve mode has already
+#   returned. Claiming is advisory here and never fails the gate.
 #
 # Env:
 #   FLOW_WORKTREE_BASE               worktree base override (issue #584, ADR
@@ -100,6 +112,13 @@ fail() {
 }
 
 usage_fail() { echo "flow-start-resolve: $1" >&2; exit 2; }
+
+# Path to a sibling helper script (installed alongside this one).
+sibling() {
+  local self_dir
+  self_dir=$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")
+  echo "$self_dir/$1"
+}
 
 # Given any checkout path, print the PRIMARY checkout's toplevel (a linked
 # worktree resolves to the main repo that owns it).
@@ -194,8 +213,27 @@ if [ "$MODE" = verify ]; then
       CURRENT="$EXPECTED_BRANCH"
       ;;
   esac
+  WT_ROOT=$("$GIT" rev-parse --show-toplevel)
+
+  # Stake the cross-session claim (issue #597). This is the only hook point that
+  # runs INSIDE the worktree on every lane: the native lane's worktree does not
+  # exist yet when resolve mode returns, so resolve cannot claim it. Advisory by
+  # design - the gate's job is to prove we are on the right branch, and a claim
+  # that cannot be taken must never turn a healthy Step 1 into a hard stop.
+  CLAIM=unknown
+  CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+  if [ -f "$CLAIM_HELPER" ]; then
+    claim_out=$(bash "$CLAIM_HELPER" claim "$WT_ROOT" --issue "$ISSUE_NUM" 2>&1) || true
+    CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM=${CLAIM:-unknown}
+    if [ "$CLAIM" = held ]; then
+      printf '%s\n' "$claim_out" | grep -v '^FLOW_CLAIM' >&2 || true
+    fi
+  fi
+
   echo "BRANCH=$CURRENT"
-  echo "WT_ROOT=$("$GIT" rev-parse --show-toplevel)"
+  echo "WT_ROOT=$WT_ROOT"
+  echo "CLAIM=$CLAIM"
   echo "FLOW_START_VERIFY: ok"
   exit 0
 fi
@@ -289,6 +327,33 @@ SLUG=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9
 SLUG=$(printf '%s' "$SLUG" | sed 's/-$//')
 [ -n "$SLUG" ] || SLUG=work
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+
+# ---- cross-session claim check (issue #597) ---------------------------------
+# Before triaging existing work, ask whether ANOTHER live session already holds
+# issue-N. Two sessions handed the same issue used to race silently: both
+# implemented it, and whichever cleaned up first deleted the other's worktree.
+# Run this BEFORE any worktree is created, so a fresh lane cannot find its own
+# brand-new checkout and report itself as the owner.
+CLAIM=none
+CLAIM_PID=-
+CLAIM_SESSION=-
+CLAIM_HELPER=$(sibling flow-worktree-claim.sh)
+if [ -f "$CLAIM_HELPER" ]; then
+  claim_out=$(bash "$CLAIM_HELPER" check --issue "$ISSUE_NUM" --repo "$TARGET_REPO" 2>/dev/null) || true
+  CLAIM=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+  CLAIM=${CLAIM:-none}
+  CLAIM_PID=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+  CLAIM_SESSION=$(printf '%s\n' "$claim_out" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+  CLAIM_PID=${CLAIM_PID:--}
+  CLAIM_SESSION=${CLAIM_SESSION:--}
+  if [ "$CLAIM" = held ]; then
+    CONFIRM_REQUIRED=1
+    echo "flow-start-resolve: issue #$ISSUE_NUM is CLAIMED by another live session (pid $CLAIM_PID, session $CLAIM_SESSION)." >&2
+    echo "  That session is working this issue right now. Proceeding would duplicate its work, and" >&2
+    echo "  whichever run cleans up first deletes the other's worktree (issue #597)." >&2
+    echo "  STOP and confirm with the user before continuing." >&2
+  fi
+fi
 
 # ---- remote sync + default branch -------------------------------------------
 if ! "$GIT" -C "$TARGET_REPO" fetch origin --quiet 2>/dev/null; then
@@ -431,6 +496,9 @@ if [ -n "$REMOTE_BRANCH" ]; then
 fi
 echo "WT_CREATED=$WT_CREATED"
 echo "LIVE_DRIVER=$LIVE_DRIVER"
+echo "CLAIM=$CLAIM"
+echo "CLAIM_PID=$CLAIM_PID"
+echo "CLAIM_SESSION=$CLAIM_SESSION"
 echo "PR_HEAD=$PR_HEAD"
 echo "CONFIRM_REQUIRED=$CONFIRM_REQUIRED"
 echo "FLOW_START_RESOLVE: ok"

--- a/scripts/flow-worktree-claim.sh
+++ b/scripts/flow-worktree-claim.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# flow-worktree-claim.sh - Cross-session ownership claim on a flow worktree
+# (issue #597).
+#
+# Motivation: nothing stopped two concurrent /flow sessions from operating on
+# the same repo, or the same worktree. The #503 live-driver guard protects
+# RESUMING into an active worktree; it does not protect an active worktree from
+# being REMOVED by someone else, and it has no notion of an owner, so it cannot
+# tell "another session is driving this" from "someone left files dirty". The
+# observed cost was silent data loss: a sibling session's Step-7 cleanup removed
+# a live session's worktree by name, destroying uncommitted work.
+#
+# This helper makes ownership explicit and machine-checkable by riding git's own
+# worktree lock. `git worktree lock --reason <text>` already makes
+# `git worktree remove --force` refuse (it demands `-f -f`), so a claim is a
+# real barrier rather than an advisory note, and the reason text is readable
+# from `git worktree list --porcelain`. The reason we write is a single line:
+#
+#   flow-claim issue=<N> pid=<PID> session=<SID> host=<HOST> ts=<EPOCH>
+#
+# Liveness: the owning session is alive when `kill -0 <pid>` succeeds AND the
+# recorded host matches this one (a pid from another machine says nothing about
+# a pid here). A claim whose owner is gone is STALE and may be taken over, so
+# the mechanism can never permanently wedge a repo. A lock this script did not
+# write (no `flow-claim` prefix) is FOREIGN and is never stolen - someone locked
+# that worktree deliberately.
+#
+# It is FAIL-OPEN by design: anything it cannot determine (not a worktree, git
+# too old, lock unsupported on the primary checkout) reports and exits 0 rather
+# than blocking a flow run. The one non-zero exit is the case it exists for -
+# `claim` losing to a LIVE foreign owner.
+#
+# Usage:
+#   flow-worktree-claim.sh claim   <WORKTREE_PATH> --issue <N> [--steal]
+#   flow-worktree-claim.sh check   <WORKTREE_PATH>
+#   flow-worktree-claim.sh check   --issue <N> [--repo <PATH>]
+#   flow-worktree-claim.sh release <WORKTREE_PATH> [--force]
+#
+#   claim    Acquire the claim. Re-claiming a self-owned worktree refreshes the
+#            timestamp (idempotent). A STALE claim is taken over automatically.
+#            A LIVE foreign claim exits 1 unless --steal is passed.
+#   check    Report the claim state without changing it. Always exits 0 unless
+#            --exit-code is passed, which returns 1 for a held claim.
+#   release  Drop a self-owned (or stale) claim. A foreign live claim is left
+#            alone unless --force. Never fails the caller.
+#
+# Output ends with a machine-readable verdict line:
+#   FLOW_CLAIM: free | self | held | stale | foreign | unsupported | unknown
+# preceded by owner detail lines (FLOW_CLAIM_OWNER_PID=, ..._SESSION=, ..._HOST=,
+# ..._TS=, ..._AGE_MIN=, FLOW_CLAIM_PATH=), each '-' when not applicable.
+#
+# Env:
+#   CLAUDE_PID              owning process id (Claude Code sets it); falls back
+#                           to $PPID
+#   CLAUDE_CODE_SESSION_ID  owning session id; falls back to '-'
+#   FLOW_CLAIM_MAX_AGE_HOURS  a claim from ANOTHER host older than this is
+#                           treated as stale (default 24) - cross-host liveness
+#                           cannot be probed, so age is the only safety valve
+# Env (test hooks - unset in normal use):
+#   FLOW_CLAIM_GIT          override the `git` binary
+#   FLOW_CLAIM_NOW          override "now" as epoch seconds
+#   FLOW_CLAIM_HOST         override this host's name
+#   FLOW_CLAIM_LIVE_PIDS    ':'-separated pids to treat as alive (bypasses
+#                           kill -0, so a test can simulate a live sibling)
+
+set -uo pipefail
+
+GIT="${FLOW_CLAIM_GIT:-git}"
+MAX_AGE_HOURS="${FLOW_CLAIM_MAX_AGE_HOURS:-24}"
+SELF_PID="${CLAUDE_PID:-$PPID}"
+SELF_SESSION="${CLAUDE_CODE_SESSION_ID:-}"
+SELF_HOST="${FLOW_CLAIM_HOST:-${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}}"
+NOW="${FLOW_CLAIM_NOW:-$(date +%s)}"
+
+CLAIM_PREFIX="flow-claim"
+
+usage_fail() { echo "flow-worktree-claim: $1" >&2; exit 2; }
+
+# Emit the owner detail block + verdict. All args default to '-'.
+emit() {
+  echo "FLOW_CLAIM_PATH=${O_PATH:--}"
+  echo "FLOW_CLAIM_OWNER_PID=${O_PID:--}"
+  echo "FLOW_CLAIM_OWNER_SESSION=${O_SESSION:--}"
+  echo "FLOW_CLAIM_OWNER_HOST=${O_HOST:--}"
+  echo "FLOW_CLAIM_TS=${O_TS:--}"
+  echo "FLOW_CLAIM_AGE_MIN=${O_AGE_MIN:--}"
+  echo "FLOW_CLAIM_ISSUE=${O_ISSUE:--}"
+  echo "FLOW_CLAIM: $1"
+}
+
+# Absolute, symlink-resolved path (git's porcelain prints resolved paths, so
+# both sides of the comparison must be normalized the same way).
+abspath() {
+  if [ -d "$1" ]; then (cd "$1" 2>/dev/null && pwd -P); else echo "$1"; fi
+}
+
+# is_alive PID HOST -> 0 when the owning session is still running here.
+is_alive() {
+  local pid="$1" host="$2"
+  [ -n "$pid" ] && [ "$pid" != "-" ] || return 1
+  # A pid only means something on the machine that recorded it.
+  [ "$host" = "$SELF_HOST" ] || return 1
+  if [ -n "${FLOW_CLAIM_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_CLAIM_LIVE_PIDS:" in
+      *":$pid:"*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Parse a claim reason string into the O_* globals. Returns 1 when the reason
+# is not one of ours (a foreign lock).
+O_PATH=""; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+parse_reason() {
+  local reason="$1" field
+  case "$reason" in
+    "$CLAIM_PREFIX "*) : ;;
+    *) return 1 ;;
+  esac
+  for field in $reason; do
+    case "$field" in
+      issue=*) O_ISSUE="${field#issue=}" ;;
+      pid=*) O_PID="${field#pid=}" ;;
+      session=*) O_SESSION="${field#session=}" ;;
+      host=*) O_HOST="${field#host=}" ;;
+      ts=*) O_TS="${field#ts=}" ;;
+    esac
+  done
+  if [ -n "$O_TS" ] && printf '%s' "$O_TS" | grep -qE '^[0-9]+$'; then
+    local age=$((NOW - O_TS))
+    [ "$age" -lt 0 ] && age=0
+    O_AGE_MIN=$((age / 60))
+  fi
+  return 0
+}
+
+# lock_reason_for PATH - print the lock reason for a worktree ('' when
+# unlocked). Locked-with-no-reason prints the sentinel '(no reason)'.
+lock_reason_for() {
+  local want cur="" locked_line=""
+  want="$(abspath "$1")"
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="$(abspath "${line#worktree }")"; locked_line="" ;;
+      "locked "*)
+        [ "$cur" = "$want" ] && { printf '%s' "${line#locked }"; return 0; }
+        ;;
+      "locked")
+        [ "$cur" = "$want" ] && { printf '%s' "(no reason)"; return 0; }
+        ;;
+    esac
+  done < <("$GIT" -C "$want" worktree list --porcelain 2>/dev/null)
+  return 0
+}
+
+# Classify the current state of WORKTREE_PATH, setting the O_* owner globals
+# and STATE. Deliberately NOT a value-returning function: the owner detail has
+# to survive into emit(), and command substitution would run this in a subshell
+# and discard every assignment.
+classify() {
+  local path="$1" reason
+  O_PATH="$path"; O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+
+  if [ ! -d "$path" ]; then STATE=unknown; return 0; fi
+  if ! "$GIT" -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    STATE=unknown; return 0
+  fi
+  # The primary checkout cannot be locked by git at all; a run on the
+  # current-branch lane therefore has no claim to make.
+  if [ ! -f "$path/.git" ]; then STATE=unsupported; return 0; fi
+
+  reason="$(lock_reason_for "$path")"
+  if [ -z "$reason" ]; then STATE=free; return 0; fi
+  if ! parse_reason "$reason"; then STATE=foreign; return 0; fi
+
+  if [ -n "$SELF_SESSION" ] && [ "$O_SESSION" = "$SELF_SESSION" ]; then
+    STATE=self; return 0
+  fi
+  if [ "$O_HOST" = "$SELF_HOST" ] && [ "$O_PID" = "$SELF_PID" ]; then
+    STATE=self; return 0
+  fi
+  if is_alive "$O_PID" "$O_HOST"; then STATE=held; return 0; fi
+  # Not provably alive. Same host + dead pid is decisively stale; a claim from
+  # another host is only stale once it has aged out.
+  if [ "$O_HOST" = "$SELF_HOST" ]; then STATE=stale; return 0; fi
+  if [ -n "$O_AGE_MIN" ] && [ "$O_AGE_MIN" -gt $((MAX_AGE_HOURS * 60)) ]; then
+    STATE=stale; return 0
+  fi
+  STATE=held
+}
+
+# ---- argument parsing -------------------------------------------------------
+VERB="${1:-}"
+[ -n "$VERB" ] || usage_fail "usage: flow-worktree-claim.sh claim|check|release <WORKTREE_PATH> [options]"
+shift
+
+case "$VERB" in
+  claim | check | release) : ;;
+  --help | -h)
+    sed -n '2,70p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *) usage_fail "unknown verb: $VERB (expected claim, check or release)" ;;
+esac
+
+WT=""
+ISSUE_NUM=""
+REPO=""
+STEAL=0
+FORCE=0
+WANT_EXIT_CODE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue)
+      [ "$#" -ge 2 ] || usage_fail "--issue requires a number"
+      ISSUE_NUM="$2"; shift
+      ;;
+    --issue=*) ISSUE_NUM="${1#--issue=}" ;;
+    --repo)
+      [ "$#" -ge 2 ] || usage_fail "--repo requires a path"
+      REPO="$2"; shift
+      ;;
+    --repo=*) REPO="${1#--repo=}" ;;
+    --steal) STEAL=1 ;;
+    --force) FORCE=1 ;;
+    --exit-code) WANT_EXIT_CODE=1 ;;
+    --*) usage_fail "unknown option: $1" ;;
+    *)
+      [ -z "$WT" ] || usage_fail "unexpected argument: $1"
+      WT="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$ISSUE_NUM" ]; then
+  printf '%s' "$ISSUE_NUM" | grep -qE '^[0-9]+$' ||
+    usage_fail "--issue must be a number, got: $ISSUE_NUM"
+fi
+
+# `check --issue N` resolves the worktree by branch, so a session can ask
+# "does anyone hold issue N?" before it has a path of its own (issue #597,
+# the cross-session claim check).
+if [ -z "$WT" ] && [ -n "$ISSUE_NUM" ] && [ "$VERB" = check ]; then
+  REPO="${REPO:-.}"
+  cur=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) cur="${line#worktree }" ;;
+      "branch refs/heads/issue-${ISSUE_NUM}-"*) WT="$cur" ;;
+    esac
+  done < <("$GIT" -C "$REPO" worktree list --porcelain 2>/dev/null)
+  if [ -z "$WT" ]; then
+    O_PATH="-"
+    emit free
+    exit 0
+  fi
+fi
+
+[ -n "$WT" ] || usage_fail "$VERB requires a worktree path"
+WT="$(abspath "$WT")"
+
+STATE=unknown
+classify "$WT"
+
+case "$VERB" in
+  check)
+    emit "$STATE"
+    if [ "$WANT_EXIT_CODE" -eq 1 ] && [ "$STATE" = held ]; then exit 1; fi
+    exit 0
+    ;;
+
+  release)
+    case "$STATE" in
+      self | stale)
+        if "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1; then
+          echo "flow-worktree-claim: released claim on '$WT'." >&2
+        fi
+        O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+        emit free
+        ;;
+      held | foreign)
+        if [ "$FORCE" -eq 1 ]; then
+          "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+          echo "flow-worktree-claim: FORCE-released a $STATE claim on '$WT' (owner pid ${O_PID:--})." >&2
+          emit free
+        else
+          echo "flow-worktree-claim: '$WT' is claimed by another session (pid ${O_PID:--}, session ${O_SESSION:--}) - not releasing. Pass --force to override." >&2
+          emit "$STATE"
+        fi
+        ;;
+      *) emit "$STATE" ;;
+    esac
+    exit 0
+    ;;
+
+  claim)
+    [ -n "$ISSUE_NUM" ] || usage_fail "claim requires --issue <N>"
+    case "$STATE" in
+      held)
+        if [ "$STEAL" -eq 0 ]; then
+          echo "flow-worktree-claim: '$WT' is CLAIMED by a live session (pid ${O_PID:--}, session ${O_SESSION:--}, host ${O_HOST:--}, ~${O_AGE_MIN:-?}m ago)." >&2
+          echo "  Another /flow run is driving this worktree right now (issue #597). Working here would race it:" >&2
+          echo "  its cleanup can delete this checkout, and yours can delete theirs." >&2
+          echo "  Either wait for that session to finish, or - if you are certain it is gone - re-run with --steal." >&2
+          emit held
+          exit 1
+        fi
+        echo "flow-worktree-claim: stealing a live claim on '$WT' (--steal; previous owner pid ${O_PID:--})." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      foreign)
+        # Someone locked this worktree for their own reasons. Never steal it,
+        # but do not fail the run either - report and move on (fail-open).
+        echo "flow-worktree-claim: '$WT' carries a non-flow lock; leaving it untouched and claiming nothing." >&2
+        emit foreign
+        exit 0
+        ;;
+      stale)
+        echo "flow-worktree-claim: taking over a stale claim on '$WT' (owner pid ${O_PID:--} is gone)." >&2
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      self)
+        # Idempotent refresh: drop our own lock so the new timestamp lands.
+        "$GIT" -C "$WT" worktree unlock "$WT" >/dev/null 2>&1
+        ;;
+      unsupported | unknown)
+        echo "flow-worktree-claim: '$WT' cannot hold a claim ($STATE) - continuing unclaimed (advisory)." >&2
+        emit "$STATE"
+        exit 0
+        ;;
+    esac
+
+    REASON="$CLAIM_PREFIX issue=$ISSUE_NUM pid=$SELF_PID session=${SELF_SESSION:--} host=$SELF_HOST ts=$NOW"
+    if ! "$GIT" -C "$WT" worktree lock --reason "$REASON" "$WT" >/dev/null 2>&1; then
+      echo "flow-worktree-claim: could not lock '$WT' (git too old, or lock unsupported) - continuing unclaimed (advisory)." >&2
+      O_PID=""; O_SESSION=""; O_HOST=""; O_TS=""; O_AGE_MIN=""; O_ISSUE=""
+      emit unsupported
+      exit 0
+    fi
+    O_PID="$SELF_PID"; O_SESSION="${SELF_SESSION:--}"; O_HOST="$SELF_HOST"
+    O_TS="$NOW"; O_AGE_MIN=0; O_ISSUE="$ISSUE_NUM"
+    echo "flow-worktree-claim: claimed '$WT' for issue #$ISSUE_NUM (pid $SELF_PID)." >&2
+    emit self
+    exit 0
+    ;;
+esac

--- a/scripts/plugin-sync.sh
+++ b/scripts/plugin-sync.sh
@@ -65,7 +65,7 @@ declare -A EXTRA_FILES=(
     # allowlist rules match - by /flow:repair (flow-helpers-install.sh, itself
     # bundled so a plugin-only user can run it). flow-start-resolve.sh resolves
     # flow-live-driver-guard.sh via $SELF_DIR, so the two must travel together.
-    [flow]="scripts/flow-start-resolve.sh scripts/flow-live-driver-guard.sh scripts/flow-stale-check.sh scripts/flow-worktree-guard.sh scripts/gh-pr-merge.sh scripts/worktree-remove.sh scripts/friction-log.sh scripts/check-ignored-additions.sh scripts/flow-helpers-install.sh"
+    [flow]="scripts/flow-start-resolve.sh scripts/flow-live-driver-guard.sh scripts/flow-worktree-claim.sh scripts/flow-stale-check.sh scripts/flow-worktree-guard.sh scripts/gh-pr-merge.sh scripts/worktree-remove.sh scripts/friction-log.sh scripts/check-ignored-additions.sh scripts/flow-helpers-install.sh"
     # /cpp:load-best-practices reads this doc; a plugin-only install has no CPP
     # checkout, so the plugin bundles it (resolved via ${CLAUDE_PLUGIN_ROOT}).
     [cpp]="docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md"

--- a/scripts/worktree-remove.sh
+++ b/scripts/worktree-remove.sh
@@ -5,12 +5,19 @@
 # changes to the main repository first (determined from the worktree's
 # .git file) to prevent breaking your shell session.
 #
+# A worktree CLAIMED by another live /flow session (issue #597) is never
+# removed: the claim is checked first and a live foreign owner is a hard stop
+# (exit 4), because removing it is exactly the silent-data-loss failure that
+# motivated the claim. A self-owned or stale claim is released and removed as
+# usual, and --steal is the deliberate override.
+#
 # Usage:
-#   worktree-remove.sh <worktree-path> [--force] [--delete-branch]
+#   worktree-remove.sh <worktree-path> [--force] [--delete-branch] [--steal]
 #
 # Options:
 #   --force          Remove even if worktree has uncommitted changes
 #   --delete-branch  Also delete the associated branch after removal
+#   --steal          Remove even when another live session claims it (#597)
 #
 # Examples:
 #   worktree-remove.sh /home/user/Projects/nhl-api-issue-42
@@ -30,6 +37,7 @@ NC='\033[0m' # No Color
 WORKTREE_PATH=""
 FORCE=""
 DELETE_BRANCH=false
+STEAL=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delete-branch)
             DELETE_BRANCH=true
+            shift
+            ;;
+        --steal)
+            STEAL=true
             shift
             ;;
         -h|--help)
@@ -52,6 +64,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force          Remove even if worktree has uncommitted changes"
             echo "  --delete-branch  Also delete the associated branch after removal"
             echo "                   (force-deletes a squash-merged branch non-interactively)"
+            echo "  --steal          Remove even when another live /flow session claims it"
+            echo "                   (issue #597; without it a live claim is a hard stop)"
             echo ""
             echo "Examples:"
             echo "  worktree-remove.sh /home/user/Projects/nhl-api-issue-42"
@@ -158,6 +172,53 @@ fi
 
 # Get the branch name before removing
 BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Cross-session claim check (issue #597) ----------------------------------
+# Another LIVE /flow session may be driving this checkout right now. Removing it
+# out from under that session is the silent-data-loss failure this guard exists
+# for, so a live foreign claim is a hard stop. A claim owned by THIS session, or
+# left behind by a session that has since died, is simply released first.
+#
+# Fail-open in both directions: a missing helper, an unreadable lock, or a git
+# too old to report one leaves the previous behavior exactly as it was.
+SELF_SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")"
+CLAIM_HELPER=""
+for cand in "$SELF_SCRIPT_DIR/flow-worktree-claim.sh" "$HOME/.claude/scripts/flow-worktree-claim.sh"; do
+    if [[ -f "$cand" ]]; then
+        CLAIM_HELPER="$cand"
+        break
+    fi
+done
+
+if [[ -n "$CLAIM_HELPER" ]]; then
+    CLAIM_OUT=$(bash "$CLAIM_HELPER" check "$WORKTREE_PATH" 2>/dev/null || true)
+    CLAIM_STATE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM: //p' | tail -1)
+    CLAIM_PID=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_PID=//p' | tail -1)
+    CLAIM_SESSION=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_OWNER_SESSION=//p' | tail -1)
+    CLAIM_ISSUE=$(printf '%s\n' "$CLAIM_OUT" | sed -n 's/^FLOW_CLAIM_ISSUE=//p' | tail -1)
+
+    case "${CLAIM_STATE:-unknown}" in
+        held | foreign)
+            if [[ "$STEAL" != true ]]; then
+                echo -e "${RED}Error: refusing to remove a worktree claimed by another session${NC}" >&2
+                echo "" >&2
+                echo "  Worktree: $WORKTREE_PATH" >&2
+                echo "  Claim:    ${CLAIM_STATE} (issue #${CLAIM_ISSUE:--}, pid ${CLAIM_PID:--}, session ${CLAIM_SESSION:--})" >&2
+                echo "" >&2
+                echo "  Another /flow session is driving this checkout. Removing it would destroy" >&2
+                echo "  its uncommitted work - the failure this claim exists to prevent (issue #597)." >&2
+                echo "  Wait for that session to finish, or pass --steal if you are certain it is gone." >&2
+                exit 4
+            fi
+            echo -e "${YELLOW}Warning: --steal given; removing a worktree claimed by pid ${CLAIM_PID:--}.${NC}" >&2
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" --force >/dev/null 2>&1 || true
+            ;;
+        self | stale)
+            # Ours, or abandoned - drop the lock so the removal below can proceed.
+            bash "$CLAIM_HELPER" release "$WORKTREE_PATH" >/dev/null 2>&1 || true
+            ;;
+    esac
+fi
 
 # Check for uncommitted changes (unless --force)
 if [[ -z "$FORCE" ]]; then

--- a/templates/claude-settings-permissions.json
+++ b/templates/claude-settings-permissions.json
@@ -37,6 +37,7 @@
       "Bash(~/.claude/scripts/flow-stale-check.sh:*)",
       "Bash(~/.claude/scripts/flow-worktree-guard.sh:*)",
       "Bash(~/.claude/scripts/flow-live-driver-guard.sh:*)",
+      "Bash(~/.claude/scripts/flow-worktree-claim.sh:*)",
       "Bash(~/.claude/scripts/gh-pr-merge.sh:*)",
       "Bash(~/.claude/scripts/worktree-remove.sh:*)"
     ]

--- a/tests/test_flow_worktree_claim.py
+++ b/tests/test_flow_worktree_claim.py
@@ -1,0 +1,307 @@
+"""Tests for the cross-session worktree claim (issue #597).
+
+Covers ``scripts/flow-worktree-claim.sh`` and the owner check it gives
+``scripts/worktree-remove.sh``.
+
+Contract:
+- ``claim`` locks the worktree with a parseable ``flow-claim`` reason; a second
+  ``check`` from the same session reports ``self`` with the owner detail intact.
+- A claim held by a LIVE foreign session reports ``held``; ``claim`` then exits 1
+  and ``worktree-remove.sh`` refuses with exit 4 - the silent-data-loss failure
+  this whole mechanism exists to prevent.
+- A claim whose owning process is gone reports ``stale`` and is taken over
+  automatically, so the mechanism can never permanently wedge a repo.
+- A lock this family did not write is ``foreign`` and is never stolen.
+- The primary checkout cannot be locked at all - ``unsupported``, fail-open.
+- ``--steal`` is the deliberate override on both scripts.
+
+Liveness is pinned with the ``FLOW_CLAIM_LIVE_PIDS`` hook rather than real
+processes, so no test depends on a pid that happens to exist. The tests build
+REAL throwaway git repos.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLAIM = ROOT / "scripts" / "flow-worktree-claim.sh"
+REMOVE = ROOT / "scripts" / "worktree-remove.sh"
+
+# These drive real `git` and `bash` subprocesses. The Woodpecker `validate` step
+# runs in `uv:python3.11-bookworm-slim`, which ships bash but NOT git, so they
+# are skipped there (issue #430). The read-only wiring tests need neither.
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="requires git and bash on PATH (absent in the CI validate container)",
+)
+
+SELF_PID = "4242"
+SELF_SESSION = "session-self"
+OTHER_PID = "9999"
+OTHER_SESSION = "session-other"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+    )
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run(
+    script: Path,
+    *args: str,
+    pid: str = SELF_PID,
+    session: str = SELF_SESSION,
+    live: str = "",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "CLAUDE_PID": pid,
+            "CLAUDE_CODE_SESSION_ID": session,
+            "FLOW_CLAIM_HOST": "testhost",
+            # Liveness is simulated: only pids listed here are "alive".
+            "FLOW_CLAIM_LIVE_PIDS": live,
+        }
+    )
+    return subprocess.run(
+        ["bash", str(script), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _verdict(proc: subprocess.CompletedProcess[str]) -> str:
+    for line in reversed(proc.stdout.splitlines()):
+        if line.startswith("FLOW_CLAIM: "):
+            return line.removeprefix("FLOW_CLAIM: ").strip()
+    return "<none>"
+
+
+def _field(proc: subprocess.CompletedProcess[str], key: str) -> str:
+    prefix = f"FLOW_CLAIM_{key}="
+    for line in reversed(proc.stdout.splitlines()):
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).strip()
+    return "<none>"
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A primary checkout plus one linked worktree on an issue branch."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-q")
+    _git(main, "commit", "-q", "--allow-empty", "-m", "init")
+    wt = tmp_path / "wt"
+    _git(main, "worktree", "add", "-q", str(wt), "-b", "issue-42-thing")
+    return main, wt
+
+
+# --- wiring (no git needed) --------------------------------------------------
+
+
+def test_claim_script_is_registered_with_the_helper_family() -> None:
+    """A helper the flow lane calls must ship with the family, or a plugin-only
+    install dead-ends at exit 127 (the #590 failure)."""
+    installer = (ROOT / "scripts" / "flow-helpers-install.sh").read_text()
+    assert "flow-worktree-claim.sh" in installer
+
+    plugin_sync = (ROOT / "scripts" / "plugin-sync.sh").read_text()
+    assert "scripts/flow-worktree-claim.sh" in plugin_sync
+
+    perms = (ROOT / "templates" / "claude-settings-permissions.json").read_text()
+    assert "Bash(~/.claude/scripts/flow-worktree-claim.sh:*)" in perms
+
+
+# --- claim lifecycle ---------------------------------------------------------
+
+
+@requires_git
+def test_free_then_claim_then_self(repo: tuple[Path, Path]) -> None:
+    _main, wt = repo
+    assert _verdict(_run(CLAIM, "check", str(wt))) == "free"
+
+    claimed = _run(CLAIM, "claim", str(wt), "--issue", "42")
+    assert claimed.returncode == 0
+    assert _verdict(claimed) == "self"
+
+    check = _run(CLAIM, "check", str(wt))
+    assert _verdict(check) == "self"
+    # The owner detail must survive out of the classifier, not be blanked.
+    assert _field(check, "OWNER_PID") == SELF_PID
+    assert _field(check, "OWNER_SESSION") == SELF_SESSION
+    assert _field(check, "ISSUE") == "42"
+
+
+@requires_git
+def test_claim_is_idempotent_for_its_owner(repo: tuple[Path, Path]) -> None:
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42")
+    again = _run(CLAIM, "claim", str(wt), "--issue", "42")
+    assert again.returncode == 0
+    assert _verdict(again) == "self"
+
+
+@requires_git
+def test_live_foreign_claim_is_held_and_blocks_claiming(
+    repo: tuple[Path, Path],
+) -> None:
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+
+    check = _run(CLAIM, "check", str(wt), live=OTHER_PID)
+    assert _verdict(check) == "held"
+    assert _field(check, "OWNER_PID") == OTHER_PID
+
+    lost = _run(CLAIM, "claim", str(wt), "--issue", "42", live=OTHER_PID)
+    assert lost.returncode == 1, "claiming a live-owned worktree must fail loudly"
+    assert _verdict(lost) == "held"
+
+
+@requires_git
+def test_dead_owner_is_stale_and_taken_over(repo: tuple[Path, Path]) -> None:
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+
+    # No live pids: the owner is gone.
+    assert _verdict(_run(CLAIM, "check", str(wt), live="")) == "stale"
+
+    taken = _run(CLAIM, "claim", str(wt), "--issue", "42", live="")
+    assert taken.returncode == 0
+    assert _verdict(taken) == "self"
+    assert _field(taken, "OWNER_PID") == SELF_PID
+
+
+@requires_git
+def test_steal_overrides_a_live_claim(repo: tuple[Path, Path]) -> None:
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+    stolen = _run(CLAIM, "claim", str(wt), "--issue", "42", "--steal", live=OTHER_PID)
+    assert stolen.returncode == 0
+    assert _verdict(stolen) == "self"
+
+
+@requires_git
+def test_non_flow_lock_is_foreign_and_never_stolen(repo: tuple[Path, Path]) -> None:
+    main, wt = repo
+    _git(main, "worktree", "lock", "--reason", "held for surgery", str(wt))
+
+    assert _verdict(_run(CLAIM, "check", str(wt))) == "foreign"
+
+    # Fail-open: claiming does not error the caller, but must not take the lock.
+    attempt = _run(CLAIM, "claim", str(wt), "--issue", "42")
+    assert attempt.returncode == 0
+    assert _verdict(attempt) == "foreign"
+    assert _verdict(_run(CLAIM, "check", str(wt))) == "foreign"
+
+
+@requires_git
+def test_primary_checkout_cannot_be_claimed(repo: tuple[Path, Path]) -> None:
+    main, _wt = repo
+    result = _run(CLAIM, "claim", str(main), "--issue", "42")
+    assert result.returncode == 0, "the current-branch lane must not be blocked"
+    assert _verdict(result) == "unsupported"
+
+
+@requires_git
+def test_check_resolves_the_worktree_by_issue_number(repo: tuple[Path, Path]) -> None:
+    """The cross-session check runs before this session has a path of its own."""
+    main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+
+    found = _run(CLAIM, "check", "--issue", "42", "--repo", str(main), live=OTHER_PID)
+    assert _verdict(found) == "held"
+    assert Path(_field(found, "PATH")).resolve() == wt.resolve()
+
+    # An issue nobody is working on is free, not an error.
+    absent = _run(CLAIM, "check", "--issue", "77", "--repo", str(main))
+    assert absent.returncode == 0
+    assert _verdict(absent) == "free"
+
+
+@requires_git
+def test_release_drops_own_claim_but_not_a_live_foreign_one(
+    repo: tuple[Path, Path],
+) -> None:
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42")
+    assert _verdict(_run(CLAIM, "release", str(wt))) == "free"
+    assert _verdict(_run(CLAIM, "check", str(wt))) == "free"
+
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+    kept = _run(CLAIM, "release", str(wt), live=OTHER_PID)
+    assert kept.returncode == 0
+    assert _verdict(kept) == "held", "another session's live claim must survive"
+    assert _verdict(_run(CLAIM, "check", str(wt), live=OTHER_PID)) == "held"
+
+
+# --- the removal guard -------------------------------------------------------
+
+
+@requires_git
+def test_remove_refuses_a_worktree_claimed_by_a_live_session(
+    repo: tuple[Path, Path],
+) -> None:
+    """The #597 headline: a sibling session's cleanup must not delete live work."""
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+    (wt / "uncommitted.txt").write_text("step 4 work nobody else knows about\n")
+
+    result = _run(REMOVE, str(wt), "--force", "--delete-branch", live=OTHER_PID)
+    assert result.returncode == 4
+    assert wt.exists(), "the claimed worktree must still be on disk"
+    assert (wt / "uncommitted.txt").exists()
+    assert OTHER_PID in result.stderr
+
+
+@requires_git
+def test_remove_steals_only_when_asked(repo: tuple[Path, Path]) -> None:
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42", pid=OTHER_PID, session=OTHER_SESSION)
+
+    result = _run(REMOVE, str(wt), "--force", "--delete-branch", "--steal", live=OTHER_PID)
+    assert result.returncode == 0
+    assert not wt.exists()
+
+
+@requires_git
+def test_remove_releases_and_removes_its_own_claim(repo: tuple[Path, Path]) -> None:
+    """A run cleaning up after itself must not be blocked by its own claim."""
+    _main, wt = repo
+    _run(CLAIM, "claim", str(wt), "--issue", "42")
+
+    result = _run(REMOVE, str(wt), "--force", "--delete-branch")
+    assert result.returncode == 0, result.stderr
+    assert not wt.exists()
+
+
+@requires_git
+def test_remove_is_unaffected_when_nothing_is_claimed(repo: tuple[Path, Path]) -> None:
+    """Fail-open: the pre-claim behaviour is preserved exactly."""
+    _main, wt = repo
+    result = _run(REMOVE, str(wt), "--force", "--delete-branch")
+    assert result.returncode == 0, result.stderr
+    assert not wt.exists()

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -314,6 +314,7 @@ FLOW_PLUGIN_SCRIPTS = PLUGINS_DIR / "flow" / "scripts"
 FLOW_BUNDLED_HELPERS = [
     "flow-start-resolve.sh",
     "flow-live-driver-guard.sh",
+    "flow-worktree-claim.sh",
     "flow-stale-check.sh",
     "flow-worktree-guard.sh",
     "gh-pr-merge.sh",


### PR DESCRIPTION
## Summary

CPP actively encourages parallel `/flow` sessions, but nothing stopped two of them from operating on one repo - or one worktree. The `#503` live-driver guard protects a session *entering* a worktree; it has no notion of an owner, so it cannot stop a sibling's Step-7 cleanup from removing an *active* checkout by name. That failure destroyed uncommitted work, and the only signal was the user noticing it was gone.

This makes ownership explicit by riding git's own worktree lock - `git worktree remove --force` already refuses a locked worktree, so a claim is a real barrier rather than an advisory note, and the reason text is readable from `git worktree list --porcelain`.

### What changed

| Failure (from the friction buffer) | Fix |
|---|---|
| 1. Sibling cleanup destroyed uncommitted work (`flow:auto #5`) | `worktree-remove.sh` exits **4** rather than removing a worktree a live sibling claims |
| 2. Second driver entered mid-run (`flow:auto #13`) | Step 4 re-runs the `#503` guard immediately before the first edit |
| 3. Duplicate deploy (`flow:auto #49`) | Step 9 skips `make deploy` when `.claude/deploy.log` already records a **successful** deploy of the current HEAD sha |
| 4. Repeated stale-base churn (`flow:auto #67`) | **Out of scope** - needs serialized merges, not an ownership claim |

- **`scripts/flow-worktree-claim.sh`** (new) - `claim` / `check` / `release`. Ownership is pid + session; liveness is `kill -0`, trusted only when the recorded host matches. An owner that is gone reads `stale` and is taken over automatically, so a claim can never wedge a repo. A lock this family did not write is `foreign` and never stolen.
- **`flow-start-resolve.sh`** - reads the claim on issue-N *before* any worktree is created (new `CLAIM`/`CLAIM_PID`/`CLAIM_SESSION` contract keys; a live claim sets `CONFIRM_REQUIRED=1`), and stakes the claim in `--verify`, the only hook point that runs inside the worktree on every lane.
- Registered with the helper family: installer, plugin bundle (`#590`), permission allowlist, `/flow:doctor`.

Fail-open everywhere except the case it exists for: claiming against a live owner exits 1.

## Test plan

- `tests/test_flow_worktree_claim.py` (new, 14 tests): claim/check/release round-trip, idempotent re-claim, live-foreign `held` + exit 1, dead-owner `stale` takeover, `--steal`, foreign non-flow lock, primary checkout `unsupported`, by-issue lookup, and the four `worktree-remove.sh` paths - including that a claimed worktree's uncommitted file is **still on disk** after the refusal.
- Guarded with `shutil.which("git")` per the core directive; `make binary-guards-check` (merged in #606 an hour ago) passes.
- `make lint`, `make test` (1124 passed), security scan: green via `lib.cicd run --plan finish`.
- Verified live during this run: the `--verify` gate reported `CLAIM=self` and locked this very worktree.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF69McvbvNqtFt1M2Qt1eF