### PR TITLE
fix(flow): commit-first stale-base handling - retire the shared-stash dance (Closes #635)

### DIFF
--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -373,7 +373,11 @@ and continue. `/flow:repair` installs the family at the stable path.)
 - If it reports `FLOW_STALE_BASE: collision` - or names a file you are about to
   touch under "Changed upstream" - bring the base in now, before piling edits on
   a stale tree: `git merge --no-edit origin/main`, resolve any conflict in the
-  named file(s), then implement. If the merge touched any
+  named file(s), then implement. If git refuses to START the merge because
+  local changes overlap incoming ones, commit the work first (`git add -A` +
+  `git commit -m "wip(flow): pre-merge snapshot"`) and merge on the clean tree
+  - never stash: the stash stack is SHARED across every worktree of the repo
+  and a bare pop can restore a sibling session's work (#635). If the merge touched any
   `.claude/commands/**/*.md`, re-run the LOCAL `scripts/plugin-sync.sh --write`
   and `python3 scripts/codex-skill-sync.py --write`, then stage `plugins/` and
   `codex/skills/`, so the in-repo generated surfaces do not drift - the parity
@@ -477,28 +481,26 @@ CPP-checkout copy):
 
 ```bash
 # If the base moved, merge it in now so the gate + commit ride the current tree.
-# The Step-4 implementation is still UNCOMMITTED here, and git refuses to merge
-# into a dirty tree ("Please commit your changes or stash them before you merge")
-# - so STASH the work FIRST, merge, then restore it. This inverts the
-# merge-then-commit order the surrounding prose implies (issue #521; hit on
-# flow:auto #502 and #509). A clean tree (e.g. a resumed run already committed)
-# skips the stash.
+# COMMIT the Step-4 work FIRST, then merge on the clean tree (issue #635; this
+# supersedes the #521 stash-first order). Stashes live in the repo's COMMON git
+# dir, so every linked worktree shares ONE stack: with ~7 concurrent sessions,
+# two runs stash-pushed seconds apart and each bare `git stash pop` silently
+# restored the OTHER session's uncommitted work into the wrong worktree. A WIP
+# commit is branch-local - a sibling session cannot take it - and the Step-7
+# squash flattens it, so nothing visible changes in what ships. (#521's premise
+# was also too broad: git refuses a dirty-tree merge only when incoming changes
+# OVERLAP locally-modified files; commit-first is safe in every case.) NEVER
+# use `git stash push` or a bare `git stash pop` in a shared-worktree flow.
 git fetch origin main --quiet
 if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
-    STASHED=0
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push -u -m "flow-auto-pre-stale-merge" && STASHED=1
+        git add -A
+        git commit -m "wip(flow): pre-merge snapshot"
     fi
     if ! git merge --no-edit origin/main; then
         echo "STOP: 'git merge origin/main' hit CONFLICTS. Resolve them, 'git add' + 'git commit', then re-run Step 6."
         git diff --name-only --diff-filter=U
-        [ "$STASHED" -eq 1 ] && echo "NOTE: your Step-4 work is stashed ('git stash list') - pop it after resolving."
-        exit 1
-    fi
-    # Restore the Step-4 work on top of the freshly-merged base.
-    if [ "$STASHED" -eq 1 ] && ! git stash pop; then
-        echo "STOP: restoring your stashed Step-4 work onto the merged base hit conflicts. Resolve them and 'git add' (do NOT 'git merge --abort'), then re-run Step 6."
-        git diff --name-only --diff-filter=U
+        echo "NOTE: your Step-4 work is safe in the 'wip(flow): pre-merge snapshot' commit on this branch."
         exit 1
     fi
     # Keep the in-repo generated surfaces from drifting when the merge pulled ANY
@@ -583,6 +585,12 @@ fi
 2. **Commit** - if there are uncommitted changes:
    - Use conventional commit format: `type(scope): Description (Closes #N)`
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+   - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
+     #635): when the stale-base merge above ran, the Step-4 work is already on
+     the branch in the `wip(flow): pre-merge snapshot` commit. Skip this commit
+     step cleanly and leave the WIP commit as-is - the Step-7 squash flattens
+     branch history and the PR title/body carry the conventional message, so
+     the WIP message never reaches `main`. Do NOT add a STOP for this state.
 
 3. **Push** the branch:
    ```bash

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -38,23 +38,21 @@ fi
 
 git fetch origin main --quiet
 if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
-    # The implementation is still UNCOMMITTED here, and git refuses to merge into a
-    # dirty tree ("Please commit your changes or stash them before you merge") - so
-    # STASH the work FIRST, merge, then restore it, inverting the merge-then-commit
-    # order the prose implies (issue #521). A clean tree skips the stash.
-    STASHED=0
+    # COMMIT the work FIRST, then merge on the clean tree (issue #635; supersedes
+    # the #521 stash-first order). Stashes live in the repo's COMMON git dir -
+    # every linked worktree shares ONE stack - and two concurrent sessions doing
+    # stash push -> merge -> bare pop silently swapped each other's uncommitted
+    # work. A WIP commit is branch-local (a sibling cannot take it) and the
+    # eventual squash-merge flattens it. NEVER use `git stash push` or a bare
+    # `git stash pop` in a shared-worktree flow.
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push -u -m "flow-finish-pre-stale-merge" && STASHED=1
+        git add -A
+        git commit -m "wip(flow): pre-merge snapshot"
     fi
     if ! git merge --no-edit origin/main; then
         echo "STOP: 'git merge origin/main' hit CONFLICTS. Resolve them, 'git add' + 'git commit', then re-run /flow:finish."
         git diff --name-only --diff-filter=U
-        [ "$STASHED" -eq 1 ] && echo "NOTE: your work is stashed ('git stash list') - pop it after resolving."
-        exit 1
-    fi
-    if [ "$STASHED" -eq 1 ] && ! git stash pop; then
-        echo "STOP: restoring your stashed work onto the merged base hit conflicts. Resolve them and 'git add' (do NOT 'git merge --abort'), then re-run /flow:finish."
-        git diff --name-only --diff-filter=U
+        echo "NOTE: your work is safe in the 'wip(flow): pre-merge snapshot' commit on this branch."
         exit 1
     fi
     # Re-sync the in-repo generated surfaces if the merge pulled ANY command-family
@@ -214,6 +212,11 @@ discipline; on exit 127 skip it):
 - If there are uncommitted changes, help the user commit them using standard git commit workflow.
 - Use conventional commit format: `type(scope): Description (Closes #N)`
 - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` if Claude helped write the code.
+- **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
+  #635): when the Step-1 stale-base merge ran, the work is already on the
+  branch in the `wip(flow): pre-merge snapshot` commit. Skip cleanly and leave
+  the WIP commit as-is - the squash-merge flattens branch history and the PR
+  title/body carry the conventional message. Do NOT add a STOP for this state.
 
 ### Step 4: Push Branch
 

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -375,7 +375,11 @@ and continue. `/flow-repair` installs the family at the stable path.)
 - If it reports `FLOW_STALE_BASE: collision` - or names a file you are about to
   touch under "Changed upstream" - bring the base in now, before piling edits on
   a stale tree: `git merge --no-edit origin/main`, resolve any conflict in the
-  named file(s), then implement. If the merge touched any
+  named file(s), then implement. If git refuses to START the merge because
+  local changes overlap incoming ones, commit the work first (`git add -A` +
+  `git commit -m "wip(flow): pre-merge snapshot"`) and merge on the clean tree
+  - never stash: the stash stack is SHARED across every worktree of the repo
+  and a bare pop can restore a sibling session's work (#635). If the merge touched any
   `.claude/commands/**/*.md`, re-run the LOCAL `scripts/plugin-sync.sh --write`
   and `python3 scripts/codex-skill-sync.py --write`, then stage `plugins/` and
   `codex/skills/`, so the in-repo generated surfaces do not drift - the parity
@@ -479,28 +483,26 @@ CPP-checkout copy):
 
 ```bash
 # If the base moved, merge it in now so the gate + commit ride the current tree.
-# The Step-4 implementation is still UNCOMMITTED here, and git refuses to merge
-# into a dirty tree ("Please commit your changes or stash them before you merge")
-# - so STASH the work FIRST, merge, then restore it. This inverts the
-# merge-then-commit order the surrounding prose implies (issue #521; hit on
-# flow:auto #502 and #509). A clean tree (e.g. a resumed run already committed)
-# skips the stash.
+# COMMIT the Step-4 work FIRST, then merge on the clean tree (issue #635; this
+# supersedes the #521 stash-first order). Stashes live in the repo's COMMON git
+# dir, so every linked worktree shares ONE stack: with ~7 concurrent sessions,
+# two runs stash-pushed seconds apart and each bare `git stash pop` silently
+# restored the OTHER session's uncommitted work into the wrong worktree. A WIP
+# commit is branch-local - a sibling session cannot take it - and the Step-7
+# squash flattens it, so nothing visible changes in what ships. (#521's premise
+# was also too broad: git refuses a dirty-tree merge only when incoming changes
+# OVERLAP locally-modified files; commit-first is safe in every case.) NEVER
+# use `git stash push` or a bare `git stash pop` in a shared-worktree flow.
 git fetch origin main --quiet
 if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
-    STASHED=0
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push -u -m "flow-auto-pre-stale-merge" && STASHED=1
+        git add -A
+        git commit -m "wip(flow): pre-merge snapshot"
     fi
     if ! git merge --no-edit origin/main; then
         echo "STOP: 'git merge origin/main' hit CONFLICTS. Resolve them, 'git add' + 'git commit', then re-run Step 6."
         git diff --name-only --diff-filter=U
-        [ "$STASHED" -eq 1 ] && echo "NOTE: your Step-4 work is stashed ('git stash list') - pop it after resolving."
-        exit 1
-    fi
-    # Restore the Step-4 work on top of the freshly-merged base.
-    if [ "$STASHED" -eq 1 ] && ! git stash pop; then
-        echo "STOP: restoring your stashed Step-4 work onto the merged base hit conflicts. Resolve them and 'git add' (do NOT 'git merge --abort'), then re-run Step 6."
-        git diff --name-only --diff-filter=U
+        echo "NOTE: your Step-4 work is safe in the 'wip(flow): pre-merge snapshot' commit on this branch."
         exit 1
     fi
     # Keep the in-repo generated surfaces from drifting when the merge pulled ANY
@@ -585,6 +587,12 @@ fi
 2. **Commit** - if there are uncommitted changes:
    - Use conventional commit format: `type(scope): Description (Closes #N)`
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+   - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
+     #635): when the stale-base merge above ran, the Step-4 work is already on
+     the branch in the `wip(flow): pre-merge snapshot` commit. Skip this commit
+     step cleanly and leave the WIP commit as-is - the Step-7 squash flattens
+     branch history and the PR title/body carry the conventional message, so
+     the WIP message never reaches `main`. Do NOT add a STOP for this state.
 
 3. **Push** the branch:
    ```bash

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -40,23 +40,21 @@ fi
 
 git fetch origin main --quiet
 if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
-    # The implementation is still UNCOMMITTED here, and git refuses to merge into a
-    # dirty tree ("Please commit your changes or stash them before you merge") - so
-    # STASH the work FIRST, merge, then restore it, inverting the merge-then-commit
-    # order the prose implies (issue #521). A clean tree skips the stash.
-    STASHED=0
+    # COMMIT the work FIRST, then merge on the clean tree (issue #635; supersedes
+    # the #521 stash-first order). Stashes live in the repo's COMMON git dir -
+    # every linked worktree shares ONE stack - and two concurrent sessions doing
+    # stash push -> merge -> bare pop silently swapped each other's uncommitted
+    # work. A WIP commit is branch-local (a sibling cannot take it) and the
+    # eventual squash-merge flattens it. NEVER use `git stash push` or a bare
+    # `git stash pop` in a shared-worktree flow.
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push -u -m "flow-finish-pre-stale-merge" && STASHED=1
+        git add -A
+        git commit -m "wip(flow): pre-merge snapshot"
     fi
     if ! git merge --no-edit origin/main; then
         echo "STOP: 'git merge origin/main' hit CONFLICTS. Resolve them, 'git add' + 'git commit', then re-run /flow-finish."
         git diff --name-only --diff-filter=U
-        [ "$STASHED" -eq 1 ] && echo "NOTE: your work is stashed ('git stash list') - pop it after resolving."
-        exit 1
-    fi
-    if [ "$STASHED" -eq 1 ] && ! git stash pop; then
-        echo "STOP: restoring your stashed work onto the merged base hit conflicts. Resolve them and 'git add' (do NOT 'git merge --abort'), then re-run /flow-finish."
-        git diff --name-only --diff-filter=U
+        echo "NOTE: your work is safe in the 'wip(flow): pre-merge snapshot' commit on this branch."
         exit 1
     fi
     # Re-sync the in-repo generated surfaces if the merge pulled ANY command-family
@@ -216,6 +214,11 @@ discipline; on exit 127 skip it):
 - If there are uncommitted changes, help the user commit them using standard git commit workflow.
 - Use conventional commit format: `type(scope): Description (Closes #N)`
 - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` if Claude helped write the code.
+- **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
+  #635): when the Step-1 stale-base merge ran, the work is already on the
+  branch in the `wip(flow): pre-merge snapshot` commit. Skip cleanly and leave
+  the WIP commit as-is - the squash-merge flattens branch history and the PR
+  title/body carry the conventional message. Do NOT add a STOP for this state.
 
 ### Step 4: Push Branch
 

--- a/plugins/flow/commands/auto.md
+++ b/plugins/flow/commands/auto.md
@@ -373,7 +373,11 @@ and continue. `/flow:repair` installs the family at the stable path.)
 - If it reports `FLOW_STALE_BASE: collision` - or names a file you are about to
   touch under "Changed upstream" - bring the base in now, before piling edits on
   a stale tree: `git merge --no-edit origin/main`, resolve any conflict in the
-  named file(s), then implement. If the merge touched any
+  named file(s), then implement. If git refuses to START the merge because
+  local changes overlap incoming ones, commit the work first (`git add -A` +
+  `git commit -m "wip(flow): pre-merge snapshot"`) and merge on the clean tree
+  - never stash: the stash stack is SHARED across every worktree of the repo
+  and a bare pop can restore a sibling session's work (#635). If the merge touched any
   `.claude/commands/**/*.md`, re-run the LOCAL `scripts/plugin-sync.sh --write`
   and `python3 scripts/codex-skill-sync.py --write`, then stage `plugins/` and
   `codex/skills/`, so the in-repo generated surfaces do not drift - the parity
@@ -477,28 +481,26 @@ CPP-checkout copy):
 
 ```bash
 # If the base moved, merge it in now so the gate + commit ride the current tree.
-# The Step-4 implementation is still UNCOMMITTED here, and git refuses to merge
-# into a dirty tree ("Please commit your changes or stash them before you merge")
-# - so STASH the work FIRST, merge, then restore it. This inverts the
-# merge-then-commit order the surrounding prose implies (issue #521; hit on
-# flow:auto #502 and #509). A clean tree (e.g. a resumed run already committed)
-# skips the stash.
+# COMMIT the Step-4 work FIRST, then merge on the clean tree (issue #635; this
+# supersedes the #521 stash-first order). Stashes live in the repo's COMMON git
+# dir, so every linked worktree shares ONE stack: with ~7 concurrent sessions,
+# two runs stash-pushed seconds apart and each bare `git stash pop` silently
+# restored the OTHER session's uncommitted work into the wrong worktree. A WIP
+# commit is branch-local - a sibling session cannot take it - and the Step-7
+# squash flattens it, so nothing visible changes in what ships. (#521's premise
+# was also too broad: git refuses a dirty-tree merge only when incoming changes
+# OVERLAP locally-modified files; commit-first is safe in every case.) NEVER
+# use `git stash push` or a bare `git stash pop` in a shared-worktree flow.
 git fetch origin main --quiet
 if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
-    STASHED=0
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push -u -m "flow-auto-pre-stale-merge" && STASHED=1
+        git add -A
+        git commit -m "wip(flow): pre-merge snapshot"
     fi
     if ! git merge --no-edit origin/main; then
         echo "STOP: 'git merge origin/main' hit CONFLICTS. Resolve them, 'git add' + 'git commit', then re-run Step 6."
         git diff --name-only --diff-filter=U
-        [ "$STASHED" -eq 1 ] && echo "NOTE: your Step-4 work is stashed ('git stash list') - pop it after resolving."
-        exit 1
-    fi
-    # Restore the Step-4 work on top of the freshly-merged base.
-    if [ "$STASHED" -eq 1 ] && ! git stash pop; then
-        echo "STOP: restoring your stashed Step-4 work onto the merged base hit conflicts. Resolve them and 'git add' (do NOT 'git merge --abort'), then re-run Step 6."
-        git diff --name-only --diff-filter=U
+        echo "NOTE: your Step-4 work is safe in the 'wip(flow): pre-merge snapshot' commit on this branch."
         exit 1
     fi
     # Keep the in-repo generated surfaces from drifting when the merge pulled ANY
@@ -583,6 +585,12 @@ fi
 2. **Commit** - if there are uncommitted changes:
    - Use conventional commit format: `type(scope): Description (Closes #N)`
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+   - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
+     #635): when the stale-base merge above ran, the Step-4 work is already on
+     the branch in the `wip(flow): pre-merge snapshot` commit. Skip this commit
+     step cleanly and leave the WIP commit as-is - the Step-7 squash flattens
+     branch history and the PR title/body carry the conventional message, so
+     the WIP message never reaches `main`. Do NOT add a STOP for this state.
 
 3. **Push** the branch:
    ```bash

--- a/plugins/flow/commands/finish.md
+++ b/plugins/flow/commands/finish.md
@@ -38,23 +38,21 @@ fi
 
 git fetch origin main --quiet
 if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
-    # The implementation is still UNCOMMITTED here, and git refuses to merge into a
-    # dirty tree ("Please commit your changes or stash them before you merge") - so
-    # STASH the work FIRST, merge, then restore it, inverting the merge-then-commit
-    # order the prose implies (issue #521). A clean tree skips the stash.
-    STASHED=0
+    # COMMIT the work FIRST, then merge on the clean tree (issue #635; supersedes
+    # the #521 stash-first order). Stashes live in the repo's COMMON git dir -
+    # every linked worktree shares ONE stack - and two concurrent sessions doing
+    # stash push -> merge -> bare pop silently swapped each other's uncommitted
+    # work. A WIP commit is branch-local (a sibling cannot take it) and the
+    # eventual squash-merge flattens it. NEVER use `git stash push` or a bare
+    # `git stash pop` in a shared-worktree flow.
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push -u -m "flow-finish-pre-stale-merge" && STASHED=1
+        git add -A
+        git commit -m "wip(flow): pre-merge snapshot"
     fi
     if ! git merge --no-edit origin/main; then
         echo "STOP: 'git merge origin/main' hit CONFLICTS. Resolve them, 'git add' + 'git commit', then re-run /flow:finish."
         git diff --name-only --diff-filter=U
-        [ "$STASHED" -eq 1 ] && echo "NOTE: your work is stashed ('git stash list') - pop it after resolving."
-        exit 1
-    fi
-    if [ "$STASHED" -eq 1 ] && ! git stash pop; then
-        echo "STOP: restoring your stashed work onto the merged base hit conflicts. Resolve them and 'git add' (do NOT 'git merge --abort'), then re-run /flow:finish."
-        git diff --name-only --diff-filter=U
+        echo "NOTE: your work is safe in the 'wip(flow): pre-merge snapshot' commit on this branch."
         exit 1
     fi
     # Re-sync the in-repo generated surfaces if the merge pulled ANY command-family
@@ -214,6 +212,11 @@ discipline; on exit 127 skip it):
 - If there are uncommitted changes, help the user commit them using standard git commit workflow.
 - Use conventional commit format: `type(scope): Description (Closes #N)`
 - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` if Claude helped write the code.
+- **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
+  #635): when the Step-1 stale-base merge ran, the work is already on the
+  branch in the `wip(flow): pre-merge snapshot` commit. Skip cleanly and leave
+  the WIP commit as-is - the squash-merge flattens branch history and the PR
+  title/body carry the conventional message. Do NOT add a STOP for this state.
 
 ### Step 4: Push Branch
 

--- a/tests/test_flow_docs_no_shared_stash.py
+++ b/tests/test_flow_docs_no_shared_stash.py
@@ -1,0 +1,77 @@
+"""Pin: the flow docs never touch the shared stash stack (issue #635).
+
+Git stashes live in the repo's COMMON git dir, so every linked worktree shares
+one stack. `/flow:auto` Step 6 and `/flow:finish` used to do
+`stash push -u -> merge -> bare stash pop`; with concurrent sessions the pops
+took whatever was top-of-stack and silently swapped uncommitted work between
+worktrees (two confirmed symmetric hits plus a near-miss, aws-learn
+2026-08-05). The fix is commit-first: WIP-commit the work, merge on the clean
+tree, let the squash flatten the snapshot.
+
+This is a doc-content pin because the regression already happened once as a
+doc edit: #521 installed the stash dance as a FIX (for merge-order inversion),
+and #635 is its residue. A future editor solving a merge-order problem must
+not be able to quietly reintroduce the shared-stack race.
+
+Comments MAY mention `git stash` (the blocks explain why it is forbidden);
+only an executable stash line - a line whose code content starts with or
+chains into `git stash` - fails the pin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FLOW_DOCS = [
+    ROOT / ".claude" / "commands" / "flow" / "auto.md",
+    ROOT / ".claude" / "commands" / "flow" / "finish.md",
+    ROOT / "plugins" / "flow" / "commands" / "auto.md",
+    ROOT / "plugins" / "flow" / "commands" / "finish.md",
+]
+
+
+def _executable_stash_lines(text: str) -> list[str]:
+    hits: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            continue  # explanatory comment - allowed to name the forbidden pattern
+        code = line
+        # Also catch chained forms: `foo && git stash pop`, `foo; git stash push`.
+        for sep in ("&&", ";", "||", "|"):
+            for part in code.split(sep):
+                if part.strip().startswith("git stash"):
+                    hits.append(raw)
+    return hits
+
+
+@pytest.mark.parametrize("doc", FLOW_DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_no_executable_stash_in_flow_docs(doc: Path) -> None:
+    hits = _executable_stash_lines(doc.read_text())
+    assert not hits, (
+        f"{doc}: executable `git stash` line(s) reintroduce the #635 shared-stack "
+        f"race - use the commit-first pattern (wip(flow): pre-merge snapshot):\n"
+        + "\n".join(hits)
+    )
+
+
+def test_commit_first_pattern_present() -> None:
+    for doc in FLOW_DOCS[:2]:
+        text = doc.read_text()
+        assert 'git commit -m "wip(flow): pre-merge snapshot"' in text, (
+            f"{doc}: the commit-first stale-base pattern (#635) is missing"
+        )
+
+
+def test_clean_tree_seam_is_documented() -> None:
+    """Condition from the #635 gate: the downstream commit step must treat an
+    already-clean tree (work riding the WIP snapshot) as legitimate."""
+    for doc in FLOW_DOCS[:2]:
+        text = doc.read_text()
+        assert "LEGITIMATE state, not a failure" in text, (
+            f"{doc}: missing the already-committed seam note (#635 condition 1)"
+        )


### PR DESCRIPTION
## Summary

Replaces the Step-6 (`auto.md`) and `/flow:finish` stash push -> merge -> bare pop sequence with commit-first: WIP-commit the uncommitted work (greppable `wip(flow): pre-merge snapshot`), merge `origin/main` on the clean tree, and let the Step-7 squash flatten the snapshot.

### Why
Stashes live in the repo's **common git dir** - every linked worktree shares ONE stack - so at ~7 concurrent sessions two runs stash-pushed seconds apart and each bare `git stash pop` silently restored the OTHER session's uncommitted work (symmetric swap + a third-session near-miss, aws-learn 2026-08-05). A WIP commit is branch-local; a sibling session cannot take it.

### Trace (per the approved gate - reachability decided from code)
The stash fired only when a run was **behind origin/main AND dirty** at Step 6. The documented flow is always dirty there (Step-4 work uncommitted), so reachability reduces to "did main move" - which reconciles both datasets: 7 unserialized aws-learn sessions hit it; the serialized poker-measure wave (13 merges, ~5h) never entered the block. Also corrects #521's premise: git refuses a dirty-tree merge only when incoming changes **overlap** locally-modified files.

### Gate conditions
- **Condition 1 (already-committed seam):** both docs now state an already-clean tree at the later commit step is a LEGITIMATE state - skip cleanly, never a STOP; the WIP message never reaches main (squash message comes from the PR). Pinned by `test_clean_tree_seam_is_documented`.
- Both pop-conflict STOP paths are gone (they cannot occur); the conflict STOP notes the work is safe in the WIP commit.
- Step-4 early-merge gets the same rule: on a dirty-overlap refusal, commit first - never stash.
- `tests/test_flow_docs_no_shared_stash.py` pins the pattern (no executable `git stash` line in the flow docs, source + plugin copies; commit-first present) - justified because #521 -> #635 already demonstrated a doc edit reintroducing the race.

### Files
- `.claude/commands/flow/auto.md`, `.claude/commands/flow/finish.md` - the rewrite
- `tests/test_flow_docs_no_shared_stash.py` - new regression pin (6 tests)
- Generated: `plugins/flow/commands/{auto,finish}.md` + codex skill copies

### Test plan
- `flow-finish-gate.sh`: **ok** - lint clean, 1343 passed / 0 skipped, mypy clean, security pass

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)