### PR TITLE
feat(project): delegate project-next's decision policy to the shared behavioral contract (Closes #636)

### DIFF
--- a/.claude/commands/project/next.md
+++ b/.claude/commands/project/next.md
@@ -1,6 +1,6 @@
 ---
 description: Prioritized next-step report from GitHub issues and worktrees (compact default; --full deep analysis, --brief single pick)
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(for :*), Bash(sort:*), Bash(printf:*), Read, Glob, Grep
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(for :*), Bash(sort:*), Bash(printf:*), Bash(grep:*), Bash(python3:*), Read, Glob, Grep
 ---
 
 # Project Next Steps Recommendation
@@ -25,7 +25,59 @@ report, not a change.
 
 ---
 
+## Step 0: Resolve the decision engine (shared behavioral contract, pinned v1.3)
+
+The DECISION POLICY - classification (in_flight / blocked / uncertain /
+available), ranking, and the top-action vs next-startable-issue split - is
+owned by the shared behavioral contract (issue #636): codex-power-pack's
+`docs/project-next-contract.md`, **pinned at contract version 1.3**, with its
+executable engine and deterministic fixture corpus as the source of truth. CPP
+keeps only Claude-side collection notes and report rendering; a second
+prompt-only decision policy is not an authoritative implementation (the
+contract's own rule).
+
+Locate the engine (first hit wins), and read the contract version it speaks:
+
+```bash
+CXPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  [ -f "$dir/scripts/project-next.py" ] && { CXPP_DIR="$dir"; break; }
+done
+[ -n "$CXPP_DIR" ] && grep -m1 "Contract version" "$CXPP_DIR/docs/project-next-contract.md"
+```
+
+- **Engine found:** compare the version line just printed against the pin. If
+  it is not `1.3`, SAY SO in the report header - "engine speaks vX, this doc
+  pinned 1.3 - output may diverge; update the pin after review" - and proceed;
+  never silently. Then run the engine and let it decide:
+
+  ```bash
+  python3 "$CXPP_DIR/scripts/project-next.py" /path/to/repo --json
+  ```
+
+  (`--brief`/`--compact`/`--full` mirror this command's own mode flags;
+  `--json` is the authoritative structured result.) Render the result through
+  the Step-5 templates - rendering is CPP's half; the classification sets,
+  ranking order, `top_action`, and `next_startable_issue` come from the engine
+  VERBATIM. Do not re-derive, filter, or "correct" them: if an engine answer
+  looks wrong, that is a contract/fixture issue for codex-power-pack, not a
+  prompt-side override. Skip Steps 1-3 entirely (the engine collects and
+  classifies); Step 4's spec-sync pointer still applies. Label the report:
+  `decision policy: contract v1.3 (engine)`.
+- **Engine present but FAILS** (crash, missing dep, unparseable JSON): report
+  the failure verbatim, then fall back to Steps 1-5 with the fallback label -
+  a broken engine must be visible, never papered over.
+- **No engine:** run Steps 1-5 as the fallback policy and LABEL the report:
+  `decision policy: CPP fallback (prompt-based), not contract v1.3 - install
+  codex-power-pack for the authoritative engine`.
+
+---
+
 ## Step 1: Resolve project and fetch state (one pass)
+
+**Steps 1-3 are the FALLBACK decision policy** - run them only when Step 0
+found no engine (or the engine failed); the report must carry the fallback
+label either way.
 
 ### 1.1 Resolve the project directory
 
@@ -166,10 +218,15 @@ In `--full` mode, show the full feature table instead.
 
 ## Step 5: Output
 
+Every mode's report opens with the decision-policy line from Step 0 -
+`decision policy: contract v1.3 (engine)` or the CPP-fallback label (plus the
+version-mismatch warning when the located contract doc is not 1.3).
+
 ### Default (compact)
 
 ```markdown
 ## {REPO} - Next Steps
+_decision policy: {contract v1.3 (engine) | CPP fallback (prompt-based)}_
 
 **State:** {N} open | {K} in-flight ({#a, #b}) | {M} blocked
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,8 @@ offline. Reconcile drift by editing the canonical repo first, then
 
 ### Project
 - `/project:init <name>` - Full project scaffolding (zero to GitHub repo)
-- `/project:next` - Prioritized next-step report (compact default ~2-4K tokens; `--full` deep 5-tier analysis ~15-30K, `--brief` single pick)
+- `/project:next` - Prioritized next-step report (compact default ~2-4K tokens; `--full` deep analysis, `--brief` single pick)
+  - Decision policy delegated to the shared behavioral contract (#636): classification/ranking/top-action come VERBATIM from codex-power-pack's engine (`scripts/project-next.py --json`, contract pinned v1.3 with a runtime version check that flags mismatch in the report) when a CxPP checkout is found; CPP keeps collection notes + rendering only. No engine -> the prompt policy runs as the LABELED non-authoritative fallback ("decision policy: CPP fallback"). Pinned by tests/test_project_next_contract.py incl. a fixture-backed dogfood that FAILS (never skips) on a broken engine when a checkout is present
 - `/project:lite` - Quick project reference (~500-800 tokens)
 
 `/project:init` delegates config scaffolding (CLAUDE.md, skills, hooks) to Claude

--- a/codex/skills/project-next/reference.md
+++ b/codex/skills/project-next/reference.md
@@ -22,7 +22,59 @@ report, not a change.
 
 ---
 
+## Step 0: Resolve the decision engine (shared behavioral contract, pinned v1.3)
+
+The DECISION POLICY - classification (in_flight / blocked / uncertain /
+available), ranking, and the top-action vs next-startable-issue split - is
+owned by the shared behavioral contract (issue #636): codex-power-pack's
+`docs/project-next-contract.md`, **pinned at contract version 1.3**, with its
+executable engine and deterministic fixture corpus as the source of truth. CPP
+keeps only Claude-side collection notes and report rendering; a second
+prompt-only decision policy is not an authoritative implementation (the
+contract's own rule).
+
+Locate the engine (first hit wins), and read the contract version it speaks:
+
+```bash
+CXPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  [ -f "$dir/scripts/project-next.py" ] && { CXPP_DIR="$dir"; break; }
+done
+[ -n "$CXPP_DIR" ] && grep -m1 "Contract version" "$CXPP_DIR/docs/project-next-contract.md"
+```
+
+- **Engine found:** compare the version line just printed against the pin. If
+  it is not `1.3`, SAY SO in the report header - "engine speaks vX, this doc
+  pinned 1.3 - output may diverge; update the pin after review" - and proceed;
+  never silently. Then run the engine and let it decide:
+
+  ```bash
+  python3 "$CXPP_DIR/scripts/project-next.py" /path/to/repo --json
+  ```
+
+  (`--brief`/`--compact`/`--full` mirror this command's own mode flags;
+  `--json` is the authoritative structured result.) Render the result through
+  the Step-5 templates - rendering is CPP's half; the classification sets,
+  ranking order, `top_action`, and `next_startable_issue` come from the engine
+  VERBATIM. Do not re-derive, filter, or "correct" them: if an engine answer
+  looks wrong, that is a contract/fixture issue for codex-power-pack, not a
+  prompt-side override. Skip Steps 1-3 entirely (the engine collects and
+  classifies); Step 4's spec-sync pointer still applies. Label the report:
+  `decision policy: contract v1.3 (engine)`.
+- **Engine present but FAILS** (crash, missing dep, unparseable JSON): report
+  the failure verbatim, then fall back to Steps 1-5 with the fallback label -
+  a broken engine must be visible, never papered over.
+- **No engine:** run Steps 1-5 as the fallback policy and LABEL the report:
+  `decision policy: CPP fallback (prompt-based), not contract v1.3 - install
+  codex-power-pack for the authoritative engine`.
+
+---
+
 ## Step 1: Resolve project and fetch state (one pass)
+
+**Steps 1-3 are the FALLBACK decision policy** - run them only when Step 0
+found no engine (or the engine failed); the report must carry the fallback
+label either way.
 
 ### 1.1 Resolve the project directory
 
@@ -163,10 +215,15 @@ In `--full` mode, show the full feature table instead.
 
 ## Step 5: Output
 
+Every mode's report opens with the decision-policy line from Step 0 -
+`decision policy: contract v1.3 (engine)` or the CPP-fallback label (plus the
+version-mismatch warning when the located contract doc is not 1.3).
+
 ### Default (compact)
 
 ```markdown
 ## {REPO} - Next Steps
+_decision policy: {contract v1.3 (engine) | CPP fallback (prompt-based)}_
 
 **State:** {N} open | {K} in-flight ({#a, #b}) | {M} blocked
 

--- a/plugins/project/commands/next.md
+++ b/plugins/project/commands/next.md
@@ -1,6 +1,6 @@
 ---
 description: Prioritized next-step report from GitHub issues and worktrees (compact default; --full deep analysis, --brief single pick)
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(for :*), Bash(sort:*), Bash(printf:*), Read, Glob, Grep
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(ls:*), Bash(for :*), Bash(sort:*), Bash(printf:*), Bash(grep:*), Bash(python3:*), Read, Glob, Grep
 ---
 
 # Project Next Steps Recommendation
@@ -25,7 +25,59 @@ report, not a change.
 
 ---
 
+## Step 0: Resolve the decision engine (shared behavioral contract, pinned v1.3)
+
+The DECISION POLICY - classification (in_flight / blocked / uncertain /
+available), ranking, and the top-action vs next-startable-issue split - is
+owned by the shared behavioral contract (issue #636): codex-power-pack's
+`docs/project-next-contract.md`, **pinned at contract version 1.3**, with its
+executable engine and deterministic fixture corpus as the source of truth. CPP
+keeps only Claude-side collection notes and report rendering; a second
+prompt-only decision policy is not an authoritative implementation (the
+contract's own rule).
+
+Locate the engine (first hit wins), and read the contract version it speaks:
+
+```bash
+CXPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  [ -f "$dir/scripts/project-next.py" ] && { CXPP_DIR="$dir"; break; }
+done
+[ -n "$CXPP_DIR" ] && grep -m1 "Contract version" "$CXPP_DIR/docs/project-next-contract.md"
+```
+
+- **Engine found:** compare the version line just printed against the pin. If
+  it is not `1.3`, SAY SO in the report header - "engine speaks vX, this doc
+  pinned 1.3 - output may diverge; update the pin after review" - and proceed;
+  never silently. Then run the engine and let it decide:
+
+  ```bash
+  python3 "$CXPP_DIR/scripts/project-next.py" /path/to/repo --json
+  ```
+
+  (`--brief`/`--compact`/`--full` mirror this command's own mode flags;
+  `--json` is the authoritative structured result.) Render the result through
+  the Step-5 templates - rendering is CPP's half; the classification sets,
+  ranking order, `top_action`, and `next_startable_issue` come from the engine
+  VERBATIM. Do not re-derive, filter, or "correct" them: if an engine answer
+  looks wrong, that is a contract/fixture issue for codex-power-pack, not a
+  prompt-side override. Skip Steps 1-3 entirely (the engine collects and
+  classifies); Step 4's spec-sync pointer still applies. Label the report:
+  `decision policy: contract v1.3 (engine)`.
+- **Engine present but FAILS** (crash, missing dep, unparseable JSON): report
+  the failure verbatim, then fall back to Steps 1-5 with the fallback label -
+  a broken engine must be visible, never papered over.
+- **No engine:** run Steps 1-5 as the fallback policy and LABEL the report:
+  `decision policy: CPP fallback (prompt-based), not contract v1.3 - install
+  codex-power-pack for the authoritative engine`.
+
+---
+
 ## Step 1: Resolve project and fetch state (one pass)
+
+**Steps 1-3 are the FALLBACK decision policy** - run them only when Step 0
+found no engine (or the engine failed); the report must carry the fallback
+label either way.
 
 ### 1.1 Resolve the project directory
 
@@ -166,10 +218,15 @@ In `--full` mode, show the full feature table instead.
 
 ## Step 5: Output
 
+Every mode's report opens with the decision-policy line from Step 0 -
+`decision policy: contract v1.3 (engine)` or the CPP-fallback label (plus the
+version-mismatch warning when the located contract doc is not 1.3).
+
 ### Default (compact)
 
 ```markdown
 ## {REPO} - Next Steps
+_decision policy: {contract v1.3 (engine) | CPP fallback (prompt-based)}_
 
 **State:** {N} open | {K} in-flight ({#a, #b}) | {M} blocked
 

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -257,7 +257,10 @@ def test_retired_bare_invocations_gone_from_sources():
     for src in sorted(SOURCE_COMMANDS.rglob("*.md")):
         text = src.read_text()
         for bare in RETIRED_BARE_INVOCATIONS:
-            if bare in text:
+            # An INVOCATION reference, not a longer token: `/project-next.py`
+            # is a filename (the CxPP engine consumed since #636), never the
+            # retired slash command - require the match to end the token.
+            if re.search(re.escape(bare) + r"(?![\w.-])", text):
                 offenders.append(f"{src.relative_to(ROOT)}: {bare}")
     assert offenders == [], f"stale bare invocations in command sources: {offenders}"
 

--- a/tests/test_project_next_contract.py
+++ b/tests/test_project_next_contract.py
@@ -1,0 +1,137 @@
+"""Pins for /project:next's adoption of the shared behavioral contract (#636).
+
+The decision policy - classification, ranking, top-action vs next-startable -
+is owned by codex-power-pack's versioned contract (v1.3) and its engine; CPP
+keeps collection notes and rendering. Two layers of coverage:
+
+- Wiring pins (always run): next.md names the pinned contract version, the
+  engine entry point, the runtime version check, and the labeled fallback -
+  the prose contract this repo actually ships.
+- Dogfood (gate condition 2 semantics): SKIPS only when no CxPP checkout is
+  present (the CI container has none). When a checkout with the engine IS
+  present, any invocation error - missing dep, crash, bad JSON - is a FAILURE,
+  never a skip: a skipif that swallows a broken engine on the one machine
+  class that can exercise it rots silently. Runs fixture-backed (--input), so
+  no network is involved.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+NEXT_MD = ROOT / ".claude" / "commands" / "project" / "next.md"
+
+CXPP_PROBES = [
+    Path.home() / "Projects" / "codex-power-pack",
+    Path("/opt/codex-power-pack"),
+    Path.home() / ".codex-power-pack",
+]
+
+
+def _cxpp_dir() -> Path | None:
+    for d in CXPP_PROBES:
+        if (d / "scripts" / "project-next.py").is_file():
+            return d
+    return None
+
+
+class TestWiring:
+    """Always-run pins on the doc contract."""
+
+    def test_pins_contract_version(self) -> None:
+        text = NEXT_MD.read_text()
+        assert "contract version 1.3" in text.lower() or "contract v1.3" in text.lower()
+
+    def test_names_engine_entry_point_and_source_of_truth(self) -> None:
+        text = NEXT_MD.read_text()
+        assert "scripts/project-next.py" in text
+        assert "codex-power-pack" in text
+        assert "not an authoritative implementation" in text
+
+    def test_runtime_version_check_instruction(self) -> None:
+        # Gate condition 3: the doc must have the model READ the located
+        # contract's stated version and flag a mismatch, never silently proceed.
+        text = NEXT_MD.read_text()
+        assert 'grep -m1 "Contract version"' in text
+        assert "update the pin after review" in text
+
+    def test_fallback_is_labeled_not_silent(self) -> None:
+        text = NEXT_MD.read_text()
+        assert "CPP fallback (prompt-based)" in text
+        assert "never papered over" in text
+
+    def test_engine_answer_is_verbatim(self) -> None:
+        # The contract's core rule: no prompt-side override of the decision.
+        text = NEXT_MD.read_text()
+        assert "VERBATIM" in text
+
+
+@pytest.mark.skipif(_cxpp_dir() is None, reason="no codex-power-pack checkout on this machine")
+class TestDogfood:
+    """Fixture-backed engine run. Present checkout + broken engine = FAIL."""
+
+    def test_engine_runs_a_contract_fixture_and_honors_output_contract(
+        self, tmp_path: Path
+    ) -> None:
+        if shutil.which("python3") is None:  # pragma: no cover
+            pytest.fail("python3 missing but a CxPP checkout is present")
+        cxpp = _cxpp_dir()
+        assert cxpp is not None
+        scenarios_file = cxpp / "tests" / "project_next" / "fixtures" / "scenarios.json"
+        assert scenarios_file.is_file(), (
+            "CxPP checkout present but fixture corpus missing - broken engine "
+            "installs must FAIL this test, not skip (gate condition 2)"
+        )
+        scenarios = json.loads(scenarios_file.read_text())
+        name, scenario = next(iter(sorted(scenarios.items())))
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps(scenario["state"]))
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(cxpp / "scripts" / "project-next.py"),
+                "--input",
+                str(state_file),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"engine invocation failed on fixture '{name}' (checkout present -> "
+            f"this is a FAILURE, not a skip):\n{proc.stderr}"
+        )
+        result = json.loads(proc.stdout)  # bad JSON raises -> failure, as required
+
+        # Output contract shape: disjoint classification sets, and
+        # next_startable never references a non-available issue.
+        def _numbers(key: str) -> set:
+            val = result.get(key) or result.get("classification", {}).get(key) or []
+            out = set()
+            for item in val:
+                out.add(item["number"] if isinstance(item, dict) else item)
+            return out
+
+        in_flight = _numbers("in_flight")
+        blocked = _numbers("blocked")
+        uncertain = _numbers("uncertain")
+        available = _numbers("available")
+        sets = [in_flight, blocked, uncertain, available]
+        for i, a in enumerate(sets):
+            for b in sets[i + 1 :]:
+                assert not (a & b), f"classification sets overlap: {a & b}"
+
+        nsi = result.get("next_startable_issue")
+        if isinstance(nsi, dict):
+            nsi = nsi.get("number")
+        if nsi is not None:
+            assert nsi not in in_flight | blocked | uncertain


### PR DESCRIPTION
## Summary

`/project:next` stops being the second authoritative prompt-only decision policy the shared contract forbids: classification, ranking, and the top-action/next-startable split now come VERBATIM from codex-power-pack's engine (contract **pinned v1.3**), with CPP keeping only collection notes and rendering.

### How it works (next.md Step 0)
- Locate the engine via checkout probe (`~/Projects/codex-power-pack`, `/opt`, `~/.codex-power-pack`).
- **Condition 3:** read the located contract doc's stated version at run time (`grep -m1 "Contract version"`); on mismatch with the pinned 1.3 the report SAYS SO ("engine speaks vX, this doc pinned 1.3 - output may diverge; update the pin after review") - never silent. No drift machinery, one sentence of doc, as ruled.
- Engine found -> `python3 scripts/project-next.py <repo> --json`; result rendered through CPP templates, decision taken VERBATIM (no prompt-side override - engine disagreements are contract/fixture issues for CxPP). Steps 1-3 skipped.
- Engine present but broken -> failure reported verbatim, then labeled fallback. No engine -> Steps 1-5 run as the LABELED fallback ("decision policy: CPP fallback (prompt-based)").
- Every report opens with the decision-policy line; compact/--brief/--full preserved.

### Tests (6 new)
- Always-run wiring pins: version pin, engine entry point + source-of-truth rule, the runtime version-check instruction, fallback labeling, the VERBATIM rule.
- **Condition 2 dogfood:** skips ONLY on checkout absence; with a checkout present, ANY engine error (missing fixtures, crash, bad JSON) FAILS. Fixture-backed via the engine's `--input` (no network) using CxPP's own scenarios.json; asserts the output contract (disjoint classification sets, next_startable not in in_flight/blocked/uncertain). **Ran live against the real engine on this box: PASSED.**

### Residual (condition 1)
Filed as #648 with the decide-the-relationship framing: wave-lane planner grammar vs contract v1.3 grammar, exact deltas cited, BOTH resolutions (converge / deliberately distinct) presented as live options.

### Drive-by (disclosed)
`test_retired_bare_invocations_gone_from_sources` used naive substring matching, so the retired `/project-next` slash command fired on the legitimate `scripts/project-next.py` filename this change references. Refined to token-end matching (`(?![\w.-])`).

### Scope note
NO Python copied into CPP - the contract's ownership rule.

### Test plan
- `flow-finish-gate.sh`: **ok** - lint clean, 1371 passed / 0 skipped, mypy clean, security pass

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)