### PR TITLE
fix(cpp): link every executable helper, not just *.sh, in the Tier 2 symlink step (Closes #669)

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -43,8 +43,8 @@ Check what's already installed (same logic as `/cpp:status`):
 COMMANDS_INSTALLED=false
 [ -L ".claude/commands" ] || [ -d ".claude/commands" ] && COMMANDS_INSTALLED=true
 
-# Tier 2 checks
-SCRIPTS_COUNT=$(ls ~/.claude/scripts/*.sh 2>/dev/null | wc -l)
+# Tier 2 checks (count every linked helper, not just .sh - issue #669)
+SCRIPTS_COUNT=$(find ~/.claude/scripts -maxdepth 1 -type l 2>/dev/null | wc -l)
 HOOKS_EXIST=false
 [ -f ".claude/hooks.json" ] && HOOKS_EXIST=true
 
@@ -269,7 +269,7 @@ This will make the following changes:
 
   To undo:
     rm .claude/commands
-    rm ~/.claude/scripts/*.sh
+    find ~/.claude/scripts -maxdepth 1 -type l -delete   # CPP installs symlinks only
     rm .claude/hooks.json
     # Remove PS1 line from ~/.bashrc or ~/.zshrc
 
@@ -431,8 +431,13 @@ fi
 # Create scripts directory
 mkdir -p ~/.claude/scripts
 
-# Symlink all scripts
-for script in "$CPP_DIR"/scripts/*.sh; do
+# Symlink all executable helpers, regardless of extension (issue #669: the
+# old *.sh-only glob skipped flow-wave-plan.py, so its shipped allow rule in
+# templates/claude-settings-permissions.json pointed at a nonexistent path).
+# The executability gate skips non-executable .py library files, directories,
+# and __pycache__.
+for script in "$CPP_DIR"/scripts/*; do
+  [ -f "$script" ] && [ -x "$script" ] || continue
   name=$(basename "$script")
   if [ ! -L ~/.claude/scripts/"$name" ]; then
     ln -sf "$script" ~/.claude/scripts/"$name"
@@ -1186,9 +1191,10 @@ to reconcile.
 `scripts/install-memory-harness.sh` links `scripts/cpp-memory` onto `PATH` and
 installs the hand-authored Codex `/cpp-memory` prompt. Its header has always
 said it is safe to re-run from `/cpp:update`, but no step ever invoked it, so
-`cpp-memory` was missing from `PATH` unless run by hand. It also covers a gap in
-the Tier 2 symlink loop, which iterates `scripts/*.sh` and therefore never
-matches `scripts/cpp-memory` (no `.sh` suffix). Idempotent.
+`cpp-memory` was missing from `PATH` unless run by hand. The Tier 2 symlink
+loop now also links `scripts/cpp-memory` into `~/.claude/scripts/` (it links
+every executable helper since issue #669), but that dir is not on `PATH` -
+this harness remains the canonical `PATH` install. Idempotent.
 
 ```bash
 bash "$CPP_DIR/scripts/install-memory-harness.sh" \

--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -444,13 +444,18 @@ helper family, issue #581). EXISTING symlinks in `~/.claude/scripts/` follow
 the pull automatically, but a NEW script has no symlink yet - and the flow
 allowlist rules delivered by Step 7.5 match the stable `~/.claude/scripts/`
 path, so without this refresh a new rule points at a path that does not exist
-and the zero-prompt lane silently degrades. Re-run the same idempotent link
-loop as `/cpp:init` Tier 2; skip when this install has no `~/.claude/scripts/`
-directory (Tier 0/1 - never self-upgrade the tier here):
+and the zero-prompt lane silently degrades. The loop links every EXECUTABLE
+file in `scripts/` regardless of extension (issue #669: the old `*.sh`-only
+glob skipped `flow-wave-plan.py`, so its shipped allow rule pointed at a
+nonexistent path); non-executable `.py` library files, directories, and
+`__pycache__` are skipped by the executability gate. Re-run the same
+idempotent link loop as `/cpp:init` Tier 2; skip when this install has no
+`~/.claude/scripts/` directory (Tier 0/1 - never self-upgrade the tier here):
 
 ```bash
 if [ -d ~/.claude/scripts ]; then
-  for script in "$CPP_DIR"/scripts/*.sh; do
+  for script in "$CPP_DIR"/scripts/*; do
+    [ -f "$script" ] && [ -x "$script" ] || continue
     name=$(basename "$script")
     if [ ! -L ~/.claude/scripts/"$name" ]; then
       ln -sf "$script" ~/.claude/scripts/"$name"

--- a/.claude/commands/flow/help.md
+++ b/.claude/commands/flow/help.md
@@ -35,8 +35,9 @@ which is what the shipped permission allowlist rules match (issue #581).
   flow@cpp`, then migrate to the checkout-backed symlink surface restored by
   #663. `/flow:repair` remains compatible with the cache during migration.
 - **Installed from a CPP clone** (`/cpp:init` Tier 2 or later `/cpp:update`):
-  nothing to do - the installer already links every `scripts/*.sh`. `/flow:repair`
-  is harmless and idempotent if you run it anyway.
+  nothing to do - the installer already links every executable helper in
+  `scripts/` (issue #669). `/flow:repair` is harmless and idempotent if you run
+  it anyway.
 
 `/flow:doctor` reports helper and allowlist state without changing anything.
 

--- a/.claude/commands/flow/repair.md
+++ b/.claude/commands/flow/repair.md
@@ -101,4 +101,5 @@ Flow Repair
 - This is the only flow command that writes outside the repo. It touches exactly
   `~/.claude/scripts/`, and only the helper family listed in the installer.
 - Clone users do not need this - `/cpp:init` Tier 2 and `/cpp:update` Step 5b
-  already link every `scripts/*.sh`. Running it anyway is harmless and idempotent.
+  already link every executable helper in `scripts/` (issue #669). Running it
+  anyway is harmless and idempotent.

--- a/codex/skills/flow-help/reference.md
+++ b/codex/skills/flow-help/reference.md
@@ -37,8 +37,9 @@ which is what the shipped permission allowlist rules match (issue #581).
   flow@cpp`, then migrate to the checkout-backed symlink surface restored by
   #663. `/flow-repair` remains compatible with the cache during migration.
 - **Installed from a CPP clone** (`/cpp:init` Tier 2 or later `/cpp:update`):
-  nothing to do - the installer already links every `scripts/*.sh`. `/flow-repair`
-  is harmless and idempotent if you run it anyway.
+  nothing to do - the installer already links every executable helper in
+  `scripts/` (issue #669). `/flow-repair` is harmless and idempotent if you run
+  it anyway.
 
 `/flow-doctor` reports helper and allowlist state without changing anything.
 

--- a/codex/skills/flow-repair/SKILL.md
+++ b/codex/skills/flow-repair/SKILL.md
@@ -108,4 +108,5 @@ Flow Repair
 - This is the only flow command that writes outside the repo. It touches exactly
   `~/.claude/scripts/`, and only the helper family listed in the installer.
 - Clone users do not need this - `/cpp:init` Tier 2 and `/cpp:update` Step 5b
-  already link every `scripts/*.sh`. Running it anyway is harmless and idempotent.
+  already link every executable helper in `scripts/` (issue #669). Running it
+  anyway is harmless and idempotent.

--- a/tests/test_permissions_template_link_parity.py
+++ b/tests/test_permissions_template_link_parity.py
@@ -1,0 +1,102 @@
+"""Pin: every helper the permissions template pre-approves gets linked (issue #669).
+
+`templates/claude-settings-permissions.json` ships allow rules matching the
+stable `~/.claude/scripts/<name>` path, and the Tier 2 link step (`/cpp:init`
+Tier 2, re-run by `/cpp:update` Step 5b) is what creates those symlinks. The
+two drifted once: the link loop iterated `scripts/*.sh` only, so the rule for
+`flow-wave-plan.py` (a Python helper, #637/#642) pointed at a path the loop
+never created and the zero-prompt lane silently degraded - a CODE-EXEC prompt
+on every wave re-plan.
+
+Two pins close the gap from both sides:
+
+1. Template-side: every `Bash(~/.claude/scripts/<name>:*)` rule names a file
+   that exists in `scripts/` AND is executable, because the widened link loop
+   gates on executability - a rule naming a non-executable (or missing) helper
+   is a rule pointing at a path the loop will not create.
+2. Doc-side: the link loops in `.claude/commands/cpp/update.md` (Step 5b) and
+   `.claude/commands/cpp/init.md` (Tier 2) iterate `"$CPP_DIR"/scripts/*` with
+   an `-x` gate - a future editor cannot quietly regress to the `.sh`-only
+   glob that caused #669.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TEMPLATE = ROOT / "templates" / "claude-settings-permissions.json"
+SCRIPTS_DIR = ROOT / "scripts"
+
+LINK_LOOP_DOCS = [
+    ROOT / ".claude" / "commands" / "cpp" / "update.md",
+    ROOT / ".claude" / "commands" / "cpp" / "init.md",
+]
+
+STABLE_PATH_RULE = re.compile(r"^Bash\(~/\.claude/scripts/([^:)]+):\*\)$")
+
+
+def _template_helper_names() -> list[str]:
+    data = json.loads(TEMPLATE.read_text())
+    names = []
+    for rule in data.get("permissions", {}).get("allow", []):
+        m = STABLE_PATH_RULE.match(rule)
+        if m:
+            names.append(m.group(1))
+    return names
+
+
+def test_template_names_at_least_the_known_family() -> None:
+    """Sanity: the parse actually finds the helper rules (guards the regex)."""
+    names = _template_helper_names()
+    assert "flow-start-resolve.sh" in names
+    assert "flow-wave-plan.py" in names, (
+        "flow-wave-plan.py rule missing from the template - the #669 repro case"
+    )
+
+
+@pytest.mark.parametrize("name", _template_helper_names())
+def test_every_templated_helper_is_created_by_the_link_step(name: str) -> None:
+    """Each stable-path allow rule must point at a file the Tier 2 loop links.
+
+    The loop iterates `scripts/*` and links files passing `[ -f ] && [ -x ]`,
+    so existence + executability in `scripts/` is exactly "the symlink will be
+    created" (issue #669).
+    """
+    src = SCRIPTS_DIR / name
+    assert src.is_file(), (
+        f"{TEMPLATE.relative_to(ROOT)} allows ~/.claude/scripts/{name} but "
+        f"scripts/{name} does not exist - the rule points at a path no link "
+        f"step will ever create (issue #669)"
+    )
+    assert os.access(src, os.X_OK), (
+        f"scripts/{name} is not executable, so the Tier 2 link loop skips it "
+        f"and its allow rule points at a nonexistent path (issue #669) - "
+        f"chmod +x scripts/{name}"
+    )
+
+
+@pytest.mark.parametrize("doc", LINK_LOOP_DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_link_loop_docs_use_the_widened_executable_gate(doc: Path) -> None:
+    """The documented link loops must not regress to the `.sh`-only glob."""
+    text = doc.read_text()
+    assert '"$CPP_DIR"/scripts/*.sh' not in text, (
+        f"{doc.relative_to(ROOT)}: the `.sh`-only link glob is the #669 "
+        f"regression - iterate \"$CPP_DIR\"/scripts/* with an executability "
+        f"gate instead"
+    )
+    assert 'for script in "$CPP_DIR"/scripts/*' in text, (
+        f"{doc.relative_to(ROOT)}: expected the widened link loop over "
+        f'"$CPP_DIR"/scripts/* (issue #669)'
+    )
+    assert '[ -f "$script" ] && [ -x "$script" ] || continue' in text, (
+        f"{doc.relative_to(ROOT)}: the link loop must gate on executability "
+        f"so directories, __pycache__, and non-executable library files are "
+        f"skipped (issue #669)"
+    )


### PR DESCRIPTION
## Summary

The `/cpp:init` Tier 2 and `/cpp:update` Step 5b link loops iterated `"$CPP_DIR"/scripts/*.sh`, so the Python helper `flow-wave-plan.py` - whose allow rule `templates/claude-settings-permissions.json` ships at the stable `~/.claude/scripts/` path (#637/#642) - was never linked. The rule pointed at a nonexistent path, and `/flow:wave` re-plans either failed (exit 127) or prompted CODE-EXEC on every scope ruling.

- Widen both link loops to `"$CPP_DIR"/scripts/*` gated on `[ -f ] && [ -x ]`: every executable helper links regardless of extension; directories, `__pycache__`, and non-executable `.py` library files are skipped.
- Update the `/cpp:init` 5f note (the widened loop now also links `scripts/cpp-memory`; `install-memory-harness.sh` remains the canonical PATH install), the Tier 2 status count, the undo disclosure, and the `flow:help`/`flow:repair` phrasing.
- Add `tests/test_permissions_template_link_parity.py` - the test the issue asked for: every `Bash(~/.claude/scripts/<file>:*)` rule in the permissions template must name an existing executable in `scripts/`, and the documented link loops must keep the widened glob + executability gate, so the allowlist and the link set can no longer silently disagree.
- Regenerate `codex/skills/` copies (`codex-skill-sync.py --write`).

`flow-helpers-install.sh` (the `/flow:repair` lane) already carries `flow-wave-plan.py` in its HELPERS list and needs no change; the open #677 (HELPERS omits `cpp-commands-link.sh`) is a separate lane and is not touched here.

## Test plan

- `flow-finish-gate`: lint, pytest (1367 passed, 1 pre-existing skip - including 17 new parity tests), mypy, security scan - all green
- `codex-skill-sync.py --check`: 75 skills in sync

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)