### PR TITLE
docs(flow): order-independent wave registration - worker-first is first-class (Closes #670)

### DIFF
--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -68,19 +68,45 @@ and is wiped by the OS at reboot - exactly when every session socket dies too.
      the user confirms the other session is genuinely gone. A dead owner's
      entry is stale and taken over automatically - no `--force` needed.
 
-3. Send the orchestrator a registration hello via `SendMessage` (to the
-   orchestrator's socket from `get orchestrator`, or reply to its most recent
-   message's `from=`), stating the role, wave, cwd, repo, and current
-   issue/branch. This message is what lets the orchestrator OBSERVE the real
-   address.
+3. Send the orchestrator a registration hello via `SendMessage`, stating the
+   role, wave, cwd, repo, and current issue/branch. This message is what lets
+   the orchestrator OBSERVE the real address. Pick the first branch that
+   applies:
+   - the orchestrator's socket from `get orchestrator` - message it directly;
+   - no usable socket, but the orchestrator has messaged this session before -
+     reply to its most recent message's `from=`;
+   - `get orchestrator` says `free`, or its socket is `unknown` - the
+     orchestrator has not (usefully) registered yet. This is NORMAL, not an
+     error (issue #670): registration already succeeded in step 2 and never
+     depends on the hello landing. Report
+     `registered; orchestrator not yet in roster; hello deferred` and carry
+     on. The hello fires on FIRST CONTACT from either side: when the
+     orchestrator arrives it initiates contact (see the orchestrator side),
+     and this session's REPLY is the deferred hello - the reply carries the
+     transport-stamped `from=` that `verify` needs.
 
 4. Confirm back to the user which orchestrator was registered with once the
-   ack arrives.
+   ack arrives - or that the hello is deferred because no orchestrator has
+   registered yet.
 
 ### Orchestrator side
 
-**On receiving a worker's hello**, reconcile the recorded address with the
-address the transport actually stamped on that message:
+**Registration is order-independent (issue #670).** Workers registering before
+the orchestrator is NORMAL practice - a user opens worker terminals first, or a
+worker session outlives an orchestrator restart. On registering as
+`orchestrator`, and on each `list`, treat every pre-existing unverified LIVE
+worker as a PENDING HANDSHAKE (the roster's `[live, unverified]` entries are
+exactly this list): initiate contact with each one at its recorded bootstrap
+socket. The worker's REPLY is its deferred hello, and the reply's
+transport-stamped `from=` feeds `verify` below - so verification is reachable
+from whichever side makes first contact. A worker whose socket recorded as
+`unknown` cannot be contacted orchestrator-first; that is the socket-bootstrap
+gap (#672), not an ordering problem - it waits until either side can produce a
+usable address.
+
+**On receiving a worker's hello** (or its reply to your first contact),
+reconcile the recorded address with the address the transport actually stamped
+on that message:
 
 ```bash
 ~/.claude/scripts/flow-wave-registry.sh verify 1 --wave cpp --from uds:/run/user/1000/cc-socks/12345.sock
@@ -154,5 +180,6 @@ usage error, else 0.
 - Registration is idempotent for the owning session: re-running refreshes the
   entry (new issue/branch/cwd) without ceremony.
 - Roles are free-form labels; `orchestrator` is just a role, so workers can
-  `get orchestrator` to discover where to send their hello.
+  `get orchestrator` to discover where to send their hello - or learn it is
+  not there yet and defer the hello to first contact (#670).
 - The helper needs `jq` (already a CPP bootstrap prerequisite).

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -45,25 +45,46 @@ plus one orchestrator error a worker caught. This command packages that loop.
 ## Setup: the roster (consume #638, do not reimplement)
 
 Addressing is exactly the `/flow:register` protocol - this command adds NO
-addressing logic of its own. Follow `register.md`:
+addressing logic of its own. Follow `register.md`.
 
-1. Register this session as the wave's orchestrator:
-   ```bash
-   ~/.claude/scripts/flow-wave-registry.sh register orchestrator --wave <WAVE> --repo <TARGET_REPO>
-   ```
-2. Have each worker run `/flow:register <role> --wave <WAVE>` and send its
-   hello; on each hello, reconcile the observed `from=`:
-   ```bash
-   ~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed uds:...>
-   ```
-   The transport-observed address is authoritative on any mismatch (#638).
-3. Ack each worker with the wave brief: its lane, stop-at-Step-3 (never
-   `--yes`), the ledger format, and the structural-pushback rule verbatim.
-4. Address workers ONLY by the registry's `uds:` socket via `SendMessage` -
-   never by `ListAgents` display names. Check the roster with:
-   ```bash
-   ~/.claude/scripts/flow-wave-registry.sh list --wave <WAVE>
-   ```
+**Registration is ORDER-INDEPENDENT (issue #670)** - these happen in any
+order; the registry file creates the wave on first touch, whoever touches it
+first:
+
+- Register this session as the wave's orchestrator:
+  ```bash
+  ~/.claude/scripts/flow-wave-registry.sh register orchestrator --wave <WAVE> --repo <TARGET_REPO>
+  ```
+- Each worker runs `/flow:register <role> --wave <WAVE>` - before or after the
+  orchestrator exists. A worker that registers first reports
+  `registered; orchestrator not yet in roster; hello deferred` and is NOT
+  stalled; its registration stands on its own.
+
+Then, on FIRST CONTACT in either direction, verify the observed address:
+
+- Orchestrator registered first: each worker sends its hello on registering.
+- Worker registered first: its roster entry reads `[live, unverified]` - a
+  PENDING HANDSHAKE. On registering, and on each `list`, initiate contact
+  with every such worker at its recorded bootstrap socket; the worker's REPLY
+  is its deferred hello.
+
+On each hello (or reply), reconcile the observed `from=`:
+
+```bash
+~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed uds:...>
+```
+
+The transport-observed address is authoritative on any mismatch (#638).
+
+Ack each worker with the wave brief: its lane, stop-at-Step-3 (never
+`--yes`), the ledger format, and the structural-pushback rule verbatim.
+
+Address workers ONLY by the registry's `uds:` socket via `SendMessage` -
+never by `ListAgents` display names. Check the roster with:
+
+```bash
+~/.claude/scripts/flow-wave-registry.sh list --wave <WAVE>
+```
 
 ## Phase 1: Scaffold the issue set
 

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -70,19 +70,45 @@ and is wiped by the OS at reboot - exactly when every session socket dies too.
      the user confirms the other session is genuinely gone. A dead owner's
      entry is stale and taken over automatically - no `--force` needed.
 
-3. Send the orchestrator a registration hello via `SendMessage` (to the
-   orchestrator's socket from `get orchestrator`, or reply to its most recent
-   message's `from=`), stating the role, wave, cwd, repo, and current
-   issue/branch. This message is what lets the orchestrator OBSERVE the real
-   address.
+3. Send the orchestrator a registration hello via `SendMessage`, stating the
+   role, wave, cwd, repo, and current issue/branch. This message is what lets
+   the orchestrator OBSERVE the real address. Pick the first branch that
+   applies:
+   - the orchestrator's socket from `get orchestrator` - message it directly;
+   - no usable socket, but the orchestrator has messaged this session before -
+     reply to its most recent message's `from=`;
+   - `get orchestrator` says `free`, or its socket is `unknown` - the
+     orchestrator has not (usefully) registered yet. This is NORMAL, not an
+     error (issue #670): registration already succeeded in step 2 and never
+     depends on the hello landing. Report
+     `registered; orchestrator not yet in roster; hello deferred` and carry
+     on. The hello fires on FIRST CONTACT from either side: when the
+     orchestrator arrives it initiates contact (see the orchestrator side),
+     and this session's REPLY is the deferred hello - the reply carries the
+     transport-stamped `from=` that `verify` needs.
 
 4. Confirm back to the user which orchestrator was registered with once the
-   ack arrives.
+   ack arrives - or that the hello is deferred because no orchestrator has
+   registered yet.
 
 ### Orchestrator side
 
-**On receiving a worker's hello**, reconcile the recorded address with the
-address the transport actually stamped on that message:
+**Registration is order-independent (issue #670).** Workers registering before
+the orchestrator is NORMAL practice - a user opens worker terminals first, or a
+worker session outlives an orchestrator restart. On registering as
+`orchestrator`, and on each `list`, treat every pre-existing unverified LIVE
+worker as a PENDING HANDSHAKE (the roster's `[live, unverified]` entries are
+exactly this list): initiate contact with each one at its recorded bootstrap
+socket. The worker's REPLY is its deferred hello, and the reply's
+transport-stamped `from=` feeds `verify` below - so verification is reachable
+from whichever side makes first contact. A worker whose socket recorded as
+`unknown` cannot be contacted orchestrator-first; that is the socket-bootstrap
+gap (#672), not an ordering problem - it waits until either side can produce a
+usable address.
+
+**On receiving a worker's hello** (or its reply to your first contact),
+reconcile the recorded address with the address the transport actually stamped
+on that message:
 
 ```bash
 ~/.claude/scripts/flow-wave-registry.sh verify 1 --wave cpp --from uds:/run/user/1000/cc-socks/12345.sock
@@ -156,5 +182,6 @@ usage error, else 0.
 - Registration is idempotent for the owning session: re-running refreshes the
   entry (new issue/branch/cwd) without ceremony.
 - Roles are free-form labels; `orchestrator` is just a role, so workers can
-  `get orchestrator` to discover where to send their hello.
+  `get orchestrator` to discover where to send their hello - or learn it is
+  not there yet and defer the hello to first contact (#670).
 - The helper needs `jq` (already a CPP bootstrap prerequisite).

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -47,25 +47,46 @@ plus one orchestrator error a worker caught. This command packages that loop.
 ## Setup: the roster (consume #638, do not reimplement)
 
 Addressing is exactly the `/flow-register` protocol - this command adds NO
-addressing logic of its own. Follow `register.md`:
+addressing logic of its own. Follow `register.md`.
 
-1. Register this session as the wave's orchestrator:
-   ```bash
-   ~/.claude/scripts/flow-wave-registry.sh register orchestrator --wave <WAVE> --repo <TARGET_REPO>
-   ```
-2. Have each worker run `/flow-register <role> --wave <WAVE>` and send its
-   hello; on each hello, reconcile the observed `from=`:
-   ```bash
-   ~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed uds:...>
-   ```
-   The transport-observed address is authoritative on any mismatch (#638).
-3. Ack each worker with the wave brief: its lane, stop-at-Step-3 (never
-   `--yes`), the ledger format, and the structural-pushback rule verbatim.
-4. Address workers ONLY by the registry's `uds:` socket via `SendMessage` -
-   never by `ListAgents` display names. Check the roster with:
-   ```bash
-   ~/.claude/scripts/flow-wave-registry.sh list --wave <WAVE>
-   ```
+**Registration is ORDER-INDEPENDENT (issue #670)** - these happen in any
+order; the registry file creates the wave on first touch, whoever touches it
+first:
+
+- Register this session as the wave's orchestrator:
+  ```bash
+  ~/.claude/scripts/flow-wave-registry.sh register orchestrator --wave <WAVE> --repo <TARGET_REPO>
+  ```
+- Each worker runs `/flow-register <role> --wave <WAVE>` - before or after the
+  orchestrator exists. A worker that registers first reports
+  `registered; orchestrator not yet in roster; hello deferred` and is NOT
+  stalled; its registration stands on its own.
+
+Then, on FIRST CONTACT in either direction, verify the observed address:
+
+- Orchestrator registered first: each worker sends its hello on registering.
+- Worker registered first: its roster entry reads `[live, unverified]` - a
+  PENDING HANDSHAKE. On registering, and on each `list`, initiate contact
+  with every such worker at its recorded bootstrap socket; the worker's REPLY
+  is its deferred hello.
+
+On each hello (or reply), reconcile the observed `from=`:
+
+```bash
+~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed uds:...>
+```
+
+The transport-observed address is authoritative on any mismatch (#638).
+
+Ack each worker with the wave brief: its lane, stop-at-Step-3 (never
+`--yes`), the ledger format, and the structural-pushback rule verbatim.
+
+Address workers ONLY by the registry's `uds:` socket via `SendMessage` -
+never by `ListAgents` display names. Check the roster with:
+
+```bash
+~/.claude/scripts/flow-wave-registry.sh list --wave <WAVE>
+```
 
 ## Phase 1: Scaffold the issue set
 


### PR DESCRIPTION
## Summary

Makes registration order-independence explicit in the #638 register/hello protocol docs. The registry file was already order-independent; only the hello/verify protocol layered on top was directional (orchestrator-first), so a worker registering before the orchestrator - observed live in the 2026-08-11 aws-learn `cpp-install` wave - stalled with no defined path to a verified address.

- `.claude/commands/flow/register.md`
  - Worker step 3: third branch for "orchestrator not yet in roster" - registration succeeds on its own, report `registered; orchestrator not yet in roster; hello deferred`, and the hello fires on first contact from either side (the worker's reply carries the transport-stamped `from=`).
  - Orchestrator side: registration is order-independent - on registering and on each `list`, pre-existing unverified LIVE workers are PENDING HANDSHAKES the orchestrator initiates contact with; verification is reachable from whichever side makes first contact. The `unknown`-socket case is explicitly deferred to #672 (bootstrap gap, not an ordering problem).
- `.claude/commands/flow/wave.md` Setup: numbered orchestrator-first sequence replaced with the order-independent formulation (in any order: orchestrator registers; each worker registers; on first contact in either direction, verify the observed `from=`).
- `codex/skills/flow-register/` + `codex/skills/flow-wave/`: regenerated (codex-skill-sync).

Docs-only; no helper-script behavior change (the roster's `[live, unverified]` display already is the pending-handshake signal).

## Test plan

- `flow-finish-gate`: lint, pytest (1367 passed, 1 skipped), mypy, security scan - all green
- `codex-skill-sync.py --check` parity holds (regenerated in-branch)

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)