### PR TITLE
fix(flow): install every stable-path helper the allowlist blesses (Closes #677)

### DIFF
--- a/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
@@ -37,6 +37,21 @@ TARGET_DIR="$HOME_DIR/.claude/scripts"
 # sibling via $SELF_DIR, so the guard must travel with it. The advisory guards
 # fail open when absent, but a legacy-cache user should keep the zero-prompt lane
 # whole, not degraded.
+#
+# Despite the script's name this is NOT a flow-only list - it already carries
+# gh-pr-merge.sh, worktree-remove.sh, friction-log.sh, check-ignored-additions.sh
+# and this installer itself. The membership rule is simpler than the name
+# suggests: THIS IS THE STABLE-PATH INSTALL SET. Anything that
+# templates/claude-settings-permissions.json pre-approves at
+# `Bash(~/.claude/scripts/<name>:*)` belongs here, whatever family it comes from,
+# because that rule matches a command PREFIX - so a helper the rule blesses but
+# nothing installs leaves the rule matching a path that does not exist (issue
+# #677: cpp-commands-link.sh and install-drift.sh were both missing, so on any
+# host provisioned WITHOUT interactive /cpp:init the rule was inert and
+# /cpp:update Step 5c fell back to the checkout copy - which the rule does not
+# match - and prompted, the exact friction the stable path removes). Do not
+# re-litigate a non-flow addition on naming grounds; the template is the
+# membership test, and tests/test_permissions_template_link_parity.py enforces it.
 HELPERS=(
     flow-start-resolve.sh
     flow-live-driver-guard.sh
@@ -50,6 +65,8 @@ HELPERS=(
     worktree-remove.sh
     friction-log.sh
     check-ignored-additions.sh
+    cpp-commands-link.sh
+    install-drift.sh
     flow-helpers-install.sh
 )
 

--- a/codex/skills/flow-repair/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-repair/scripts/flow-helpers-install.sh
@@ -37,6 +37,21 @@ TARGET_DIR="$HOME_DIR/.claude/scripts"
 # sibling via $SELF_DIR, so the guard must travel with it. The advisory guards
 # fail open when absent, but a legacy-cache user should keep the zero-prompt lane
 # whole, not degraded.
+#
+# Despite the script's name this is NOT a flow-only list - it already carries
+# gh-pr-merge.sh, worktree-remove.sh, friction-log.sh, check-ignored-additions.sh
+# and this installer itself. The membership rule is simpler than the name
+# suggests: THIS IS THE STABLE-PATH INSTALL SET. Anything that
+# templates/claude-settings-permissions.json pre-approves at
+# `Bash(~/.claude/scripts/<name>:*)` belongs here, whatever family it comes from,
+# because that rule matches a command PREFIX - so a helper the rule blesses but
+# nothing installs leaves the rule matching a path that does not exist (issue
+# #677: cpp-commands-link.sh and install-drift.sh were both missing, so on any
+# host provisioned WITHOUT interactive /cpp:init the rule was inert and
+# /cpp:update Step 5c fell back to the checkout copy - which the rule does not
+# match - and prompted, the exact friction the stable path removes). Do not
+# re-litigate a non-flow addition on naming grounds; the template is the
+# membership test, and tests/test_permissions_template_link_parity.py enforces it.
 HELPERS=(
     flow-start-resolve.sh
     flow-live-driver-guard.sh
@@ -50,6 +65,8 @@ HELPERS=(
     worktree-remove.sh
     friction-log.sh
     check-ignored-additions.sh
+    cpp-commands-link.sh
+    install-drift.sh
     flow-helpers-install.sh
 )
 

--- a/scripts/flow-helpers-install.sh
+++ b/scripts/flow-helpers-install.sh
@@ -37,6 +37,21 @@ TARGET_DIR="$HOME_DIR/.claude/scripts"
 # sibling via $SELF_DIR, so the guard must travel with it. The advisory guards
 # fail open when absent, but a legacy-cache user should keep the zero-prompt lane
 # whole, not degraded.
+#
+# Despite the script's name this is NOT a flow-only list - it already carries
+# gh-pr-merge.sh, worktree-remove.sh, friction-log.sh, check-ignored-additions.sh
+# and this installer itself. The membership rule is simpler than the name
+# suggests: THIS IS THE STABLE-PATH INSTALL SET. Anything that
+# templates/claude-settings-permissions.json pre-approves at
+# `Bash(~/.claude/scripts/<name>:*)` belongs here, whatever family it comes from,
+# because that rule matches a command PREFIX - so a helper the rule blesses but
+# nothing installs leaves the rule matching a path that does not exist (issue
+# #677: cpp-commands-link.sh and install-drift.sh were both missing, so on any
+# host provisioned WITHOUT interactive /cpp:init the rule was inert and
+# /cpp:update Step 5c fell back to the checkout copy - which the rule does not
+# match - and prompted, the exact friction the stable path removes). Do not
+# re-litigate a non-flow addition on naming grounds; the template is the
+# membership test, and tests/test_permissions_template_link_parity.py enforces it.
 HELPERS=(
     flow-start-resolve.sh
     flow-live-driver-guard.sh
@@ -50,6 +65,8 @@ HELPERS=(
     worktree-remove.sh
     friction-log.sh
     check-ignored-additions.sh
+    cpp-commands-link.sh
+    install-drift.sh
     flow-helpers-install.sh
 )
 

--- a/tests/test_flow_helpers_install.py
+++ b/tests/test_flow_helpers_install.py
@@ -16,20 +16,18 @@ from pathlib import Path
 
 import pytest
 
+from tests.test_permissions_template_link_parity import installer_helper_names
+
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "flow-helpers-install.sh"
 
-HELPERS = [
-    "flow-start-resolve.sh",
-    "flow-live-driver-guard.sh",
-    "flow-stale-check.sh",
-    "flow-worktree-guard.sh",
-    "gh-pr-merge.sh",
-    "worktree-remove.sh",
-    "friction-log.sh",
-    "check-ignored-additions.sh",
-    "flow-helpers-install.sh",
-]
+# DERIVED from the script, never duplicated (issue #677). This list used to be a
+# hardcoded 9-entry copy beside a 13-entry array - missing flow-worktree-claim.sh,
+# flow-wave-registry.sh, flow-wave-plan.py and flow-finish-gate.sh - so it could
+# not detect an omission from the thing it was testing; it only proved the copy
+# matched itself, and stayed green while two required helpers were missing from
+# the array. Parsing the array is what makes these tests cover the real family.
+HELPERS = installer_helper_names()
 
 
 def _run(

--- a/tests/test_permissions_template_link_parity.py
+++ b/tests/test_permissions_template_link_parity.py
@@ -18,6 +18,23 @@ Two pins close the gap from both sides:
    `.claude/commands/cpp/init.md` (Tier 2) iterate `"$CPP_DIR"/scripts/*` with
    an `-x` gate - a future editor cannot quietly regress to the `.sh`-only
    glob that caused #669.
+
+THE SECOND INSTALLER (issue #677). The two pins above cover `/cpp:init` Tier 2,
+which is only ONE of the two things that populate `~/.claude/scripts/`. The
+other is `scripts/flow-helpers-install.sh` (`/flow:repair`), which installs a
+CURATED array rather than globbing - and it omitted `cpp-commands-link.sh` and
+`install-drift.sh`. So on any host provisioned WITHOUT interactive `/cpp:init` -
+scripted provisioning being the motivating case - those two rules matched paths
+nothing ever created: inert rules, and `/cpp:update` Step 5c falling back to the
+checkout copy, whose path the rule does not match, and prompting.
+
+#669's fix and this file both landed 27 minutes BEFORE #677 was filed, and did
+not catch it, because they pin template -> Tier-2-loop and #677 lives on
+template -> curated-array. Pin 3 below adds that axis. The disease was never one
+missing entry; it was three hand-maintained lists (template rules, the
+installer's array, and a copy of that array inside
+`tests/test_flow_helpers_install.py` that had itself drifted to 9 of 13 entries)
+with no two of them checked against each other.
 """
 
 from __future__ import annotations
@@ -33,6 +50,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 TEMPLATE = ROOT / "templates" / "claude-settings-permissions.json"
 SCRIPTS_DIR = ROOT / "scripts"
+INSTALLER = ROOT / "scripts" / "flow-helpers-install.sh"
 
 LINK_LOOP_DOCS = [
     ROOT / ".claude" / "commands" / "cpp" / "update.md",
@@ -40,6 +58,7 @@ LINK_LOOP_DOCS = [
 ]
 
 STABLE_PATH_RULE = re.compile(r"^Bash\(~/\.claude/scripts/([^:)]+):\*\)$")
+HELPERS_ARRAY = re.compile(r"^HELPERS=\(\n(.*?)^\)$", re.DOTALL | re.MULTILINE)
 
 
 def _template_helper_names() -> list[str]:
@@ -49,6 +68,30 @@ def _template_helper_names() -> list[str]:
         m = STABLE_PATH_RULE.match(rule)
         if m:
             names.append(m.group(1))
+    return names
+
+
+def installer_helper_names() -> list[str]:
+    """The HELPERS array from flow-helpers-install.sh, parsed from the script.
+
+    Deliberately PARSED rather than duplicated (issue #677): a test that keeps
+    its own copy of the list under test cannot detect an omission from that
+    list - it only proves the copy matches itself, which is exactly how the
+    9-entry copy in tests/test_flow_helpers_install.py sat green beside a
+    13-entry array missing two required helpers. Shared with that module so one
+    source of truth serves both.
+    """
+    m = HELPERS_ARRAY.search(INSTALLER.read_text())
+    assert m, (
+        f"could not find the HELPERS=( ... ) array in "
+        f"{INSTALLER.relative_to(ROOT)} - if the array was reformatted, update "
+        f"this parser; do NOT hardcode a copy of the list (issue #677)"
+    )
+    names = []
+    for line in m.group(1).splitlines():
+        entry = line.strip()
+        if entry and not entry.startswith("#"):
+            names.append(entry)
     return names
 
 
@@ -79,6 +122,43 @@ def test_every_templated_helper_is_created_by_the_link_step(name: str) -> None:
         f"scripts/{name} is not executable, so the Tier 2 link loop skips it "
         f"and its allow rule points at a nonexistent path (issue #669) - "
         f"chmod +x scripts/{name}"
+    )
+
+
+def test_installer_array_parses_to_a_plausible_family() -> None:
+    """Sanity: the array parse works (guards the regex, as #669 guards its own).
+
+    Without this, a reformat that broke the parse would silently empty the list
+    and make the parity test below vacuously true - a green test asserting
+    nothing, the failure mode this whole file exists to prevent.
+    """
+    names = installer_helper_names()
+    assert len(names) >= 10, f"suspiciously short HELPERS parse: {names}"
+    assert "flow-start-resolve.sh" in names
+    assert "flow-helpers-install.sh" in names, "the installer installs itself"
+
+
+@pytest.mark.parametrize("name", _template_helper_names())
+def test_every_templated_helper_is_installed_by_flow_helpers_install(name: str) -> None:
+    """Each stable-path allow rule must also be in the curated installer array.
+
+    The #669 pins above only prove `/cpp:init` Tier 2 creates the path. A host
+    provisioned without interactive `/cpp:init` gets its stable paths from
+    `flow-helpers-install.sh` instead, and that installer globs nothing - it
+    installs exactly the names in HELPERS. A rule outside that array is inert on
+    such a host: it matches a path no installer creates, so the command prompts
+    with the matching rule already installed (issue #677).
+
+    The array may legitimately be a SUPERSET (flow-helpers-install.sh installs
+    itself and has no allow rule of its own). Only the other direction is a
+    defect.
+    """
+    assert name in installer_helper_names(), (
+        f"{TEMPLATE.relative_to(ROOT)} pre-approves ~/.claude/scripts/{name} but "
+        f"{INSTALLER.relative_to(ROOT)}'s HELPERS array does not install it - the "
+        f"rule is INERT on any host provisioned without interactive /cpp:init "
+        f"(issue #677). Add {name} to HELPERS; the array is the stable-path "
+        f"install set, not a flow-only list."
     )
 
 


### PR DESCRIPTION
## Summary

`templates/claude-settings-permissions.json` pre-approves 14 helpers at `Bash(~/.claude/scripts/<name>:*)`. `scripts/flow-helpers-install.sh` installs a **curated array** that omitted two of them. An allow rule matches a command **prefix**, so on any host provisioned without interactive `/cpp:init` — scripted provisioning is the motivating case, from aws-learn#785 — those rules matched paths nothing ever created.

`/cpp:update` Step 5c then hits exit 127, falls back to the checkout copy whose path the rule does *not* match, and prompts. The rule that exists to prevent that prompt prevents nothing, and nothing fails loudly — a human just approves one more dialog and never learns the safety net was missing.

### Reproduced and fixed, against a scratch `$HOME`

```
BEFORE (origin/main installer):  ABSENT: neither helper installed
AFTER  (this branch):            cpp-commands-link.sh
                                 install-drift.sh
stable path resolves:            exit=2 (ran) — 127 would mean still missing
```

### The near-miss worth recording

**#669 fixed this same disease in the *other* installer** — it widened `/cpp:init` Tier 2 from `scripts/*.sh` to every executable, because `flow-wave-plan.py`'s rule pointed at a path the loop never created — and added `tests/test_permissions_template_link_parity.py`. Both landed **27 minutes before #677 was filed** and did not catch it, because they pin `template-rule -> Tier-2-loop` while this defect lives on `template-rule -> curated-array`.

### Root cause: three lists, no two checked against each other

The missing entry is the symptom. The disease is that three hand-maintained lists must agree:

1. the template's stable-path rules
2. `flow-helpers-install.sh`'s `HELPERS` array
3. **a hardcoded copy of that array inside `tests/test_flow_helpers_install.py`** — which had itself drifted to 9 of 13 entries (missing `flow-worktree-claim.sh`, `flow-wave-registry.sh`, `flow-wave-plan.py`, `flow-finish-gate.sh`)

List 3 is why this was invisible: a test that keeps its own copy of the list under test cannot detect an omission from that list. It only proves the copy matches itself, and it sat green while two required helpers were missing.

## Changes

- **`scripts/flow-helpers-install.sh`** — `HELPERS` gains `cpp-commands-link.sh` and `install-drift.sh`. The array comment now states the membership rule plainly: this is the **stable-path install set**, not a flow-only list (it already carried `gh-pr-merge.sh`, `worktree-remove.sh`, `friction-log.sh`, `check-ignored-additions.sh` and the installer itself), so a future non-flow addition is not re-litigated on naming grounds. The template is the membership test.
- **`tests/test_permissions_template_link_parity.py`** — adds the missing axis: every template stable-path rule must also appear in `HELPERS`, parsed from the script. A **superset is legal** (the installer installs itself and has no rule of its own); only the inert-rule direction is a defect. A parse-sanity test guards the regex, so a reformat cannot silently empty the list and make the parity assertion vacuously true.
- **`tests/test_flow_helpers_install.py`** — derives `HELPERS` from the script instead of duplicating it, eliminating list 3.
- **`codex/skills/{flow-doctor,flow-repair}/scripts/`** — bundled copies re-synced (#506).

## Scope note — a second instance, deliberately included

`install-drift.sh` is **not named in #677**. Fixing it here was required rather than drive-by: the new parity test is **red** on it otherwise, and shipping a test that fails on a defect deliberately left is not an option. The alternatives were strictly worse — a one-name exception guts the invariant the test exists to pin, and a follow-up issue for a one-word change that this test already detects is bookkeeping. Authorized as a scope expansion before implementation.

CPP's own callers happen to dodge the `install-drift.sh` case (`Makefile:170` uses a checkout-relative path; `hook-pending-retro.sh:98` resolves a sibling via `$SELF`), so it bit only a user or provisioning script invoking the blessed path — the same shape as the reported case.

## Test plan

`make verify` green: **1428 passed, 1 skipped**, mypy clean over 147 files, binary-guards ok, codex-skills in sync.

- **Negative control run:** removing `cpp-commands-link.sh` from the array turns the new parity test red with an actionable message naming the file, the consequence, and the fix. Restored and re-verified green.
- **End-to-end:** `origin/main`'s installer into a clean `FLOW_HELPERS_HOME` installs neither helper; this branch's installs both, and the stable path resolves.
- **Coverage widening:** `test_flow_helpers_install.py`'s real coverage went from 9 helpers to 15. Nothing newly covered failed — no latent defect surfaced in the four previously-untested helpers.

## Out of scope, reported not fixed

- **`--help` prints past the header.** `flow-helpers-install.sh:80` does `sed -n '2,37p'`, but the doc block ends at line 28, so `--help` emits `set -uo pipefail`, three variable assignments, and two stray comment lines. Verified **pre-existing on `origin/main`** via `git show origin/main:...` — byte-identical before and after this PR, which only added lines past 37. One-character fix, but a separate defect.
- **Convergence question:** #669 widened Tier 2 to install every executable while this installer keeps a curated list. Whether the non-interactive installer should also glob is real but out of scope — and now genuinely optional, because the parity test closes the drift class whether or not the lists ever converge.

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)