### PR TITLE
docs(flow): the wave address is a transport-opaque token, not a socket (Closes #675)

### DIFF
--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -2,20 +2,30 @@
 
 A worker session announces its own role to the wave orchestrator; the
 orchestrator records the authoritative return address and addresses the worker
-by socket forever after (issue #638, companion to the #637 wave loop).
+by that address forever after (issue #638, companion to the #637 wave loop).
 
 ## Why this exists
 
 Session identity is unresolvable from the orchestrator's side, and the failure
 is silent. `ListAgents` prints `projects-xx [ref]` display labels that do NOT
 map to assigned roles; guessing misrouted three times in one four-worker wave
-(2026-08-10), twice handing two workers each other's issue. The only address
-that cannot be gotten wrong is the one the messaging transport itself stamps on
-a delivered message - the `uds:/run/user/<uid>/cc-socks/<pid>.sock` value in
-`from=`. Two facts make guessing unrecoverable: GitHub authorship cannot
+(2026-08-10), and those labels MUTATE mid-session - a send that succeeded
+against a label failed minutes later after the label silently changed, same
+session, same ref (#672). The only address that cannot be gotten wrong is the
+one the messaging transport itself stamps on a delivered message: the `from=`
+value. Two facts make guessing unrecoverable: GitHub authorship cannot
 disambiguate sessions (every worker commits as the same user), and a `/clear`ed
 worker cannot vouch for its own history. So identity is DECLARED going forward
 and stored outside any session's transcript.
+
+**The address is an OPAQUE, transport-stamped token** (issue #675). The registry
+stores whatever the transport put in `from=` and never parses or validates it -
+`verify` is a string comparison. `uds:/run/user/<uid>/cc-socks/<pid>.sock` is
+one form; a Remote Control lane stamps `bridge:session_<id>`; a future transport
+will stamp something else again, and all of them work unchanged. Treat the token
+as an identifier to carry, never as a path to interpret. The one genuinely
+socket-specific mechanism is SELF-DERIVATION at registration (below), which
+guesses this session's own address before any message has been delivered.
 
 ## Arguments
 
@@ -37,6 +47,10 @@ and stored outside any session's transcript.
 - `--socket <addr>`: register an address learned by some means other than
   self-derivation (harness env, user relay) - the manual bootstrap lane for a
   session that cannot derive its own (#672). Always wins over derivation.
+  Despite the name it takes ANY transport's address verbatim - `bridge:...` is
+  as valid as `uds:...` (#675). The name predates the transport-opaque contract
+  and is kept because it is a published flag; the same applies to the
+  `FLOW_WAVE_SOCKET_*` output keys below.
 
 ## Instructions
 
@@ -55,7 +69,7 @@ copy; tell the user to run `/flow:repair` to restore the prompt-free lane.)
 The registry is a host-level file OUTSIDE any repo and outside transcripts
 (`$XDG_RUNTIME_DIR/cc-flow-wave/registry.json`): it survives a worker's
 `/clear`, can never become shared mutable repo state (the #635 hazard class),
-and is wiped by the OS at reboot - exactly when every session socket dies too.
+and is wiped by the OS at reboot - exactly when every session's address dies too.
 
 ### Worker side - `/flow:register <role> [--wave W]`
 
@@ -65,12 +79,20 @@ and is wiped by the OS at reboot - exactly when every session socket dies too.
    ~/.claude/scripts/flow-wave-registry.sh register 1 --wave cpp --cwd /path/to/worktree --repo /path/to/repo --issue 42 --branch issue-42-slug
    ```
 
-   The helper self-derives this session's socket by walking ancestor pids
-   against the socket dir. That self-derived address is **bootstrap only** - an
-   assertion, not an observation (see the trust model below). If it cannot be
-   derived, the entry records `unknown` and registration still succeeds - but
-   read `FLOW_WAVE_BOOTSTRAP` before assuming the address arrives later
-   (see "When there is no address" below).
+   The helper self-derives this session's address by walking ancestor pids
+   against the socket dir. **This step is genuinely uds-specific** and is the
+   only one that is (#675): it can produce a `uds:` address or nothing, because
+   guessing an address before any message has been delivered means looking for a
+   socket file on disk, and no other transport leaves one. Everything downstream
+   - storing, verifying, addressing - is transport-opaque.
+
+   That self-derived address is **bootstrap only** - an assertion, not an
+   observation (see the trust model below). If it cannot be derived, the entry
+   records `unknown` and registration still succeeds - but read
+   `FLOW_WAVE_BOOTSTRAP` before assuming the address arrives later (see "When
+   there is no address" below). On a transport that exposes no sockets this is
+   the NORMAL path, not a fault: the address arrives from the first delivered
+   message instead.
 
 2. Act on the verdict line:
    - `FLOW_WAVE: registered` / `updated` - proceed.
@@ -84,10 +106,10 @@ and is wiped by the OS at reboot - exactly when every session socket dies too.
    role, wave, cwd, repo, and current issue/branch. This message is what lets
    the orchestrator OBSERVE the real address. Pick the first branch that
    applies:
-   - the orchestrator's socket from `get orchestrator` - message it directly;
-   - no usable socket, but the orchestrator has messaged this session before -
+   - the orchestrator's address from `get orchestrator` - message it directly;
+   - no usable address, but the orchestrator has messaged this session before -
      reply to its most recent message's `from=`;
-   - `get orchestrator` says `free`, or its socket is `unknown` - the
+   - `get orchestrator` says `free`, or its address is `unknown` - the
      orchestrator has not (usefully) registered yet. This is NORMAL, not an
      error (issue #670): registration already succeeded in step 2 and never
      depends on the hello landing. Report
@@ -120,13 +142,25 @@ this, reading a healthy-looking verdict while both sessions stood by.
 - **`no-match`** - the dir exists but no ancestor pid of this session owns a
   socket in it. A retry alone will not change that; use lane 2 or 3.
 
+**Order the lanes by the evidence in front of you** (#675). `no-sock-dir` does
+not distinguish "not yet" from "not this transport", and the two want opposite
+first moves. Let the OBSERVED traffic decide rather than a verdict about the
+host: if messages are arriving stamped with a non-`uds:` scheme, that is
+evidence this host's live transport is not uds, so retrying self-derivation is
+unlikely to pay and lanes 2/3 are the better first move. With no such evidence,
+`no-sock-dir` really may be the lazily-created dir and lane 1 is the cheap try.
+Neither reading is a permanent claim about the host - a host with no dir at
+07:52 had one at 10:27, and this wave ran on that host's later state.
+
 Three lanes produce an address without self-derivation:
 
 1. **Re-register.** Re-run the same `register` command. It re-derives and
    adopts a socket that has since appeared (`FLOW_WAVE_SOCKET_SOURCE=self`).
-2. **`register --socket <addr>`** - the manual lane. Pass an address learned by
-   any means (harness env, or the user relaying it from the other session); an
-   explicit `--socket` always wins (`SOURCE=explicit`).
+   Only this lane depends on a uds transport.
+2. **`register --socket <addr>`** - the manual lane, and the one that works on
+   any transport. Pass an address learned by any means (harness env, or the user
+   relaying it from the other session), in whatever form that transport stamps;
+   an explicit `--socket` always wins (`SOURCE=explicit`).
 3. **User-relayed hello.** The user pastes this session's `FLOW_WAVE_*` block
    into the counterpart session; the counterpart's reply arrives over the real
    transport, and its `from=` is what `verify` needs.
@@ -145,29 +179,45 @@ worker session outlives an orchestrator restart. On registering as
 `orchestrator`, and on each `list`, treat every pre-existing unverified LIVE
 worker as a PENDING HANDSHAKE (the roster's `[live, unverified]` entries are
 exactly this list): initiate contact with each one at its recorded bootstrap
-socket. The worker's REPLY is its deferred hello, and the reply's
+address. The worker's REPLY is its deferred hello, and the reply's
 transport-stamped `from=` feeds `verify` below - so verification is reachable
-from whichever side makes first contact. A worker whose socket recorded as
-`unknown` cannot be contacted orchestrator-first; that is the socket-bootstrap
+from whichever side makes first contact. A worker whose address recorded as
+`unknown` cannot be contacted orchestrator-first; that is the address-bootstrap
 gap (#672), not an ordering problem - it waits until either side can produce a
 usable address - see "When there is no address" above for the three lanes that
-produce one, and tell the worker to re-register first (the socket dir is
-created lazily, so a retry often resolves it outright).
+produce one, and pick the lane by the evidence described there.
 
 **On receiving a worker's hello** (or its reply to your first contact),
 reconcile the recorded address with the address the transport actually stamped
 on that message:
 
 ```bash
-~/.claude/scripts/flow-wave-registry.sh verify 1 --wave cpp --from uds:/run/user/1000/cc-socks/12345.sock
+~/.claude/scripts/flow-wave-registry.sh verify 1 --wave cpp --from <observed-address>
+```
+
+Pass the `from=` value VERBATIM, whatever its shape. Two forms seen in the field
+(#675) - neither is privileged, and the registry stores either unchanged:
+
+```
+uds:/run/user/1000/cc-socks/12345.sock     # unix socket lane
+bridge:session_01RLE...                    # Remote Control lane
 ```
 
 **Trust model (gate condition, #638): the transport-observed `from=` is
-authoritative.** On `FLOW_WAVE: mismatch-corrected`, the observed address has
-REPLACED the self-derived one as canonical and the entry is flagged
-(`address_mismatch`); investigate the discrepancy, but keep addressing the
-observed socket. The reverse never happens - a self-derived address never
-survives a mismatch, and "flagged but self-derived kept" is not an outcome.
+authoritative.** Whatever `verify` observes REPLACES what was recorded and
+becomes canonical - the reverse never happens, and "flagged but self-derived
+kept" is not an outcome. That principle is transport-independent: it rests on
+observation outranking assertion, never on which transport did the stamping.
+
+`verify` reports which of two things happened, and the distinction is about
+PROVENANCE, not trust: `address_filled` when the recorded value was `unknown`
+and observation supplied one (the documented bootstrap fallback succeeding -
+unflagged, and the only possible outcome on a transport where self-derivation
+cannot run), `mismatch-corrected` when a recorded REAL address was contradicted
+(loud, flagged, investigate it). Neither is a lesser grade than `verified`: the
+address is transport-observed either way, and the word records how it was
+established, never how much to trust it. The output contract below defines both
+verdicts in full.
 
 **Ack with the protocol.** The registration ack is the handshake: send the
 worker its wave brief so the rules survive its compaction - the gate points
@@ -203,10 +253,14 @@ re-brief for a worker whose compaction dropped more detail than expected.
   above has no target for them either - work the bootstrap lanes before
   assigning anything to those roles (#672).
 
-**Addressing rule: socket-only.** Address workers exclusively by the registry's
-`uds:` socket via `SendMessage`. Never address by `ListAgents` display names
-(`projects-xx`) - those labels do not map to roles, and name-addressing is the
-misrouting failure this command exists to remove.
+**Addressing rule: registry-address-only.** Address workers exclusively by the
+address the registry holds, in whatever form the transport stamped it, via
+`SendMessage`. Never address by `ListAgents` display names (`projects-xx`) -
+those labels do not map to roles AND they mutate mid-session, so a send that
+worked once can silently reach the wrong session later; name-addressing is the
+misrouting failure this command exists to remove. The rule was written as
+"socket-only" (#675); the intent was always "not by display label", never a
+claim that the address must be a socket.
 
 ### Release - `/flow:register --release`
 
@@ -215,8 +269,18 @@ misrouting failure this command exists to remove.
 ```
 
 Run on leaving the wave. Sessions that die without releasing are caught by
-staleness detection (socket gone + pid dead); their entries persist as `stale`.
-Releasing a role owned by another LIVE session refuses without `--force`.
+staleness detection; their entries persist as `stale`. Releasing a role owned by
+another LIVE session refuses without `--force`.
+
+**Liveness is two-factor only where sockets exist** (#675). The primary proof is
+the recorded pid, signalled on the recorded host. A live socket FILE is a
+SECOND, independent proof, covering a pid the helper cannot signal - but reading
+it means stat-ing a path, so it can only ever apply to a `uds:` address. On a
+transport that stamps something else there is no file to stat and liveness rests
+on the pid alone. That is a property of the design, not an oversight: sockets
+are what the second factor reads, so a transport without them has one factor.
+(#689 makes the scheme test explicit rather than relying on a prefix-strip that
+silently no-ops; it exposes the asymmetry, it does not remove it.)
 
 ## Output contract
 
@@ -242,7 +306,13 @@ session is never reported as a healthy pending handshake:
 | Line | Values |
 |------|--------|
 | `FLOW_WAVE_SOCKET_SOURCE` | `explicit` (`--socket`) / `self` (derived) / `preserved` (derivation failed, recorded address kept) / `unknown` (no address) |
-| `FLOW_WAVE_SOCKET_REASON` | `-` / `no-sock-dir` (no transport on this host YET - created lazily, so retry) / `no-match` (dir exists, no ancestor socket) |
+| `FLOW_WAVE_SOCKET_REASON` | `-` / `no-sock-dir` (no socket dir on this host - see the lane-ordering note above before assuming a retry helps) / `no-match` (dir exists, no ancestor socket) |
+
+Both keys carry `SOCKET` for historical reasons and are published contract, so
+they are not renamed (#675). `SOURCE` describes any address whatever its
+transport - only the `self` value implies uds, since self-derivation is the one
+uds-specific step. `REASON` is inherently uds-specific: it explains why a
+socket-file guess failed, and is `-` when no guess was needed.
 | `FLOW_WAVE_BOOTSTRAP` | `ok` / `deadlock` (the address is `unknown`, so `verify` cannot fire - blocked, not pending) |
 
 ## Notes

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -65,22 +65,32 @@ Then, on FIRST CONTACT in either direction, verify the observed address:
 - Orchestrator registered first: each worker sends its hello on registering.
 - Worker registered first: its roster entry reads `[live, unverified]` - a
   PENDING HANDSHAKE. On registering, and on each `list`, initiate contact
-  with every such worker at its recorded bootstrap socket; the worker's REPLY
+  with every such worker at its recorded bootstrap address; the worker's REPLY
   is its deferred hello.
 
 On each hello (or reply), reconcile the observed `from=`:
 
 ```bash
-~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed uds:...>
+~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed-address>
 ```
 
-The transport-observed address is authoritative on any mismatch (#638).
+Pass the `from=` value verbatim - it is an OPAQUE transport-stamped token, not a
+path (#675). `uds:/run/user/1000/cc-socks/12345.sock` and
+`bridge:session_01RLE...` are both valid and are stored unchanged.
+
+The transport-observed address is authoritative and becomes canonical (#638).
+`verify` distinguishes two ways that happens (#674): `address_filled` when the
+recorded value was `unknown` and observation supplied one - unflagged, and the
+ONLY outcome on a transport where self-derivation cannot run - and
+`mismatch-corrected` when a recorded real address was contradicted, which stays
+loud and warrants investigation. `filled` is not a lesser grade than `verified`.
 
 Ack each worker with the wave brief: its lane, stop-at-Step-3 (never
 `--yes`), the ledger format, and the structural-pushback rule verbatim.
 
-Address workers ONLY by the registry's `uds:` socket via `SendMessage` -
-never by `ListAgents` display names. Check the roster with:
+Address workers ONLY by the address the registry holds, via `SendMessage` -
+never by `ListAgents` display names, which do not map to roles and mutate
+mid-session. Check the roster with:
 
 ```bash
 ~/.claude/scripts/flow-wave-registry.sh list --wave <WAVE>

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -4,20 +4,30 @@
 
 A worker session announces its own role to the wave orchestrator; the
 orchestrator records the authoritative return address and addresses the worker
-by socket forever after (issue #638, companion to the #637 wave loop).
+by that address forever after (issue #638, companion to the #637 wave loop).
 
 ## Why this exists
 
 Session identity is unresolvable from the orchestrator's side, and the failure
 is silent. `ListAgents` prints `projects-xx [ref]` display labels that do NOT
 map to assigned roles; guessing misrouted three times in one four-worker wave
-(2026-08-10), twice handing two workers each other's issue. The only address
-that cannot be gotten wrong is the one the messaging transport itself stamps on
-a delivered message - the `uds:/run/user/<uid>/cc-socks/<pid>.sock` value in
-`from=`. Two facts make guessing unrecoverable: GitHub authorship cannot
+(2026-08-10), and those labels MUTATE mid-session - a send that succeeded
+against a label failed minutes later after the label silently changed, same
+session, same ref (#672). The only address that cannot be gotten wrong is the
+one the messaging transport itself stamps on a delivered message: the `from=`
+value. Two facts make guessing unrecoverable: GitHub authorship cannot
 disambiguate sessions (every worker commits as the same user), and a `/clear`ed
 worker cannot vouch for its own history. So identity is DECLARED going forward
 and stored outside any session's transcript.
+
+**The address is an OPAQUE, transport-stamped token** (issue #675). The registry
+stores whatever the transport put in `from=` and never parses or validates it -
+`verify` is a string comparison. `uds:/run/user/<uid>/cc-socks/<pid>.sock` is
+one form; a Remote Control lane stamps `bridge:session_<id>`; a future transport
+will stamp something else again, and all of them work unchanged. Treat the token
+as an identifier to carry, never as a path to interpret. The one genuinely
+socket-specific mechanism is SELF-DERIVATION at registration (below), which
+guesses this session's own address before any message has been delivered.
 
 ## Arguments
 
@@ -39,6 +49,10 @@ and stored outside any session's transcript.
 - `--socket <addr>`: register an address learned by some means other than
   self-derivation (harness env, user relay) - the manual bootstrap lane for a
   session that cannot derive its own (#672). Always wins over derivation.
+  Despite the name it takes ANY transport's address verbatim - `bridge:...` is
+  as valid as `uds:...` (#675). The name predates the transport-opaque contract
+  and is kept because it is a published flag; the same applies to the
+  `FLOW_WAVE_SOCKET_*` output keys below.
 
 ## Instructions
 
@@ -57,7 +71,7 @@ copy; tell the user to run `/flow-repair` to restore the prompt-free lane.)
 The registry is a host-level file OUTSIDE any repo and outside transcripts
 (`$XDG_RUNTIME_DIR/cc-flow-wave/registry.json`): it survives a worker's
 `/clear`, can never become shared mutable repo state (the #635 hazard class),
-and is wiped by the OS at reboot - exactly when every session socket dies too.
+and is wiped by the OS at reboot - exactly when every session's address dies too.
 
 ### Worker side - `/flow-register <role> [--wave W]`
 
@@ -67,12 +81,20 @@ and is wiped by the OS at reboot - exactly when every session socket dies too.
    ~/.claude/scripts/flow-wave-registry.sh register 1 --wave cpp --cwd /path/to/worktree --repo /path/to/repo --issue 42 --branch issue-42-slug
    ```
 
-   The helper self-derives this session's socket by walking ancestor pids
-   against the socket dir. That self-derived address is **bootstrap only** - an
-   assertion, not an observation (see the trust model below). If it cannot be
-   derived, the entry records `unknown` and registration still succeeds - but
-   read `FLOW_WAVE_BOOTSTRAP` before assuming the address arrives later
-   (see "When there is no address" below).
+   The helper self-derives this session's address by walking ancestor pids
+   against the socket dir. **This step is genuinely uds-specific** and is the
+   only one that is (#675): it can produce a `uds:` address or nothing, because
+   guessing an address before any message has been delivered means looking for a
+   socket file on disk, and no other transport leaves one. Everything downstream
+   - storing, verifying, addressing - is transport-opaque.
+
+   That self-derived address is **bootstrap only** - an assertion, not an
+   observation (see the trust model below). If it cannot be derived, the entry
+   records `unknown` and registration still succeeds - but read
+   `FLOW_WAVE_BOOTSTRAP` before assuming the address arrives later (see "When
+   there is no address" below). On a transport that exposes no sockets this is
+   the NORMAL path, not a fault: the address arrives from the first delivered
+   message instead.
 
 2. Act on the verdict line:
    - `FLOW_WAVE: registered` / `updated` - proceed.
@@ -86,10 +108,10 @@ and is wiped by the OS at reboot - exactly when every session socket dies too.
    role, wave, cwd, repo, and current issue/branch. This message is what lets
    the orchestrator OBSERVE the real address. Pick the first branch that
    applies:
-   - the orchestrator's socket from `get orchestrator` - message it directly;
-   - no usable socket, but the orchestrator has messaged this session before -
+   - the orchestrator's address from `get orchestrator` - message it directly;
+   - no usable address, but the orchestrator has messaged this session before -
      reply to its most recent message's `from=`;
-   - `get orchestrator` says `free`, or its socket is `unknown` - the
+   - `get orchestrator` says `free`, or its address is `unknown` - the
      orchestrator has not (usefully) registered yet. This is NORMAL, not an
      error (issue #670): registration already succeeded in step 2 and never
      depends on the hello landing. Report
@@ -122,13 +144,25 @@ this, reading a healthy-looking verdict while both sessions stood by.
 - **`no-match`** - the dir exists but no ancestor pid of this session owns a
   socket in it. A retry alone will not change that; use lane 2 or 3.
 
+**Order the lanes by the evidence in front of you** (#675). `no-sock-dir` does
+not distinguish "not yet" from "not this transport", and the two want opposite
+first moves. Let the OBSERVED traffic decide rather than a verdict about the
+host: if messages are arriving stamped with a non-`uds:` scheme, that is
+evidence this host's live transport is not uds, so retrying self-derivation is
+unlikely to pay and lanes 2/3 are the better first move. With no such evidence,
+`no-sock-dir` really may be the lazily-created dir and lane 1 is the cheap try.
+Neither reading is a permanent claim about the host - a host with no dir at
+07:52 had one at 10:27, and this wave ran on that host's later state.
+
 Three lanes produce an address without self-derivation:
 
 1. **Re-register.** Re-run the same `register` command. It re-derives and
    adopts a socket that has since appeared (`FLOW_WAVE_SOCKET_SOURCE=self`).
-2. **`register --socket <addr>`** - the manual lane. Pass an address learned by
-   any means (harness env, or the user relaying it from the other session); an
-   explicit `--socket` always wins (`SOURCE=explicit`).
+   Only this lane depends on a uds transport.
+2. **`register --socket <addr>`** - the manual lane, and the one that works on
+   any transport. Pass an address learned by any means (harness env, or the user
+   relaying it from the other session), in whatever form that transport stamps;
+   an explicit `--socket` always wins (`SOURCE=explicit`).
 3. **User-relayed hello.** The user pastes this session's `FLOW_WAVE_*` block
    into the counterpart session; the counterpart's reply arrives over the real
    transport, and its `from=` is what `verify` needs.
@@ -147,29 +181,45 @@ worker session outlives an orchestrator restart. On registering as
 `orchestrator`, and on each `list`, treat every pre-existing unverified LIVE
 worker as a PENDING HANDSHAKE (the roster's `[live, unverified]` entries are
 exactly this list): initiate contact with each one at its recorded bootstrap
-socket. The worker's REPLY is its deferred hello, and the reply's
+address. The worker's REPLY is its deferred hello, and the reply's
 transport-stamped `from=` feeds `verify` below - so verification is reachable
-from whichever side makes first contact. A worker whose socket recorded as
-`unknown` cannot be contacted orchestrator-first; that is the socket-bootstrap
+from whichever side makes first contact. A worker whose address recorded as
+`unknown` cannot be contacted orchestrator-first; that is the address-bootstrap
 gap (#672), not an ordering problem - it waits until either side can produce a
 usable address - see "When there is no address" above for the three lanes that
-produce one, and tell the worker to re-register first (the socket dir is
-created lazily, so a retry often resolves it outright).
+produce one, and pick the lane by the evidence described there.
 
 **On receiving a worker's hello** (or its reply to your first contact),
 reconcile the recorded address with the address the transport actually stamped
 on that message:
 
 ```bash
-~/.claude/scripts/flow-wave-registry.sh verify 1 --wave cpp --from uds:/run/user/1000/cc-socks/12345.sock
+~/.claude/scripts/flow-wave-registry.sh verify 1 --wave cpp --from <observed-address>
+```
+
+Pass the `from=` value VERBATIM, whatever its shape. Two forms seen in the field
+(#675) - neither is privileged, and the registry stores either unchanged:
+
+```
+uds:/run/user/1000/cc-socks/12345.sock     # unix socket lane
+bridge:session_01RLE...                    # Remote Control lane
 ```
 
 **Trust model (gate condition, #638): the transport-observed `from=` is
-authoritative.** On `FLOW_WAVE: mismatch-corrected`, the observed address has
-REPLACED the self-derived one as canonical and the entry is flagged
-(`address_mismatch`); investigate the discrepancy, but keep addressing the
-observed socket. The reverse never happens - a self-derived address never
-survives a mismatch, and "flagged but self-derived kept" is not an outcome.
+authoritative.** Whatever `verify` observes REPLACES what was recorded and
+becomes canonical - the reverse never happens, and "flagged but self-derived
+kept" is not an outcome. That principle is transport-independent: it rests on
+observation outranking assertion, never on which transport did the stamping.
+
+`verify` reports which of two things happened, and the distinction is about
+PROVENANCE, not trust: `address_filled` when the recorded value was `unknown`
+and observation supplied one (the documented bootstrap fallback succeeding -
+unflagged, and the only possible outcome on a transport where self-derivation
+cannot run), `mismatch-corrected` when a recorded REAL address was contradicted
+(loud, flagged, investigate it). Neither is a lesser grade than `verified`: the
+address is transport-observed either way, and the word records how it was
+established, never how much to trust it. The output contract below defines both
+verdicts in full.
 
 **Ack with the protocol.** The registration ack is the handshake: send the
 worker its wave brief so the rules survive its compaction - the gate points
@@ -205,10 +255,14 @@ re-brief for a worker whose compaction dropped more detail than expected.
   above has no target for them either - work the bootstrap lanes before
   assigning anything to those roles (#672).
 
-**Addressing rule: socket-only.** Address workers exclusively by the registry's
-`uds:` socket via `SendMessage`. Never address by `ListAgents` display names
-(`projects-xx`) - those labels do not map to roles, and name-addressing is the
-misrouting failure this command exists to remove.
+**Addressing rule: registry-address-only.** Address workers exclusively by the
+address the registry holds, in whatever form the transport stamped it, via
+`SendMessage`. Never address by `ListAgents` display names (`projects-xx`) -
+those labels do not map to roles AND they mutate mid-session, so a send that
+worked once can silently reach the wrong session later; name-addressing is the
+misrouting failure this command exists to remove. The rule was written as
+"socket-only" (#675); the intent was always "not by display label", never a
+claim that the address must be a socket.
 
 ### Release - `/flow-register --release`
 
@@ -217,8 +271,18 @@ misrouting failure this command exists to remove.
 ```
 
 Run on leaving the wave. Sessions that die without releasing are caught by
-staleness detection (socket gone + pid dead); their entries persist as `stale`.
-Releasing a role owned by another LIVE session refuses without `--force`.
+staleness detection; their entries persist as `stale`. Releasing a role owned by
+another LIVE session refuses without `--force`.
+
+**Liveness is two-factor only where sockets exist** (#675). The primary proof is
+the recorded pid, signalled on the recorded host. A live socket FILE is a
+SECOND, independent proof, covering a pid the helper cannot signal - but reading
+it means stat-ing a path, so it can only ever apply to a `uds:` address. On a
+transport that stamps something else there is no file to stat and liveness rests
+on the pid alone. That is a property of the design, not an oversight: sockets
+are what the second factor reads, so a transport without them has one factor.
+(#689 makes the scheme test explicit rather than relying on a prefix-strip that
+silently no-ops; it exposes the asymmetry, it does not remove it.)
 
 ## Output contract
 
@@ -244,7 +308,13 @@ session is never reported as a healthy pending handshake:
 | Line | Values |
 |------|--------|
 | `FLOW_WAVE_SOCKET_SOURCE` | `explicit` (`--socket`) / `self` (derived) / `preserved` (derivation failed, recorded address kept) / `unknown` (no address) |
-| `FLOW_WAVE_SOCKET_REASON` | `-` / `no-sock-dir` (no transport on this host YET - created lazily, so retry) / `no-match` (dir exists, no ancestor socket) |
+| `FLOW_WAVE_SOCKET_REASON` | `-` / `no-sock-dir` (no socket dir on this host - see the lane-ordering note above before assuming a retry helps) / `no-match` (dir exists, no ancestor socket) |
+
+Both keys carry `SOCKET` for historical reasons and are published contract, so
+they are not renamed (#675). `SOURCE` describes any address whatever its
+transport - only the `self` value implies uds, since self-derivation is the one
+uds-specific step. `REASON` is inherently uds-specific: it explains why a
+socket-file guess failed, and is `-` when no guess was needed.
 | `FLOW_WAVE_BOOTSTRAP` | `ok` / `deadlock` (the address is `unknown`, so `verify` cannot fire - blocked, not pending) |
 
 ## Notes

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -67,22 +67,32 @@ Then, on FIRST CONTACT in either direction, verify the observed address:
 - Orchestrator registered first: each worker sends its hello on registering.
 - Worker registered first: its roster entry reads `[live, unverified]` - a
   PENDING HANDSHAKE. On registering, and on each `list`, initiate contact
-  with every such worker at its recorded bootstrap socket; the worker's REPLY
+  with every such worker at its recorded bootstrap address; the worker's REPLY
   is its deferred hello.
 
 On each hello (or reply), reconcile the observed `from=`:
 
 ```bash
-~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed uds:...>
+~/.claude/scripts/flow-wave-registry.sh verify <role> --wave <WAVE> --from <observed-address>
 ```
 
-The transport-observed address is authoritative on any mismatch (#638).
+Pass the `from=` value verbatim - it is an OPAQUE transport-stamped token, not a
+path (#675). `uds:/run/user/1000/cc-socks/12345.sock` and
+`bridge:session_01RLE...` are both valid and are stored unchanged.
+
+The transport-observed address is authoritative and becomes canonical (#638).
+`verify` distinguishes two ways that happens (#674): `address_filled` when the
+recorded value was `unknown` and observation supplied one - unflagged, and the
+ONLY outcome on a transport where self-derivation cannot run - and
+`mismatch-corrected` when a recorded real address was contradicted, which stays
+loud and warrants investigation. `filled` is not a lesser grade than `verified`.
 
 Ack each worker with the wave brief: its lane, stop-at-Step-3 (never
 `--yes`), the ledger format, and the structural-pushback rule verbatim.
 
-Address workers ONLY by the registry's `uds:` socket via `SendMessage` -
-never by `ListAgents` display names. Check the roster with:
+Address workers ONLY by the address the registry holds, via `SendMessage` -
+never by `ListAgents` display names, which do not map to roles and mutate
+mid-session. Check the roster with:
 
 ```bash
 ~/.claude/scripts/flow-wave-registry.sh list --wave <WAVE>

--- a/tests/test_wave_addressing_transport_opaque.py
+++ b/tests/test_wave_addressing_transport_opaque.py
@@ -1,0 +1,85 @@
+"""Pin: the wave-addressing docs show more than one transport (issue #675).
+
+`flow-wave-registry.sh verify` accepts any transport-stamped token - it is a
+string comparison with no scheme validation. The DOCS said otherwise: every
+example was a `uds:` socket and the addressing rule read "socket-only". On a
+host whose live transport stamps `bridge:session_...`, a worker read that
+literally and reported the wave as structurally broken. The tool was fine; the
+description was the blocker.
+
+The prose itself is not testable and this file does not try. What IS testable is
+the specific regression that created the defect: collapsing the examples back to
+a single transport, so the one shown form reads as the required form. One
+instance always teaches itself as the rule.
+
+Deliberately narrow, so an innocent rewording cannot fail it:
+  - no line numbers, no section scoping, no required phrasing
+  - only two facts per file - a uds example is present, and at least one non-uds
+    example is present
+  - adding a THIRD transport passes untouched; that is the point of the list
+
+A doc test that breaks on rephrasing is worse than no doc test, so if this ever
+fails, check first whether an example was REMOVED before rewording anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Files that document how an orchestrator addresses a worker.
+ADDRESSING_DOCS = [
+    ROOT / ".claude" / "commands" / "flow" / "register.md",
+    ROOT / ".claude" / "commands" / "flow" / "wave.md",
+]
+
+UDS_SCHEME = "uds:"
+
+# Every non-uds transport whose stamped form the docs may use as the contrasting
+# example. ADD to this list when a new transport appears - never narrow it to
+# whichever one the docs happen to use today, which would re-privilege a single
+# transport in the very test that exists to prevent that.
+NON_UDS_SCHEMES = ("bridge:",)
+
+
+@pytest.mark.parametrize("doc", ADDRESSING_DOCS, ids=lambda p: p.name)
+def test_doc_shows_a_uds_example(doc: Path) -> None:
+    """The uds form must survive: it is real, and it is what most hosts stamp."""
+    assert UDS_SCHEME in doc.read_text(encoding="utf-8"), (
+        f"{doc.relative_to(ROOT)} shows no {UDS_SCHEME} example. The fix for "
+        f"#675 was to show SEVERAL transports, not to swap which single one is "
+        f"privileged - dropping uds mirrors the original bug."
+    )
+
+
+@pytest.mark.parametrize("doc", ADDRESSING_DOCS, ids=lambda p: p.name)
+def test_doc_shows_a_non_uds_example(doc: Path) -> None:
+    """The regression pin (#675): a second transport must be visible.
+
+    With only `uds:` on the page, a reader on any other transport concludes the
+    addressing scheme has nothing to point at - the reported field failure.
+    """
+    text = doc.read_text(encoding="utf-8")
+    assert any(scheme in text for scheme in NON_UDS_SCHEMES), (
+        f"{doc.relative_to(ROOT)} shows only {UDS_SCHEME} addresses. The "
+        f"registry stores whatever the transport stamped and never parses it, "
+        f"so a uds-only page misdescribes the contract (issue #675): a worker "
+        f"on a {NON_UDS_SCHEMES[0]}... lane read exactly this and reported the "
+        f"wave broken. Show at least one of {list(NON_UDS_SCHEMES)} alongside "
+        f"the uds example - or add the new transport to NON_UDS_SCHEMES here."
+    )
+
+
+def test_addressing_rule_is_not_worded_socket_only() -> None:
+    """The rule's INTENT (never address by mutable display labels) survives; its
+    old wording claimed a transport (#675). Pinned because the phrase is what a
+    reader obeys literally - it is the sentence the field report acted on."""
+    text = (ROOT / ".claude" / "commands" / "flow" / "register.md").read_text(encoding="utf-8")
+    assert "Addressing rule: socket-only" not in text, (
+        "register.md restates the addressing rule as 'socket-only' (issue "
+        "#675). The rule means 'by the registry address, never by a ListAgents "
+        "display label' - it never required a socket. Word it transport-neutrally."
+    )


### PR DESCRIPTION
## Summary

`flow-wave-registry.sh verify` has **always** accepted any transport's address — it is a string comparison (`[ "$RECORDED" = "$A_FROM" ]`) that stores `--from` verbatim, with no scheme validation anywhere in the argument path. The docs said otherwise: every example was a `uds:` socket and the addressing rule read *"Addressing rule: socket-only."*

On a host whose live transport stamps `bridge:session_...`, a worker read that literally and reported the wave as **structurally broken** — while the wave was running fine on bridge addresses at that very moment. Nothing was broken except the description.

## Changes

**The address is an opaque, transport-stamped token.** The registry stores whatever the transport put in `from=` and never parses it. Self-derivation at registration is called out as the **one genuinely uds-specific step**, and why: it runs *before* any message has been delivered, so guessing your own address means looking for a socket file on disk, and no other transport leaves one. Everything downstream is transport-opaque.

**The verify example** leads with a `<observed-address>` placeholder and shows **both** forms:

```
uds:/run/user/1000/cc-socks/12345.sock     # unix socket lane
bridge:session_01RLE...                    # Remote Control lane
```

One instance always teaches itself as the rule — which is exactly how the uds-only example produced the field failure. A lone `bridge:` example would mirror the bug rather than fix it.

**`Addressing rule: socket-only` → `registry-address-only`.** The intent — never address by mutable `ListAgents` display labels — is unchanged, and now carries the #672 datum that those labels *mutate mid-session*: a send that succeeded against a label failed minutes later, same session, same ref.

**The trust-model paragraph** now covers both #674 verdicts as one paragraph. It states the principle (observation outranks assertion, transport-independently) and **defers to the output-contract section** for the mechanics rather than re-defining them. Phrasing is echoed from that section deliberately: two definitions of one verdict is how two correct descriptions start reading as two different tools.

**`wave.md`** gets the same treatment *plus* the #674 verdict split — #690 did not touch `wave.md` at all, so `address_filled` was undocumented there.

**Bootstrap lane ordering** is conditioned on **observed evidence**, not on a verdict about the host: messages arriving stamped non-uds is evidence the live transport is not uds, so lanes 2/3 are the better first move. Deliberately *not* a permanent claim — `no-sock-dir` is genuinely point-in-time on a uds host (none at 07:52, derived at 10:27 on the same box), and asserting permanence would re-commit #672's error with the polarity flipped.

**The liveness asymmetry** is documented as a property of the design, not a bug worked around: the socket *file* is a second, independent proof of liveness, so a transport without sockets has one factor. Sockets are what the second factor reads. (#689 makes the scheme test explicit; it *exposes* the asymmetry rather than removing it.)

**`--socket` / `FLOW_WAVE_SOCKET_*`** are documented as taking and reporting transport-agnostic values. **Not renamed** — they are published contract, and renaming breaks every consumer to fix a noun.

## Test plan — and an honest limit

`make verify` green: **1438 passed, 1 skipped**, mypy clean over 148 files, binary-guards ok, codex-skills in sync. `FLOW_FINISH_GATE: ok` with `executed: 1438`.

**Read that green tick narrowly.** No test covers prose. The suite proves the Codex generated surface is in sync and that the new pin holds — it cannot tell you the writing is correct or that the two voices cohere. A broken version of this measurement would print exactly what a working one prints. Verification here is the reviewer's read of the diff.

What *is* pinned, in `tests/test_wave_addressing_transport_opaque.py`, is the **regression** rather than the prose: each addressing doc must show a `uds:` example **and** at least one non-uds example, and the rule must not read "socket-only".

Deliberately narrow so an innocent rewording cannot fail it — no line numbers, no section scoping, no required phrasing; only "an example of each kind exists". Adding a *third* transport passes untouched, and the non-uds list is a named constant to extend rather than narrow.

**Negative control:** collapsing `wave.md` back to a single transport turns it red on exactly that assertion; restored and re-verified green.

## Scope

`register.md` (13 sites), `wave.md` (3 sites + the stale verdict), the mandatory Codex regeneration, and the new pin. **No code changes** — `scripts/flow-wave-registry.sh` is untouched. `CLAUDE.md:67` was already corrected by #690.

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)