### PR TITLE
fix(cpp): --check reports link topology, and stops implying health (Closes #685, Closes #686)

### DIFF
--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -482,6 +482,21 @@ helper BARE (allowlist rule matches the stable path):
 ```
 
 - `CPP_COMMANDS_LINK: ok` - report `✓ Command symlinks current` and continue.
+  **Report it as a TOPOLOGY result, never as an install-health verdict** (issue
+  #685): it means the 16 family links resolve to this checkout, and says nothing
+  about whether the checkout's CONTENT is correct. A restore-over-clone accident
+  produced a working tree with 106 files reverted and 111 upstream-deleted files
+  resurrected; every link resolved, this step read `ok`, and the Step-3 `git
+  pull` said "Already up to date" - three green signals while every served
+  command was stale. Do not summarise this step as "command surface healthy".
+- A `checkout: N tracked modified, M untracked (-uall) ...` line may precede the
+  verdict. It is an ADVISORY observation, not drift: relay it with its counts
+  and leave the verdict alone. Dirtiness is not staleness - a maintainer
+  mid-edit and a corrupted restore look the same from here, which is why the
+  counts are split (a handful of untracked scratch reads very differently from
+  106 tracked modifications). If the numbers look wrong for the host, the
+  content checks are `git -C "$CPP_DIR" status --porcelain -uall` (expect empty)
+  and `git -C "$CPP_DIR" rev-parse HEAD origin/main` (expect equal).
 - `CPP_COMMANDS_LINK: drift` (exit 1) - families are missing or point at
   another checkout. Ask the user, then run the install (bare, no flags):
   `~/.claude/scripts/cpp-commands-link.sh`

--- a/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
@@ -77,7 +77,12 @@ for arg in "$@"; do
         --check) MODE="check" ;;
         --force) FORCE=1 ;;
         --help|-h)
-            sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+            # 2,28p: the doc block ends at line 28 (the last `# Env:` entry).
+            # It was 2,37p, which spilled `set -uo pipefail`, three variable
+            # assignments and two stray comment lines into --help output (#686).
+            # tests/test_flow_helpers_install.py pins the boundary so the range
+            # cannot silently re-drift when the header grows.
+            sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)

--- a/codex/skills/flow-repair/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-repair/scripts/flow-helpers-install.sh
@@ -77,7 +77,12 @@ for arg in "$@"; do
         --check) MODE="check" ;;
         --force) FORCE=1 ;;
         --help|-h)
-            sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+            # 2,28p: the doc block ends at line 28 (the last `# Env:` entry).
+            # It was 2,37p, which spilled `set -uo pipefail`, three variable
+            # assignments and two stray comment lines into --help output (#686).
+            # tests/test_flow_helpers_install.py pins the boundary so the range
+            # cannot silently re-drift when the header grows.
+            sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)

--- a/scripts/cpp-commands-link.sh
+++ b/scripts/cpp-commands-link.sh
@@ -4,11 +4,22 @@
 # Purpose:
 #   Serve the CPP command surface to EVERY session on this host by symlinking
 #   each family dir of the checkout's .claude/commands/ into
-#   ~/.claude/commands/<family>. A symlink follows `git pull` atomically, so
-#   command drift is structurally impossible - the property the /plugin
-#   marketplace cache lost (#662: `/plugin update` no-ops on a version stamp
-#   that never moves, `/plugin install` refuses when installed, and the only
-#   reconciliation is per-family uninstall+reinstall by hand).
+#   ~/.claude/commands/<family>. A symlink follows `git pull` atomically with no
+#   cache to reconcile - the property the /plugin marketplace cache lost (#662:
+#   `/plugin update` no-ops on a version stamp that never moves, `/plugin
+#   install` refuses when installed, and the only reconciliation is per-family
+#   uninstall+reinstall by hand).
+#
+#   SCOPE OF THAT GUARANTEE (issue #685). A link follows the checkout's REF; it
+#   cannot follow the checkout's CONTENT. This header used to conclude "command
+#   drift is structurally impossible", and that inference is false: the premise
+#   above is true, the conclusion is not. A restore-over-clone accident produced
+#   a working tree with 106 files reverted to month-old content and 111
+#   upstream-deleted files resurrected, HEAD untouched. Every link resolved,
+#   `--check` reported ok, and `git pull` said "Already up to date" - three
+#   independent green signals on a fully corrupted install, every served command
+#   stale. Cache drift is what this design eliminates. Working-tree corruption is
+#   a different failure and nothing here prevents it.
 #
 #   Per-FAMILY links (never the whole dir) so the user's own files in
 #   ~/.claude/commands/ - hand-written commands, other tools' surfaces - are
@@ -34,8 +45,21 @@
 #                   (exit 1) when any is missing or stale; foreign entries are
 #                   reported but are NOT drift - the user's content wins
 #
+#   `ok` IS A TOPOLOGY VERDICT, NOT A HEALTH VERDICT (#685). It says the 16
+#   links resolve to this checkout. It says NOTHING about whether the checkout's
+#   content is what it should be. To assess content:
+#       git -C <checkout> status --porcelain -uall   # expect empty
+#       git -C <checkout> rev-parse HEAD origin/main # expect equal
+#   `-uall` is load-bearing: default `git status` collapses an untracked
+#   directory to ONE entry, under-reporting resurrected files (measured 3 vs 1
+#   on a clean dev box; ~16x in the #685 field case).
+#
+#   --check also prints one ADVISORY line when the checkout is dirty (below).
+#   It is an observation, never part of the verdict.
+#
 # Env:
 #   CPP_COMMANDS_LINK_HOME   override $HOME (install target root; tests)
+#   CPP_COMMANDS_LINK_NO_PROBE=1  skip the dirtiness advisory entirely
 
 set -uo pipefail
 
@@ -175,7 +199,43 @@ fi
 
 echo "families: ${#families[@]} ok: $ok changed: $changed missing: $missing stale: $stale foreign: $foreign"
 
+# --- Content advisory (issue #685) -----------------------------------------
+# Topology and content are separate questions and this script only answers the
+# first. The advisory stops the second from being SILENT: it reports what the
+# checkout's working tree looks like, and nothing else.
+#
+# It is NOT a verdict. It never changes the marker or the exit code, because
+# dirtiness is not staleness - this cannot tell a maintainer mid-edit from a
+# corrupted restore, and pretending otherwise would swap a silent gap for a
+# false alarm.
+#
+# The counts are reported SPLIT rather than as one total, which is what makes
+# the line diagnostic instead of merely noisy: a clean dev box reads
+# "0 tracked, 3 untracked" (measured on this repo - benign scratch), while the
+# #685 corruption read 106 tracked and 111 untracked. One merged number makes
+# those two look the same, and a line that reads identically in the healthy and
+# broken cases is the exact failure this advisory exists to end.
+#
+# FAIL-OPEN at every step: no git binary, not a repo, or any git error prints
+# NOTHING and leaves the verdict untouched. A check that starts erroring because
+# git is absent would be a worse regression than the silence it replaces.
+content_advisory() {
+    [ -n "${CPP_COMMANDS_LINK_NO_PROBE:-}" ] && return 0
+    command -v git >/dev/null 2>&1 || return 0
+    git -C "$SRC" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+    local tracked untracked
+    tracked="$(git -C "$SRC" diff --name-only HEAD -- 2>/dev/null | grep -c . || true)"
+    untracked="$(git -C "$SRC" ls-files --others --exclude-standard 2>/dev/null | grep -c . || true)"
+    [ -n "$tracked" ] || return 0
+    [ -n "$untracked" ] || return 0
+    [ $((tracked + untracked)) -gt 0 ] || return 0
+
+    echo "checkout: $tracked tracked modified, $untracked untracked (-uall) - links resolve; content not verified"
+}
+
 if [ "$MODE" = "check" ]; then
+    content_advisory
     if [ $((missing + stale)) -gt 0 ]; then
         echo "CPP_COMMANDS_LINK: drift"
         exit 1

--- a/scripts/flow-helpers-install.sh
+++ b/scripts/flow-helpers-install.sh
@@ -77,7 +77,12 @@ for arg in "$@"; do
         --check) MODE="check" ;;
         --force) FORCE=1 ;;
         --help|-h)
-            sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+            # 2,28p: the doc block ends at line 28 (the last `# Env:` entry).
+            # It was 2,37p, which spilled `set -uo pipefail`, three variable
+            # assignments and two stray comment lines into --help output (#686).
+            # tests/test_flow_helpers_install.py pins the boundary so the range
+            # cannot silently re-drift when the header grows.
+            sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)

--- a/tests/test_cpp_commands_link.py
+++ b/tests/test_cpp_commands_link.py
@@ -9,13 +9,18 @@ Ownership contract under test: the script may only ever touch SYMLINKS whose
 readlink target ends in `/.claude/commands/<family>`. Real files, real dirs,
 and symlinks pointing anywhere else are foreign - reported, never modified.
 
-Pure filesystem: the script shells only ln/readlink/mkdir/rm, so no
-binary guards are needed (the guarded set is git/docker/gitleaks).
+Mostly pure filesystem: the script shells ln/readlink/mkdir/rm for its real
+work. Since #685 `--check` ALSO shells `git` for a fail-open content advisory,
+so the tests that exercise that path carry the required `shutil.which("git")`
+guard; the rest need none (the guarded set is git/docker/gitleaks).
 """
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "cpp-commands-link.sh"
@@ -191,3 +196,193 @@ def test_unknown_argument_errors(tmp_path: Path):
     result = _run(tmp_path, src, "--bogus")
     assert result.returncode == 2
     assert "CPP_COMMANDS_LINK: error" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Content advisory: `ok` is topology, not health (issue #685)
+#
+# A restore-over-clone accident left 106 files reverted and 111 upstream-deleted
+# files resurrected, HEAD untouched. Every link resolved, `--check` said ok, and
+# `git pull` said "Already up to date" - three green signals on a corrupted
+# install. The advisory does not fix that (dirtiness is not staleness and this
+# cannot tell a mid-edit maintainer from a corrupted restore); it stops the
+# second question from being SILENT while the first answers ok.
+# --------------------------------------------------------------------------- #
+needs_git = pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+
+ADVISORY = "content not verified"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+def _git_source(tmp_path: Path) -> Path:
+    """A fake checkout that is a real git repo with everything committed."""
+    src = _make_source(tmp_path)
+    repo = tmp_path / "checkout"
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "initial")
+    return src
+
+
+@needs_git
+def test_clean_checkout_prints_no_advisory(tmp_path: Path) -> None:
+    """The line must not fire on a healthy checkout - a warning that appears on
+    every box trains everyone to ignore it, which is the antipattern this whole
+    advisory is meant to avoid rather than join."""
+    src = _git_source(tmp_path)
+    _run(tmp_path, src)
+    res = _run(tmp_path, src, "--check")
+    assert ADVISORY not in res.stdout
+    assert "CPP_COMMANDS_LINK: ok" in res.stdout
+    assert res.returncode == 0
+
+
+@needs_git
+def test_dirty_checkout_reports_split_counts(tmp_path: Path) -> None:
+    """Tracked and untracked are reported SEPARATELY, which is what makes the
+    line diagnostic: a maintainer mid-edit reads `1 tracked, 1 untracked`, the
+    #685 corruption read 106 and 111. One merged total makes those identical."""
+    src = _git_source(tmp_path)
+    _run(tmp_path, src)
+    (src / "flow" / "flow-cmd.md").write_text("# tampered\n")   # tracked change
+    (src / "flow" / "resurrected.md").write_text("# zombie\n")  # untracked add
+
+    res = _run(tmp_path, src, "--check")
+    assert "checkout: 1 tracked modified, 1 untracked (-uall)" in res.stdout
+
+
+@needs_git
+def test_advisory_never_changes_the_verdict_or_exit_code(tmp_path: Path) -> None:
+    """THE #685 THESIS, as a test: a corrupted working tree still reports `ok`,
+    because topology really is fine. The advisory is an observation printed
+    alongside the verdict - it must never become the verdict."""
+    src = _git_source(tmp_path)
+    _run(tmp_path, src)
+    (src / "cicd" / "cicd-cmd.md").write_text("# month-old content\n")
+
+    res = _run(tmp_path, src, "--check")
+    assert ADVISORY in res.stdout                      # the silence is broken
+    assert "CPP_COMMANDS_LINK: ok" in res.stdout       # ...but ok still means ok
+    assert "CPP_COMMANDS_LINK: drift" not in res.stdout
+    assert res.returncode == 0
+    assert "WARNING" not in res.stdout
+
+
+@needs_git
+def test_advisory_is_suppressible(tmp_path: Path) -> None:
+    src = _git_source(tmp_path)
+    _run(tmp_path, src)
+    (src / "flow" / "flow-cmd.md").write_text("# tampered\n")
+
+    env = dict(os.environ)
+    env["CPP_COMMANDS_LINK_HOME"] = str(tmp_path / "home")
+    env["CPP_COMMANDS_LINK_NO_PROBE"] = "1"
+    res = subprocess.run(
+        ["bash", str(SCRIPT), "--source", str(src), "--check"],
+        capture_output=True, text=True, env=env,
+    )
+    assert ADVISORY not in res.stdout
+    assert "CPP_COMMANDS_LINK: ok" in res.stdout
+
+
+# --- Fail-open: TESTED, not asserted ---------------------------------------
+# `--check` had no git dependency before #685. A fail-open that only works when
+# someone remembered to write it correctly is not fail-open, so each path gets
+# its own test: the check must keep working exactly as it did with no git at
+# all, outside a repo, and when git itself errors.
+def test_fail_open_when_source_is_not_a_repo(tmp_path: Path) -> None:
+    """The pre-#685 fixture: a plain directory. No advisory, unchanged verdict."""
+    src = _make_source(tmp_path)
+    _run(tmp_path, src)
+    res = _run(tmp_path, src, "--check")
+    assert ADVISORY not in res.stdout
+    assert "CPP_COMMANDS_LINK: ok" in res.stdout
+    assert res.returncode == 0
+
+
+def test_fail_open_when_git_is_absent(tmp_path: Path) -> None:
+    """PATH carrying the coreutils the script needs but NO git - the
+    CI-container shape (uv:python3.11-slim ships none of git/docker/gitleaks).
+    The check must still answer its own question rather than erroring on a
+    dependency it never needed before #685.
+
+    The PATH is built from explicit symlinks rather than emptied outright: an
+    empty PATH also removes `ln`/`mkdir`/`readlink`, so the script would fail
+    for reasons that have nothing to do with git and the test would pass while
+    proving nothing.
+    """
+    src = _make_source(tmp_path)
+    stub_path = tmp_path / "nogitbin"
+    stub_path.mkdir()
+    for tool in ("mkdir", "ln", "rm", "readlink", "basename", "grep", "bash"):
+        found = shutil.which(tool)
+        if found:
+            (stub_path / tool).symlink_to(found)
+    assert shutil.which("git", path=str(stub_path)) is None, "fixture must lack git"
+
+    env = dict(os.environ)
+    env["CPP_COMMANDS_LINK_HOME"] = str(tmp_path / "home")
+    env["PATH"] = str(stub_path)
+    for args in ((), ("--check",)):
+        res = subprocess.run(
+            ["bash", str(SCRIPT), "--source", str(src), *args],
+            capture_output=True, text=True, env=env,
+        )
+        assert ADVISORY not in res.stdout
+        assert res.returncode == 0, res.stderr
+    assert "CPP_COMMANDS_LINK: ok" in res.stdout
+
+
+def test_fail_open_when_git_errors(tmp_path: Path) -> None:
+    """A git on PATH that fails every invocation (broken install, bad config).
+    Errors must be swallowed - no advisory, no stderr leakage into the verdict,
+    no exit-code change."""
+    src = _make_source(tmp_path)
+    stub_path = tmp_path / "brokenbin"
+    stub_path.mkdir()
+    stub = stub_path / "git"
+    stub.write_text("#!/usr/bin/env bash\necho 'fatal: broken' >&2\nexit 128\n")
+    stub.chmod(0o755)
+
+    env = dict(os.environ)
+    env["CPP_COMMANDS_LINK_HOME"] = str(tmp_path / "home")
+    env["PATH"] = f"{stub_path}:{env['PATH']}"
+    subprocess.run(["bash", str(SCRIPT), "--source", str(src)],
+                   capture_output=True, text=True, env=env)
+    res = subprocess.run(
+        ["bash", str(SCRIPT), "--source", str(src), "--check"],
+        capture_output=True, text=True, env=env,
+    )
+    assert ADVISORY not in res.stdout
+    assert "CPP_COMMANDS_LINK: ok" in res.stdout
+    assert res.returncode == 0
+
+
+def test_header_states_ok_is_topology_not_health() -> None:
+    """The claim-shaped half of #685. The old header concluded that command
+    drift was 'structurally impossible' - true of CACHE drift, false of
+    working-tree corruption, and that inference is what made `ok` read as a
+    health verdict.
+
+    Asserted POSITIVELY, on the corrective claims being present. The obvious
+    negative check - that the phrase 'structurally impossible' is absent - is
+    wrong here and this test failed on it first: the header now QUOTES the old
+    conclusion in order to correct it, which is exactly the shape a reader needs
+    and a substring ban forbids. Banning a phrase bans its retraction too.
+    """
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "TOPOLOGY VERDICT, NOT A HEALTH VERDICT" in text, (
+        "the --check contract no longer says `ok` is topology-only (issue #685)"
+    )
+    assert "cannot follow the checkout's CONTENT" in text, (
+        "the header no longer explains WHY topology and content differ - a link "
+        "follows the ref, not the working tree (issue #685)"
+    )

--- a/tests/test_flow_helpers_install.py
+++ b/tests/test_flow_helpers_install.py
@@ -185,3 +185,30 @@ def test_unknown_argument_is_rejected(tmp_path: Path, plugin_source: Path):
     proc = _run("--nope", home=tmp_path / "home", source=plugin_source)
     assert proc.returncode == 2
     assert "unknown argument" in proc.stderr
+
+
+def test_help_stops_at_the_doc_block(tmp_path: Path):
+    """--help must print the header and nothing after it (issue #686).
+
+    The extractor is a hardcoded `sed -n '2,Np'` range, so it silently drifts
+    whenever the header grows or shrinks - it was `2,37p` against a block ending
+    at line 28, spilling `set -uo pipefail`, three variable assignments and two
+    stray comment lines into user-visible output. Asserting on the CODE that
+    must not appear (rather than on an exact line count) survives the header
+    being edited, which is the thing that will happen next.
+    """
+    proc = _run("--help", home=tmp_path / "home")
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout
+
+    # The real help text is present...
+    assert "flow-helpers-install.sh - Install the flow helper family" in out
+    assert "FLOW_HELPERS_SOURCE" in out, "the last Env entry is the doc block's end"
+
+    # ...and no executable code leaked past it.
+    for leaked in ("set -uo pipefail", "SELF_DIR=", "HOME_DIR=", "TARGET_DIR=",
+                   "HELPERS=("):
+        assert leaked not in out, (
+            f"--help leaked {leaked!r} - the sed range extends past the doc "
+            f"block, which ends at the last `# Env:` entry (issue #686)"
+        )


### PR DESCRIPTION
## #685 — `ok` was a topology verdict wearing a health verdict's clothes

`cpp-commands-link.sh --check` asks one question — do the 16 family links resolve to this checkout — and answers it **correctly**. The problem is what the answer sounds like.

A restore-over-clone accident produced a working tree with **106 files reverted** to month-old content and **111 upstream-deleted files resurrected**, HEAD untouched. Every link resolved, so `--check` said `ok`. The damage was working-tree, not ref-level, so `git pull` said "Already up to date". **Three independent green signals on a fully corrupted install**, every served command stale.

### The overclaim was not where the issue pointed

The `--check` contract is precisely worded and overclaims nothing. The false claim was in the header's *Purpose* paragraph:

> A symlink follows `git pull` atomically, so **command drift is structurally impossible**

The premise is true — there genuinely is no cache to reconcile, which is the real contrast with the retired `/plugin` lane. **The inference is false.** A link follows the checkout's **ref**; it cannot follow the checkout's **content**. Cache drift is what this design eliminates; working-tree corruption is a different failure and nothing here prevents it.

Found by reading the file linearly rather than grepping — a keyword search for `check`/`ok` would have concluded the script was fine. (`CLAUDE.md` carries the premise and never draws the conclusion, so it needs no change.)

## Changes

**Header + contract** state the scope of the guarantee, name the field case, and say plainly that `ok` is a **topology** verdict with the two commands that actually assess content.

**`--check` prints one advisory line** when the checkout is dirty:

```
checkout: 6 tracked modified, 9 untracked (-uall) - links resolve; content not verified
CPP_COMMANDS_LINK: ok
```

**The counts are split, not totalled — deliberately, against the issue's proposal.** The issue asked for one number. Measured on a clean primary checkout: **3 dirty entries**, all benign untracked scratch. A single total therefore fires on every maintainer machine and reads *identically* to the corruption — the cry-wolf antipattern this wave has spent the day removing. Split, `0 / 3` reads as nothing and `106 / 111` reads as alarming, with no threshold to invent or tune.

**`-uall` is kept**, and its cost is documented. Default `git status` collapses an untracked directory to one entry: measured **3 vs 1** on a clean box, ~16x in the field case. It under-reports exactly the resurrected-file damage.

**It is an observation, never a verdict.** No exit-code change, no `drift`, no `WARNING`. Dirtiness is not staleness — this cannot distinguish a maintainer mid-edit from a corrupted restore, and the header says so rather than pretending otherwise.

**Fail-open is tested, not asserted.** `--check` had *no* git dependency before this, so adding one is a real coupling change. Three tests, one per path:

| path | asserted |
|---|---|
| no `git` on PATH (the CI-container shape) | no advisory, verdict + exit code untouched |
| source is not a repo (the pre-existing fixture) | same |
| `git` present but errors on every call | same |

The no-git fixture builds a PATH from explicit coreutils symlinks rather than emptying it — an empty PATH also removes `ln`/`mkdir`/`readlink`, so the script would fail for reasons unrelated to git and the test would pass while proving nothing.

`CPP_COMMANDS_LINK_NO_PROBE=1` opts out entirely.

## #686 — the `--help` range

`sed -n '2,37p'` against a doc block ending at line 28, so `--help` printed `set -uo pipefail`, three variable assignments and two stray comment lines. Now `2,28p`.

Pinned by a test asserting on **the code that must not appear** rather than a line count, so the range cannot silently re-drift when the header grows. This closes the residual reported and deliberately left in #677.

## Test plan

`make verify` green: **1461 passed, 1 skipped**, mypy clean over 148 files, `binary-guards: ok` (the new git-shelling tests carry the required `shutil.which` guard), codex-skills in sync. `FLOW_FINISH_GATE: ok`.

**Thesis test:** a corrupted working tree still reports `ok`, because topology really is fine — the advisory appears alongside it and never becomes it.

**Field-scale demonstration** against a synthetic corruption (6 tracked reverted + 9 untracked resurrected): `families: 2 ok: 2 ... / checkout: 6 tracked modified, 9 untracked / CPP_COMMANDS_LINK: ok`.

One test of mine failed first and the fix is worth naming: I initially asserted that `structurally impossible` was **absent** from the header. It isn't — the header now *quotes* the old conclusion in order to correct it, which is exactly what a reader needs. Banning a phrase bans its retraction, so the test asserts the corrective claims are present instead.

## #688 — recommendation only, not implemented

Recommend closing as decided: **keep the curated `HELPERS` array.** Converging on a Tier-2-style glob installs **24 additional scripts** to the allowlisted stable path (15 array entries vs 39 executables in `scripts/`), several consequential, none with an allow rule. `/cpp:init` Tier 2 is the full install, so globbing is right there; `flow-helpers-install.sh` is `/flow:repair`, a targeted repair whose array has a principled tested membership rule since #677. Convergence trades a closed drift class for a wider host-install surface.

Closes #685
Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)