### PR TITLE
fix(flow): claim records keep empty fields - one separator, one parser (Closes #698)

### DIFF
--- a/codex/skills/flow-register/scripts/flow-wave-registry.sh
+++ b/codex/skills/flow-register/scripts/flow-wave-registry.sh
@@ -365,6 +365,38 @@ cwd_is_shared_parent() {
 # failed derivation never invents one. On a transport that stamps something
 # else this simply finds nothing, which is the correct answer rather than a
 # confident wrong one.
+# CLAIM_FS - the ONE field separator for claim records (#698), shared by the
+# producer and the parser so the format has a single definition.
+#
+# ASCII unit separator (0x1F), deliberately NOT tab. Tab is IFS *whitespace*, so
+# shell field splitting collapses a run of it into a single delimiter and an
+# EMPTY field vanishes rather than arriving empty - every later field shifts up
+# one slot. #687 shipped with tab and a branchless (detached-HEAD) claim
+# therefore rendered its worktree path as a branch and the repo root as its
+# worktree, and fed those wrong values into overlap detection. `\037` is not IFS
+# whitespace, so empty fields survive in every position - middle, trailing, and
+# both at once, which matters because an absent observed address is the COMMON
+# case for an unregistered claim, not an edge one.
+#
+# Four independent definitions of this separator (one printf format + three
+# `IFS=` expressions) were what made #698 possible, and the failure mode is
+# shifted fields rather than an error - so a future edit to any one of them
+# would break silently. One constant, one parser: see parse_claim_record.
+CLAIM_FS="$(printf '\037')"
+
+# parse_claim_record RECORD -> sets C_ISSUE C_PID C_SESSION C_BRANCH C_WT
+#                              C_REPO C_ADDR
+#
+# The ONE place that knows the field order and the separator. Call sites read
+# whole lines (`IFS= read -r rec`, the same single-field idiom every other read
+# loop in scripts/ uses and the reason they were all immune to #698) and hand
+# the record here.
+parse_claim_record() {
+  IFS="$CLAIM_FS" read -r C_ISSUE C_PID C_SESSION C_BRANCH C_WT C_REPO C_ADDR <<EOF
+$1
+EOF
+}
+
 claim_address() {
   local pid="$1"
   [ -n "$pid" ] || return 0
@@ -439,7 +471,11 @@ $(printf '%s' "$e" | jq -r '.session // empty')"
           if [ -n "$c_pid" ] && printf '%s\n' "$known_pids" | grep -Fxq -- "$c_pid"; then continue; fi
           if [ -n "$c_session" ] && printf '%s\n' "$known_sessions" | grep -Fxq -- "$c_session"; then continue; fi
           addr="$(claim_address "$c_pid")"
-          printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+          # CLAIM_FS is interpolated into the FORMAT string, which is normally a
+          # smell (a '%' in the variable would be read as a conversion). Safe
+          # here by construction: CLAIM_FS is a fixed control character set once
+          # at the top of this file, never derived from input.
+          printf "%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s\n" \
             "$c_issue" "$c_pid" "$c_session" "$cur_branch" "$cur_wt" "$repo" "$addr"
           ;;
       esac
@@ -891,7 +927,10 @@ $rp"
       # very breaking change this avoids. The key appears only when there is
       # something to report, so a claim-free run is byte-identical to pre-#687.
       if [ -n "$CLAIMS" ]; then
-        CLAIM_JSON="$(printf '%s\n' "$CLAIMS" | jq -R -s 'split("\n") | map(select(length > 0) | split("\t")) | map({issue: .[0], pid: .[1], session: .[2], branch: .[3], worktree: .[4], repo: .[5], address: (if .[6] == "" then null else .[6] end), source: "flow-claim-lock", registered: false})')"
+        # jq splits on the SAME constant (#698). This was the fifth independent
+        # definition of the delimiter and the one the original four-definitions
+        # count missed - which is the argument for the constant, not against it.
+        CLAIM_JSON="$(printf '%s\n' "$CLAIMS" | jq -R -s --arg fs "$CLAIM_FS" 'split("\n") | map(select(length > 0) | split($fs)) | map({issue: .[0], pid: .[1], session: .[2], branch: .[3], worktree: .[4], repo: .[5], address: (if (.[6] // "") == "" then null else .[6] end), source: "flow-claim-lock", registered: false})')"
         OUT="$(printf '%s' "$OUT" | jq -c --argjson c "$CLAIM_JSON" '. + {unregistered_claims: $c}')"
       fi
       printf '%s\n' "$OUT" | jq .
@@ -909,9 +948,10 @@ $rp"
       # "nothing registered" while a lock is held would be the original bug.
       if [ -n "$CLAIMS" ]; then
         echo "  -- unregistered flow-claim locks (live, not registry entries - contactable, but not addressable as roles) --"
-        while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-          [ -n "$c_pid" ] || continue
-          echo "  (claim) -> ${c_addr:-no observed address} [live, unregistered] issue=${c_iss:--} branch=${c_br:--} pid=$c_pid wt=$c_wt"
+        while IFS= read -r rec; do
+          [ -n "$rec" ] || continue
+          parse_claim_record "$rec"
+          echo "  (claim) -> ${C_ADDR:-no observed address} [live, unregistered] issue=${C_ISSUE:--} branch=${C_BRANCH:--} pid=$C_PID wt=$C_WT"
         done <<EOF
 $CLAIMS
 EOF
@@ -940,9 +980,10 @@ EOF
     # issue was free while a live session was minutes from a PR on it.
     if [ -n "$CLAIMS" ]; then
       echo "  -- unregistered flow-claim locks (live, not registry entries - contactable, but not addressable as roles) --"
-      while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-        [ -n "$c_pid" ] || continue
-        echo "  (claim) -> ${c_addr:-no observed address} [live, unregistered] issue=${c_iss:--} branch=${c_br:--} pid=$c_pid wt=$c_wt"
+      while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        parse_claim_record "$rec"
+        echo "  (claim) -> ${C_ADDR:-no observed address} [live, unregistered] issue=${C_ISSUE:--} branch=${C_BRANCH:--} pid=$C_PID wt=$C_WT"
       done <<EOF
 $CLAIMS
 EOF
@@ -1020,15 +1061,16 @@ EOF
     # never skipped; that is checked by test, not left to reasoning, because
     # those conditions have changed before.
     if [ -n "$CLAIMS" ]; then
-      while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-        [ -n "$c_pid" ] || continue
+      while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        parse_claim_record "$rec"
         for b in $LIVE_ROLES; do
           eb="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$b" '.[$w].roles[$r]')"
           rb="$(printf '%s' "$eb" | jq -r '.repo // ""')"
           ib="$(printf '%s' "$eb" | jq -r '.issue // ""')"
           bb="$(printf '%s' "$eb" | jq -r '.branch // ""')"
           cb="$(printf '%s' "$eb" | jq -r '.cwd // ""')"
-          report_overlap "claim(pid $c_pid)" "$c_iss" "$c_br" "$c_wt" "$c_repo" \
+          report_overlap "claim(pid $C_PID)" "$C_ISSUE" "$C_BRANCH" "$C_WT" "$C_REPO" \
             "$b" "$ib" "$bb" "$cb" "$rb"
         done
       done <<EOF

--- a/codex/skills/flow-wave/scripts/flow-wave-registry.sh
+++ b/codex/skills/flow-wave/scripts/flow-wave-registry.sh
@@ -365,6 +365,38 @@ cwd_is_shared_parent() {
 # failed derivation never invents one. On a transport that stamps something
 # else this simply finds nothing, which is the correct answer rather than a
 # confident wrong one.
+# CLAIM_FS - the ONE field separator for claim records (#698), shared by the
+# producer and the parser so the format has a single definition.
+#
+# ASCII unit separator (0x1F), deliberately NOT tab. Tab is IFS *whitespace*, so
+# shell field splitting collapses a run of it into a single delimiter and an
+# EMPTY field vanishes rather than arriving empty - every later field shifts up
+# one slot. #687 shipped with tab and a branchless (detached-HEAD) claim
+# therefore rendered its worktree path as a branch and the repo root as its
+# worktree, and fed those wrong values into overlap detection. `\037` is not IFS
+# whitespace, so empty fields survive in every position - middle, trailing, and
+# both at once, which matters because an absent observed address is the COMMON
+# case for an unregistered claim, not an edge one.
+#
+# Four independent definitions of this separator (one printf format + three
+# `IFS=` expressions) were what made #698 possible, and the failure mode is
+# shifted fields rather than an error - so a future edit to any one of them
+# would break silently. One constant, one parser: see parse_claim_record.
+CLAIM_FS="$(printf '\037')"
+
+# parse_claim_record RECORD -> sets C_ISSUE C_PID C_SESSION C_BRANCH C_WT
+#                              C_REPO C_ADDR
+#
+# The ONE place that knows the field order and the separator. Call sites read
+# whole lines (`IFS= read -r rec`, the same single-field idiom every other read
+# loop in scripts/ uses and the reason they were all immune to #698) and hand
+# the record here.
+parse_claim_record() {
+  IFS="$CLAIM_FS" read -r C_ISSUE C_PID C_SESSION C_BRANCH C_WT C_REPO C_ADDR <<EOF
+$1
+EOF
+}
+
 claim_address() {
   local pid="$1"
   [ -n "$pid" ] || return 0
@@ -439,7 +471,11 @@ $(printf '%s' "$e" | jq -r '.session // empty')"
           if [ -n "$c_pid" ] && printf '%s\n' "$known_pids" | grep -Fxq -- "$c_pid"; then continue; fi
           if [ -n "$c_session" ] && printf '%s\n' "$known_sessions" | grep -Fxq -- "$c_session"; then continue; fi
           addr="$(claim_address "$c_pid")"
-          printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+          # CLAIM_FS is interpolated into the FORMAT string, which is normally a
+          # smell (a '%' in the variable would be read as a conversion). Safe
+          # here by construction: CLAIM_FS is a fixed control character set once
+          # at the top of this file, never derived from input.
+          printf "%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s\n" \
             "$c_issue" "$c_pid" "$c_session" "$cur_branch" "$cur_wt" "$repo" "$addr"
           ;;
       esac
@@ -891,7 +927,10 @@ $rp"
       # very breaking change this avoids. The key appears only when there is
       # something to report, so a claim-free run is byte-identical to pre-#687.
       if [ -n "$CLAIMS" ]; then
-        CLAIM_JSON="$(printf '%s\n' "$CLAIMS" | jq -R -s 'split("\n") | map(select(length > 0) | split("\t")) | map({issue: .[0], pid: .[1], session: .[2], branch: .[3], worktree: .[4], repo: .[5], address: (if .[6] == "" then null else .[6] end), source: "flow-claim-lock", registered: false})')"
+        # jq splits on the SAME constant (#698). This was the fifth independent
+        # definition of the delimiter and the one the original four-definitions
+        # count missed - which is the argument for the constant, not against it.
+        CLAIM_JSON="$(printf '%s\n' "$CLAIMS" | jq -R -s --arg fs "$CLAIM_FS" 'split("\n") | map(select(length > 0) | split($fs)) | map({issue: .[0], pid: .[1], session: .[2], branch: .[3], worktree: .[4], repo: .[5], address: (if (.[6] // "") == "" then null else .[6] end), source: "flow-claim-lock", registered: false})')"
         OUT="$(printf '%s' "$OUT" | jq -c --argjson c "$CLAIM_JSON" '. + {unregistered_claims: $c}')"
       fi
       printf '%s\n' "$OUT" | jq .
@@ -909,9 +948,10 @@ $rp"
       # "nothing registered" while a lock is held would be the original bug.
       if [ -n "$CLAIMS" ]; then
         echo "  -- unregistered flow-claim locks (live, not registry entries - contactable, but not addressable as roles) --"
-        while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-          [ -n "$c_pid" ] || continue
-          echo "  (claim) -> ${c_addr:-no observed address} [live, unregistered] issue=${c_iss:--} branch=${c_br:--} pid=$c_pid wt=$c_wt"
+        while IFS= read -r rec; do
+          [ -n "$rec" ] || continue
+          parse_claim_record "$rec"
+          echo "  (claim) -> ${C_ADDR:-no observed address} [live, unregistered] issue=${C_ISSUE:--} branch=${C_BRANCH:--} pid=$C_PID wt=$C_WT"
         done <<EOF
 $CLAIMS
 EOF
@@ -940,9 +980,10 @@ EOF
     # issue was free while a live session was minutes from a PR on it.
     if [ -n "$CLAIMS" ]; then
       echo "  -- unregistered flow-claim locks (live, not registry entries - contactable, but not addressable as roles) --"
-      while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-        [ -n "$c_pid" ] || continue
-        echo "  (claim) -> ${c_addr:-no observed address} [live, unregistered] issue=${c_iss:--} branch=${c_br:--} pid=$c_pid wt=$c_wt"
+      while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        parse_claim_record "$rec"
+        echo "  (claim) -> ${C_ADDR:-no observed address} [live, unregistered] issue=${C_ISSUE:--} branch=${C_BRANCH:--} pid=$C_PID wt=$C_WT"
       done <<EOF
 $CLAIMS
 EOF
@@ -1020,15 +1061,16 @@ EOF
     # never skipped; that is checked by test, not left to reasoning, because
     # those conditions have changed before.
     if [ -n "$CLAIMS" ]; then
-      while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-        [ -n "$c_pid" ] || continue
+      while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        parse_claim_record "$rec"
         for b in $LIVE_ROLES; do
           eb="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$b" '.[$w].roles[$r]')"
           rb="$(printf '%s' "$eb" | jq -r '.repo // ""')"
           ib="$(printf '%s' "$eb" | jq -r '.issue // ""')"
           bb="$(printf '%s' "$eb" | jq -r '.branch // ""')"
           cb="$(printf '%s' "$eb" | jq -r '.cwd // ""')"
-          report_overlap "claim(pid $c_pid)" "$c_iss" "$c_br" "$c_wt" "$c_repo" \
+          report_overlap "claim(pid $C_PID)" "$C_ISSUE" "$C_BRANCH" "$C_WT" "$C_REPO" \
             "$b" "$ib" "$bb" "$cb" "$rb"
         done
       done <<EOF

--- a/scripts/flow-wave-registry.sh
+++ b/scripts/flow-wave-registry.sh
@@ -365,6 +365,38 @@ cwd_is_shared_parent() {
 # failed derivation never invents one. On a transport that stamps something
 # else this simply finds nothing, which is the correct answer rather than a
 # confident wrong one.
+# CLAIM_FS - the ONE field separator for claim records (#698), shared by the
+# producer and the parser so the format has a single definition.
+#
+# ASCII unit separator (0x1F), deliberately NOT tab. Tab is IFS *whitespace*, so
+# shell field splitting collapses a run of it into a single delimiter and an
+# EMPTY field vanishes rather than arriving empty - every later field shifts up
+# one slot. #687 shipped with tab and a branchless (detached-HEAD) claim
+# therefore rendered its worktree path as a branch and the repo root as its
+# worktree, and fed those wrong values into overlap detection. `\037` is not IFS
+# whitespace, so empty fields survive in every position - middle, trailing, and
+# both at once, which matters because an absent observed address is the COMMON
+# case for an unregistered claim, not an edge one.
+#
+# Four independent definitions of this separator (one printf format + three
+# `IFS=` expressions) were what made #698 possible, and the failure mode is
+# shifted fields rather than an error - so a future edit to any one of them
+# would break silently. One constant, one parser: see parse_claim_record.
+CLAIM_FS="$(printf '\037')"
+
+# parse_claim_record RECORD -> sets C_ISSUE C_PID C_SESSION C_BRANCH C_WT
+#                              C_REPO C_ADDR
+#
+# The ONE place that knows the field order and the separator. Call sites read
+# whole lines (`IFS= read -r rec`, the same single-field idiom every other read
+# loop in scripts/ uses and the reason they were all immune to #698) and hand
+# the record here.
+parse_claim_record() {
+  IFS="$CLAIM_FS" read -r C_ISSUE C_PID C_SESSION C_BRANCH C_WT C_REPO C_ADDR <<EOF
+$1
+EOF
+}
+
 claim_address() {
   local pid="$1"
   [ -n "$pid" ] || return 0
@@ -439,7 +471,11 @@ $(printf '%s' "$e" | jq -r '.session // empty')"
           if [ -n "$c_pid" ] && printf '%s\n' "$known_pids" | grep -Fxq -- "$c_pid"; then continue; fi
           if [ -n "$c_session" ] && printf '%s\n' "$known_sessions" | grep -Fxq -- "$c_session"; then continue; fi
           addr="$(claim_address "$c_pid")"
-          printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+          # CLAIM_FS is interpolated into the FORMAT string, which is normally a
+          # smell (a '%' in the variable would be read as a conversion). Safe
+          # here by construction: CLAIM_FS is a fixed control character set once
+          # at the top of this file, never derived from input.
+          printf "%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s${CLAIM_FS}%s\n" \
             "$c_issue" "$c_pid" "$c_session" "$cur_branch" "$cur_wt" "$repo" "$addr"
           ;;
       esac
@@ -891,7 +927,10 @@ $rp"
       # very breaking change this avoids. The key appears only when there is
       # something to report, so a claim-free run is byte-identical to pre-#687.
       if [ -n "$CLAIMS" ]; then
-        CLAIM_JSON="$(printf '%s\n' "$CLAIMS" | jq -R -s 'split("\n") | map(select(length > 0) | split("\t")) | map({issue: .[0], pid: .[1], session: .[2], branch: .[3], worktree: .[4], repo: .[5], address: (if .[6] == "" then null else .[6] end), source: "flow-claim-lock", registered: false})')"
+        # jq splits on the SAME constant (#698). This was the fifth independent
+        # definition of the delimiter and the one the original four-definitions
+        # count missed - which is the argument for the constant, not against it.
+        CLAIM_JSON="$(printf '%s\n' "$CLAIMS" | jq -R -s --arg fs "$CLAIM_FS" 'split("\n") | map(select(length > 0) | split($fs)) | map({issue: .[0], pid: .[1], session: .[2], branch: .[3], worktree: .[4], repo: .[5], address: (if (.[6] // "") == "" then null else .[6] end), source: "flow-claim-lock", registered: false})')"
         OUT="$(printf '%s' "$OUT" | jq -c --argjson c "$CLAIM_JSON" '. + {unregistered_claims: $c}')"
       fi
       printf '%s\n' "$OUT" | jq .
@@ -909,9 +948,10 @@ $rp"
       # "nothing registered" while a lock is held would be the original bug.
       if [ -n "$CLAIMS" ]; then
         echo "  -- unregistered flow-claim locks (live, not registry entries - contactable, but not addressable as roles) --"
-        while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-          [ -n "$c_pid" ] || continue
-          echo "  (claim) -> ${c_addr:-no observed address} [live, unregistered] issue=${c_iss:--} branch=${c_br:--} pid=$c_pid wt=$c_wt"
+        while IFS= read -r rec; do
+          [ -n "$rec" ] || continue
+          parse_claim_record "$rec"
+          echo "  (claim) -> ${C_ADDR:-no observed address} [live, unregistered] issue=${C_ISSUE:--} branch=${C_BRANCH:--} pid=$C_PID wt=$C_WT"
         done <<EOF
 $CLAIMS
 EOF
@@ -940,9 +980,10 @@ EOF
     # issue was free while a live session was minutes from a PR on it.
     if [ -n "$CLAIMS" ]; then
       echo "  -- unregistered flow-claim locks (live, not registry entries - contactable, but not addressable as roles) --"
-      while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-        [ -n "$c_pid" ] || continue
-        echo "  (claim) -> ${c_addr:-no observed address} [live, unregistered] issue=${c_iss:--} branch=${c_br:--} pid=$c_pid wt=$c_wt"
+      while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        parse_claim_record "$rec"
+        echo "  (claim) -> ${C_ADDR:-no observed address} [live, unregistered] issue=${C_ISSUE:--} branch=${C_BRANCH:--} pid=$C_PID wt=$C_WT"
       done <<EOF
 $CLAIMS
 EOF
@@ -1020,15 +1061,16 @@ EOF
     # never skipped; that is checked by test, not left to reasoning, because
     # those conditions have changed before.
     if [ -n "$CLAIMS" ]; then
-      while IFS="$(printf '\t')" read -r c_iss c_pid c_ses c_br c_wt c_repo c_addr; do
-        [ -n "$c_pid" ] || continue
+      while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        parse_claim_record "$rec"
         for b in $LIVE_ROLES; do
           eb="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$b" '.[$w].roles[$r]')"
           rb="$(printf '%s' "$eb" | jq -r '.repo // ""')"
           ib="$(printf '%s' "$eb" | jq -r '.issue // ""')"
           bb="$(printf '%s' "$eb" | jq -r '.branch // ""')"
           cb="$(printf '%s' "$eb" | jq -r '.cwd // ""')"
-          report_overlap "claim(pid $c_pid)" "$c_iss" "$c_br" "$c_wt" "$c_repo" \
+          report_overlap "claim(pid $C_PID)" "$C_ISSUE" "$C_BRANCH" "$C_WT" "$C_REPO" \
             "$b" "$ib" "$bb" "$cb" "$rb"
         done
       done <<EOF

--- a/tests/test_flow_wave_registry.py
+++ b/tests/test_flow_wave_registry.py
@@ -608,7 +608,8 @@ def _claim_repo(
     pid: str = CLAIM_PID,
     session: str = CLAIM_SESSION,
     host: str = HOST,
-    branch: str = "issue-999-alpha",
+    branch: str | None = "issue-999-alpha",
+    reason: str | None = None,
 ) -> Path:
     """A git repo with a linked worktree carrying a real flow-claim lock.
 
@@ -625,8 +626,14 @@ def _claim_repo(
     subprocess.run([*git, "add", "f"], check=True, capture_output=True)
     subprocess.run([*git, "commit", "-qm", "init"], check=True, capture_output=True)
     wt = tmp / "wt-a"
-    subprocess.run([*git, "worktree", "add", "-q", str(wt), "-b", branch], check=True, capture_output=True)
-    reason = f"flow-claim issue={issue} pid={pid} session={session} host={host} ts=1700000000"
+    if branch is None:
+        # Detached HEAD -> `git worktree list --porcelain` emits no `branch` line,
+        # so the claim record carries an EMPTY middle field (issue #698).
+        subprocess.run([*git, "worktree", "add", "-q", "--detach", str(wt)], check=True, capture_output=True)
+    else:
+        subprocess.run([*git, "worktree", "add", "-q", str(wt), "-b", branch], check=True, capture_output=True)
+    if reason is None:
+        reason = f"flow-claim issue={issue} pid={pid} session={session} host={host} ts=1700000000"
     subprocess.run([*git, "worktree", "lock", "--reason", reason, str(wt)], check=True, capture_output=True)
     return repo
 
@@ -785,6 +792,102 @@ class TestUnregisteredClaimReconciliation:
         assert p.returncode == 0
         assert _verdict(p) == "listed"
         assert "A -> uds:/tmp/a.sock" in p.stdout
+
+
+@requires_git_tools
+class TestClaimRecordPreservesEmptyFields:
+    """Empty fields survive the claim record round-trip (issue #698).
+
+    #687 joined seven fields with TAB and split them with ``IFS=$'\\t'``. Tab is
+    IFS *whitespace*, so shell field splitting collapses a run of it and an EMPTY
+    field vanishes instead of arriving empty - every later field shifts up one
+    slot. A detached-HEAD worktree has no branch, so the claim rendered its
+    worktree path as a branch and the repo root as its worktree, and fed those
+    wrong values into overlap detection.
+
+    EVERY test here is a negative control: each asserts a field value that the
+    tab-delimited code got demonstrably WRONG, so a test passing against both the
+    old and the new implementation would not be a regression test at all. The
+    observed broken output for the branchless fixture was
+    ``branch=<worktree path>`` and ``wt=<repo root>``.
+    """
+
+    def _register_orchestrator(self, tmp: Path, repo: Path) -> None:
+        _run(tmp, "register", "orchestrator", "--wave", "w", "--socket", "uds:/tmp/o.sock",
+             "--cwd", str(tmp), "--repo", str(repo), pid="100", session="orch")
+
+    def test_branchless_claim_keeps_every_later_field_in_place(self, tmp_path: Path) -> None:
+        """Empty MIDDLE field. Broken code printed the worktree path as the branch."""
+        repo = _claim_repo(tmp_path, branch=None)
+        self._register_orchestrator(tmp_path, repo)
+        p = _run(tmp_path, "list", "--wave", "w", live=f"100:{CLAIM_PID}")
+        assert "branch=-" in p.stdout  # empty, not the worktree path
+        assert f"wt={tmp_path / 'wt-a'}" in p.stdout  # the worktree, not the repo
+        assert f"wt={repo}" not in p.stdout
+        assert "issue=999" in p.stdout
+        assert f"pid={CLAIM_PID}" in p.stdout
+
+    def test_branchless_claim_overlaps_on_its_real_worktree(self, tmp_path: Path) -> None:
+        """The field shift corrupted overlap detection, not only the display.
+
+        A registered role sits in the claim's actual worktree. Fixed: the claim's
+        worktree field holds that path, so the pair collides and WARNS. Broken:
+        the field held the repo root instead, which is neither equal to nor
+        nested under the role's cwd, so no warning was produced - this assertion
+        fails against tab-delimited records.
+        """
+        repo = _claim_repo(tmp_path, branch=None)
+        self._register_orchestrator(tmp_path, repo)
+        _run(tmp_path, "register", "A", "--wave", "w", "--socket", "uds:/tmp/a.sock",
+             "--cwd", str(tmp_path / "wt-a"), "--repo", str(repo),
+             "--issue", "1", "--branch", "b1", pid="101", session="s1")
+        p = _run(tmp_path, "list", "--wave", "w", live=f"100:101:{CLAIM_PID}")
+        assert "WARNING" in p.stdout
+        assert "same/nested worktrees" in p.stdout
+
+    def test_empty_trailing_address_does_not_shift_earlier_fields(self, tmp_path: Path) -> None:
+        """Empty TRAILING field - the COMMON case, not an edge one.
+
+        An unregistered claim usually has no observed address. The render path
+        masks this on its own (``${C_ADDR:-no observed address}`` prints the same
+        whether the field is empty or shifted away), so this asserts the fields
+        BEFORE it, which is where a collapse would show.
+        """
+        repo = _claim_repo(tmp_path, branch="issue-999-alpha")
+        self._register_orchestrator(tmp_path, repo)
+        p = _run(tmp_path, "list", "--wave", "w", live=f"100:{CLAIM_PID}")
+        assert "no observed address" in p.stdout
+        assert "branch=issue-999-alpha" in p.stdout
+        assert f"wt={tmp_path / 'wt-a'}" in p.stdout
+
+    def test_lock_reason_missing_session_still_parses(self, tmp_path: Path) -> None:
+        """The other empty-middle producer: a hand-written lock reason.
+
+        A non-flow worktree locked by hand is exactly the irregular claim #687
+        exists to see, and it need not carry every key.
+        """
+        repo = _claim_repo(
+            tmp_path,
+            reason=f"flow-claim issue=555 pid={CLAIM_PID} host={HOST} ts=1700000000",
+        )
+        self._register_orchestrator(tmp_path, repo)
+        p = _run(tmp_path, "list", "--wave", "w", live=f"100:{CLAIM_PID}")
+        assert "issue=555" in p.stdout
+        assert f"pid={CLAIM_PID}" in p.stdout
+        assert f"wt={tmp_path / 'wt-a'}" in p.stdout
+
+    def test_json_fields_are_not_shifted_for_a_branchless_claim(self, tmp_path: Path) -> None:
+        """The same corruption reached --json consumers, not just the roster."""
+        repo = _claim_repo(tmp_path, branch=None)
+        self._register_orchestrator(tmp_path, repo)
+        p = _run(tmp_path, "list", "--wave", "w", "--json", live=f"100:{CLAIM_PID}")
+        claim = _json_payload(p)["unregistered_claims"][0]
+        assert claim["issue"] == "999"
+        assert claim["pid"] == CLAIM_PID
+        assert claim["branch"] == ""
+        assert claim["worktree"] == str(tmp_path / "wt-a")
+        assert claim["repo"] == str(repo)
+        assert claim["address"] is None
 
 
 @requires_tools


### PR DESCRIPTION
## The bug

#687 joined seven claim fields with TAB and split them with `IFS=$'\t'`. **Tab is IFS *whitespace***, so shell field splitting collapses a run of it into a single delimiter and an EMPTY field vanishes rather than arriving empty — every later field shifts up one slot.

Same fixture, a detached-HEAD (branchless) worktree, against both implementations:

```
broken: (claim) ... branch=/tmp/.../wt-detached   wt=/home/.../claude-power-pack
fixed:  (claim) ... branch=-                      wt=/tmp/.../wt-detached
```

`branch=` held the worktree path; `wt=` held the repo root.

## Not cosmetic

One of the three readers feeds **claim-vs-role lane-overlap detection**, so a branchless claim compared a worktree path as its branch and a repo root as its worktree. Against #687's acceptance bar — *an orchestrator reading the roster cannot double-assign a claimed issue* — issue matching survived (field 1 precedes the gap), but branch and same/nested-worktree matching were compromised for **exactly the irregular claims #687 exists to see**. A hand-made or non-flow worktree is where an unregistered claim is most likely in the first place.

## One constant and one parser, not four patches

The separator had **five** independent definitions, not the four the original analysis counted: the producer's printf format, three reader `IFS=` expressions, and a jq `split("\t")` in the `--json` path. The fifth was caught by the new tests during this fix — which is an argument for the constant, not against it. A format with five definitions whose failure mode is *shifted fields rather than an error* is a bug waiting on any single future edit.

- **`CLAIM_FS`** (ASCII unit separator, `0x1F`) — defined once, shared by producer, parser and jq. Not IFS whitespace, so empty fields survive in every position: middle, trailing, and both at once. The trailing case is the **common** one, not an edge — an unregistered claim usually has no observed address.
- **`parse_claim_record`** owns field order and splitting. The three call sites become `while IFS= read -r rec` — the same whole-line, single-field idiom every other read loop in `scripts/` already uses, which is precisely why they were all immune to this.

Only the per-record parse was extracted; the loops stay at their call sites and get simpler.

## Tests are negative controls by construction

Each new test asserts a field value the tab-delimited code got **demonstrably wrong**, so none can pass against both implementations. A test that passes on old and new code is not a regression test — and that matters doubly here, where the broken version produced *plausible* output.

Covers all three empty-field producers:
- detached HEAD (empty middle)
- no observed address (empty trailing)
- a lock reason missing `session=` (hand-written lock)

…and asserts the **overlap comparison**, not only the rendered row: `${C_ADDR:-no observed address}` prints identically whether the field is empty or shifted away, so a render-only assertion cannot distinguish fixed from broken. The overlap test is a *positive* discriminator — a registered role sits in the claim's real worktree, so the pair collides and WARNS under the fix, while the broken code held the repo root there and produced no warning.

## Provenance

Found by the wave orchestrator running a live demonstration of #687 against a real lock, at this session's suggestion that the feature be exercised rather than trusted from its own suite. The structural reason it mattered: an implementer's suite can only build well-formed claims, and #687's target population is claims made by sessions that **did not follow the flow**. The unimagined case *was* the target population.

## Test plan

- `make verify` — 1477 passed, 1 skipped, mypy clean over 148 files, `binary-guards: ok`
- `codex-skill-sync --check` 75 in sync; `eli5-check`, `tool-risk-check` green
- Fixed-vs-broken comparison run against both this worktree's copy and merged main, by explicit path

## Falsifies-owns

Neither `CLAUDE.md` nor `register.md` is falsified — both describe behavior, not the wire format. Checked, and reported as a result rather than as silence. Neither file is touched.

## Out of scope

`scripts/speckit-tasks-to-issues.sh:81` uses the same idiom (`IFS=$'\t'`, 2-field). Verified **latent, not live**: the shape is vulnerable to an empty *first* field, and it is safe only because field 1 is a GitHub issue number, which is never empty. Tracked separately as #700.

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)