### PR TITLE
docs(spec): balance agentic development workflows

### DIFF
--- a/.specify/specs/balanced-agentic-development/plan.md
+++ b/.specify/specs/balanced-agentic-development/plan.md
@@ -1,0 +1,360 @@
+# Implementation Plan: Balanced Agentic Development
+
+> **Branch:** `spec/balanced-agentic-development`
+> **Spec:** [spec.md](./spec.md)
+> **Created:** 2026-08-15
+> **Status:** Approved
+
+---
+
+## Summary
+
+Implement the approved workflow in six bounded PRs. First put an executable
+issue-economy control around `flow:wave`; then repair skill discovery and extract
+the deterministic `project:init` engine in parallel. Add the Wayfinder discovery
+gate only after initialization is testable, teach `project:next` the resulting
+planning graph, and trim always-loaded context last. This order prevents review
+from multiplying work while the remaining improvements are underway and avoids
+rewriting prose before executable sources of truth exist.
+
+---
+
+## Technical Context
+
+| Aspect | Choice | Rationale |
+|--------|--------|-----------|
+| Runtime | Python 3.11+ | Matches the constitution and supports portable, testable state machines |
+| State | Repository-local JSONL/JSON under the existing wave runtime directory; checkpoint JSON for project init | Auditable and deterministic without a service dependency |
+| Tracker | GitHub CLI/API with text/local fallback contracts | Reuses current CPP integration while preserving offline tests |
+| Skill packaging | Native directory + `SKILL.md`, generated Codex packages, reference files | Aligns discovery surfaces and progressive disclosure |
+| Testing | pytest fixtures, CLI integration tests, mutation/negative tests | Proves behavior rather than prompt wording |
+| Delivery | One PR per coarse task, dependency ordered | Keeps review scope small without regenerating micro-issues |
+
+---
+
+## Constitution Check
+
+- [x] **P1 Context Efficiency:** Entrypoints route to deep references; required
+      recovery/state detail stays on demand.
+- [x] **P2 Issue-Driven:** Six coarse implementation tasks are synchronized to
+      GitHub after this plan is approved.
+- [x] **P3 Spec-First:** This approved spec and plan precede implementation.
+- [x] **P4 Test-Driven:** Behavioral scenarios and seams are defined for every
+      task.
+- [x] **P5 Cross-Platform:** New executable workflow logic is Python 3.11+;
+      shell remains only as a compatibility adapter where necessary.
+- [x] **P6 Infrastructure Resilience:** Repeated issue amplification, generation
+      errors, skipped contracts, and scaffold bugs become explicit validators.
+
+---
+
+## Architecture
+
+### Component Overview
+
+```text
+project:init command adapter
+        |
+        v
+destination + route classifier ---> Wayfinder map adapter ---> spec/tasks
+        |                                  |
+        v                                  v
+deterministic scaffold engine        project:next collector/router
+        |                                  |
+        +------------- tested contracts ---+
+
+flow:wave reviewer ---> residual candidate ledger ---> close-time promotion
+                              |                         |
+                              +---- metrics + audit ----+
+
+canonical skill sources ---> surface validator ---> Claude/Codex installs
+                                      |
+                                      v
+                            compact CLAUDE.md routing
+```
+
+### Key Design Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|--------------------|--------|-----------|
+| Residual handling | Immediate issues; ignore extras; candidate ledger | Candidate ledger plus one close-time promotion pass | Preserves observations without treating every observation as authorized backlog |
+| Promotion authority | Reviewer; automated severity threshold; human at close | Human approval at closed-wave final tree | Severity labels alone did not stop generational issue growth |
+| Review enforcement | Prompt prose; GitHub hook only; executable local state machine | Executable state machine called by workflow adapters, backed by prompt guidance | Testable offline and hard to bypass accidentally |
+| Skill migration | Keep flat files; symlink mirrors; canonical package conversion | Canonical native packages and generated installs with parity validation | One source of truth and predictable discovery |
+| Project-init refactor | Rewrite command in place; Python engine under thin adapter | Characterization tests, then deterministic engine extraction | Protects current outputs while fixing known heredoc and branch defects |
+| Wayfinder trigger | Every init; every large project; unclear multi-session only | Destination first, then clarity x session-count gate | Matches the upstream narrow trigger and avoids planning tax |
+| Wayfinder storage | Full history in one prompt; map index plus linked decision records | Low-resolution map with linked decision records and explicit frontier | Supports multi-session work without loading full history every time |
+| Project-next engine | Optional sibling checkout; duplicate prompt logic; vendored contract core | Check in or package the authoritative deterministic core and fixture corpus with a drift/update procedure | CI must exercise the decision contract, not skip it |
+| Verbosity control | Universal line cap; preserve everything; layered information budget | Compact routing metadata, explicit modes, deep references for execution | Depth is retained where it changes decisions or prevents known failure |
+
+---
+
+## Component Contracts
+
+### Residual candidate ledger
+
+The implementation should expose a small CLI/module (provisional name
+`scripts/flow-wave-residuals.py`) with operations equivalent to:
+
+- `record`: validate and append a candidate or canonical-duplicate link.
+- `classify`: set the disposition allowed by the policy matrix.
+- `list`: return deterministic JSON for summaries and tests.
+- `close-wave`: freeze worker/reviewer mutation and enter promotion review.
+- `promote`: require closed wave, final-tree evidence, dedup result, eligible
+  classification, and explicit human approval before invoking issue creation.
+- `summary`: emit seed, recorded, duplicate, promoted, and ratio metrics.
+
+The ledger belongs in the existing wave runtime directory, uses an atomic write
+strategy, and records schema version and timestamps. Tests inject a fake issue
+creator; they never require network access.
+
+### Skill surface validator
+
+The validator walks canonical Claude and Codex skill packages, parses required
+metadata, resolves local references, identifies deprecated flat files and stale
+mirrors, and distinguishes managed installed content from user-authored content.
+`make skills-check` is read-only. Install/repair remains an explicit separate
+operation. Migration retains activation summaries under the constitution's
+200-character limit and moves long lookup material into `reference.md` only when
+the owning workflow can load it on demand.
+
+### Project initialization engine
+
+Extract template rendering and repository mutation behind typed input/output
+models. A plan phase returns proposed writes and commands; an apply phase performs
+them; checkpoints record completed semantic steps rather than prompt line
+numbers. `--dry-run` executes plan only. Resume revalidates the input fingerprint
+and current filesystem before continuing. Framework fixtures lock current
+supported outputs before refactoring.
+
+### Wayfinder adapter
+
+The adapter first records a human-confirmed destination, then classifies two
+axes: route clarity and whether planning exceeds one agent session. It routes:
+
+| Route | Expected sessions | Action |
+|-------|-------------------|--------|
+| Clear | One | Scaffold |
+| Clear | Multiple | Spec and implementation tasks |
+| Unclear | One | Focused clarification/grill, then reclassify |
+| Unclear | Multiple | Offer Wayfinder map; after approval, chart decisions and stop |
+
+The map is an index with destination, one-line decisions, fog, out of scope, and
+links. Questions live in decision records with blocking edges and one of
+`grilling`, `prototype`, `research`, or decision-blocking `task`. Production
+implementation is prohibited in the map. Tracker mutations are exposed as a
+plan first and require confirmation.
+
+### Project-next planning contract
+
+Extend collection to native issue graph and ownership fields, preserving the
+existing documented text grammar as fallback. Normalize both sources into one
+tested model with provenance and uncertainty. Planning artifacts produce actions
+such as `resolve decision`, `clarify destination`, or `collapse cleared map to
+spec`; implementation artifacts retain current flow actions. Brief, compact, and
+full renderers consume the same decision result.
+
+### Persistent context budget
+
+Reduce `CLAUDE.md` only after canonical code and reference locations exist.
+Retain global safety, repository topology, source-of-truth pointers, quality
+commands, and the smallest routing table. Move detailed histories, examples, and
+state-machine instructions to owned references. Add a word-budget and broken-link
+test; do not treat the word target as permission to delete required invariants.
+
+---
+
+## Dependencies
+
+### External Dependencies
+
+No new runtime packages or services are planned. GitHub interaction continues
+through the existing `gh` integration. Wayfinder concepts are adapted from the
+MIT-licensed `mattpocock/skills` project with attribution; the upstream skill is
+not copied or fetched at runtime.
+
+### Internal Dependencies
+
+| Module or surface | Purpose |
+|-------------------|---------|
+| `.claude/commands/flow/wave.md` and `register.md` | Wave orchestration and reviewer policy adapters |
+| `scripts/flow-wave-lexicon.sh` and wave runtime helpers | Existing state/ledger validation seams |
+| `.claude/skills/`, `codex/skills/`, `scripts/codex-skill-sync.py` | Canonical and generated skill surfaces |
+| `.claude/commands/project/init.md` | Current scaffold behavior and future thin adapter |
+| `.claude/commands/project/next.md`, `docs/project-next-contract.md` | Current planning/implementation routing contract |
+| `tests/test_project_next_contract.py` | Existing optional-engine contract test to make authoritative |
+| `scripts/eli5-vendor.py` and drift tests | Pattern for checked-in external deterministic core/fixture updates |
+| `CLAUDE.md` | Always-loaded repository context to trim last |
+
+---
+
+## Expected File Structure
+
+Exact names may be refined in each issue, but ownership should converge on:
+
+```text
+scripts/
+├── flow-wave-residuals.py
+├── skill-surface-check.py
+├── project-init.py
+└── project-next.py                 # or packaged equivalent
+templates/project-init/
+├── python/
+├── node/
+├── go/
+└── rust/
+tests/
+├── test_flow_wave_residuals.py
+├── test_skill_surface_check.py
+├── test_project_init.py
+├── test_project_wayfinder.py
+└── test_project_next_contract.py
+.claude/skills/<skill>/
+├── SKILL.md
+└── reference.md                    # only when depth is required
+.claude/commands/project/
+├── init.md
+└── next.md
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Control backlog growth
+
+| Task ID | Description | Primary files | Dependencies |
+|---------|-------------|---------------|--------------|
+| T001 | Implement the residual candidate ledger, close-time promotion gate, metrics, and behavioral wave tests | `scripts/flow-wave-residuals.py`, wave command/reference mirrors, `tests/` | - |
+
+This PR lands first. It is the control plane for all later review work.
+
+### Phase 2: Establish deterministic foundations
+
+| Task ID | Description | Primary files | Dependencies |
+|---------|-------------|---------------|--------------|
+| T002 | Canonicalize native skill packages and add read-only source/reference/install parity validation | `.claude/skills/`, `codex/skills/`, `scripts/`, `Makefile`, `tests/` | T001 |
+| T003 | Characterize and extract deterministic project initialization with dry-run/resume support and known scaffold fixes | `.claude/commands/project/init.md`, `scripts/project-init.py`, templates, `tests/` | T001 |
+
+T002 and T003 may run in parallel with at most two workers.
+
+### Phase 3: Integrate discovery and routing
+
+| Task ID | Description | Primary files | Dependencies |
+|---------|-------------|---------------|--------------|
+| T004 | Add destination-first Wayfinder classification, approved map creation, decision frontier, and resumable handoff to spec | project init adapter/engine, project command/skill references, `tests/` | T003 |
+| T005 | Consume native issue relationships, route planning artifacts safely, and make the authoritative project-next engine/fixtures available in CI | project-next engine/contract/docs/tests | T004 |
+
+These land sequentially because T005 consumes T004's artifact contract.
+
+### Phase 4: Reduce persistent context
+
+| Task ID | Description | Primary files | Dependencies |
+|---------|-------------|---------------|--------------|
+| T006 | Trim `CLAUDE.md` to durable invariants and routing pointers, with budget/reference/behavior checks | `CLAUDE.md`, owned references, `tests/` | T002, T003, T004, T005 |
+
+Trimming last ensures every removed detail already has a tested owner.
+
+---
+
+## Delivery and Wave Policy
+
+- One GitHub issue and one focused PR per task.
+- T001 lands alone.
+- T002 and T003 form a two-worker wave after T001.
+- T004 and T005 are sequential; T006 is final.
+- At most three seed issues and two workers in any wave.
+- Worker/reviewer residuals go to the candidate ledger. They do not create
+  implementation issues during the wave.
+- Active-PR defects are repaired before merge.
+- After the final tested tree, run one candidate promotion pass and report the
+  recorded/promoted ratio.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| The promotion gate suppresses real defects | Medium | High | Record every finding, preserve evidence, support human close-time promotion, measure both recorded and promoted |
+| Prose adapters bypass executable policy | Medium | High | Give all adapters one CLI/module and test forbidden state transitions |
+| Skill migration breaks discovery for one agent | Medium | High | Inventory before mutation, parity fixtures, managed-only install repair, rollback mapping |
+| Project-init refactor changes generated files | Medium | High | Characterization fixtures first, byte-level plan snapshots, separate refactor from Wayfinder behavior |
+| Wayfinder becomes a default bureaucracy | Medium | High | Narrow two-axis trigger, opening no-fog escape, explicit approval before map creation |
+| Decision tickets drift into implementation tasks | High | Medium | Enforce question-form/type contract and route them away from `flow:auto` |
+| Native GitHub fields vary by API availability | Medium | Medium | Normalize provenance, retain text fallback, expose uncertainty |
+| Vendored project-next core drifts | Medium | Medium | Manifest/upstream version, deterministic update command, drift test patterned after ELI5 |
+| CLAUDE.md trimming removes a safety invariant | Low | High | Inventory retained invariants, link checks, workflow regression tests, final task only |
+| Metrics are gamed by not declaring residuals | Medium | High | Reviewer completion requires ledger record or canonical duplicate; report review completeness separately |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Residual schema, classification transitions, generation rules,
+  deduplication, approval, ratios, and atomic persistence.
+- Skill metadata length, required fields, link resolution, duplicate ownership,
+  managed marker behavior, and stale mirror detection.
+- Project input validation, template rendering, plan hashing, checkpoint resume,
+  and default branch selection.
+- Route classifier truth table and Wayfinder ticket/map invariants.
+- Native/text issue normalization, uncertainty, action routing, and renderer
+  equivalence.
+- Persistent-context budget and reference resolution.
+
+### Integration Tests
+
+- Run a simulated wave from residual declaration through closed-wave promotion
+  using a fake issue creator; assert no call occurs earlier.
+- Compare current and extracted scaffold fixtures for Python, Node, Go, and Rust;
+  verify dry-run leaves an empty target unchanged.
+- Simulate a foggy initialization, approval, decision resolution, map clear, spec
+  handoff, and resume.
+- Exercise `project:next` against fixture graphs containing native blockers,
+  parents/sub-issues, assignments, Wayfinder maps, and implementation issues.
+- Run `make skills-check`, Codex generated-surface checks, and standard `make
+  verify` from a clean checkout.
+
+### Mutation and Negative Tests
+
+- Remove a residual consequence/evidence field and assert promotion fails.
+- Attempt promotion while the wave is active and assert the issue creator is not
+  called.
+- Break one skill reference or add a stale managed install file and assert the
+  check fails without deleting user content.
+- Restore the quoted-heredoc and implicit-default-branch bugs in fixtures and
+  assert tests fail.
+- Route a `wayfinder:grilling` item to `flow:auto` and assert the contract fails.
+- Remove the bundled project-next core/fixtures and assert CI fails rather than
+  skips.
+
+### Manual Verification
+
+- Review the first real wave summary for understandable recorded/promoted
+  metrics and conduct the explicit promotion confirmation.
+- Exercise one small-clear and one large-foggy `project:init` flow in Claude Code
+  and Codex installs.
+- Read the compact `project:next` output to confirm it remains decision-complete,
+  then compare `--brief` and `--full` views.
+- Review the final `CLAUDE.md` as a cold-start agent navigation document.
+
+---
+
+## Rollout and Measurement
+
+1. Land T001 and use it for all subsequent waves.
+2. Capture baseline and per-wave counts in close summaries: seeds, residuals
+   recorded, duplicates, promoted issues, amplification, and promotion rate.
+3. If a four-seed wave promotes more than one issue, pause new waves and inspect
+   classification/evidence quality before changing thresholds.
+4. After three eligible waves, review whether amplification is <= 0.25 and
+   whether any undeclared defects escaped. Tune the policy from evidence rather
+   than prompt length.
+5. Keep each compatibility migration reversible until its installed-surface and
+   behavioral tests pass in a clean environment.
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License).*

--- a/.specify/specs/balanced-agentic-development/spec.md
+++ b/.specify/specs/balanced-agentic-development/spec.md
@@ -1,0 +1,320 @@
+# Feature Specification: Balanced Agentic Development
+
+> **Branch:** `spec/balanced-agentic-development`
+> **Created:** 2026-08-15
+> **Status:** Approved
+
+---
+
+## Overview
+
+Claude Power Pack (CPP) should remain thorough where thoroughness changes a
+development decision, while becoming compact at discovery and routing seams.
+Today those concerns are mixed: some skills expose implementation detail before
+it is needed, `project:init` scaffolds before it establishes whether the route is
+known, and `flow:wave` can turn review observations into a self-expanding issue
+graph. The result is contradictory feedback that the pack is simultaneously too
+verbose, too prescriptive, and not explicit enough.
+
+This feature defines one balancing model:
+
+1. **Compact routing, deep execution.** Entrypoints state when to use a workflow,
+   its contract, and where deeper guidance lives. Stateful execution skills may
+   remain detailed when omission has caused observed failures.
+2. **Decisions before implementation.** `project:init` names the destination and
+   selects a discovery path before choosing a framework or writing files.
+3. **Evidence before backlog growth.** Review records every residual, but only a
+   post-wave promotion pass may create a follow-up issue.
+4. **Executable contracts over prose enforcement.** Critical workflow rules are
+   represented by deterministic state, validators, and behavioral tests.
+
+The Wayfinder portion adapts Matt Pocock's situational planning on-ramp: an
+effort that is both larger than one agent session and whose route is unclear is
+charted as a map of decision questions, then handed to specification and
+implementation only after the route is clear. It is not a default planning tax
+and does not execute product work. See the upstream
+[Wayfinder documentation](https://github.com/mattpocock/skills/blob/main/docs/engineering/wayfinder.md)
+(MIT).
+
+---
+
+## User Stories
+
+### US1: Review without backlog amplification [P1]
+
+**As a** wave orchestrator,
+**I want** reviewers to record residual findings without immediately filing
+issues,
+**So that** review remains complete without creating work faster than a wave
+closes it.
+
+**Acceptance Criteria:**
+- [ ] Every review residual is recorded in a structured candidate ledger.
+- [ ] Review and worker sessions cannot create ordinary residual issues during
+      an active wave.
+- [ ] Acceptance-criteria failures and regressions introduced by the active PR
+      are fixed in that PR, not deferred.
+- [ ] Follow-up issues are created only by a single post-wave promotion pass
+      after final-tree revalidation, deduplication, evidence review, and human
+      approval.
+- [ ] The wave summary reports seed count, recorded candidates, promoted
+      candidates, and amplification ratio.
+
+**Test Scenarios:**
+1. Given a reviewer finds a current-PR regression, when it classifies the
+   finding, then the ledger marks it `fix-current-pr` and the issue promotion
+   path rejects it.
+2. Given a serious pre-existing defect with reproducible evidence, when the wave
+   closes, then a human may promote one deduplicated candidate after it is
+   revalidated against the final tree.
+3. Given a speculative improvement or a generation-2 residual, when promotion
+   runs, then it remains ledger-only unless the emergency exception and explicit
+   human approval both apply.
+
+---
+
+### US2: Trustworthy native skill discovery [P1]
+
+**As a** CPP maintainer or installer,
+**I want** every supported agent to discover the same valid skill surface,
+**So that** installed behavior does not depend on stale mirrors, legacy flat
+files, or broken references.
+
+**Acceptance Criteria:**
+- [ ] Claude-native skills use directory-based `SKILL.md` structure with concise
+      activation metadata and progressively disclosed reference material.
+- [ ] A repository check validates skill metadata, relative references, source
+      parity, and installed-surface parity without mutating user-authored skills.
+- [ ] Stale `.agents/skills` mirrors and retired wrappers are either removed or
+      reported with an actionable owner/source-of-truth message.
+- [ ] `make skills-check` fails deterministically for a broken reference,
+      duplicate surface, or managed install drift.
+
+---
+
+### US3: Deterministic project initialization [P1]
+
+**As a** developer starting or resuming a project,
+**I want** `project:init` to produce predictable, testable output,
+**So that** orchestration prose cannot silently generate malformed repositories.
+
+**Acceptance Criteria:**
+- [ ] Existing Python, Node, Go, and Rust scaffold behavior is characterized by
+      tests before it is refactored.
+- [ ] File generation, template rendering, checkpoint state, dry-run, and resume
+      behavior live behind a deterministic Python interface.
+- [ ] Generated files contain resolved values rather than literal shell variable
+      placeholders.
+- [ ] New Git repositories consistently use `main` regardless of local Git
+      defaults.
+- [ ] The command document becomes an orchestration adapter rather than the only
+      executable definition of the workflow.
+
+---
+
+### US4: Wayfinder discovery gate [P1]
+
+**As a** developer with a new project idea,
+**I want** initialization to distinguish a clear route from multi-session fog,
+**So that** simple projects start quickly and ambiguous projects resolve
+decisions before committing to a stack.
+
+**Acceptance Criteria:**
+- [ ] `project:init` records an agreed destination before framework selection or
+      file generation.
+- [ ] A clear, single-session effort proceeds directly to scaffolding.
+- [ ] A clear, multi-session effort proceeds to the existing spec/task workflow
+      without creating a Wayfinder map.
+- [ ] An unclear, multi-session effort offers a Wayfinder map and stops before
+      production scaffolding; map creation requires explicit user approval.
+- [ ] Wayfinder items are decision questions, not implementation slices, and the
+      cleared map hands off to a spec rather than code or a pull request.
+- [ ] The map preserves destination, decisions so far, not-yet-specified fog,
+      out-of-scope items, blocking edges, and the open/unblocked frontier.
+
+**Test Scenarios:**
+1. Given a well-scoped CLI, when initialization classifies it as clear and
+   single-session, then no map or planning issues are created.
+2. Given a large application with settled architecture, when initialization
+   classifies it as clear and multi-session, then it creates or links a spec and
+   implementation tasks without Wayfinder decision tickets.
+3. Given a large idea whose key route decisions are unknown, when the user
+   approves Wayfinder, then initialization records the map and exits with a
+   resumable `awaiting-decisions` state.
+
+---
+
+### US5: Planning-aware next-action routing [P2]
+
+**As a** developer asking what to do next,
+**I want** `project:next` to understand native issue relationships and planning
+artifacts,
+**So that** it recommends the real frontier and never sends a decision question
+to an implementation workflow.
+
+**Acceptance Criteria:**
+- [ ] The collector consumes GitHub `blockedBy`, `blocking`, parent, sub-issue,
+      and assignee data when available, with explicit uncertainty when not.
+- [ ] Wayfinder maps and decision tickets route to planning/resolution actions,
+      never `flow:auto`.
+- [ ] The authoritative decision engine and contract fixture are available in CI;
+      contract tests do not skip because a sibling repository is absent.
+- [ ] `project:next` retains brief, compact, and full views. Required evidence is
+      preserved in compact output rather than removed to meet an arbitrary line
+      target.
+
+---
+
+### US6: Small persistent context, deep on-demand guidance [P2]
+
+**As an** agent working in CPP,
+**I want** always-loaded instructions to contain only durable invariants and
+routing pointers,
+**So that** context is spent on the active problem without weakening necessary
+execution guidance.
+
+**Acceptance Criteria:**
+- [ ] `CLAUDE.md` contains repository identity, safety constraints, source-of-truth
+      pointers, verification commands, and workflow routing—not command histories
+      or duplicated manuals.
+- [ ] Detailed state machines remain in the skill or reference that owns them.
+- [ ] An automated budget and reference check prevents persistent context from
+      silently expanding or pointing to missing documentation.
+- [ ] No execution skill is shortened solely by line count; reductions require a
+      preserved behavioral contract and regression coverage.
+
+---
+
+## Residual Classification and Promotion Policy
+
+| Classification | During the wave | At close |
+|----------------|-----------------|----------|
+| Current issue acceptance failure | Fix before issue closes | Never promote |
+| Defect introduced by active PR | Fix in the same PR | Never promote |
+| Serious pre-existing, out-of-scope defect | Record candidate with consequence and evidence | Revalidate, dedupe, then offer for human promotion |
+| Security/data-loss/work-blocking emergency | Record and stop unsafe work if needed | Human may explicitly promote despite generation limit |
+| Speculative improvement or cleanup | Record as observation | Ledger-only by default |
+| Duplicate of existing issue/candidate | Link the canonical record | Never create another issue |
+
+Each candidate MUST contain `candidate_id`, `root_issue`, `source_issue`,
+`generation`, `classification`, `consequence`, `evidence`, `disposition`, and
+timestamps. Promotion is impossible while the wave is active. Generation 2+
+candidates cannot be auto-promoted; in normal operation no candidate is
+auto-promoted at any generation.
+
+---
+
+## Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| A finding changes classification after another PR lands | Revalidate against the final tested tree and update the ledger; do not preserve a stale promotion decision |
+| A worker tries to call `gh issue create` for a residual | The wave policy blocks the path and instructs the worker to append a candidate record |
+| The same defect is found by several reviewers | Merge evidence into one candidate and retain all source links |
+| There are zero seed issues | Do not compute a misleading amplification ratio; report `not-applicable` |
+| A candidate has no reproducible evidence | Keep it recorded but ineligible for promotion |
+| GitHub native dependency fields are unavailable | Fall back to documented text parsing and mark the inferred edge uncertain |
+| Wayfinder's opening check finds no fog | Skip the map and continue to spec or scaffold according to expected session count |
+| A Wayfinder item says "build X" | Reject or reclassify it; implementation belongs downstream of the cleared map |
+| Initialization is resumed after decisions clear | Collapse linked decisions into the spec, then continue from the saved checkpoint without re-asking settled questions |
+| A generated project directory already contains files | Preserve current conflict/resume semantics and make the dry-run disclose every proposed write |
+| A detailed skill is long because it encodes recovery states | Move lookup material to references where safe, but retain state transitions and behavioral tests |
+
+---
+
+## Out of Scope
+
+- Replacing CPP's entire issue-driven development model.
+- Automatically importing or continuously updating Matt Pocock's full skill set.
+- Running Wayfinder for this already-decided CPP improvement effort.
+- Allowing Wayfinder to implement production code.
+- Filing an issue for every review observation.
+- Shortening `project:next` or `flow:wave` by deleting evidence, recovery states,
+  or previously proven safeguards.
+- Changing model/provider selection or adding a runtime service dependency.
+- Retrofitting historical waves or historical issue metrics.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Priority | User Story |
+|----|-------------|----------|------------|
+| R1 | Persist all wave residuals in a machine-readable candidate ledger | Must | US1 |
+| R2 | Enforce the residual classification and promotion state machine in code, not prose alone | Must | US1 |
+| R3 | Permit issue creation only in a closed-wave, human-approved promotion transaction | Must | US1 |
+| R4 | Report issue-economy metrics in every wave close summary | Must | US1 |
+| R5 | Validate canonical skill layout, references, mirrors, and managed install parity | Must | US2 |
+| R6 | Convert supported Claude-native skills to directory-based `SKILL.md` packages with progressive disclosure | Must | US2 |
+| R7 | Characterize and extract deterministic project generation before changing its user-visible routing | Must | US3 |
+| R8 | Support idempotent dry-run and checkpointed resume across Python, Node, Go, and Rust | Must | US3 |
+| R9 | Classify discovery by route clarity and expected session count after recording the destination | Must | US4 |
+| R10 | Create a Wayfinder map only for unclear multi-session work and only after user approval | Must | US4 |
+| R11 | Keep decision tickets distinct from implementation tasks and hand a cleared map to specification | Must | US4 |
+| R12 | Consume native issue graph and ownership fields with explicit fallbacks | Should | US5 |
+| R13 | Route Wayfinder artifacts to planning actions and make the project-next engine testable in this repository | Must | US5 |
+| R14 | Preserve brief, compact, and full `project:next` views under a shared decision contract | Must | US5 |
+| R15 | Reduce always-loaded repository guidance while keeping execution detail available on demand | Should | US6 |
+| R16 | Run each implementation task through behavioral tests and the standard finish gate | Must | All |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Metric |
+|----|-------------|--------|
+| NFR1 | Issue economy | Over the first three eligible waves after release, promoted follow-ups / seed issues is <= 0.25; pause and review the policy when a four-seed wave promotes more than one follow-up |
+| NFR2 | Review completeness | 100% of declared residuals have a ledger record or a linked canonical duplicate |
+| NFR3 | Promotion safety | 0 generation-2+ candidates are promoted without explicit human approval and emergency consequence evidence |
+| NFR4 | Determinism | Repeating `project:init --dry-run` with the same inputs produces byte-identical output and no filesystem mutation |
+| NFR5 | Context efficiency | `CLAUDE.md` is <= 2,000 words, all references resolve, and detailed command state machines live outside always-loaded context |
+| NFR6 | Test reliability | No project-next contract test skips because an optional sibling checkout is missing |
+| NFR7 | Compatibility | Existing command names and documented modes remain available unless a task explicitly documents a migration |
+| NFR8 | Portability | New executable workflow logic uses Python 3.11+ and passes Linux/macOS-compatible tests without network access |
+
+---
+
+## Success Criteria
+
+- [ ] A behavioral test proves an in-wave reviewer cannot promote a residual issue.
+- [ ] A behavioral test proves a current-PR defect is routed back to that PR.
+- [ ] Wave summaries distinguish residuals recorded from follow-ups promoted.
+- [ ] `make skills-check` detects broken references and managed-surface drift.
+- [ ] Characterization fixtures cover all four supported project families plus
+      dry-run, resume, placeholder rendering, and default branch behavior.
+- [ ] Wayfinder routing tests cover all four clarity/session combinations and
+      require approval before tracker mutation.
+- [ ] Project-next tests exercise native relationships and planning-only routes
+      without a sibling repository.
+- [ ] `CLAUDE.md` satisfies its context budget without moving required global
+      safety rules out of persistent context.
+- [ ] Standard repository verification passes for every implementation PR.
+- [ ] Documentation explains when depth is valuable instead of describing all
+      verbosity as a defect.
+
+---
+
+## Operating Constraints
+
+- Run at most three seed issues in one implementation wave and at most two
+  concurrent workers until issue-economy metrics demonstrate stability.
+- Do not create residual issues during worker execution or review.
+- Repair active-PR regressions in the active PR.
+- Run one promotion pass after the wave reaches a final tested tree.
+- Require evidence for promotion; generation 2+ remains ledger-only absent an
+  explicit human-approved emergency.
+- Report both recorded and promoted counts so apparent review thoroughness is
+  not confused with backlog growth.
+
+---
+
+## Open Questions
+
+No blocking product questions remain. Each implementation task may refine file
+placement through tests, but it must preserve this routing and issue-economy
+contract.
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License).*
+*Wayfinder concepts adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT License); no upstream skill text is vendored by this specification.*

--- a/.specify/specs/balanced-agentic-development/tasks.md
+++ b/.specify/specs/balanced-agentic-development/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: Balanced Agentic Development
+
+> **Plan:** [plan.md](./plan.md)
+> **Created:** 2026-08-15
+> **Status:** Ready
+
+---
+
+## Task Format
+
+```text
+[ID] [P?] [Story] Description (depends on X, Y)
+```
+
+These are intentionally coarse delivery tasks: one issue and one reviewable PR
+per task. Acceptance criteria live in the linked spec and in each task's
+checkpoint. Implementation discoveries are recorded in the residual ledger and
+are not automatically expanded into more tasks.
+
+---
+
+## Wave 1: Establish issue economy
+
+- [ ] T001 [US1] Implement an executable `flow:wave` residual candidate ledger, classification state machine, final-tree human promotion gate, issue-economy metrics, prompt/reference integration, and behavioral tests
+
+**Checkpoint:** A simulated wave records every residual, cannot create a
+follow-up while active, routes active-PR defects back to the PR, and can promote
+only one eligible, revalidated, deduplicated, human-approved candidate after
+closure. The summary reports seeds, recorded, duplicates, promoted,
+amplification, and promotion rate.
+
+---
+
+## Wave 2: Repair foundations
+
+- [ ] T002 [P] [US2] Convert supported native skills to canonical directory-based `SKILL.md` packages, remove or report stale mirrors/retired wrappers, and add non-mutating source/reference/managed-install parity checks through `make skills-check` (depends on T001)
+- [ ] T003 [P] [US3] Add Python/Node/Go/Rust characterization fixtures and extract a deterministic `project:init` planning/apply engine with idempotent dry-run, validated resume checkpoints, resolved template values, and explicit `main` initialization (depends on T001)
+
+**Checkpoint:** T002 and T003 each pass independently. A clean skill install has
+surface parity without touching user-authored skills. Repeated init plans are
+byte-identical, dry-run does not mutate, resume does not repeat completed work,
+and existing supported scaffold outputs remain compatible except for the two
+specified bug fixes.
+
+---
+
+## Wave 3: Add discovery and planning-aware routing
+
+- [ ] T004 [US4] Add a destination-first clarity/session-count gate to `project:init`, explicitly approved Wayfinder maps of decision questions with fog/frontier/blocking state, and a resumable cleared-map handoff to specification without production implementation (depends on T003)
+- [ ] T005 [US5] Extend `project:next` with native blockedBy/blocking/parent/sub-issue/assignee collection, planning-only Wayfinder routes, explicit fallback uncertainty, shared brief/compact/full decisions, and an authoritative in-repo engine/fixture contract that cannot skip in CI (depends on T004)
+
+**Checkpoint:** All four discovery routes are covered. No tracker mutation occurs
+without approval, no decision ticket routes to `flow:auto`, and native and
+fallback issue graphs produce explainable recommendations from the same tested
+decision core.
+
+---
+
+## Wave 4: Minimize persistent context safely
+
+- [ ] T006 [US6] Reduce `CLAUDE.md` to durable invariants, safety rules, verification commands, source-of-truth pointers, and workflow routing; move owned depth to on-demand references and add word-budget, link, and behavior-preservation checks (depends on T002, T003, T004, T005)
+
+**Checkpoint:** `CLAUDE.md` is at most 2,000 words, every pointer resolves, cold
+start navigation remains sufficient, detailed state machines remain available
+from their owning skills, and the full repository verification suite passes.
+
+---
+
+## Delivery Guardrails
+
+- Land T001 before starting Wave 2.
+- Run at most two workers concurrently; T002 and T003 are the only planned
+  parallel pair.
+- Keep each task to one focused PR and fix regressions introduced by that PR
+  before merge.
+- Do not file issues from worker or reviewer residuals. Use the candidate ledger
+  and one post-wave promotion pass.
+- Require evidence and final-tree revalidation for promotion. Generation 2+
+  candidates remain ledger-only absent a human-approved security, data-loss, or
+  work-blocking emergency.
+- Report recorded and promoted counts at every checkpoint.
+
+---
+
+## Issue Sync
+
+> Generated once from this file with `scripts/speckit-tasks-to-issues.sh` after
+> validation. The mapping below is updated in the same specification PR.
+
+| Task | Issue | Status |
+|------|-------|--------|
+| T001 | [#719](https://github.com/cooneycw/claude-power-pack/issues/719) | open |
+| T002 | [#720](https://github.com/cooneycw/claude-power-pack/issues/720) | open |
+| T003 | [#721](https://github.com/cooneycw/claude-power-pack/issues/721) | open |
+| T004 | [#722](https://github.com/cooneycw/claude-power-pack/issues/722) | open |
+| T005 | [#723](https://github.com/cooneycw/claude-power-pack/issues/723) | open |
+| T006 | [#724](https://github.com/cooneycw/claude-power-pack/issues/724) | open |
+
+---
+
+## Notes
+
+- `[P]` means the task may run alongside the other `[P]` task after all listed
+  dependencies have merged.
+- Task issues are the approved implementation plan, not residual issues created
+  by review.
+- Wayfinder is not used for this work because its destination and route are
+  already specified; T004 adds it for future foggy, multi-session projects.
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License).*


### PR DESCRIPTION
## Summary

- define an executable issue-economy policy for `flow:wave` residuals
- plan deterministic skill discovery and `project:init` foundations
- adapt Wayfinder as a narrow, destination-first discovery gate
- preserve decision-complete `project:next` depth while reducing persistent context
- sync six coarse, dependency-ordered implementation tasks (#719-#724)

The implementation issues intentionally remain open; this PR publishes their approved source-of-truth spec and plan.

## Verification

- `make verify` (1648 passed, 1 existing skip)
- `scripts/flow-finish-gate.sh` (4/4: lint, test, typecheck, security)
- task sync repeat dry-run: 0 creates, 6 skips