### PR TITLE
docs(spec): add knowledge graduation lifecycle

### DIFF
--- a/.specify/specs/balanced-agentic-development/plan.md
+++ b/.specify/specs/balanced-agentic-development/plan.md
@@ -3,6 +3,7 @@
 > **Branch:** `spec/balanced-agentic-development`
 > **Spec:** [spec.md](./spec.md)
 > **Created:** 2026-08-15
+> **Amended:** 2026-08-16 - knowledge graduation lifecycle
 > **Status:** Approved
 
 ---
@@ -15,7 +16,10 @@ the deterministic `project:init` engine in parallel. Add the Wayfinder discovery
 gate only after initialization is testable, teach `project:next` the resulting
 planning graph, and trim always-loaded context last. This order prevents review
 from multiplying work while the remaining improvements are underway and avoids
-rewriting prose before executable sources of truth exist.
+rewriting prose before executable sources of truth exist. The final phase also
+adds a knowledge-graduation gate: active specs coordinate delivery, then durable
+facts move into code, tests, narrow documentation, or explicit remaining issues
+before the completed spec is removed.
 
 ---
 
@@ -149,7 +153,9 @@ The map is an index with destination, one-line decisions, fog, out of scope, and
 links. Questions live in decision records with blocking edges and one of
 `grilling`, `prototype`, `research`, or decision-blocking `task`. Production
 implementation is prohibited in the map. Tracker mutations are exposed as a
-plan first and require confirmation.
+plan first and require confirmation. A cleared map creates an `active`,
+transitional implementation spec linked to its decision evidence; it does not
+create permanent product documentation by default.
 
 ### Project-next planning contract
 
@@ -158,7 +164,11 @@ existing documented text grammar as fallback. Normalize both sources into one
 tested model with provenance and uncertainty. Planning artifacts produce actions
 such as `resolve decision`, `clarify destination`, or `collapse cleared map to
 spec`; implementation artifacts retain current flow actions. Brief, compact, and
-full renderers consume the same decision result.
+full renderers consume the same decision result. The normalized model also
+tracks spec lifecycle: `active` still governs unresolved work, `graduated` is
+intentionally absent after a verified knowledge transfer, and `stale` conflicts
+with current tracker or implementation evidence. Missing-file warnings apply to
+active specs, not graduated ones.
 
 ### Persistent context budget
 
@@ -167,6 +177,27 @@ Retain global safety, repository topology, source-of-truth pointers, quality
 commands, and the smallest routing table. Move detailed histories, examples, and
 state-machine instructions to owned references. Add a word-budget and broken-link
 test; do not treat the word target as permission to delete required invariants.
+New projects receive only a compact knowledge-lifecycle rule and pointer, not a
+copy of the full policy.
+
+### Knowledge graduation contract
+
+Create one canonical reference, provisionally
+`docs/agents/knowledge-lifecycle.md`, that defines the mapping from completed
+spec knowledge to code/tests, schemas, local intent comments, ADRs, domain
+glossaries, runbooks, public contracts, or remaining issues. Project setup,
+Wayfinder/spec handoff, implementation review, finish/close-out, project-next,
+and documentation guidance point to that contract only at their lifecycle
+boundary.
+
+The graduation check consumes the active spec, its tasks/issues, the final diff
+and tests, and an explicit mapping record. It fails closed for an unmapped
+acceptance criterion, unresolved task, or missing durable owner. It records a
+machine-readable `graduated` marker and evidence links on the tracker/PR before
+the spec is removed. Regulatory, contractual, compliance, public-protocol, and
+cross-team interface specs are marked `retained` with an owner instead. The
+balanced-agentic-development spec is the first graduation candidate after all
+six implementation tasks complete.
 
 ---
 
@@ -191,6 +222,8 @@ not copied or fetched at runtime.
 | `tests/test_project_next_contract.py` | Existing optional-engine contract test to make authoritative |
 | `scripts/eli5-vendor.py` and drift tests | Pattern for checked-in external deterministic core/fixture updates |
 | `CLAUDE.md` | Always-loaded repository context to trim last |
+| `docs/agents/knowledge-lifecycle.md` | Canonical knowledge-graduation policy loaded only at lifecycle boundaries |
+| Spec/review/finish command and skill references | Graduation producers and enforcement points |
 
 ---
 
@@ -214,7 +247,10 @@ tests/
 ├── test_skill_surface_check.py
 ├── test_project_init.py
 ├── test_project_wayfinder.py
-└── test_project_next_contract.py
+├── test_project_next_contract.py
+└── test_knowledge_graduation.py
+docs/agents/
+└── knowledge-lifecycle.md
 .claude/skills/<skill>/
 ├── SKILL.md
 └── reference.md                    # only when depth is required
@@ -248,8 +284,8 @@ T002 and T003 may run in parallel with at most two workers.
 
 | Task ID | Description | Primary files | Dependencies |
 |---------|-------------|---------------|--------------|
-| T004 | Add destination-first Wayfinder classification, approved map creation, decision frontier, and resumable handoff to spec | project init adapter/engine, project command/skill references, `tests/` | T003 |
-| T005 | Consume native issue relationships, route planning artifacts safely, and make the authoritative project-next engine/fixtures available in CI | project-next engine/contract/docs/tests | T004 |
+| T004 | Add destination-first Wayfinder classification, approved map creation, decision frontier, and resumable handoff to an active transitional spec | project init adapter/engine, project command/skill references, `tests/` | T003 |
+| T005 | Consume native issue relationships, route planning artifacts safely, model active/graduated/stale specs, and make the authoritative project-next engine/fixtures available in CI | project-next engine/contract/docs/tests | T004 |
 
 These land sequentially because T005 consumes T004's artifact contract.
 
@@ -257,7 +293,7 @@ These land sequentially because T005 consumes T004's artifact contract.
 
 | Task ID | Description | Primary files | Dependencies |
 |---------|-------------|---------------|--------------|
-| T006 | Trim `CLAUDE.md` to durable invariants and routing pointers, with budget/reference/behavior checks | `CLAUDE.md`, owned references, `tests/` | T002, T003, T004, T005 |
+| T006 | Trim `CLAUDE.md`, install the compact generated-project lifecycle rule, add one canonical graduation contract and boundary-skill pointers, and enforce verified spec graduation | `CLAUDE.md`, project setup/config guidance, lifecycle references, finish/review surfaces, `tests/` | T002, T003, T004, T005 |
 
 Trimming last ensures every removed detail already has a tested owner.
 
@@ -292,6 +328,9 @@ Trimming last ensures every removed detail already has a tested owner.
 | Vendored project-next core drifts | Medium | Medium | Manifest/upstream version, deterministic update command, drift test patterned after ELI5 |
 | CLAUDE.md trimming removes a safety invariant | Low | High | Inventory retained invariants, link checks, workflow regression tests, final task only |
 | Metrics are gamed by not declaring residuals | Medium | High | Reviewer completion requires ledger record or canonical duplicate; report review completeness separately |
+| Specs are deleted before durable knowledge is represented | Medium | High | Fail-closed criterion mapping, unresolved-task check, tracker evidence, and retained-spec exceptions |
+| The graduation rule is copied into every skill and drifts | Medium | Medium | One canonical normative reference; compact pointers only at lifecycle boundaries |
+| `project:next` treats intentional graduation as missing documentation | Medium | Medium | Explicit lifecycle markers and fixtures for active, graduated, stale, and retained states |
 
 ---
 
@@ -310,6 +349,8 @@ Trimming last ensures every removed detail already has a tested owner.
 - Native/text issue normalization, uncertainty, action routing, and renderer
   equivalence.
 - Persistent-context budget and reference resolution.
+- Graduation state transitions, criterion mappings, retained-spec exceptions,
+  and canonical-policy locality.
 
 ### Integration Tests
 
@@ -318,9 +359,12 @@ Trimming last ensures every removed detail already has a tested owner.
 - Compare current and extracted scaffold fixtures for Python, Node, Go, and Rust;
   verify dry-run leaves an empty target unchanged.
 - Simulate a foggy initialization, approval, decision resolution, map clear, spec
-  handoff, and resume.
+  handoff with active lifecycle metadata, and resume.
 - Exercise `project:next` against fixture graphs containing native blockers,
-  parents/sub-issues, assignments, Wayfinder maps, and implementation issues.
+  parents/sub-issues, assignments, Wayfinder maps, implementation issues, and
+  active/graduated/stale spec states.
+- Run a completed-spec graduation fixture through acceptance mapping, tracker
+  evidence, removal, and a subsequent `project:next` scan.
 - Run `make skills-check`, Codex generated-surface checks, and standard `make
   verify` from a clean checkout.
 
@@ -336,6 +380,10 @@ Trimming last ensures every removed detail already has a tested owner.
 - Route a `wayfinder:grilling` item to `flow:auto` and assert the contract fails.
 - Remove the bundled project-next core/fixtures and assert CI fails rather than
   skips.
+- Leave one acceptance criterion unmapped or mark a regulatory contract for
+  deletion and assert graduation fails.
+- Duplicate the normative lifecycle policy into a skill and assert the locality
+  check fails.
 
 ### Manual Verification
 
@@ -346,6 +394,8 @@ Trimming last ensures every removed detail already has a tested owner.
 - Read the compact `project:next` output to confirm it remains decision-complete,
   then compare `--brief` and `--full` views.
 - Review the final `CLAUDE.md` as a cold-start agent navigation document.
+- Review a newly initialized project's compact lifecycle rule and perform the
+  balanced-agentic-development spec's graduation decision after T006.
 
 ---
 
@@ -361,6 +411,9 @@ Trimming last ensures every removed detail already has a tested owner.
    than prompt length.
 5. Keep each compatibility migration reversible until its installed-surface and
    behavioral tests pass in a clean environment.
+6. After T006, evaluate this specification with the graduation check. Remove it
+   only when all criteria map to durable sources and all six task issues are
+   complete; otherwise keep it active with the failing mappings reported.
 
 ---
 

--- a/.specify/specs/balanced-agentic-development/spec.md
+++ b/.specify/specs/balanced-agentic-development/spec.md
@@ -2,6 +2,7 @@
 
 > **Branch:** `spec/balanced-agentic-development`
 > **Created:** 2026-08-15
+> **Amended:** 2026-08-16 - knowledge graduation lifecycle
 > **Status:** Approved
 
 ---
@@ -27,6 +28,10 @@ This feature defines one balancing model:
    post-wave promotion pass may create a follow-up issue.
 4. **Executable contracts over prose enforcement.** Critical workflow rules are
    represented by deterministic state, validators, and behavioral tests.
+5. **Graduate knowledge after delivery.** Specs coordinate unresolved work. Once
+   implementation is verified, each durable fact moves to its authoritative
+   home and the completed spec is removed instead of becoming a second,
+   drifting description of the code.
 
 The Wayfinder portion adapts Matt Pocock's situational planning on-ramp: an
 effort that is both larger than one agent session and whose route is unclear is
@@ -136,6 +141,9 @@ decisions before committing to a stack.
       production scaffolding; map creation requires explicit user approval.
 - [ ] Wayfinder items are decision questions, not implementation slices, and the
       cleared map hands off to a spec rather than code or a pull request.
+- [ ] The handed-off spec is explicitly `active` and transitional: it governs
+      unresolved implementation work, but is not designated as permanent
+      product documentation.
 - [ ] The map preserves destination, decisions so far, not-yet-specified fog,
       out-of-scope items, blocking edges, and the open/unblocked frontier.
 
@@ -148,6 +156,9 @@ decisions before committing to a stack.
 3. Given a large idea whose key route decisions are unknown, when the user
    approves Wayfinder, then initialization records the map and exits with a
    resumable `awaiting-decisions` state.
+4. Given a cleared Wayfinder map, when it is collapsed for implementation, then
+   the resulting spec records an active lifecycle state and links back to the
+   decisions that produced it.
 
 ---
 
@@ -169,6 +180,11 @@ to an implementation workflow.
 - [ ] `project:next` retains brief, compact, and full views. Required evidence is
       preserved in compact output rather than removed to meet an arbitrary line
       target.
+- [ ] `project:next` distinguishes `active`, `graduated`, and `stale` spec
+      lifecycles using tracked issue/PR evidence; an intentionally removed,
+      graduated spec is not reported as missing or pending.
+- [ ] An active spec that disagrees with its issues or implementation is surfaced
+      as stale rather than silently preferred forever.
 
 ---
 
@@ -189,6 +205,38 @@ execution guidance.
       silently expanding or pointing to missing documentation.
 - [ ] No execution skill is shortened solely by line count; reductions require a
       preserved behavioral contract and regression coverage.
+- [ ] Newly initialized projects receive a compact knowledge-lifecycle principle
+      in `CLAUDE.md` plus a pointer to one canonical reference; skills do not
+      duplicate the full policy.
+- [ ] Relevant lifecycle-boundary skills invoke a graduation check that maps
+      durable knowledge before a completed spec can be removed.
+
+---
+
+## Knowledge Graduation Policy
+
+Specs are temporary coordination artifacts. They remain authoritative while
+requirements are unresolved or implementation is in flight. After delivery, a
+graduation check maps every durable fact to the narrowest maintained source that
+can enforce or explain it:
+
+| Knowledge in the completed spec | Durable home |
+|---------------------------------|--------------|
+| Observable behavior and acceptance criteria | Production code plus behavioral tests |
+| Types, interfaces, data shape, and machine contracts | Types, schemas, validators, and API definitions |
+| Non-obvious local intent or invariant | A nearby comment that explains why, never a restatement of what the code does |
+| Consequential, hard-to-reverse trade-off and rejected alternatives | ADR |
+| Canonical domain language | `CONTEXT.md` or the configured domain glossary |
+| Operational procedure, recovery, or deployment behavior | Runbook and executable checks |
+| Public or cross-team contract | Maintained user/API/interface documentation |
+| Unimplemented or deliberately deferred requirement | Linked open issue or explicit rejection record |
+
+Graduation requires implementation and review evidence, a mapping for every
+acceptance criterion, resolution of every task, and a tracker/PR marker linking
+the evidence. Only then may the completed spec be removed from the current tree;
+Git and tracker history preserve provenance. Specifications with independent
+contractual, regulatory, compliance, public-protocol, or cross-team value are
+retained and maintained instead of graduated away.
 
 ---
 
@@ -227,6 +275,10 @@ auto-promoted at any generation.
 | A generated project directory already contains files | Preserve current conflict/resume semantics and make the dry-run disclose every proposed write |
 | A detailed skill is long because it encodes recovery states | Move lookup material to references where safe, but retain state transitions and behavioral tests |
 | A CPP-authored skill uses the same workflow family name as an upstream skill | Record inspiration separately if appropriate; do not label it vendored without a copied or adapted source |
+| A completed spec contains an acceptance criterion with no code/test mapping | Graduation fails; keep the spec active until the gap is implemented, rejected, or tracked |
+| A removed spec was explicitly marked graduated in its closing PR/issue | `project:next` follows the graduation evidence and does not flag the absent file as drift |
+| Code explains behavior but not why a surprising choice was made | Graduate the rationale to an ADR or local intent comment before deleting the spec |
+| A spec is a regulatory record, public protocol, or cross-team contract | Retain it as independently valuable documentation and require an owner/update path |
 
 ---
 
@@ -241,6 +293,8 @@ auto-promoted at any generation.
   or previously proven safeguards.
 - Changing model/provider selection or adding a runtime service dependency.
 - Retrofitting historical waves or historical issue metrics.
+- Deleting active specs, unresolved acceptance criteria, or documentation with
+  independent contractual, regulatory, compliance, public, or cross-team value.
 
 ---
 
@@ -267,6 +321,11 @@ auto-promoted at any generation.
 | R15 | Reduce always-loaded repository guidance while keeping execution detail available on demand | Should | US6 |
 | R16 | Run each implementation task through behavioral tests and the standard finish gate | Must | All |
 | R17 | Validate provenance for vendored/adapted skills and distinguish it from inspiration or CPP authorship | Must | US2 |
+| R18 | Mark Wayfinder-produced implementation specs as active transitional artifacts linked to their decision map | Must | US4 |
+| R19 | Model active, graduated, and stale spec states without treating an intentionally graduated file as missing | Must | US5 |
+| R20 | Install a compact knowledge-lifecycle principle and canonical-reference pointer in new project `CLAUDE.md` files | Must | US6 |
+| R21 | Keep one canonical knowledge-graduation reference and route only lifecycle-boundary skills to it | Must | US6 |
+| R22 | Require a verified acceptance-to-durable-source mapping before removing a completed spec | Must | US6 |
 
 ### Non-Functional Requirements
 
@@ -280,6 +339,8 @@ auto-promoted at any generation.
 | NFR6 | Test reliability | No project-next contract test skips because an optional sibling checkout is missing |
 | NFR7 | Compatibility | Existing command names and documented modes remain available unless a task explicitly documents a migration |
 | NFR8 | Portability | New executable workflow logic uses Python 3.11+ and passes Linux/macOS-compatible tests without network access |
+| NFR9 | Graduation completeness | 100% of completed-spec acceptance criteria map to code/tests, durable documentation, a linked open issue, or an explicit rejection before removal |
+| NFR10 | Policy locality | One canonical normative knowledge-lifecycle reference; `CLAUDE.md` and skills contain only a compact rule or routing pointer |
 
 ---
 
@@ -300,6 +361,14 @@ auto-promoted at any generation.
       without a sibling repository.
 - [ ] `CLAUDE.md` satisfies its context budget without moving required global
       safety rules out of persistent context.
+- [ ] Generated `CLAUDE.md` files contain the compact knowledge-lifecycle rule
+      and a resolving pointer to the canonical reference.
+- [ ] A graduation test rejects an unmapped acceptance criterion, preserves an
+      independently valuable contract, and accepts an intentionally graduated
+      spec without making `project:next` report it missing.
+- [ ] The balanced-agentic-development spec is evaluated as the first graduation
+      candidate after T001-T006 are implemented; it is removed only if its own
+      graduation check passes.
 - [ ] Standard repository verification passes for every implementation PR.
 - [ ] Documentation explains when depth is valuable instead of describing all
       verbosity as a defect.

--- a/.specify/specs/balanced-agentic-development/tasks.md
+++ b/.specify/specs/balanced-agentic-development/tasks.md
@@ -2,6 +2,7 @@
 
 > **Plan:** [plan.md](./plan.md)
 > **Created:** 2026-08-15
+> **Amended:** 2026-08-16 - knowledge graduation lifecycle
 > **Status:** Ready
 
 ---
@@ -48,23 +49,29 @@ specified bug fixes.
 
 ## Wave 3: Add discovery and planning-aware routing
 
-- [ ] T004 [US4] Add a destination-first clarity/session-count gate to `project:init`, explicitly approved Wayfinder maps of decision questions with fog/frontier/blocking state, and a resumable cleared-map handoff to specification without production implementation (depends on T003)
-- [ ] T005 [US5] Extend `project:next` with native blockedBy/blocking/parent/sub-issue/assignee collection, planning-only Wayfinder routes, explicit fallback uncertainty, shared brief/compact/full decisions, and an authoritative in-repo engine/fixture contract that cannot skip in CI (depends on T004)
+- [ ] T004 [US4] Add a destination-first clarity/session-count gate to `project:init`, explicitly approved Wayfinder maps of decision questions with fog/frontier/blocking state, and a resumable cleared-map handoff to an active transitional specification without production implementation (depends on T003)
+- [ ] T005 [US5] Extend `project:next` with native blockedBy/blocking/parent/sub-issue/assignee collection, planning-only Wayfinder routes, active/graduated/stale spec lifecycles, explicit fallback uncertainty, shared brief/compact/full decisions, and an authoritative in-repo engine/fixture contract that cannot skip in CI (depends on T004)
 
 **Checkpoint:** All four discovery routes are covered. No tracker mutation occurs
 without approval, no decision ticket routes to `flow:auto`, and native and
 fallback issue graphs produce explainable recommendations from the same tested
-decision core.
+decision core. A cleared map produces an active transitional spec; an
+intentionally graduated spec is not reported missing, while a conflicting active
+spec is reported stale.
 
 ---
 
 ## Wave 4: Minimize persistent context safely
 
-- [ ] T006 [US6] Reduce `CLAUDE.md` to durable invariants, safety rules, verification commands, source-of-truth pointers, and workflow routing; move owned depth to on-demand references and add word-budget, link, and behavior-preservation checks (depends on T002, T003, T004, T005)
+- [ ] T006 [US6] Reduce `CLAUDE.md` to durable invariants and routing, add the compact knowledge-lifecycle principle to new-project guidance, establish one canonical graduation reference used only by lifecycle-boundary skills, and require verified acceptance-to-code/tests/docs/issues mapping before a completed spec is removed (depends on T002, T003, T004, T005)
 
 **Checkpoint:** `CLAUDE.md` is at most 2,000 words, every pointer resolves, cold
 start navigation remains sufficient, detailed state machines remain available
 from their owning skills, and the full repository verification suite passes.
+Generated projects receive the compact rule plus a resolving pointer, not a
+duplicated manual. Graduation fails for unmapped criteria and independently
+valuable contracts, succeeds without a later `project:next` missing-spec warning,
+and evaluates this specification as the first candidate after T001-T006 finish.
 
 ---
 
@@ -81,6 +88,9 @@ from their owning skills, and the full repository verification suite passes.
   candidates remain ledger-only absent a human-approved security, data-loss, or
   work-blocking emergency.
 - Report recorded and promoted counts at every checkpoint.
+- Keep active specs until the graduation gate maps every acceptance criterion;
+  retain independently valuable contracts and remove only verified duplicates
+  of durable code/tests/documentation.
 
 ---
 


### PR DESCRIPTION
## Summary

- define specs as active transitional coordination artifacts
- add a fail-closed knowledge-graduation contract and durable-home mapping
- extend Wayfinder handoff and project-next with active, graduated, stale, and retained states
- add compact generated-CLAUDE.md guidance plus one canonical policy reference
- extend existing tasks #722-#724 without creating new issues

The balanced-agentic-development spec becomes the first graduation candidate after T001-T006 complete. It is removed only if every acceptance criterion maps to code, tests, durable documentation, a remaining issue, or an explicit rejection.

## Verification

- `make verify` - 1648 passed, 1 existing skip
- `scripts/flow-finish-gate.sh` - 4/4 lint, test, typecheck, security
- task sync dry run - 0 creates, 6 existing skips
- issue body verification - #722-#724 blockers and lifecycle additions present

The implementation issues remain open by design.
