### PR TITLE
feat(governance): add proportional response — tiered process for tiered scope

### DIFF
--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -402,6 +402,12 @@ if [ ! -d ".specify" ]; then
 
 {Description of the principle and how it guides development.}
 
+### P3: Proportional response
+
+Match ceremony to scope. The cost of governance process must not exceed
+the cost of the change it governs. Default to the lightest sufficient
+process and escalate only when analysis reveals the need.
+
 ---
 
 ## Development Workflow
@@ -412,6 +418,15 @@ if [ ! -d ".specify" ]; then
 4. Break into tasks
 5. Sync tasks to issues
 6. Implement with tests
+
+### Governance Tiers
+
+- **Tier 1 (Surgical):** 1-3 files, single concern. Branch, implement+test,
+  PR. No spec, ELI5 auto-approves.
+- **Tier 2 (Considered):** 4-10 files, new model/endpoint. Branch, ELI5+
+  approval, implement+test, PR.
+- **Tier 3 (Architectural):** New subsystem, security boundary, multi-issue.
+  Full .specify/ pipeline + ELI5 + implement + PR.
 
 ---
 

--- a/.claude/commands/spec/help.md
+++ b/.claude/commands/spec/help.md
@@ -29,6 +29,13 @@ Constitution (principles) → Spec (what) → Plan (how) → Tasks (work) → Is
 Authoring itself is done with the upstream `/speckit-*` skills that `/spec:adopt`
 installs, not with CPP-specific commands.
 
+## When to Use the Spec Pipeline
+
+The full spec→plan→tasks pipeline is for **Tier 3 (Architectural)** work: new
+subsystems, security boundaries, or multi-issue efforts. Tier 1 (Surgical) and
+Tier 2 (Considered) work should skip the spec pipeline and go directly to
+issue → `/flow:auto`.
+
 ## Supported Workflow
 
 1. **Adopt spec-kit** (once per project):

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -61,6 +61,12 @@ After two or more failures from the same root cause, propose systemic hardening 
 - Suggest canary validation before fleet-wide rollout
 - Prevent classes of failures, not just instances
 
+### P7: Proportional response
+
+Match ceremony to scope. The cost of governance process must not exceed
+the cost of the change it governs. Default to the lightest sufficient
+process and escalate only when analysis reveals the need.
+
 ---
 
 ## Development Workflow
@@ -92,6 +98,15 @@ After two or more failures from the same root cause, propose systemic hardening 
 ---
 
 ## Governance
+
+### Governance Tiers
+
+- **Tier 1 (Surgical):** 1-3 files, single concern. Branch, implement+test,
+  PR. No spec, ELI5 auto-approves.
+- **Tier 2 (Considered):** 4-10 files, new model/endpoint. Branch, ELI5+
+  approval, implement+test, PR.
+- **Tier 3 (Architectural):** New subsystem, security boundary, multi-issue.
+  Full .specify/ pipeline + ELI5 + implement + PR.
 
 ### Compliance
 - All PRs must verify alignment with constitution

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -26,13 +26,12 @@
 
 ## Constitution Check
 
-Before proceeding, verify alignment with constitution:
+Before proceeding, verify alignment with your project constitution.
+Replace the placeholders below with your project's actual principles:
 
-- [ ] **P1 Context Efficiency:** Does this add minimal context overhead?
-- [ ] **P2 Issue-Driven:** Is there a GitHub issue for this work?
-- [ ] **P3 Spec-First:** Is the spec complete and approved?
-- [ ] **P4 Test-Driven:** Are test scenarios defined?
-- [ ] **P5 Cross-Platform:** Will this work on Linux/Mac/Windows?
+- [ ] **P1:** {First principle — does this change align?}
+- [ ] **P2:** {Second principle — does this change align?}
+- [ ] **Proportional response:** Is this the lightest process that fits?
 
 ---
 

--- a/ISSUE_DRIVEN_DEVELOPMENT.md
+++ b/ISSUE_DRIVEN_DEVELOPMENT.md
@@ -728,6 +728,23 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 ---
 
+## Proportional Governance
+
+Not every issue needs the full ceremony. Match process weight to change scope:
+
+| Tier | Scope | Process |
+|------|-------|---------|
+| **Tier 1 (Surgical)** | 1-3 files, single concern | Branch → implement+test → PR. No spec, ELI5 auto-approves. |
+| **Tier 2 (Considered)** | 4-10 files, new model/endpoint | Branch → ELI5+approval → implement+test → PR. |
+| **Tier 3 (Architectural)** | New subsystem, security boundary, multi-issue | Full .specify/ pipeline → ELI5 → implement → PR. |
+
+Default to Tier 1. Escalate only when analysis shows the need — the cost of
+governance process must not exceed the cost of the change it governs. The full
+spec→plan→tasks pipeline described in this guide is Tier 3; most day-to-day
+issues ship through `/flow:auto` at Tier 1 or 2.
+
+---
+
 ## Related Documentation
 
 - [Claude Code Best Practices](CLAUDE_CODE_BEST_PRACTICES_COMPREHENSIVE.md)

--- a/codex/skills/project-init/reference.md
+++ b/codex/skills/project-init/reference.md
@@ -399,6 +399,12 @@ if [ ! -d ".specify" ]; then
 
 {Description of the principle and how it guides development.}
 
+### P3: Proportional response
+
+Match ceremony to scope. The cost of governance process must not exceed
+the cost of the change it governs. Default to the lightest sufficient
+process and escalate only when analysis reveals the need.
+
 ---
 
 ## Development Workflow
@@ -409,6 +415,15 @@ if [ ! -d ".specify" ]; then
 4. Break into tasks
 5. Sync tasks to issues
 6. Implement with tests
+
+### Governance Tiers
+
+- **Tier 1 (Surgical):** 1-3 files, single concern. Branch, implement+test,
+  PR. No spec, ELI5 auto-approves.
+- **Tier 2 (Considered):** 4-10 files, new model/endpoint. Branch, ELI5+
+  approval, implement+test, PR.
+- **Tier 3 (Architectural):** New subsystem, security boundary, multi-issue.
+  Full .specify/ pipeline + ELI5 + implement + PR.
 
 ---
 

--- a/tests/test_skills_check.py
+++ b/tests/test_skills_check.py
@@ -22,6 +22,11 @@ _spec.loader.exec_module(skills_check)  # type: ignore[union-attr]
 
 
 EXPECTED_LOADING_METADATA = {
+    "boot": {
+        "name": "Boot",
+        "description": "Menu-driven session identity registration for Kyle-compatible local-network discovery",
+        "trigger": "boot, register, identity, session type, kyle",
+    },
     "best-practices": {
         "name": "Best Practices Dispatcher",
         "description": "Routes to topic-specific best practices skills for context efficiency",


### PR DESCRIPTION
Add proportional governance (P7) to CPP's constitution and templates so downstream projects default to tiered process instead of maximum ceremony for every change.

## Changes

- **Constitution:** Add P7 (Proportional response) + Governance Tiers (Surgical/Considered/Architectural)
- **Plan template:** Generalize Constitution Check with project-specific placeholders instead of hardcoded CPP P1-P5
- **project:init:** Add proportional response as default principle and governance tiers in constitution heredoc template
- **spec:help:** Note full spec pipeline is Tier 3; Tier 1/2 skip to flow:auto
- **ISSUE_DRIVEN_DEVELOPMENT.md:** Add Proportional Governance section

## Context

Kyle project (the first downstream consumer) has already adopted tiered governance (ADR 0002). These upstream changes ensure new CPP projects get proportional governance from day one, and fix the plan template's Constitution Check which was hardcoding CPP-specific principles into downstream projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011m7HTzFwaJJWEMb4EEeDZW