### PR TITLE
refactor(qwen): replace the Codex CLI harness with Qwen Code CLI (Closes #745)

### DIFF
--- a/.claude/commands/cpp/help.md
+++ b/.claude/commands/cpp/help.md
@@ -81,9 +81,9 @@ CPP uses a tiered installation model:
 ### Tier 6 - Local Qwen (optional)
 - **Qwen Auto** (`/qwen:auto`): Full issue lifecycle delegated to a locally hosted Qwen model (Ollama-served, zero API cost)
 - **Qwen Exec** (`/qwen:exec`): One-shot local Qwen execution with JSONL monitoring
-- **Harness**: reuses the Codex CLI in `--oss` mode (no OpenAI API key needed)
-- **Network serving**: one machine hosts the model; others reach it over LAN/Tailscale via a Codex profile
-- **Same safety machinery**: execution fence, `workspace-write` sandbox, overrun verification
+- **Harness**: Qwen Code CLI in headless mode (no cloud API key needed; Codex harness retired in issue #745)
+- **Network serving**: one machine hosts the model; others reach it over LAN/Tailscale via `QWEN_OLLAMA_URL`
+- **Same safety machinery**: execution fence, sandbox, overrun verification
 
 ## CI/CD Commands (Tier 4)
 

--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -406,13 +406,13 @@ This will make the following changes:
     (see above; Tiers 2-5 are NOT required for this tier)
 
   [Tier 6 - Local Qwen]
-    - Requires: Codex CLI as the agentic harness (npm install -g @openai/codex)
-      NOTE: no OpenAI API key is needed - the harness runs in --oss mode
+    - Requires: Qwen Code CLI as the agentic harness
+      (npm install -g @qwen-code/qwen-code)
+      NOTE: no cloud API key is needed - the harness talks straight to Ollama
     - Requires: an Ollama server with the Qwen model, either on this machine
       (ollama pull qwen3.8:27b + tuned qwen3.8-code tag) or reachable over the
-      network (QWEN_OLLAMA_URL / QWEN_CODEX_PROFILE)
+      network (QWEN_OLLAMA_URL)
     - Installs: /qwen:auto, /qwen:exec, /qwen:status, /qwen:help commands
-    - Optional: write a Codex model_providers profile for remote access
 
   Disk usage: ~0 MB (commands via symlink); the model itself is ~17 GB
   and lives on the serving machine only.
@@ -1315,25 +1315,31 @@ Only run when the user selected Tier 6. This tier layers on Tier 1 only; do
 not force Tiers 2-5 first. Ask whether this machine SERVES the model or
 CONSUMES a remote server before running the checks.
 
-#### 6a. Verify the Codex CLI Harness (no API key needed)
+#### 6a. Verify the Qwen Code CLI Harness (no API key needed)
 
 ```bash
 echo ""
 echo "=== Tier 6: Local Qwen Orchestration ==="
 echo ""
 
-if command -v codex &>/dev/null; then
-  CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
-  echo "[x] Codex CLI harness: $CODEX_VERSION"
-  if ! codex exec --help 2>&1 | grep -q -- "--oss"; then
-    echo "[!] This Codex version lacks --oss local-provider support"
-    echo "    Upgrade: npm install -g @openai/codex"
+if command -v qwen &>/dev/null; then
+  QWEN_CLI_VERSION=$(qwen --version 2>/dev/null || echo "unknown")
+  echo "[x] Qwen Code CLI harness: $QWEN_CLI_VERSION"
+  if ! qwen --help 2>&1 | grep -q -- "--output-format"; then
+    echo "[!] This Qwen Code version lacks headless stream-json support"
+    echo "    Upgrade: npm install -g @qwen-code/qwen-code"
   fi
 else
-  echo "[ ] Codex CLI: not installed (required as the local-model harness)"
-  echo "    NOTE: /qwen:* uses --oss mode - no OpenAI API key is required"
+  echo "[ ] Qwen Code CLI: not installed (required as the local-model harness)"
+  echo "    NOTE: /qwen:* talks straight to Ollama - no cloud API key is required"
   # Ask user if they want to install; if yes:
-  npm install -g @openai/codex
+  npm install -g @qwen-code/qwen-code
+fi
+
+# Flag the retired Codex-harness env var if still set (issue #745)
+if [ -n "$QWEN_CODEX_PROFILE" ]; then
+  echo "[~] QWEN_CODEX_PROFILE is set but no longer used (Codex harness retired,"
+  echo "    issue #745). Remote machines need only QWEN_OLLAMA_URL. Unset it."
 fi
 ```
 
@@ -1362,31 +1368,29 @@ else
 fi
 ```
 
-#### 6c. Remote Access Profile (consumer machines only)
+#### 6c. Remote Access (consumer machines only)
 
-The Codex harness ignores OLLAMA_HOST; remote machines need a
-`model_providers` profile. Offer to append to `~/.codex/config.toml`
-(never overwrite existing content; skip if the profile exists):
+No harness config file is needed for a remote Ollama server. Instruct the
+user to set one environment variable (e.g., in shell rc):
 
-```toml
-[model_providers.qwen-local]
-name = "Qwen on local network"
-base_url = "http://<serving-machine-ip>:11434/v1"
-wire_api = "chat"
-
-[profiles.qwen]
-model_provider = "qwen-local"
-model = "qwen3.8-code:latest"
+```bash
+export QWEN_OLLAMA_URL=http://<serving-machine-ip>:11434
 ```
 
-Then instruct the user to set `QWEN_CODEX_PROFILE=qwen` (e.g., in shell rc)
-so `/qwen:auto` and `/qwen:exec` route through it.
+`/qwen:auto`, `/qwen:exec`, and `/qwen:status` derive the harness endpoint
+from it (`$QWEN_OLLAMA_URL/v1` via `--openai-base-url`). If the user still
+has a `QWEN_CODEX_PROFILE` export or a `[model_providers.qwen-local]` block
+in `~/.codex/config.toml` from the retired Codex harness (issue #745), advise
+removing them - a leftover `wire_api = "chat"` provider block hard-errors
+every modern Codex invocation, including unrelated `/codex:*` commands.
 
 #### 6d. Smoke Test (optional)
 
 ```bash
-codex exec --oss --local-provider ollama -m "$QWEN_MODEL" \
-  --sandbox read-only --skip-git-repo-check \
+QWEN_ENDPOINT="${QWEN_OLLAMA_URL:-http://127.0.0.1:11434}"
+qwen --openai-base-url "$QWEN_ENDPOINT/v1" --openai-api-key ollama \
+  --auth-type openai -m "$QWEN_MODEL" \
+  --approval-mode plan --output-format text --max-wall-time 10m \
   "Reply with exactly: QWEN-HARNESS-OK" < /dev/null 2>&1 | tail -3
 ```
 

--- a/.claude/commands/cpp/status.md
+++ b/.claude/commands/cpp/status.md
@@ -466,8 +466,8 @@ fi
 ## Step 7: Check Tier 6 (Local Qwen Orchestration)
 
 Tier 6 is OPTIONAL and additive - report it as "not installed (optional)"
-rather than "missing" when absent. It needs the Codex CLI as a harness (no
-OpenAI key) plus a reachable Ollama server holding the Qwen model.
+rather than "missing" when absent. It needs the Qwen Code CLI as a harness
+(no cloud API key) plus a reachable Ollama server holding the Qwen model.
 
 ```bash
 echo ""
@@ -477,10 +477,10 @@ QWEN_ENDPOINT="${QWEN_OLLAMA_URL:-http://127.0.0.1:11434}"
 QWEN_MODEL="${QWEN_MODEL:-qwen3.8-code:latest}"
 
 # Harness
-if command -v codex &>/dev/null && codex exec --help 2>&1 | grep -q -- "--oss"; then
-  echo "  [x] Codex CLI harness with --oss support"
+if command -v qwen &>/dev/null && qwen --help 2>&1 | grep -q -- "--output-format"; then
+  echo "  [x] Qwen Code CLI harness with headless stream-json support"
 else
-  echo "  [ ] Codex CLI harness: missing or lacks --oss (npm install -g @openai/codex)"
+  echo "  [ ] Qwen Code CLI harness: missing or outdated (npm install -g @qwen-code/qwen-code)"
 fi
 
 # Server
@@ -504,13 +504,10 @@ for cmd in auto exec status help; do
 done
 echo "  [x] Qwen commands: $QWEN_CMDS/4 available"
 
-# Remote profile (consumer machines)
+# Retired Codex-harness env var (issue #745)
 if [ -n "$QWEN_CODEX_PROFILE" ]; then
-  if grep -q "\[profiles.$QWEN_CODEX_PROFILE\]" ~/.codex/config.toml 2>/dev/null; then
-    echo "  [x] Remote profile: $QWEN_CODEX_PROFILE (in ~/.codex/config.toml)"
-  else
-    echo "  [!] QWEN_CODEX_PROFILE set but profile missing from ~/.codex/config.toml"
-  fi
+  echo "  [~] QWEN_CODEX_PROFILE set but no longer used (Codex harness retired,"
+  echo "      issue #745) - remote machines need only QWEN_OLLAMA_URL. Unset it."
 fi
 ```
 
@@ -574,7 +571,7 @@ Tier 5 (Codex):
   Status: Complete
 
 Tier 6 (Local Qwen - optional):
-  [x] Codex CLI harness with --oss support
+  [x] Qwen Code CLI harness with headless stream-json support
   [x] Ollama server reachable at http://127.0.0.1:11434
   [x] Model present: qwen3.8-code:latest
   [x] Qwen commands: 4/4 available

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -1,14 +1,15 @@
 ---
 description: Full issue lifecycle delegated to a local Qwen model - worktree, implement, review, quality gates, PR
-allowed-tools: Bash(codex:*), Bash(ollama:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(mkdir:*), Bash(cd:*), Bash(pwd), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(make:*), Bash(sleep:*)
+allowed-tools: Bash(qwen:*), Bash(ollama:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(mkdir:*), Bash(cd:*), Bash(pwd), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(make:*), Bash(sleep:*)
 ---
 
 # Qwen Auto: Full Issue Lifecycle via Local Qwen Model
 
 Mirrors `/codex:auto` but delegates implementation (Step 3) to a locally hosted
-Qwen model served by Ollama, driven through the Codex CLI harness
-(`codex exec --oss`). Claude Code acts as supervisor/reviewer while the local
-Qwen model writes the code. No cloud API key or per-token cost is involved.
+Qwen model served by Ollama, driven through the Qwen Code CLI harness
+(`qwen` in headless mode; the Codex CLI harness was retired in issue #745).
+Claude Code acts as supervisor/reviewer while the local Qwen model writes the
+code. No cloud API key or per-token cost is involved.
 
 ## Arguments
 
@@ -17,10 +18,11 @@ Qwen model writes the code. No cloud API key or per-token cost is involved.
 ## Environment
 
 - `QWEN_MODEL` (optional): Ollama model tag to use. Default: `qwen3.8-code:latest`.
-- `QWEN_CODEX_PROFILE` (optional): a Codex config profile name. When set, the
-  model is reached via `codex exec --profile "$QWEN_CODEX_PROFILE"` instead of
-  `--oss --local-provider ollama`. Use this on machines that reach the Qwen
-  server over the network (see `/qwen:help` for the profile recipe).
+- `QWEN_OLLAMA_URL` (optional): base URL of the Ollama server, for machines
+  that reach the Qwen server over the network (e.g.,
+  `http://<serving-machine-tailscale-ip>:11434`). Default:
+  `http://127.0.0.1:11434`. No tunnel or harness config file is needed
+  (see `/qwen:help`).
 
 ## Instructions
 
@@ -33,7 +35,7 @@ Qwen Auto: Issue #<ISSUE> - Full Lifecycle
 
 Step 1/7: Start (create worktree and branch)
 Step 2/7: Analyze (understand issue, build Qwen prompt)
-Step 3/7: Execute Qwen (delegate implementation to local Qwen via Codex CLI)
+Step 3/7: Execute Qwen (delegate implementation to local Qwen via Qwen Code CLI)
 Step 4/7: Review (Claude reviews Qwen's diff)
 Step 5/7: Quality Gates (lint, test, security - with fix loop)
 Step 6/7: Finish (commit, push, create PR)
@@ -139,32 +141,33 @@ Report: `Step 2/7: Analyze complete - Qwen prompt built ({N} files referenced)`
 
 ### Step 3: Execute Qwen - Delegate Implementation
 
-Run the local Qwen model through the Codex CLI harness in the worktree with
-**workspace-write** sandbox only (same rationale as issue #735: the sandbox
-mechanically prevents network operations even if the textual fence is ignored).
+Run the local Qwen model through the Qwen Code CLI harness in the worktree,
+sandboxed (macOS Seatbelt / Docker). The sandbox blocks writes outside the
+working directory (same rationale as issue #735); network from model-run shell
+commands is NOT blocked by the default profile, so the textual fence plus the
+post-execution overrun verification below carry that boundary.
 
 ```bash
 # Verify the harness and the model server
-if ! command -v codex &>/dev/null; then
-    echo "ERROR: Codex CLI not found (it is the local-model harness)."
-    echo "Install with: npm install -g @openai/codex"
+if ! command -v qwen &>/dev/null; then
+    echo "ERROR: Qwen Code CLI not found (it is the local-model harness)."
+    echo "Install with: npm install -g @qwen-code/qwen-code"
     exit 1
 fi
 
 QWEN_MODEL="${QWEN_MODEL:-qwen3.8-code:latest}"
+QWEN_ENDPOINT="${QWEN_OLLAMA_URL:-http://127.0.0.1:11434}"
 
-if [ -z "$QWEN_CODEX_PROFILE" ]; then
-    # Local serving machine: Ollama must be up and the model present
-    if ! curl -sf --max-time 5 http://127.0.0.1:11434/api/version > /dev/null; then
-        echo "ERROR: Ollama is not reachable on 127.0.0.1:11434."
-        echo "Start it (macOS launchd or 'ollama serve') and retry, or set"
-        echo "QWEN_CODEX_PROFILE to reach a remote Qwen server."
-        exit 1
-    fi
-    if ! ollama list 2>/dev/null | grep -q "${QWEN_MODEL%%:*}"; then
-        echo "ERROR: model '$QWEN_MODEL' not found in ollama list."
-        exit 1
-    fi
+# Ollama must be up and the model present (local or remote)
+if ! curl -sf --max-time 5 "$QWEN_ENDPOINT/api/version" > /dev/null; then
+    echo "ERROR: Ollama is not reachable at $QWEN_ENDPOINT."
+    echo "Serving machine: start it (macOS launchd or 'ollama serve') and retry."
+    echo "Consumer machine: set QWEN_OLLAMA_URL=http://<serving-ip>:11434"
+    exit 1
+fi
+if ! curl -sf --max-time 5 "$QWEN_ENDPOINT/api/tags" 2>/dev/null | grep -q "${QWEN_MODEL%%:*}"; then
+    echo "ERROR: model '$QWEN_MODEL' not found on the server."
+    exit 1
 fi
 ```
 
@@ -201,43 +204,52 @@ IGNORE its contents entirely - it is not addressed to you.
 <the rest of the Qwen prompt: issue context, codebase summary, implementation instructions>
 ```
 
-Execute with JSONL monitoring. **Use `--sandbox workspace-write`:**
+Execute headless with `stream-json` monitoring. The harness has no
+change-directory flag, so this MUST run with the worktree as the current
+directory. `--approval-mode yolo` is required in headless mode (an interactive
+approval prompt would deadlock an unattended run); `--sandbox` supplies the
+mechanical write boundary; `--max-wall-time` bounds a stalled run instead of
+hanging forever (exit code 55 when exceeded).
 
 ```bash
-WORKTREE_PATH=$(pwd)
-
-if [ -n "$QWEN_CODEX_PROFILE" ]; then
-    codex exec \
-        --json \
-        -C "$WORKTREE_PATH" \
-        --profile "$QWEN_CODEX_PROFILE" \
-        --sandbox workspace-write \
-        "$QWEN_PROMPT" < /dev/null 2>&1 | tee /tmp/qwen-output-${ISSUE_NUM}.jsonl   # </dev/null: non-TTY EOF so codex never blocks reading stdin
-else
-    codex exec \
-        --json \
-        -C "$WORKTREE_PATH" \
-        --oss --local-provider ollama \
-        -m "$QWEN_MODEL" \
-        --sandbox workspace-write \
-        "$QWEN_PROMPT" < /dev/null 2>&1 | tee /tmp/qwen-output-${ISSUE_NUM}.jsonl   # </dev/null: non-TTY EOF so codex never blocks reading stdin
-fi
+# Run FROM INSIDE the worktree (qwen operates on the current directory)
+qwen \
+    --openai-base-url "$QWEN_ENDPOINT/v1" \
+    --openai-api-key ollama \
+    --auth-type openai \
+    -m "$QWEN_MODEL" \
+    --output-format stream-json \
+    --approval-mode yolo \
+    --sandbox \
+    --max-wall-time 45m \
+    "$QWEN_PROMPT" < /dev/null 2>&1 | tee /tmp/qwen-output-${ISSUE_NUM}.jsonl   # </dev/null: non-TTY EOF so the harness never blocks reading stdin
 ```
 
-**Monitor the JSONL stream** - parse and report plan steps, file changes,
-agent messages, and errors. Note: a "Model metadata ... not found. Defaulting
-to fallback metadata" item is benign for Ollama-served models.
+(The `--openai-api-key` value is a placeholder; Ollama ignores it. No cloud
+API key is involved.)
+
+**Monitor the JSONL stream** - each line is a JSON message with a `type` field
+(system/init metadata, assistant messages, tool events, and a final `result`
+message with run stats). Parse and report plan steps, file changes, agent
+messages, and errors.
 
 **Expect local-model pacing:** a 27B model on Apple Silicon generates at
-roughly 15-20 tok/s. A single implementation turn can take several minutes.
-Do not kill the run for slowness alone; kill it if the JSONL stream shows a
-hard error or no events for 15+ minutes.
+roughly 15-20 tok/s, and a thinking-enabled model (the `qwen3.8` family
+thinks by default) spends minutes reasoning before its first edit - the
+harness streams those reasoning tokens, so the JSONL shows liveness. Do not
+kill the run for slowness alone; kill it if the JSONL stream shows a hard
+error or no events for 15+ minutes. If thinking latency dominates runs,
+see the "Thinking Tokens" section of `/qwen:help` (non-thinking coder tags,
+server-side `reasoning_effort`).
 
 ```bash
 # After execution, check exit code
-CODEX_EXIT=$?
-if [ "$CODEX_EXIT" -ne 0 ]; then
-    echo "ERROR: Qwen execution failed (exit code: $CODEX_EXIT)"
+QWEN_EXIT=$?
+if [ "$QWEN_EXIT" -ne 0 ]; then
+    echo "ERROR: Qwen execution failed (exit code: $QWEN_EXIT)"
+    if [ "$QWEN_EXIT" -eq 55 ]; then
+        echo "(exit 55 = --max-wall-time budget exceeded - the run stalled or the task is too big)"
+    fi
     echo "Last 20 lines of output:"
     tail -20 /tmp/qwen-output-${ISSUE_NUM}.jsonl
     exit 1
@@ -375,7 +387,7 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
 1. **Commit** the changes:
    - Use conventional commit format: `type(scope): Description (Closes #N)`
    - Note the Qwen model tag as implementer in the commit body
-     (e.g., `Implemented-By: qwen3.8-code:latest via codex exec --oss`)
+     (e.g., `Implemented-By: qwen3.8-code:latest via Qwen Code CLI (headless)`)
 
 2. **Push** the branch: `git push -u origin "$BRANCH"`
 
@@ -411,7 +423,7 @@ Report: `Step 7/7: Cleanup complete - PR merged, worktree removed` or `Step 7/7:
 Qwen Auto Complete
 
   Issue:       #{N} - {title}
-  Implementer: {QWEN_MODEL} via codex exec --oss (local, zero API cost)
+  Implementer: {QWEN_MODEL} via Qwen Code CLI headless (local, zero API cost)
   Reviewer:    Claude Code (cross-model review)
   Changes:     Modified {N} files ({summary})
   Fix Loop:    {N} retry(s) needed / no retries needed
@@ -443,7 +455,7 @@ Qwen Auto stopped at Step N/7: {Step Name}
 ```
 
 Key failure scenarios:
-- **Codex CLI not installed:** Stop at step 3; it is required as the harness even though no OpenAI key is used
+- **Qwen Code CLI not installed:** Stop at step 3; it is required as the harness (no cloud API key is used)
 - **Ollama unreachable / model missing:** Stop at step 3; run `/qwen:status` to diagnose
 - **Execution fails or stalls:** Stop at step 3, show last 20 lines of JSONL output
 - **Model makes no changes:** Stop at step 3; tighten the prompt or escalate to `/codex:auto`
@@ -452,9 +464,9 @@ Key failure scenarios:
 
 ## Notes
 
-- The implementer is a LOCAL model (default `qwen3.8-code:latest`, Qwen3.8-27B Q4_K_M served by Ollama) driven through `codex exec --oss --local-provider ollama`; no OpenAI API key or per-token cost is involved
-- The Codex CLI is reused purely as an agentic harness: JSONL event stream, sandboxing, and tool loop
-- Same defense-in-depth as `/codex:auto` (issue #735): textual execution fence + `workspace-write` sandbox + post-execution overrun verification
+- The implementer is a LOCAL model (default `qwen3.8-code:latest`, Qwen3.8-27B Q4_K_M served by Ollama) driven through the Qwen Code CLI in headless mode; no cloud API key or per-token cost is involved
+- The Qwen Code CLI (QwenLM/qwen-code, `npm install -g @qwen-code/qwen-code`) is used purely as an agentic harness: stream-json event output, Seatbelt/Docker sandboxing, tool loop, and native Qwen 3 reasoning-token handling (the Codex CLI harness was retired in issue #745 - its chat wire API was deleted upstream and its `/v1/responses` path hangs on Qwen 3 thinking output)
+- Same defense-in-depth as `/codex:auto` (issue #735): textual execution fence + sandbox + post-execution overrun verification (the sandbox blocks out-of-worktree writes; the fence and overrun checks cover git/gh/network overreach)
 - Local-model calibration: prompts must be more explicit, scope smaller, review stricter; escalate to `/codex:auto` when the issue is broad or the fix loop exhausts
-- On a remote machine, set `QWEN_CODEX_PROFILE` to a Codex profile whose provider `base_url` points at the serving machine (see `/qwen:help`)
+- On a remote machine, set `QWEN_OLLAMA_URL=http://<serving-machine-ip>:11434`; no tunnel or harness config file is needed (see `/qwen:help`)
 - To check readiness (server, model, harness), use `/qwen:status`

--- a/.claude/commands/qwen/exec.md
+++ b/.claude/commands/qwen/exec.md
@@ -1,13 +1,13 @@
 ---
 description: One-shot local Qwen execution in current directory with JSONL monitoring
-allowed-tools: Bash(codex:*), Bash(ollama:*), Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(pwd), Bash(tee:*)
+allowed-tools: Bash(qwen:*), Bash(ollama:*), Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(pwd), Bash(tee:*)
 ---
 
 # Qwen Exec: One-Shot Local Qwen Execution
 
-Run the local Qwen model (via the Codex CLI harness) in the current directory
-with JSONL monitoring. For quick tasks without the full issue lifecycle.
-Zero API cost - the model runs on local hardware through Ollama.
+Run the local Qwen model (via the Qwen Code CLI harness) in the current
+directory with JSONL monitoring. For quick tasks without the full issue
+lifecycle. Zero API cost - the model runs on local hardware through Ollama.
 
 ## Arguments
 
@@ -16,8 +16,9 @@ Zero API cost - the model runs on local hardware through Ollama.
 ## Environment
 
 - `QWEN_MODEL` (optional): Ollama model tag. Default: `qwen3.8-code:latest`.
-- `QWEN_CODEX_PROFILE` (optional): Codex config profile for reaching a remote
-  Qwen server; replaces the `--oss` flags when set (see `/qwen:help`).
+- `QWEN_OLLAMA_URL` (optional): base URL of the Ollama server for remote
+  serving machines (e.g., `http://<tailscale-ip>:11434`). Default:
+  `http://127.0.0.1:11434`. See `/qwen:help`.
 
 ## Instructions
 
@@ -26,67 +27,73 @@ When the user invokes `/qwen:exec <PROMPT>`, perform these steps:
 ### Step 1: Verify Availability
 
 ```bash
-if ! command -v codex &>/dev/null; then
-    echo "ERROR: Codex CLI not found (required as the local-model harness)."
-    echo "Install with: npm install -g @openai/codex"
+if ! command -v qwen &>/dev/null; then
+    echo "ERROR: Qwen Code CLI not found (required as the local-model harness)."
+    echo "Install with: npm install -g @qwen-code/qwen-code"
     exit 1
 fi
 
 QWEN_MODEL="${QWEN_MODEL:-qwen3.8-code:latest}"
+QWEN_ENDPOINT="${QWEN_OLLAMA_URL:-http://127.0.0.1:11434}"
 
-if [ -z "$QWEN_CODEX_PROFILE" ]; then
-    if ! curl -sf --max-time 5 http://127.0.0.1:11434/api/version > /dev/null; then
-        echo "ERROR: Ollama not reachable on 127.0.0.1:11434. Run /qwen:status to diagnose."
-        exit 1
-    fi
+if ! curl -sf --max-time 5 "$QWEN_ENDPOINT/api/version" > /dev/null; then
+    echo "ERROR: Ollama not reachable at $QWEN_ENDPOINT. Run /qwen:status to diagnose."
+    echo "Remote serving machine: set QWEN_OLLAMA_URL=http://<serving-ip>:11434"
+    exit 1
 fi
 
-echo "Harness: $(codex --version 2>/dev/null)"
-echo "Model:   $QWEN_MODEL"
+echo "Harness: qwen $(qwen --version 2>/dev/null)"
+echo "Model:   $QWEN_MODEL via $QWEN_ENDPOINT"
 echo "Working directory: $(pwd)"
 ```
 
 ### Step 2: Execute
 
-Run with JSONL output for structured monitoring. Unlike `/codex:exec`, the
-sandbox is **workspace-write** (not `danger-full-access`): a local model
-warrants the tighter mechanical boundary.
+Run headless with `stream-json` output for structured monitoring. The harness
+runs sandboxed (macOS Seatbelt / Docker) with `yolo` approval so the headless
+run never blocks on an interactive confirmation; `--max-wall-time` bounds a
+runaway or stalled run (exit code 55 when exceeded).
 
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 OUTPUT_FILE="/tmp/qwen-exec-${TIMESTAMP}.jsonl"
 
-if [ -n "$QWEN_CODEX_PROFILE" ]; then
-    codex exec \
-        --json \
-        --profile "$QWEN_CODEX_PROFILE" \
-        --sandbox workspace-write \
-        "$PROMPT" < /dev/null 2>&1 | tee "$OUTPUT_FILE"   # </dev/null: non-TTY EOF so codex never blocks reading stdin
-else
-    codex exec \
-        --json \
-        --oss --local-provider ollama \
-        -m "$QWEN_MODEL" \
-        --sandbox workspace-write \
-        "$PROMPT" < /dev/null 2>&1 | tee "$OUTPUT_FILE"   # </dev/null: non-TTY EOF so codex never blocks reading stdin
-fi
+qwen \
+    --openai-base-url "$QWEN_ENDPOINT/v1" \
+    --openai-api-key ollama \
+    --auth-type openai \
+    -m "$QWEN_MODEL" \
+    --output-format stream-json \
+    --approval-mode yolo \
+    --sandbox \
+    --max-wall-time 30m \
+    "$PROMPT" < /dev/null 2>&1 | tee "$OUTPUT_FILE"   # </dev/null: non-TTY EOF so the harness never blocks reading stdin
 
-CODEX_EXIT=$?
+QWEN_EXIT=$?
 ```
+
+(The `--openai-api-key` value is a placeholder; Ollama ignores it. No cloud
+API key is involved.)
 
 ### Step 3: Monitor and Report
 
-**While it runs**, parse the JSONL stream and report plan steps, file changes,
-messages, and errors. A "Model metadata ... not found. Defaulting to fallback
-metadata" item is benign for Ollama-served models. Expect ~15-20 tok/s
-generation; a substantial task can take several minutes per turn.
+**While it runs**, parse the JSONL stream and report progress: each line is a
+JSON message with a `type` field (system/init metadata, assistant messages,
+tool events, and a final `result` message carrying stats). Report file changes,
+agent messages, and errors as they stream. Expect ~15-20 tok/s generation; a
+substantial task can take several minutes per turn, and a thinking-enabled
+model spends minutes reasoning before its first edit - the stream shows
+liveness either way.
 
 ### Step 4: Summary
 
 ```bash
-if [ "$CODEX_EXIT" -ne 0 ]; then
+if [ "$QWEN_EXIT" -ne 0 ]; then
     echo ""
-    echo "Qwen execution failed (exit code: $CODEX_EXIT)"
+    echo "Qwen execution failed (exit code: $QWEN_EXIT)"
+    if [ "$QWEN_EXIT" -eq 55 ]; then
+        echo "(exit 55 = --max-wall-time or --max-tool-calls budget exceeded)"
+    fi
     echo "Output saved to: $OUTPUT_FILE"
     exit 1
 fi
@@ -117,7 +124,10 @@ or git checkout -- . to discard.
 ## Notes
 
 - Runs in the CURRENT directory (not a worktree) - changes are applied directly
-- Uses `--sandbox workspace-write` - the model cannot reach the network or escape the directory
+- The sandbox (default macOS Seatbelt profile) blocks writes outside the
+  working directory; shell commands the model runs retain network access, so
+  the execution-fence + overrun-verification pattern from `/qwen:auto` still
+  applies for anything beyond quick tasks
 - JSONL output is saved to /tmp for later inspection
 - No automatic commit - user reviews and commits manually
 - For full issue lifecycle with review and quality gates, use `/qwen:auto`

--- a/.claude/commands/qwen/help.md
+++ b/.claude/commands/qwen/help.md
@@ -15,16 +15,16 @@ and available to every machine on the tailnet/LAN.
 |---------|-------------|
 | `/qwen:auto <ISSUE>` | Full issue lifecycle delegated to local Qwen - worktree, implement, review, quality gates, PR |
 | `/qwen:exec <PROMPT>` | One-shot local Qwen execution in current directory with JSONL monitoring |
-| `/qwen:status` | Check Ollama server, model, and Codex harness readiness |
+| `/qwen:status` | Check Ollama server, model, and Qwen Code harness readiness |
 | `/qwen:help` | This help overview |
 
 ## Architecture
 
 ```
-Claude Code (supervisor)            Local Qwen via Codex CLI harness
+Claude Code (supervisor)            Local Qwen via Qwen Code CLI harness
   1. Read GH issue
   2. Create worktree + branch
-  3. Build prompt from issue     --> 4. codex exec --json --oss --local-provider ollama
+  3. Build prompt from issue     --> 4. qwen --output-format stream-json
   5. Monitor JSONL stream        <--    -m qwen3.8-code:latest (served by Ollama)
   7. Review Qwen's diff                6. Plan, code, test (~15-20 tok/s locally)
   8. Run quality gates (lint/test/security)
@@ -44,8 +44,46 @@ Claude Code (supervisor)            Local Qwen via Codex CLI harness
   use it. On macOS this is a launchd agent with `OLLAMA_HOST=0.0.0.0:11434`
   (plus `OLLAMA_FLASH_ATTENTION=1`, `OLLAMA_KV_CACHE_TYPE=q8_0`,
   `OLLAMA_KEEP_ALIVE=30m`).
-- **Harness:** Codex CLI (`npm install -g @openai/codex`) drives the model
-  agentically. No OpenAI API key is used in `--oss` mode.
+- **Harness:** Qwen Code CLI (`npm install -g @qwen-code/qwen-code`, pin 0.23.0
+  or later) drives the model agentically over Ollama's OpenAI-compatible
+  endpoint. Built by the Qwen team, so Qwen 3 reasoning/thinking stream fields
+  are parsed natively. No cloud API key is used - the `--openai-api-key` value
+  is a placeholder that Ollama ignores.
+
+### Why not the Codex CLI harness? (issue #745)
+
+The original `/qwen:*` harness was `codex exec --oss --local-provider ollama`.
+That path is retired:
+
+- Codex deleted the chat-completions wire API at v0.95 (openai/codex#10157);
+  `wire_api = "chat"` in any `~/.codex/config.toml` provider is now a hard
+  startup error, which broke the previously documented remote profile recipe.
+- `--oss` speaks Ollama's `/v1/responses` endpoint, where Qwen 3 thinking
+  models hit an unfixed answer-swallowing bug (ollama/ollama#18187) and the
+  thinking phase renders as an apparent indefinite hang.
+- OpenAI closed remote-Ollama support as not-planned (openai/codex#8240) and
+  the local-provider path regressed repeatedly through 2026.
+
+Qwen Code CLI meets every harness requirement Codex covered: headless one-shot
+mode, `stream-json` event output, an OS sandbox (macOS Seatbelt / Docker), and
+first-class custom OpenAI-compatible endpoints.
+
+## Thinking Tokens (read before changing models)
+
+Qwen 3 hybrid models (including `qwen3.8`) emit reasoning/thinking tokens by
+default. The Qwen Code harness parses them correctly, but they are slow on
+local hardware (minutes of thinking at ~15-20 tok/s before any code appears):
+
+- **Prefer a non-thinking coder tag** for implementation work when available
+  (e.g. `qwen3-coder:30b`): Qwen3-Coder models never emit thinking blocks and
+  are trained specifically for agentic coding.
+- **Or lower the effort server-side:** Ollama's OpenAI-compatible endpoint
+  accepts `reasoning_effort` (`"none"`, `"low"`, `"medium"`, `"high"`); the
+  native API equivalent is `think: false`. Note the Qwen team's guidance that
+  low effort on hybrid models degrades hard multi-step reasoning - for broad
+  issues, escalate to `/codex:auto` rather than running a de-thinking hybrid.
+- The `/no_think` soft prompt switch is unreliable on post-2507 Qwen models;
+  do not depend on it.
 
 ## Using the Model From Other Machines
 
@@ -56,21 +94,16 @@ export OLLAMA_HOST=http://<serving-machine-tailscale-ip>:11434   # ollama CLI
 # or OpenAI-compatible: base_url http://<ip>:11434/v1, any api_key string
 ```
 
-For `/qwen:auto` and `/qwen:exec` on a REMOTE machine, the Codex harness needs
-a config profile (Codex ignores OLLAMA_HOST). Add to `~/.codex/config.toml`:
+For `/qwen:auto` and `/qwen:exec` on a REMOTE machine, no SSH tunnel and no
+harness config file are needed - set one environment variable:
 
-```toml
-[model_providers.qwen-local]
-name = "Qwen on local network"
-base_url = "http://<serving-machine-tailscale-ip>:11434/v1"
-wire_api = "chat"
-
-[profiles.qwen]
-model_provider = "qwen-local"
-model = "qwen3.8-code:latest"
+```bash
+export QWEN_OLLAMA_URL=http://<serving-machine-tailscale-ip>:11434
 ```
 
-Then set `QWEN_CODEX_PROFILE=qwen` before invoking `/qwen:auto` or `/qwen:exec`.
+The commands derive the harness endpoint from it
+(`$QWEN_OLLAMA_URL/v1`) and pass it via `--openai-base-url`. Unset, the
+commands default to `http://127.0.0.1:11434`.
 
 ## Quick Start
 
@@ -90,11 +123,12 @@ Then set `QWEN_CODEX_PROFILE=qwen` before invoking `/qwen:auto` or `/qwen:exec`.
 | Aspect | `/codex:auto` | `/qwen:auto` |
 |--------|---------------|--------------|
 | Implementer | Codex CLI (OpenAI cloud) | Local Qwen3.8-27B via Ollama |
+| Harness | Codex CLI | Qwen Code CLI |
 | Cost | OpenAI API tokens | Zero (local hardware) |
 | Privacy | Code sent to OpenAI | Code never leaves the network |
 | Speed | Fast (cloud inference) | ~15-20 tok/s (Apple Silicon) |
 | Capability | Frontier model | Strong 27B - needs tighter prompts, stricter review |
-| Sandbox | `workspace-write` | `workspace-write` |
+| Sandbox | `workspace-write` | Seatbelt/Docker sandbox + yolo approval |
 | Escalation path | - | Falls back to `/codex:auto` when it struggles |
 
 ## When To Use Which
@@ -118,15 +152,15 @@ review. Server-side env knobs: `OLLAMA_BASE_URL`, `OLLAMA_MODEL`,
 ## Installation
 
 Run `/cpp:init` and select **Tier 6 (Local Qwen)** to:
-1. Verify/install the Codex CLI harness (no OpenAI key needed)
+1. Verify/install the Qwen Code CLI harness (no cloud API key needed)
 2. Verify the Ollama server is reachable (local or via `QWEN_OLLAMA_URL`)
 3. Verify the model is present (pull/create if on the serving machine)
-4. Optionally write the remote-access Codex profile
-5. Optionally enable the always-on second opinion (mcp-second-opinion v2.3.0+)
+4. Optionally enable the always-on second opinion (mcp-second-opinion v2.3.0+)
 
 ## Notes
 
-- Same defense-in-depth as `/codex:auto`: execution fence + `workspace-write` sandbox + overrun verification
+- Same defense-in-depth as `/codex:auto`: execution fence + sandbox + overrun verification
 - A local model wanders more than a frontier model - the fence and the Claude review step are mandatory, never skipped
 - `QWEN_MODEL` overrides the model tag; any Ollama-served coding model works (e.g., `qwen3-coder:30b`)
 - Expect minutes-per-turn pacing on the serving hardware; the JSONL stream shows liveness
+- The Qwen Code sandbox (default macOS Seatbelt profile) blocks writes outside the working directory but does NOT block network from shell commands the model runs - the execution fence plus post-run overrun verification cover that gap, exactly as they did under Codex

--- a/.claude/commands/qwen/status.md
+++ b/.claude/commands/qwen/status.md
@@ -1,12 +1,12 @@
 ---
-description: Check local Qwen serving stack - Ollama server, model, and Codex harness readiness
-allowed-tools: Bash(codex:*), Bash(ollama:*), Bash(command -v:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(test:*), Bash(head:*), Bash(launchctl:*)
+description: Check local Qwen serving stack - Ollama server, model, and Qwen Code harness readiness
+allowed-tools: Bash(qwen:*), Bash(ollama:*), Bash(command -v:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(test:*), Bash(head:*), Bash(launchctl:*)
 ---
 
 # Qwen Status: Check Local Qwen Stack Readiness
 
-Check the Ollama server, the Qwen model, network exposure, and the Codex CLI
-harness that `/qwen:auto` and `/qwen:exec` depend on.
+Check the Ollama server, the Qwen model, network exposure, and the Qwen Code
+CLI harness that `/qwen:auto` and `/qwen:exec` depend on.
 
 ## Instructions
 
@@ -65,36 +65,33 @@ if command -v ollama &>/dev/null; then
 fi
 ```
 
-### Step 3: Check Codex CLI Harness
+### Step 3: Check Qwen Code CLI Harness
 
 ```bash
 echo ""
-echo "=== Codex CLI Harness ==="
+echo "=== Qwen Code CLI Harness ==="
 echo ""
 
-if command -v codex &>/dev/null; then
-    CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
-    echo "[x] Codex CLI: $CODEX_VERSION"
-    if codex exec --help 2>&1 | grep -q -- "--oss"; then
-        echo "[x] --oss local-provider support: present"
+if command -v qwen &>/dev/null; then
+    QWEN_CLI_VERSION=$(qwen --version 2>/dev/null || echo "unknown")
+    echo "[x] Qwen Code CLI: $QWEN_CLI_VERSION"
+    if qwen --help 2>&1 | grep -q -- "--output-format"; then
+        echo "[x] Headless stream-json support: present"
     else
-        echo "[ ] --oss flag not supported - upgrade: npm install -g @openai/codex"
+        echo "[ ] --output-format not supported - upgrade: npm install -g @qwen-code/qwen-code"
     fi
 else
-    echo "[ ] Codex CLI: not installed (required as the local-model harness)"
-    echo "    Install with: npm install -g @openai/codex"
-    echo "    NOTE: no OpenAI API key is needed for /qwen:* usage"
+    echo "[ ] Qwen Code CLI: not installed (required as the local-model harness)"
+    echo "    Install with: npm install -g @qwen-code/qwen-code"
+    echo "    NOTE: no cloud API key is needed for /qwen:* usage"
 fi
 
-# Remote profile, if configured
+# Flag the retired Codex harness path if its env var is still set
 if [ -n "$QWEN_CODEX_PROFILE" ]; then
     echo ""
-    if grep -q "\[profiles.$QWEN_CODEX_PROFILE\]" ~/.codex/config.toml 2>/dev/null; then
-        echo "[x] Remote profile '$QWEN_CODEX_PROFILE' found in ~/.codex/config.toml"
-    else
-        echo "[ ] QWEN_CODEX_PROFILE='$QWEN_CODEX_PROFILE' set but not found in ~/.codex/config.toml"
-        echo "    See /qwen:help for the profile recipe"
-    fi
+    echo "[~] QWEN_CODEX_PROFILE is set but no longer used: the Codex CLI"
+    echo "    harness was retired (issue #745). Remote serving machines now"
+    echo "    need only QWEN_OLLAMA_URL - see /qwen:help. Unset it."
 fi
 ```
 
@@ -106,11 +103,13 @@ If the server and model are present, offer a quick generation probe:
 echo ""
 echo "=== Latency Probe ==="
 curl -s "$QWEN_ENDPOINT/api/generate" \
-  -d "{\"model\":\"$QWEN_MODEL\",\"prompt\":\"Say OK. /no_think\",\"stream\":false}" \
+  -d "{\"model\":\"$QWEN_MODEL\",\"prompt\":\"Say OK.\",\"think\":false,\"stream\":false}" \
   --max-time 120 | grep -o '"eval_count":[0-9]*\|"eval_duration":[0-9]*' || echo "(probe failed or timed out)"
 ```
 
 Report tokens/second if the probe succeeds (eval_count / (eval_duration / 1e9)).
+(`"think": false` keeps the probe fast on thinking-enabled models; it is the
+native-API hard switch, more reliable than the `/no_think` soft prompt.)
 
 ### Step 5: Summary
 
@@ -119,7 +118,7 @@ echo ""
 echo "==================================="
 
 READY=true
-command -v codex &>/dev/null || READY=false
+command -v qwen &>/dev/null || READY=false
 curl -sf --max-time 5 "$QWEN_ENDPOINT/api/version" > /dev/null 2>&1 || READY=false
 
 if [ "$READY" = "true" ]; then
@@ -140,5 +139,5 @@ echo "==================================="
 ## Notes
 
 - This command is read-only - it checks state but does not modify anything
-- `QWEN_OLLAMA_URL` lets a remote machine check the serving machine's stack
-- The Codex CLI is required only as an agentic harness; `/qwen:*` never uses an OpenAI API key
+- `QWEN_OLLAMA_URL` lets a remote machine check (and use) the serving machine's stack
+- The Qwen Code CLI is required only as an agentic harness; `/qwen:*` never uses a cloud API key

--- a/codex/skills/cpp-help/reference.md
+++ b/codex/skills/cpp-help/reference.md
@@ -79,9 +79,9 @@ CPP uses a tiered installation model:
 ### Tier 6 - Local Qwen (optional)
 - **Qwen Auto** (`/qwen:auto`): Full issue lifecycle delegated to a locally hosted Qwen model (Ollama-served, zero API cost)
 - **Qwen Exec** (`/qwen:exec`): One-shot local Qwen execution with JSONL monitoring
-- **Harness**: reuses the Codex CLI in `--oss` mode (no OpenAI API key needed)
-- **Network serving**: one machine hosts the model; others reach it over LAN/Tailscale via a Codex profile
-- **Same safety machinery**: execution fence, `workspace-write` sandbox, overrun verification
+- **Harness**: Qwen Code CLI in headless mode (no cloud API key needed; Codex harness retired in issue #745)
+- **Network serving**: one machine hosts the model; others reach it over LAN/Tailscale via `QWEN_OLLAMA_URL`
+- **Same safety machinery**: execution fence, sandbox, overrun verification
 
 ## CI/CD Commands (Tier 4)
 

--- a/codex/skills/flow-auto/scripts/codex-skill-sync.py
+++ b/codex/skills/flow-auto/scripts/codex-skill-sync.py
@@ -72,8 +72,8 @@ EXCLUDE: dict[str, set[str]] = {
 # Families deliberately not generated as Codex skills (#582 completeness gate):
 #   spec: spec-kit is the upstream product; /spec:adopt installs it.
 #   codex: orchestrates the Codex CLI itself - circular as a Codex skill.
-#   qwen: drives a local model THROUGH the Codex CLI (--oss harness) - same
-#     circularity as the codex family.
+#   qwen: Claude-supervised local-model orchestration (Qwen Code CLI harness
+#     since #745); not a workflow a Codex session drives.
 UNPACKAGED_FAMILIES: set[str] = {"spec", "codex", "qwen"}
 
 # Loose *.md files allowed directly under .claude/commands/. Empty by design

--- a/codex/skills/flow-finish/scripts/codex-skill-sync.py
+++ b/codex/skills/flow-finish/scripts/codex-skill-sync.py
@@ -72,8 +72,8 @@ EXCLUDE: dict[str, set[str]] = {
 # Families deliberately not generated as Codex skills (#582 completeness gate):
 #   spec: spec-kit is the upstream product; /spec:adopt installs it.
 #   codex: orchestrates the Codex CLI itself - circular as a Codex skill.
-#   qwen: drives a local model THROUGH the Codex CLI (--oss harness) - same
-#     circularity as the codex family.
+#   qwen: Claude-supervised local-model orchestration (Qwen Code CLI harness
+#     since #745); not a workflow a Codex session drives.
 UNPACKAGED_FAMILIES: set[str] = {"spec", "codex", "qwen"}
 
 # Loose *.md files allowed directly under .claude/commands/. Empty by design

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -235,11 +235,11 @@ qualifiers such as `/qa:test` being single-session) are not lost.
 - `/codex:help` - Codex commands overview
 ### Local Qwen Orchestration (Tier 6, optional)
 
-- `/qwen:auto <ISSUE>` - Full issue lifecycle delegated to a locally hosted Qwen model (Ollama-served, driven through the Codex CLI harness in `--oss` mode; no OpenAI API key or per-token cost)
-- `/qwen:exec <PROMPT>` - One-shot local Qwen execution in current directory with JSONL monitoring (`workspace-write` sandbox)
-- `/qwen:status` - Check the Ollama server, model presence, network exposure, and Codex harness readiness
-- `/qwen:help` - Qwen commands overview, serving-stack recipe, and remote-access Codex profile setup
-- Design notes: same supervisor/implementer split and issue #735 safety machinery as `/codex:auto` (execution fence, `workspace-write` sandbox, overrun verification); local-model calibration demands tighter prompts and stricter Claude review, with escalation to `/codex:auto` when the fix loop exhausts. One machine serves the model (Ollama bound to `0.0.0.0:11434`); consumer machines reach it via `QWEN_OLLAMA_URL` for status checks and a `model_providers` profile in `~/.codex/config.toml` (selected with `QWEN_CODEX_PROFILE`) for execution, because the Codex harness ignores `OLLAMA_HOST`.
+- `/qwen:auto <ISSUE>` - Full issue lifecycle delegated to a locally hosted Qwen model (Ollama-served, driven through the Qwen Code CLI harness in headless stream-json mode; no cloud API key or per-token cost)
+- `/qwen:exec <PROMPT>` - One-shot local Qwen execution in current directory with JSONL monitoring (Seatbelt/Docker sandbox, yolo approval, wall-time budget)
+- `/qwen:status` - Check the Ollama server, model presence, network exposure, and Qwen Code harness readiness
+- `/qwen:help` - Qwen commands overview, serving-stack recipe, thinking-token guidance, and remote-access setup
+- Design notes: same supervisor/implementer split and issue #735 safety machinery as `/codex:auto` (execution fence, sandbox, overrun verification); local-model calibration demands tighter prompts and stricter Claude review, with escalation to `/codex:auto` when the fix loop exhausts. One machine serves the model (Ollama bound to `0.0.0.0:11434`); consumer machines reach it by setting `QWEN_OLLAMA_URL`, which every `/qwen:*` command uses for both status checks and execution (`--openai-base-url $QWEN_OLLAMA_URL/v1`). The original Codex CLI harness (`codex exec --oss`, `QWEN_CODEX_PROFILE`) was retired in issue #745: Codex deleted the chat-completions wire API at v0.95 (a leftover `wire_api = "chat"` provider block hard-errors every Codex run), its `/v1/responses` path hangs on Qwen 3 thinking output (ollama/ollama#18187), and upstream closed remote-Ollama support as not-planned.
 ### Security
 
 - `/security:scan` - Full scan: native + external tools

--- a/scripts/codex-skill-sync.py
+++ b/scripts/codex-skill-sync.py
@@ -72,8 +72,8 @@ EXCLUDE: dict[str, set[str]] = {
 # Families deliberately not generated as Codex skills (#582 completeness gate):
 #   spec: spec-kit is the upstream product; /spec:adopt installs it.
 #   codex: orchestrates the Codex CLI itself - circular as a Codex skill.
-#   qwen: drives a local model THROUGH the Codex CLI (--oss harness) - same
-#     circularity as the codex family.
+#   qwen: Claude-supervised local-model orchestration (Qwen Code CLI harness
+#     since #745); not a workflow a Codex session drives.
 UNPACKAGED_FAMILIES: set[str] = {"spec", "codex", "qwen"}
 
 # Loose *.md files allowed directly under .claude/commands/. Empty by design


### PR DESCRIPTION
## Summary

`/qwen:auto` hung at Step 3 because the Codex CLI harness path it rode is dead upstream, and the issue's original diagnosis (chat-completions `reasoning` deltas) no longer matches how modern Codex works:

- Codex deleted the chat-completions wire API at v0.95 (openai/codex#10157). CPP's documented remote recipe (`wire_api = "chat"` in `~/.codex/config.toml`) is now a **hard startup error** for every Codex invocation.
- `codex exec --oss` speaks Ollama's `/v1/responses`, where Qwen 3 thinking models hit an unfixed answer-swallowing bug (ollama/ollama#18187) and the invisible thinking phase (minutes at ~15-20 tok/s, `show_raw_agent_reasoning` off by default) reads as an indefinite hang.
- Remote-Ollama support was closed not-planned (openai/codex#8240); the `--oss` path regressed repeatedly through 2026.

Per a 5-harness evaluation (Qwen Code, OpenCode, Goose, Crush, Aider), the `/qwen:*` family now uses **Qwen Code CLI** (QwenLM/qwen-code, >=0.23.0): headless `stream-json` events, Seatbelt/Docker sandbox, `--max-wall-time` budgets (exit 55), first-class remote endpoints via `--openai-base-url` (no SSH tunnel, no config file - just `QWEN_OLLAMA_URL`), and native Qwen 3 reasoning-token parsing.

## Changes

- `qwen/auto.md`, `qwen/exec.md` - qwen headless invocation (verified against the real 0.23.0 binary); execution fence + overrun verification unchanged
- `qwen/help.md` - retirement rationale, thinking-token guidance (non-thinking coder tags, Ollama `reasoning_effort`), `QWEN_OLLAMA_URL` remote recipe
- `qwen/status.md`, `cpp/status.md`, `cpp/init.md` Tier 6 - probe the qwen CLI; warn on stale `QWEN_CODEX_PROFILE` / `wire_api = "chat"` leftovers (which break `/codex:*` too)
- `docs/commands-reference.md`, `cpp/help.md`, `scripts/codex-skill-sync.py` comment; `codex/skills/` mirrors regenerated

## Test plan

- `make lint` passes; `codex-skill-sync` regenerated clean (75 skills current)
- `make test`: 116 failures on this macOS host, **byte-identical on clean main** (flow-wave suites shell out to `flock`, absent on macOS; plus pre-existing drift/gh-pr-merge failures) - zero regressions attributable to this docs-only change; CI on Linux is authoritative
- Live smoke test of `/qwen:status` + `/qwen:exec` against the MacBook Ollama server to be run post-merge on the serving machine (documented in `cpp/init.md` 6d)

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnQLKE6YR3yk8uM4BLaBNf