### PR TITLE
fix(qwen): replace --max-wall-time with bash timeout wrapper (Closes #748)

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -1388,9 +1388,9 @@ every modern Codex invocation, including unrelated `/codex:*` commands.
 
 ```bash
 QWEN_ENDPOINT="${QWEN_OLLAMA_URL:-http://127.0.0.1:11434}"
-qwen --openai-base-url "$QWEN_ENDPOINT/v1" --openai-api-key ollama \
+timeout 600 qwen --openai-base-url "$QWEN_ENDPOINT/v1" --openai-api-key ollama \
   --auth-type openai -m "$QWEN_MODEL" \
-  --approval-mode plan --output-format text --max-wall-time 10m \
+  --approval-mode plan --output-format text \
   "Reply with exactly: QWEN-HARNESS-OK" < /dev/null 2>&1 | tail -3
 ```
 

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -208,12 +208,13 @@ Execute headless with `stream-json` monitoring. The harness has no
 change-directory flag, so this MUST run with the worktree as the current
 directory. `--approval-mode yolo` is required in headless mode (an interactive
 approval prompt would deadlock an unattended run); `--sandbox` supplies the
-mechanical write boundary; `--max-wall-time` bounds a stalled run instead of
-hanging forever (exit code 55 when exceeded).
+mechanical write boundary; bash `timeout` bounds a stalled run instead of
+hanging forever (exit code 124 when exceeded - Qwen Code CLI has no native
+wall-time flag).
 
 ```bash
 # Run FROM INSIDE the worktree (qwen operates on the current directory)
-qwen \
+timeout 2700 qwen \
     --openai-base-url "$QWEN_ENDPOINT/v1" \
     --openai-api-key ollama \
     --auth-type openai \
@@ -221,7 +222,6 @@ qwen \
     --output-format stream-json \
     --approval-mode yolo \
     --sandbox \
-    --max-wall-time 45m \
     "$QWEN_PROMPT" < /dev/null 2>&1 | tee /tmp/qwen-output-${ISSUE_NUM}.jsonl   # </dev/null: non-TTY EOF so the harness never blocks reading stdin
 ```
 
@@ -247,8 +247,8 @@ server-side `reasoning_effort`).
 QWEN_EXIT=$?
 if [ "$QWEN_EXIT" -ne 0 ]; then
     echo "ERROR: Qwen execution failed (exit code: $QWEN_EXIT)"
-    if [ "$QWEN_EXIT" -eq 55 ]; then
-        echo "(exit 55 = --max-wall-time budget exceeded - the run stalled or the task is too big)"
+    if [ "$QWEN_EXIT" -eq 124 ]; then
+        echo "(exit 124 = timeout exceeded - the run stalled or the task is too big)"
     fi
     echo "Last 20 lines of output:"
     tail -20 /tmp/qwen-output-${ISSUE_NUM}.jsonl

--- a/.claude/commands/qwen/exec.md
+++ b/.claude/commands/qwen/exec.md
@@ -51,14 +51,15 @@ echo "Working directory: $(pwd)"
 
 Run headless with `stream-json` output for structured monitoring. The harness
 runs sandboxed (macOS Seatbelt / Docker) with `yolo` approval so the headless
-run never blocks on an interactive confirmation; `--max-wall-time` bounds a
-runaway or stalled run (exit code 55 when exceeded).
+run never blocks on an interactive confirmation; bash `timeout` bounds a
+runaway or stalled run (exit code 124 when exceeded - Qwen Code CLI has no
+native wall-time flag).
 
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 OUTPUT_FILE="/tmp/qwen-exec-${TIMESTAMP}.jsonl"
 
-qwen \
+timeout 1800 qwen \
     --openai-base-url "$QWEN_ENDPOINT/v1" \
     --openai-api-key ollama \
     --auth-type openai \
@@ -66,7 +67,6 @@ qwen \
     --output-format stream-json \
     --approval-mode yolo \
     --sandbox \
-    --max-wall-time 30m \
     "$PROMPT" < /dev/null 2>&1 | tee "$OUTPUT_FILE"   # </dev/null: non-TTY EOF so the harness never blocks reading stdin
 
 QWEN_EXIT=$?
@@ -91,8 +91,8 @@ liveness either way.
 if [ "$QWEN_EXIT" -ne 0 ]; then
     echo ""
     echo "Qwen execution failed (exit code: $QWEN_EXIT)"
-    if [ "$QWEN_EXIT" -eq 55 ]; then
-        echo "(exit 55 = --max-wall-time or --max-tool-calls budget exceeded)"
+    if [ "$QWEN_EXIT" -eq 124 ]; then
+        echo "(exit 124 = timeout exceeded - the run stalled or the task is too big)"
     fi
     echo "Output saved to: $OUTPUT_FILE"
     exit 1


### PR DESCRIPTION
## Summary

Qwen Code CLI v0.15.10 does not support the `--max-wall-time` flag that was carried over from the Codex CLI harness in PR #747. The CLI rejects it with `Unknown arguments: max-wall-time, maxWallTime`, causing every `/qwen:auto` and `/qwen:exec` run to fail at launch.

## Changes

Replace `--max-wall-time` with bash `timeout` wrappers in all three invocation sites:

| File | Old | New |
|------|-----|-----|
| `.claude/commands/qwen/auto.md` | `--max-wall-time 45m` | `timeout 2700` |
| `.claude/commands/qwen/exec.md` | `--max-wall-time 30m` | `timeout 1800` |
| `.claude/commands/cpp/init.md` | `--max-wall-time 10m` | `timeout 600` |

Updated exit-code documentation from exit 55 (Codex-specific) to exit 124 (`timeout`'s standard signal).

## Test Plan

- All 1777 tests pass
- Lint, typecheck, and security scan clean
- Verified no remaining `max-wall-time` references in the codebase

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF8C3HdZynjuRbS68mKQgf