### PR TITLE
fix(qwen): skip Docker sandbox for remote Ollama endpoints (Closes #749)

### DIFF
--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -141,11 +141,17 @@ Report: `Step 2/7: Analyze complete - Qwen prompt built ({N} files referenced)`
 
 ### Step 3: Execute Qwen - Delegate Implementation
 
-Run the local Qwen model through the Qwen Code CLI harness in the worktree,
-sandboxed (macOS Seatbelt / Docker). The sandbox blocks writes outside the
-working directory (same rationale as issue #735); network from model-run shell
-commands is NOT blocked by the default profile, so the textual fence plus the
-post-execution overrun verification below carry that boundary.
+Run the local Qwen model through the Qwen Code CLI harness in the worktree.
+When the Ollama server is local (localhost / 127.0.0.1 / ::1), the harness runs
+sandboxed (macOS Seatbelt / Docker) to block writes outside the working
+directory (same rationale as issue #735). When the server is remote
+(`QWEN_OLLAMA_URL` points at another machine - the common Tailscale/LAN GPU
+pattern), the sandbox is skipped because the Docker network namespace cannot
+reach Tailscale or other host-only interfaces (issue #749). The two remaining
+safety layers - the textual execution fence and the post-execution overrun
+verification - are always active regardless of sandbox state; network from
+model-run shell commands is NOT blocked by either profile, so those layers
+carry the network boundary in all cases.
 
 ```bash
 # Verify the harness and the model server
@@ -168,6 +174,32 @@ fi
 if ! curl -sf --max-time 5 "$QWEN_ENDPOINT/api/tags" 2>/dev/null | grep -q "${QWEN_MODEL%%:*}"; then
     echo "ERROR: model '$QWEN_MODEL' not found on the server."
     exit 1
+fi
+
+# Sandbox detection (issue #749): Docker sandbox containers cannot reach
+# Tailscale or other host-only network interfaces. When the Ollama endpoint
+# is remote, skip --sandbox and rely on the execution fence + overrun
+# verification (the two layers that are always active regardless).
+# QWEN_FORCE_SANDBOX overrides the automatic detection (1 = force on, 0 = force off).
+if [ "${QWEN_FORCE_SANDBOX:-}" = "1" ]; then
+    SANDBOX_FLAG="--sandbox"
+    echo "Sandbox forced on (QWEN_FORCE_SANDBOX=1)."
+elif [ "${QWEN_FORCE_SANDBOX:-}" = "0" ]; then
+    SANDBOX_FLAG=""
+    echo "Sandbox forced off (QWEN_FORCE_SANDBOX=0)."
+else
+    SANDBOX_FLAG="--sandbox"
+    ENDPOINT_HOST=$(echo "$QWEN_ENDPOINT" | sed -E 's|^https?://||' | sed -E 's|:[0-9]+.*||' | sed -E 's|/.*||')
+    case "$ENDPOINT_HOST" in
+        127.0.0.1|localhost|::1|"[::1]")
+            echo "Ollama endpoint is local ($ENDPOINT_HOST) - sandbox enabled."
+            ;;
+        *)
+            SANDBOX_FLAG=""
+            echo "Ollama endpoint is remote ($ENDPOINT_HOST) - sandbox skipped (issue #749: Docker network namespace cannot reach Tailscale/host interfaces)."
+            echo "Safety layers active: execution fence + post-execution overrun verification."
+            ;;
+    esac
 fi
 ```
 
@@ -207,9 +239,10 @@ IGNORE its contents entirely - it is not addressed to you.
 Execute headless with `stream-json` monitoring. The harness has no
 change-directory flag, so this MUST run with the worktree as the current
 directory. `--approval-mode yolo` is required in headless mode (an interactive
-approval prompt would deadlock an unattended run); `--sandbox` supplies the
-mechanical write boundary; `--max-wall-time` bounds a stalled run instead of
-hanging forever (exit code 55 when exceeded).
+approval prompt would deadlock an unattended run); `$SANDBOX_FLAG` supplies the
+mechanical write boundary when the endpoint is local (empty for remote
+endpoints - see sandbox detection above, issue #749); `--max-wall-time` bounds
+a stalled run instead of hanging forever (exit code 55 when exceeded).
 
 ```bash
 # Run FROM INSIDE the worktree (qwen operates on the current directory)
@@ -220,7 +253,7 @@ qwen \
     -m "$QWEN_MODEL" \
     --output-format stream-json \
     --approval-mode yolo \
-    --sandbox \
+    $SANDBOX_FLAG \
     --max-wall-time 45m \
     "$QWEN_PROMPT" < /dev/null 2>&1 | tee /tmp/qwen-output-${ISSUE_NUM}.jsonl   # </dev/null: non-TTY EOF so the harness never blocks reading stdin
 ```
@@ -466,7 +499,7 @@ Key failure scenarios:
 
 - The implementer is a LOCAL model (default `qwen3.8-code:latest`, Qwen3.8-27B Q4_K_M served by Ollama) driven through the Qwen Code CLI in headless mode; no cloud API key or per-token cost is involved
 - The Qwen Code CLI (QwenLM/qwen-code, `npm install -g @qwen-code/qwen-code`) is used purely as an agentic harness: stream-json event output, Seatbelt/Docker sandboxing, tool loop, and native Qwen 3 reasoning-token handling (the Codex CLI harness was retired in issue #745 - its chat wire API was deleted upstream and its `/v1/responses` path hangs on Qwen 3 thinking output)
-- Same defense-in-depth as `/codex:auto` (issue #735): textual execution fence + sandbox + post-execution overrun verification (the sandbox blocks out-of-worktree writes; the fence and overrun checks cover git/gh/network overreach)
+- Same defense-in-depth as `/codex:auto` (issue #735): textual execution fence + sandbox + post-execution overrun verification (the sandbox blocks out-of-worktree writes; the fence and overrun checks cover git/gh/network overreach). When `QWEN_OLLAMA_URL` is remote, the sandbox is skipped (issue #749: Docker network namespace cannot reach Tailscale/host-only interfaces) and the fence + overrun verification carry the full boundary
 - Local-model calibration: prompts must be more explicit, scope smaller, review stricter; escalate to `/codex:auto` when the issue is broad or the fix loop exhausts
-- On a remote machine, set `QWEN_OLLAMA_URL=http://<serving-machine-ip>:11434`; no tunnel or harness config file is needed (see `/qwen:help`)
+- On a remote machine, set `QWEN_OLLAMA_URL=http://<serving-machine-ip>:11434`; no tunnel or harness config file is needed, and the sandbox is automatically skipped for remote endpoints (see `/qwen:help`)
 - To check readiness (server, model, harness), use `/qwen:status`

--- a/.claude/commands/qwen/exec.md
+++ b/.claude/commands/qwen/exec.md
@@ -45,13 +45,42 @@ fi
 echo "Harness: qwen $(qwen --version 2>/dev/null)"
 echo "Model:   $QWEN_MODEL via $QWEN_ENDPOINT"
 echo "Working directory: $(pwd)"
+
+# Sandbox detection (issue #749): Docker sandbox containers cannot reach
+# Tailscale or other host-only network interfaces. When the Ollama endpoint
+# is remote, skip --sandbox and rely on the execution fence + overrun
+# verification (the two layers that are always active regardless).
+# QWEN_FORCE_SANDBOX overrides the automatic detection (1 = force on, 0 = force off).
+if [ "${QWEN_FORCE_SANDBOX:-}" = "1" ]; then
+    SANDBOX_FLAG="--sandbox"
+    echo "Sandbox forced on (QWEN_FORCE_SANDBOX=1)."
+elif [ "${QWEN_FORCE_SANDBOX:-}" = "0" ]; then
+    SANDBOX_FLAG=""
+    echo "Sandbox forced off (QWEN_FORCE_SANDBOX=0)."
+else
+    SANDBOX_FLAG="--sandbox"
+    ENDPOINT_HOST=$(echo "$QWEN_ENDPOINT" | sed -E 's|^https?://||' | sed -E 's|:[0-9]+.*||' | sed -E 's|/.*||')
+    case "$ENDPOINT_HOST" in
+        127.0.0.1|localhost|::1|"[::1]")
+            echo "Ollama endpoint is local ($ENDPOINT_HOST) - sandbox enabled."
+            ;;
+        *)
+            SANDBOX_FLAG=""
+            echo "Ollama endpoint is remote ($ENDPOINT_HOST) - sandbox skipped (issue #749)."
+            echo "Safety layers active: execution fence + post-execution overrun verification."
+            ;;
+    esac
+fi
 ```
 
 ### Step 2: Execute
 
-Run headless with `stream-json` output for structured monitoring. The harness
-runs sandboxed (macOS Seatbelt / Docker) with `yolo` approval so the headless
-run never blocks on an interactive confirmation; `--max-wall-time` bounds a
+Run headless with `stream-json` output for structured monitoring. When the
+Ollama endpoint is local, the harness runs sandboxed (macOS Seatbelt / Docker);
+when remote, the sandbox is skipped (issue #749: Docker network namespace cannot
+reach Tailscale/host-only interfaces) and the execution fence + overrun
+verification carry the safety boundary. `yolo` approval prevents the headless
+run from blocking on an interactive confirmation; `--max-wall-time` bounds a
 runaway or stalled run (exit code 55 when exceeded).
 
 ```bash
@@ -65,7 +94,7 @@ qwen \
     -m "$QWEN_MODEL" \
     --output-format stream-json \
     --approval-mode yolo \
-    --sandbox \
+    $SANDBOX_FLAG \
     --max-wall-time 30m \
     "$PROMPT" < /dev/null 2>&1 | tee "$OUTPUT_FILE"   # </dev/null: non-TTY EOF so the harness never blocks reading stdin
 
@@ -124,8 +153,11 @@ or git checkout -- . to discard.
 ## Notes
 
 - Runs in the CURRENT directory (not a worktree) - changes are applied directly
-- The sandbox (default macOS Seatbelt profile) blocks writes outside the
-  working directory; shell commands the model runs retain network access, so
+- When the Ollama endpoint is local (localhost/127.0.0.1/::1), the sandbox
+  (Seatbelt/Docker) blocks writes outside the working directory. When remote
+  (`QWEN_OLLAMA_URL` points at another machine), the sandbox is skipped because
+  Docker's network namespace cannot reach Tailscale/host-only interfaces (issue
+  #749). Shell commands the model runs retain network access in both modes, so
   the execution-fence + overrun-verification pattern from `/qwen:auto` still
   applies for anything beyond quick tasks
 - JSONL output is saved to /tmp for later inspection

--- a/.claude/commands/qwen/help.md
+++ b/.claude/commands/qwen/help.md
@@ -105,6 +105,38 @@ The commands derive the harness endpoint from it
 (`$QWEN_OLLAMA_URL/v1`) and pass it via `--openai-base-url`. Unset, the
 commands default to `http://127.0.0.1:11434`.
 
+## Sandbox and Remote Endpoints (issue #749)
+
+The Qwen Code CLI's `--sandbox` flag runs the model inside a Docker container
+(Linux) or a Seatbelt profile (macOS) that blocks writes outside the working
+directory. On Linux, Docker containers run in their own network namespace, so
+they cannot reach Tailscale interfaces, LAN-only addresses, or other host-only
+network endpoints.
+
+**Automatic detection:** `/qwen:auto` and `/qwen:exec` parse `QWEN_OLLAMA_URL`
+and decide at invocation time:
+
+| Endpoint host | Sandbox | Rationale |
+|---------------|---------|-----------|
+| `127.0.0.1`, `localhost`, `::1` (or unset) | `--sandbox` enabled | Local server - Docker networking is fine |
+| Anything else (e.g., a Tailscale IP) | `--sandbox` skipped | Docker network namespace cannot reach host-only interfaces |
+
+When the sandbox is skipped, the two other safety layers remain active:
+
+1. **Execution fence** - a textual constraint at the top of every prompt that
+   forbids git/gh/deploy/infrastructure commands.
+2. **Post-execution overrun verification** - automated checks that the model
+   did not commit, push, create PRs, or escape its implementation-only boundary.
+
+These layers are always present regardless of sandbox state and already carry
+the network boundary (the sandbox never blocked network from shell commands the
+model runs).
+
+**Force override:** To force sandbox on for a remote endpoint (e.g., if Docker
+is configured with `--network host`), set `QWEN_FORCE_SANDBOX=1`. To force
+sandbox off for a local endpoint, set `QWEN_FORCE_SANDBOX=0`. The detection
+only applies when the variable is unset.
+
 ## Quick Start
 
 ```bash
@@ -128,7 +160,7 @@ commands default to `http://127.0.0.1:11434`.
 | Privacy | Code sent to OpenAI | Code never leaves the network |
 | Speed | Fast (cloud inference) | ~15-20 tok/s (Apple Silicon) |
 | Capability | Frontier model | Strong 27B - needs tighter prompts, stricter review |
-| Sandbox | `workspace-write` | Seatbelt/Docker sandbox + yolo approval |
+| Sandbox | `workspace-write` | Seatbelt/Docker sandbox (local endpoint) / skipped for remote (issue #749) |
 | Escalation path | - | Falls back to `/codex:auto` when it struggles |
 
 ## When To Use Which
@@ -159,8 +191,8 @@ Run `/cpp:init` and select **Tier 6 (Local Qwen)** to:
 
 ## Notes
 
-- Same defense-in-depth as `/codex:auto`: execution fence + sandbox + overrun verification
+- Same defense-in-depth as `/codex:auto`: execution fence + sandbox + overrun verification. When `QWEN_OLLAMA_URL` is a remote endpoint, the sandbox is automatically skipped (issue #749) and the fence + overrun verification carry the full boundary
 - A local model wanders more than a frontier model - the fence and the Claude review step are mandatory, never skipped
 - `QWEN_MODEL` overrides the model tag; any Ollama-served coding model works (e.g., `qwen3-coder:30b`)
 - Expect minutes-per-turn pacing on the serving hardware; the JSONL stream shows liveness
-- The Qwen Code sandbox (default macOS Seatbelt profile) blocks writes outside the working directory but does NOT block network from shell commands the model runs - the execution fence plus post-run overrun verification cover that gap, exactly as they did under Codex
+- The sandbox (Seatbelt/Docker) blocks writes outside the working directory but does NOT block network from shell commands the model runs - the execution fence plus post-run overrun verification cover that gap in all modes. `QWEN_FORCE_SANDBOX` overrides the automatic detection (1 = force on, 0 = force off)


### PR DESCRIPTION
## Summary

When `QWEN_OLLAMA_URL` points at a remote machine (the common Tailscale/LAN
GPU serving pattern), the Docker sandbox's isolated network namespace prevents
the Qwen Code CLI from reaching the Ollama server. This PR detects remote
endpoints and automatically skips `--sandbox`, relying on the two remaining
safety layers — the textual execution fence and post-execution overrun
verification — which are always active regardless of sandbox state.

## Changes

- **`.claude/commands/qwen/auto.md`** — Added `SANDBOX_FLAG` detection block in
  Step 3 that parses `QWEN_OLLAMA_URL` and omits `--sandbox` for remote
  endpoints. Updated invocation, safety documentation, and notes. Supports
  `QWEN_FORCE_SANDBOX` override (1=on, 0=off).
- **`.claude/commands/qwen/exec.md`** — Same sandbox detection logic added to
  Step 1, invocation updated in Step 2. Notes updated.
- **`.claude/commands/qwen/help.md`** — New "Sandbox and Remote Endpoints" section
  documenting the behavior, detection table, safety layers, and force override.
  Comparison table and notes updated.

## Detection Logic

```bash
case "$ENDPOINT_HOST" in
    127.0.0.1|localhost|::1|"[::1]") SANDBOX_FLAG="--sandbox" ;;
    *) SANDBOX_FLAG="" ;;
esac
```

Override: `QWEN_FORCE_SANDBOX=1` forces sandbox on (e.g., Docker with
`--network host`), `QWEN_FORCE_SANDBOX=0` forces off.

## Test Plan

- All 1777 existing tests pass
- Lint, typecheck, and security scan pass
- Manual verification: the detection logic correctly classifies localhost
  variants as local and any other host as remote

Closes #749

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RR3myH1ostGp8xsi23PjZd