### PR TITLE
fix(local-models): persist the Ollama endpoint and diagnose an unset one honestly (Closes #755)

### DIFF
--- a/.claude/commands/cpp/init.md
+++ b/.claude/commands/cpp/init.md
@@ -1412,11 +1412,54 @@ fi
 
 #### 6c. Remote Access (consumer machines only)
 
-No harness config file is needed for a remote Ollama server. Instruct the
-user to set one environment variable (e.g., in shell rc):
+No harness config file is needed for a remote Ollama server. Only offer to
+persist the endpoint when `QWEN_ENDPOINT` is not
+`http://127.0.0.1:11434`, or when the user said this machine consumes a
+remote server. If the user identified it as a consumer but the endpoint is
+still the localhost default, ask for the actual serving endpoint first and
+use that value. Do not offer this on the serving machine: the localhost
+default already works there, and a hardcoded export is a liability. This
+closes the fresh-shell persistence gap tracked in issue #755.
+
+Choose the rc file from the user's shell: `~/.zshrc` when `$SHELL` ends in
+`zsh`, otherwise `~/.bashrc`:
 
 ```bash
-export QWEN_OLLAMA_URL=http://<serving-machine-ip>:11434
+case "${SHELL##*/}" in
+  zsh) QWEN_RC="$HOME/.zshrc"; QWEN_RC_DISPLAY="~/.zshrc" ;;
+  *) QWEN_RC="$HOME/.bashrc"; QWEN_RC_DISPLAY="~/.bashrc" ;;
+esac
+```
+
+Show the actual `QWEN_ENDPOINT` and selected rc file in this prompt, not
+placeholders:
+
+```
+=== Optional: Persist Qwen Endpoint ===
+
+Remote Qwen commands need this setting in every fresh shell. I can add:
+  # Claude Power Pack - Qwen serving endpoint (issue #755)
+  export QWEN_OLLAMA_URL=${QWEN_ENDPOINT}
+
+Add to ${QWEN_RC_DISPLAY}? [y/N]
+```
+
+If yes:
+```bash
+if grep -q 'QWEN_OLLAMA_URL' "$QWEN_RC" 2>/dev/null; then
+  echo "-> QWEN_OLLAMA_URL already in $QWEN_RC_DISPLAY (skipped)"
+else
+  printf '\n# Claude Power Pack - Qwen serving endpoint (issue #755)\nexport QWEN_OLLAMA_URL=%s\n' "$QWEN_ENDPOINT" >> "$QWEN_RC"
+  echo "✓ QWEN_OLLAMA_URL saved in $QWEN_RC_DISPLAY"
+  echo "  Restart the shell or source $QWEN_RC_DISPLAY"
+fi
+```
+
+If no:
+```bash
+echo "-> QWEN_OLLAMA_URL persistence skipped"
+echo "  Add these exact lines to $QWEN_RC_DISPLAY later:"
+printf '# Claude Power Pack - Qwen serving endpoint (issue #755)\nexport QWEN_OLLAMA_URL=%s\n' "$QWEN_ENDPOINT"
 ```
 
 `/qwen:auto`, `/qwen:exec`, and `/qwen:status` derive the harness endpoint
@@ -1516,6 +1559,61 @@ fi
 The `num_ctx` bump is not optional tuning. Ollama's 32K default silently
 truncates long agent transcripts mid-run - no error, the model just loses the
 start of its own session.
+
+#### 7b.1 Persist the Gemma Endpoint (consumer machines only)
+
+Only offer to persist the endpoint when `GEMMA_ENDPOINT` is not
+`http://127.0.0.1:11434`, or when the user said this machine consumes a
+remote server. If the user identified it as a consumer but the endpoint is
+still the localhost default, ask for the actual serving endpoint first and
+use that value. Do not offer this on the serving machine: the localhost
+default already works there, and a hardcoded export is a liability.
+
+This matters specifically for Gemma because the OpenCode provider's
+`baseURL` is the literal `{env:GEMMA_OLLAMA_URL}`. OpenCode resolves it at
+invocation time, so an unset variable does not preserve a discovered remote
+endpoint - the lane silently addresses localhost (issue #755).
+
+Choose the rc file from the user's shell: `~/.zshrc` when `$SHELL` ends in
+`zsh`, otherwise `~/.bashrc`:
+
+```bash
+case "${SHELL##*/}" in
+  zsh) GEMMA_RC="$HOME/.zshrc"; GEMMA_RC_DISPLAY="~/.zshrc" ;;
+  *) GEMMA_RC="$HOME/.bashrc"; GEMMA_RC_DISPLAY="~/.bashrc" ;;
+esac
+```
+
+Show the actual `GEMMA_ENDPOINT` and selected rc file in this prompt, not
+placeholders:
+
+```
+=== Optional: Persist Gemma Endpoint ===
+
+Remote Gemma commands need this setting in every fresh shell. I can add:
+  # Claude Power Pack - Gemma serving endpoint (issue #755)
+  export GEMMA_OLLAMA_URL=${GEMMA_ENDPOINT}
+
+Add to ${GEMMA_RC_DISPLAY}? [y/N]
+```
+
+If yes:
+```bash
+if grep -q 'GEMMA_OLLAMA_URL' "$GEMMA_RC" 2>/dev/null; then
+  echo "-> GEMMA_OLLAMA_URL already in $GEMMA_RC_DISPLAY (skipped)"
+else
+  printf '\n# Claude Power Pack - Gemma serving endpoint (issue #755)\nexport GEMMA_OLLAMA_URL=%s\n' "$GEMMA_ENDPOINT" >> "$GEMMA_RC"
+  echo "✓ GEMMA_OLLAMA_URL saved in $GEMMA_RC_DISPLAY"
+  echo "  Restart the shell or source $GEMMA_RC_DISPLAY"
+fi
+```
+
+If no:
+```bash
+echo "-> GEMMA_OLLAMA_URL persistence skipped"
+echo "  Add these exact lines to $GEMMA_RC_DISPLAY later:"
+printf '# Claude Power Pack - Gemma serving endpoint (issue #755)\nexport GEMMA_OLLAMA_URL=%s\n' "$GEMMA_ENDPOINT"
+```
 
 #### 7c. Install the Provider and the Mechanical Fence
 

--- a/.claude/commands/gemma/status.md
+++ b/.claude/commands/gemma/status.md
@@ -24,11 +24,16 @@ GEMMA_ENDPOINT="${GEMMA_OLLAMA_URL:-http://127.0.0.1:11434}"
 VERSION_JSON=$(curl -sf --max-time 5 "$GEMMA_ENDPOINT/api/version" 2>/dev/null)
 if [ -n "$VERSION_JSON" ]; then
     echo "[x] Ollama reachable at $GEMMA_ENDPOINT: $VERSION_JSON"
+elif [ -z "${GEMMA_OLLAMA_URL:-}" ]; then
+    echo "[ ] GEMMA_OLLAMA_URL is unset - no serving machine URL was provided, and localhost is not answering."
+    echo "    If the model is served on another machine:"
+    echo "      export GEMMA_OLLAMA_URL=http://<serving-host>:11434"
+    echo "    Run /cpp:init and select Tier 7 to persist it (issue #755)."
+    echo "    If this is the serving machine, start the service ('ollama serve')."
 else
     echo "[ ] Ollama NOT reachable at $GEMMA_ENDPOINT"
-    echo "    Local machine: start the service ('ollama serve')"
-    echo "    Remote machine: set GEMMA_OLLAMA_URL to the serving machine's URL"
-    echo "    (e.g. GEMMA_OLLAMA_URL=http://proxvmgemma23:11434)"
+    echo "    This endpoint came from GEMMA_OLLAMA_URL. Check that the server is"
+    echo "    running and that the configured host is correct."
 fi
 ```
 
@@ -195,7 +200,11 @@ if [ "$READY" = "true" ]; then
 else
     echo "Status: NOT READY"
     echo ""
-    echo "See /gemma:help for setup (endpoint, Modelfile, OpenCode provider config)"
+    if [ -z "${GEMMA_OLLAMA_URL:-}" ]; then
+        echo "Likely cause: GEMMA_OLLAMA_URL is unset; /cpp:init Tier 7 can persist it"
+    else
+        echo "See /gemma:help for setup (endpoint, Modelfile, OpenCode provider config)"
+    fi
 fi
 
 echo "==================================="
@@ -210,6 +219,8 @@ echo "==================================="
   provider's `baseURL` in `~/.config/opencode/opencode.json` is
   `{env:GEMMA_OLLAMA_URL}` (OpenCode's env-var substitution, resolved at
   invocation time, not hardcoded)
+- An unset `GEMMA_OLLAMA_URL` is diagnosed separately from a configured but
+  unreachable endpoint (issue #755)
 - The OpenCode CLI is required only as an agentic harness; `/gemma:*` never
   uses a cloud API key
 - Step 4 is the one check that actually exercises the failure mode from

--- a/.claude/commands/qwen/status.md
+++ b/.claude/commands/qwen/status.md
@@ -23,10 +23,16 @@ QWEN_ENDPOINT="${QWEN_OLLAMA_URL:-http://127.0.0.1:11434}"
 VERSION_JSON=$(curl -sf --max-time 5 "$QWEN_ENDPOINT/api/version" 2>/dev/null)
 if [ -n "$VERSION_JSON" ]; then
     echo "[x] Ollama reachable at $QWEN_ENDPOINT: $VERSION_JSON"
+elif [ -z "${QWEN_OLLAMA_URL:-}" ]; then
+    echo "[ ] QWEN_OLLAMA_URL is unset - no serving machine URL was provided, and localhost is not answering."
+    echo "    If the model is served on another machine:"
+    echo "      export QWEN_OLLAMA_URL=http://<serving-host>:11434"
+    echo "    Run /cpp:init and select Tier 6 to persist it (issue #755)."
+    echo "    If this is the serving machine, start the service (launchd agent or 'ollama serve')."
 else
     echo "[ ] Ollama NOT reachable at $QWEN_ENDPOINT"
-    echo "    Local machine: start the service (launchd agent or 'ollama serve')"
-    echo "    Remote machine: set QWEN_OLLAMA_URL to the serving machine's URL"
+    echo "    This endpoint came from QWEN_OLLAMA_URL. Check that the server is"
+    echo "    running and that the configured host is correct."
 fi
 
 # On the serving machine, report network exposure
@@ -130,7 +136,11 @@ if [ "$READY" = "true" ]; then
 else
     echo "Status: NOT READY"
     echo ""
-    echo "To set up: /cpp:init (select Tier 6 - Local Qwen), or see /qwen:help"
+    if [ -z "${QWEN_OLLAMA_URL:-}" ]; then
+        echo "Likely cause: QWEN_OLLAMA_URL is unset; /cpp:init Tier 6 can persist it"
+    else
+        echo "To set up: /cpp:init (select Tier 6 - Local Qwen), or see /qwen:help"
+    fi
 fi
 
 echo "==================================="
@@ -140,4 +150,6 @@ echo "==================================="
 
 - This command is read-only - it checks state but does not modify anything
 - `QWEN_OLLAMA_URL` lets a remote machine check (and use) the serving machine's stack
+- An unset `QWEN_OLLAMA_URL` is diagnosed separately from a configured but
+  unreachable endpoint (issue #755)
 - The Qwen Code CLI is required only as an agentic harness; `/qwen:*` never uses a cloud API key


### PR DESCRIPTION
## Summary

`/cpp:init` Tier 7 writes an OpenCode provider whose `baseURL` is the literal `{env:GEMMA_OLLAMA_URL}` - OpenCode resolves it from the environment at invocation time. That design is deliberate and good: one config file works on the serving machine and on every consumer machine.

But **nothing in CPP ever persisted the variable.** No shell rc export, no `/cpp:init` step, no prompt. So on every fresh shell the lane reported itself broken on a host where it works perfectly. `QWEN_OLLAMA_URL` had the identical latent gap - it just bites less often because the Qwen box is more often the local machine.

The failure message was the sharper half. `[ ] Ollama NOT reachable at http://127.0.0.1:11434` reads as *"the server is down"*. The actual state was *"you never told me where the server is"*. A user follows the message, checks the serving box, finds Ollama healthy, and has no path forward.

## Part 1: Persist it (`.claude/commands/cpp/init.md`)

- **Tier 6 step 6c** grows from "instruct the user to export this" into a real offer that appends the export, keeping the existing `QWEN_CODEX_PROFILE` guidance (#745) intact.
- **New Tier 7 step 7b.1** adds the equivalent for Gemma, with the reason this tier needs it most: an unset `{env:GEMMA_OLLAMA_URL}` does not fall back to anything useful, so the lane silently addresses localhost.

Both follow the existing Tier 2 shell-rc consent pattern:

| Property | How |
|---|---|
| Shell-aware | rc file resolved from `$SHELL` (zsh -> `~/.zshrc`, else `~/.bashrc`) **before** the prompt renders it - a Gemma or Qwen box is often macOS |
| Idempotent | `grep -q` guard, prints `-> ... already in <rc> (skipped)` rather than appending a duplicate |
| Declinable | An `If no:` branch prints the exact lines to add later |
| Findable | A `# Claude Power Pack - ...` marker written in the same append as the export, so the two can never be separated |
| Consumer-only | Not offered on the serving machine, where the localhost default already works and a hardcoded export is a liability |

## Part 2: Diagnose it honestly (`gemma/status.md`, `qwen/status.md` Step 1)

Three states are now distinct where two used to collapse into one:

| State | Message |
|---|---|
| set + reachable | unchanged `[x]` line with the version JSON |
| set + unreachable | says the endpoint **came from the variable**, so the user knows the address is theirs and not a default |
| unset + localhost not answering | names **both** real causes: the model is served elsewhere and nobody said where, **or** this is the serving machine and Ollama is down |

Step 5's `NOT READY` line names the unset variable as the likely cause instead of sending the user to generic setup docs, and both `## Notes` sections record the split.

The Gemma Step 4 tool-calling pre-flight smoke test - the load-bearing `/v1` guard - is untouched.

## Acceptance criteria

- [x] `/cpp:init` Tier 6/7 offers to append the export to the user's shell rc, reusing the Tier 2 machinery and consent pattern
- [x] `/gemma:status` and `/qwen:status` distinguish "endpoint unset" from "endpoint unreachable"

## Process

Implementation delegated to **Codex CLI** (`gpt-5.6-sol`) under an implementation-only execution fence, `--sandbox workspace-write`. No unexpected commits, pushes, or PRs.

**Claude Code cross-model review** found three defects, all fixed in a second round:
1. **Regression** - the new unset branch dropped the old `Local machine: start the service ('ollama serve')` advice, trading one misleading message for another: a user on the serving box with a stopped Ollama was told to go look for a different machine.
2. The rc path was rendered in the prompt (`Add to ${QWEN_RC_DISPLAY}?`) *before* the `case` that assigns it, so the prompt showed an empty path and the no-branch had to duplicate the detection.
3. The appended export carried no `# Claude Power Pack` marker comment, unlike every other rc edit in the file.

## Test plan

- `make verify` - 1777 tests, mypy across 186 source files, binary-guard, negative-fixture, CLAUDE.md budget/links/behavior, project-next vendor contract
- `make skills-check` - canonical packages and managed installs valid
- `make codex-skills-check` - 75 skills in sync
- Style: no Unicode em/en dashes, `git diff --check` clean

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYEwVQKrk3Wht1bHymUysu