### PR TITLE
docs(lanes): document the auto-vs-exec precondition split and route greenfield work (Closes #758)

### DIFF
--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -36,6 +36,10 @@ Proceeding...
 
 ### Step 1: Start - Create Worktree
 
+This step has two preconditions: the current directory is an existing git
+checkout, and `<ISSUE>` is the number of an OPEN GitHub issue in that
+repository.
+
 **CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master.**
 
 ```bash
@@ -499,6 +503,10 @@ Codex Auto stopped at Step N/7: {Step Name}
 ```
 
 Key failure scenarios:
+- **Greenfield or missing issue:** If there is no git repository, no issue
+  number, or `gh issue view` fails because the issue does not exist, stop. This
+  is not a repair of `/codex:auto`; run
+  `/codex:exec "<what you wanted to build>"` in the target directory instead
 - **Codex not installed:** Stop at step 3, suggest `npm install -g @openai/codex`
 - **Codex execution fails:** Stop at step 3, show last 20 lines of JSONL output
 - **Codex makes no changes:** Stop at step 3, suggest reviewing the prompt

--- a/.claude/commands/codex/exec.md
+++ b/.claude/commands/codex/exec.md
@@ -8,6 +8,10 @@ allowed-tools: Bash(codex:*), Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(grep:*)
 Run Codex CLI in the current directory with JSONL monitoring.
 For quick tasks without the full issue lifecycle.
 
+This is also the greenfield command: it needs no repo or issue and works in a
+brand-new empty directory. `/codex:auto` is narrower and requires both an
+existing git checkout and a filed issue.
+
 ## Arguments
 
 - `PROMPT` (required): The task prompt for Codex (e.g., `"Add input validation to the login form"`)

--- a/.claude/commands/codex/help.md
+++ b/.claude/commands/codex/help.md
@@ -11,8 +11,8 @@ Cross-model implementation and review - Claude manages the workflow, Codex write
 
 | Command | Description |
 |---------|-------------|
-| `/codex:auto <ISSUE>` | Full issue lifecycle delegated to Codex - worktree, implement, review, quality gates, PR |
-| `/codex:exec <PROMPT>` | One-shot Codex execution in current directory with JSONL monitoring |
+| `/codex:auto <ISSUE>` | Full lifecycle for an existing repo with a filed issue - worktree, implement, review, quality gates, PR |
+| `/codex:exec <PROMPT>` | Any task in the current directory - no repo or issue needed, and no automatic commit |
 | `/codex:ask <QUESTION>` | Delegate a read-only question to Codex and relay its answer (network opt-in on request) |
 | `/codex:code_review [BASE]` | Codex reviews the current branch (read-only) and returns structured findings - used by `/flow:auto_codex` as the pre-PR review stage |
 | `/codex:status` | Check Codex CLI installation, config, and readiness |
@@ -33,6 +33,14 @@ Claude Code (supervisor)            Codex CLI (implementer)
 ```
 
 ## Quick Start
+
+Choose by precondition, not task size:
+
+- `/codex:auto <ISSUE>` - an EXISTING repo with a FILED issue. Creates a
+  worktree and runs the full lifecycle through review, quality gates, and PR.
+- `/codex:exec <PROMPT>` - anything else, including a brand-new empty
+  directory. Runs in the current directory with no repo or issue required and
+  no automatic commit.
 
 ```bash
 # Check if Codex is ready

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -55,6 +55,10 @@ Proceeding...
 
 ### Step 1: Start - Create Worktree
 
+This step has two preconditions: the current directory is an existing git
+checkout, and `<ISSUE>` is the number of an OPEN GitHub issue in that
+repository.
+
 **CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master.**
 
 ```bash
@@ -509,6 +513,10 @@ Gemma Auto stopped at Step N/7: {Step Name}
 ```
 
 Key failure scenarios:
+- **Greenfield or missing issue:** If there is no git repository, no issue
+  number, or `gh issue view` fails because the issue does not exist, stop. This
+  is not a repair of `/gemma:auto`; run
+  `/gemma:exec "<what you wanted to build>"` in the target directory instead
 - **OpenCode CLI not installed:** Stop at step 3; it is required as the harness (no cloud API key is used)
 - **Agent profile missing:** Stop at step 3; the mechanical fence is mandatory, install it from `templates/opencode-gemma.json` or via `/cpp:init` Tier 7
 - **Ollama unreachable / model missing:** Stop at step 3; run `/gemma:status` to diagnose. On the reference server this can mean another VM holds the GPU claim

--- a/.claude/commands/gemma/exec.md
+++ b/.claude/commands/gemma/exec.md
@@ -9,6 +9,10 @@ Run the local Gemma 4 model (via the OpenCode harness) in the current directory
 with JSONL monitoring. For quick tasks without the full issue lifecycle. Zero
 API cost - the model runs on local GPU hardware through Ollama.
 
+This is also the greenfield command: it needs no repo or issue and works in a
+brand-new empty directory. `/gemma:auto` is narrower and requires both an
+existing git checkout and a filed issue.
+
 ## Arguments
 
 - `PROMPT` (required): The task prompt (e.g., `"Add input validation to the login form"`)

--- a/.claude/commands/gemma/help.md
+++ b/.claude/commands/gemma/help.md
@@ -13,8 +13,8 @@ privacy, and available to every machine on the tailnet/LAN.
 
 | Command | Description |
 |---------|-------------|
-| `/gemma:auto <ISSUE>` | Full issue lifecycle delegated to local Gemma - worktree, implement, review, quality gates, PR |
-| `/gemma:exec <PROMPT>` | One-shot local Gemma execution in current directory with JSONL monitoring |
+| `/gemma:auto <ISSUE>` | Full lifecycle for an existing repo with a filed issue - worktree, implement, review, quality gates, PR |
+| `/gemma:exec <PROMPT>` | Any task in the current directory - no repo or issue needed, and no automatic commit |
 | `/gemma:status` | Check Ollama server, model, OpenCode harness, agent profile, and tool-calling readiness |
 | `/gemma:help` | This help overview |
 
@@ -186,6 +186,14 @@ export OLLAMA_HOST=http://proxvmgemma23:11434   # ollama CLI
 ```
 
 ## Quick Start
+
+Choose by precondition, not task size:
+
+- `/gemma:auto <ISSUE>` - an EXISTING repo with a FILED issue. Creates a
+  worktree and runs the full lifecycle through review, quality gates, and PR.
+- `/gemma:exec <PROMPT>` - anything else, including a brand-new empty
+  directory. Runs in the current directory with no repo or issue required and
+  no automatic commit.
 
 ```bash
 # Check if the stack is ready (includes a real tool-calling smoke test)

--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -1,6 +1,6 @@
 ---
 description: Full project scaffolding orchestrator - zero to GitHub repo in one command
-allowed-tools: Bash(mkdir:*), Bash(cd:*), Bash(ls:*), Bash(git:*), Bash(gh:*), Bash(uv:*), Bash(npm:*), Bash(cat:*), Bash(test:*), Bash(echo:*), Bash(cp:*), Bash(ln:*), Bash(touch:*), Bash(PYTHONPATH=:*), Read, Write, Glob, Grep, AskUserQuestion, Skill
+allowed-tools: Bash(mkdir:*), Bash(cd:*), Bash(ls:*), Bash(git:*), Bash(gh:*), Bash(uv:*), Bash(npm:*), Bash(cat:*), Bash(test:*), Bash(echo:*), Bash(cp:*), Bash(ln:*), Bash(touch:*), Bash(command -v:*), Bash(PYTHONPATH=:*), Read, Write, Glob, Grep, AskUserQuestion, Skill
 ---
 
 # /project:init - Full Project Scaffolding
@@ -229,6 +229,44 @@ it succeeds, treat the local repository-mutation block at the start of Step 3 as
 complete and continue with the visibility question and `gh repo create`. If the
 engine stops because Git identity is missing, complete Step 3's user-name/email
 configuration and rerun the same engine command with `--resume`.
+
+### Optional: Flesh Out the Scaffold
+
+After the engine succeeds and before reporting Step 2, detect the available
+greenfield lanes:
+
+```bash
+GREENFIELD_EXEC=()
+if command -v opencode &>/dev/null; then
+    GREENFIELD_EXEC+=(
+        '/gemma:exec "Flesh out this scaffold to deliver: {confirmed destination}"'
+    )
+fi
+if command -v qwen &>/dev/null; then
+    GREENFIELD_EXEC+=(
+        '/qwen:exec "Flesh out this scaffold to deliver: {confirmed destination}"'
+    )
+fi
+if [ "${#GREENFIELD_EXEC[@]}" -eq 0 ] && command -v codex &>/dev/null; then
+    GREENFIELD_EXEC+=(
+        '/codex:exec "Flesh out this scaffold to deliver: {confirmed destination}"'
+    )
+fi
+```
+
+If `GREENFIELD_EXEC` is not empty, make one `AskUserQuestion` offer to flesh
+out the scaffold now, listing only the detected command or commands. The Gemma
+and Qwen lanes run locally at zero API cost. Mention `/codex:exec` only when no
+local lane was detected and Codex is installed. If the user accepts, invoke the
+selected lane with the `Skill` tool (`skill: "gemma:exec"`, `skill: "qwen:exec"`,
+or `skill: "codex:exec"`). The session must already be working in `$TARGET_DIR`
+so the lane's current directory is the new project. Otherwise continue to Step 3.
+
+Explain the boundary with the offer: at this point the project has a skeleton
+but no issue tracker content or filed issues, so `/gemma:auto`, `/qwen:auto`,
+and `/codex:auto` cannot serve it. Their `exec` commands are the greenfield
+route. Once Step 3 creates the GitHub repo and Step 5's spec produces filed
+issues, the corresponding `auto` lanes become available for those issues.
 
 Report: `Step 2/6: {Framework} scaffold planned and applied by project-init engine`
 
@@ -611,6 +649,9 @@ Key failure scenarios:
 - This command is **idempotent** - safe to run again if interrupted
 - Each step checks for prior completion before executing
 - The scaffold is minimal - just enough to start coding
+- Greenfield project-specific code after Step 2 uses an installed
+  `/gemma:exec` or `/qwen:exec` lane, with `/codex:exec` as the installed
+  fallback; `auto` requires a filed issue (issue #758)
 - Framework detection from `lib/cicd` is reused for Makefile generation
 - Config scaffolding (CLAUDE.md, skills, hooks) is **delegated to native `/init`**
   (Step 4c); CPP keeps only the governance overlay via `/claude-md:lint`. CPP does

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -48,6 +48,10 @@ Proceeding...
 
 ### Step 1: Start - Create Worktree
 
+This step has two preconditions: the current directory is an existing git
+checkout, and `<ISSUE>` is the number of an OPEN GitHub issue in that
+repository.
+
 **CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master.**
 
 ```bash
@@ -488,6 +492,10 @@ Qwen Auto stopped at Step N/7: {Step Name}
 ```
 
 Key failure scenarios:
+- **Greenfield or missing issue:** If there is no git repository, no issue
+  number, or `gh issue view` fails because the issue does not exist, stop. This
+  is not a repair of `/qwen:auto`; run
+  `/qwen:exec "<what you wanted to build>"` in the target directory instead
 - **Qwen Code CLI not installed:** Stop at step 3; it is required as the harness (no cloud API key is used)
 - **Ollama unreachable / model missing:** Stop at step 3; run `/qwen:status` to diagnose
 - **Execution fails or stalls:** Stop at step 3, show last 20 lines of JSONL output

--- a/.claude/commands/qwen/exec.md
+++ b/.claude/commands/qwen/exec.md
@@ -9,6 +9,10 @@ Run the local Qwen model (via the Qwen Code CLI harness) in the current
 directory with JSONL monitoring. For quick tasks without the full issue
 lifecycle. Zero API cost - the model runs on local hardware through Ollama.
 
+This is also the greenfield command: it needs no repo or issue and works in a
+brand-new empty directory. `/qwen:auto` is narrower and requires both an
+existing git checkout and a filed issue.
+
 ## Arguments
 
 - `PROMPT` (required): The task prompt (e.g., `"Add input validation to the login form"`)

--- a/.claude/commands/qwen/help.md
+++ b/.claude/commands/qwen/help.md
@@ -13,8 +13,8 @@ and available to every machine on the tailnet/LAN.
 
 | Command | Description |
 |---------|-------------|
-| `/qwen:auto <ISSUE>` | Full issue lifecycle delegated to local Qwen - worktree, implement, review, quality gates, PR |
-| `/qwen:exec <PROMPT>` | One-shot local Qwen execution in current directory with JSONL monitoring |
+| `/qwen:auto <ISSUE>` | Full lifecycle for an existing repo with a filed issue - worktree, implement, review, quality gates, PR |
+| `/qwen:exec <PROMPT>` | Any task in the current directory - no repo or issue needed, and no automatic commit |
 | `/qwen:status` | Check Ollama server, model, and Qwen Code harness readiness |
 | `/qwen:help` | This help overview |
 
@@ -138,6 +138,14 @@ sandbox off for a local endpoint, set `QWEN_FORCE_SANDBOX=0`. The detection
 only applies when the variable is unset.
 
 ## Quick Start
+
+Choose by precondition, not task size:
+
+- `/qwen:auto <ISSUE>` - an EXISTING repo with a FILED issue. Creates a
+  worktree and runs the full lifecycle through review, quality gates, and PR.
+- `/qwen:exec <PROMPT>` - anything else, including a brand-new empty
+  directory. Runs in the current directory with no repo or issue required and
+  no automatic commit.
 
 ```bash
 # Check if the stack is ready

--- a/codex/skills/project-init/reference.md
+++ b/codex/skills/project-init/reference.md
@@ -227,6 +227,44 @@ complete and continue with the visibility question and `gh repo create`. If the
 engine stops because Git identity is missing, complete Step 3's user-name/email
 configuration and rerun the same engine command with `--resume`.
 
+### Optional: Flesh Out the Scaffold
+
+After the engine succeeds and before reporting Step 2, detect the available
+greenfield lanes:
+
+```bash
+GREENFIELD_EXEC=()
+if command -v opencode &>/dev/null; then
+    GREENFIELD_EXEC+=(
+        '/gemma:exec "Flesh out this scaffold to deliver: {confirmed destination}"'
+    )
+fi
+if command -v qwen &>/dev/null; then
+    GREENFIELD_EXEC+=(
+        '/qwen:exec "Flesh out this scaffold to deliver: {confirmed destination}"'
+    )
+fi
+if [ "${#GREENFIELD_EXEC[@]}" -eq 0 ] && command -v codex &>/dev/null; then
+    GREENFIELD_EXEC+=(
+        '/codex:exec "Flesh out this scaffold to deliver: {confirmed destination}"'
+    )
+fi
+```
+
+If `GREENFIELD_EXEC` is not empty, make one `AskUserQuestion` offer to flesh
+out the scaffold now, listing only the detected command or commands. The Gemma
+and Qwen lanes run locally at zero API cost. Mention `/codex:exec` only when no
+local lane was detected and Codex is installed. If the user accepts, invoke the
+selected lane with the `Skill` tool (`skill: "gemma:exec"`, `skill: "qwen:exec"`,
+or `skill: "codex:exec"`). The session must already be working in `$TARGET_DIR`
+so the lane's current directory is the new project. Otherwise continue to Step 3.
+
+Explain the boundary with the offer: at this point the project has a skeleton
+but no issue tracker content or filed issues, so `/gemma:auto`, `/qwen:auto`,
+and `/codex:auto` cannot serve it. Their `exec` commands are the greenfield
+route. Once Step 3 creates the GitHub repo and Step 5's spec produces filed
+issues, the corresponding `auto` lanes become available for those issues.
+
 Report: `Step 2/6: {Framework} scaffold planned and applied by project-init engine`
 
 ---
@@ -608,6 +646,9 @@ Key failure scenarios:
 - This command is **idempotent** - safe to run again if interrupted
 - Each step checks for prior completion before executing
 - The scaffold is minimal - just enough to start coding
+- Greenfield project-specific code after Step 2 uses an installed
+  `/gemma:exec` or `/qwen:exec` lane, with `/codex:exec` as the installed
+  fallback; `auto` requires a filed issue (issue #758)
 - Framework detection from `lib/cicd` is reused for Makefile generation
 - Config scaffolding (CLAUDE.md, skills, hooks) is **delegated to native `/init`**
   (Step 4c); CPP keeps only the governance overlay via `/claude-md-lint`. CPP does


### PR DESCRIPTION
## Summary

Asked to *"use `/gemma:auto` to scaffold a new Flask example project"*, there is no route through `auto`. It requires **a GitHub issue number** (Step 1 runs `gh issue view`) and **an existing git checkout** (Step 1 creates a worktree and enforces an `issue-<N>-<slug>` branch). A brand-new directory has neither, and the same holds for `/qwen:auto` and `/codex:auto`.

The correct command is `exec` - but nothing said so. The help pages presented the pair as a capability ladder:

```
/gemma:auto <ISSUE>   - Full issue lifecycle delegated to local Gemma
/gemma:exec <PROMPT>  - One-shot local Gemma execution
```

Read quickly, that scans as *"big task vs small task"*, not *"existing repo + filed issue vs literally anything else"*. The word `auto` reinforces the wrong reading: it sounds like the more capable option rather than the more **constrained** one. Scaffolding a new project is one of the most natural things to hand a zero-cost local model, and it is exactly the case the lane could not express.

## Part A - document the split where the choice is made

`gemma/help.md`, `qwen/help.md`, `codex/help.md`:

- The **Available Commands** table now names the precondition in the `auto` row and the freedom in the `exec` row, so the table alone cannot be misread as a size ladder.
- Each **Quick Start** opens with *"Choose by precondition, not task size"* and the two-line contrast the issue specifies.

## Part B - signpost from the failure, not only from the docs

A user who tries `auto` first has to be told where to go.

- Each `auto.md` states its two preconditions at the top of Step 1, before the first command runs.
- Each `auto.md` **Error Handling** gains the greenfield case: no repo, no issue number, or a `gh issue view` that fails is **not a repair of `auto`** - it is a redirect to `/<lane>:exec "<what you wanted to build>"` in the target directory.
- Each `exec.md` says near the top that it is the greenfield command, works in a brand-new empty directory, and that `auto` is the narrower option.

## Part C - a first-class greenfield route in `/project:init`

Step 2 gains a presence-gated offer to flesh out the freshly scaffolded project with a local lane, invoked through the `Skill` tool the way Step 4c already delegates to native `/init`. Local lanes are offered first (zero API cost); `/codex:exec` is named only when no local lane is installed.

The offer explains the boundary: at that moment the project has a skeleton but **no filed issues**, so the `auto` lanes cannot serve it - and they *become* available once Step 3 creates the GitHub repo and Step 5's spec produces issues. That is the part a user cannot infer.

**The deterministic scaffold stays deterministic.** `scripts/project-init.py` and its template catalog are untouched, as are the engine invocation, dry-run, resume, and Wayfinder blocks. The local lane is offered for the project-specific code the engine's templates do not and cannot render, not for the skeleton itself.

`codex/skills/project-init/reference.md` regenerated via `make codex-skills`.

## Acceptance criteria

- [x] The `auto`/`exec` split is documented where the choice is made (both help Quick Starts, plus the command tables)
- [x] Greenfield has a real route: `exec` is named as the greenfield command, and `/project:init` offers a local-model lane for the post-scaffold step

## Process

Implementation delegated to **Codex CLI** (`gpt-5.6-sol`) under an implementation-only execution fence, `--sandbox workspace-write`. No unexpected commits, pushes, or PRs.

**Claude Code review** found two defects, both fixed:
1. `allowed-tools` was widened to `Bash(command:*)`; the repo convention across `cpp/init.md`, `cpp/update.md`, `codex/status.md`, `gemma/status.md` and `qwen/status.md` is the narrower `Bash(command -v:*)`, which is all the new block needs.
2. The offer said to *"run the chosen command from `$TARGET_DIR`"* - but `/gemma:exec` is a command document, not a shell command. Reworded to match Step 4c's explicit `Skill`-tool convention.

## Test plan

- `make verify` - 1781 tests, mypy across 186 source files, all repo checks
- `make codex-skills` then `make codex-skills-check` - 75 skills in sync
- `make skills-check` - canonical packages valid
- Style: no Unicode em/en dashes, `git diff --check` clean

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYEwVQKrk3Wht1bHymUysu