### PR TITLE
docs(cpp): stop hardcoding the family count in the symlink topology claim (Closes #757)

### DIFF
--- a/.claude/commands/cpp/update.md
+++ b/.claude/commands/cpp/update.md
@@ -490,12 +490,14 @@ needs a human.
 
 - `CPP_COMMANDS_LINK: ok` - report `✓ Command symlinks current` and continue.
   **Report it as a TOPOLOGY result, never as an install-health verdict** (issue
-  #685): it means the 16 family links resolve to this checkout, and says nothing
-  about whether the checkout's CONTENT is correct. A restore-over-clone accident
-  produced a working tree with 106 files reverted and 111 upstream-deleted files
-  resurrected; every link resolved, this step read `ok`, and the Step-3 `git
-  pull` said "Already up to date" - three green signals while every served
-  command was stale. Do not summarise this step as "command surface healthy".
+  #685): quote the helper's own `families:` and `ok:` numbers from its summary
+  line; the `ok:` number means that many family links resolve to this checkout,
+  and says nothing about whether the checkout's CONTENT is correct. A
+  restore-over-clone accident produced a working tree with 106 files reverted
+  and 111 upstream-deleted files resurrected; every link resolved, this step
+  read `ok`, and the Step-3 `git pull` said "Already up to date" - three green
+  signals while every served command was stale. Do not summarise this step as
+  "command surface healthy".
 - A `checkout: N tracked modified, M untracked (-uall) ...` line may precede the
   verdict. It is an ADVISORY observation, not drift: relay it with its counts
   and leave the verdict alone. Dirtiness is not staleness - a maintainer

--- a/scripts/cpp-commands-link.sh
+++ b/scripts/cpp-commands-link.sh
@@ -48,8 +48,8 @@
 #                   exits 2. Foreign entries are NOT drift - the user's
 #                   content wins.
 #
-#   `ok` IS A TOPOLOGY VERDICT, NOT A HEALTH VERDICT (#685). It says the 16
-#   links resolve to this checkout. It says NOTHING about whether the checkout's
+#   `ok` IS A TOPOLOGY VERDICT, NOT A HEALTH VERDICT (#685). It says every family
+#   link resolves to this checkout. It says NOTHING about whether the checkout's
 #   content is what it should be. To assess content:
 #       git -C <checkout> status --porcelain -uall   # expect empty
 #       git -C <checkout> rev-parse HEAD origin/main # expect equal


### PR DESCRIPTION
## Summary

`/cpp:update` Step 5c told the model to report the symlink check as covering a literal count:

> it means **the 16 family links** resolve to this checkout, and says nothing about whether the checkout's CONTENT is correct

The checkout ships **18** - and the helper prints the true number itself:

```
families: 18 ok: 17 changed: 1 missing: 0 stale: 0 foreign: 0
```

A hardcoded count in prose drifts silently every time a family is added, and it had already drifted **twice** (spec, then gemma). It is also the kind of wrong number that erodes trust in the surrounding paragraph, which is doing real work: the #685 warning that `ok` is a **topology** verdict and not a **health** verdict.

## Two instances, fixed the way each surface allows

| File | Fix |
|---|---|
| `.claude/commands/cpp/update.md` Step 5c | Quote the helper's own `families:` / `ok:` numbers from the summary line it already prints, so the figure comes from run-time output and can never go stale. This is the issue's preferred option. |
| `scripts/cpp-commands-link.sh` header | Carried the identical constant in the block that states the very contract Step 5c relays. A header comment cannot quote run-time output, so it takes the maintenance-free wording: *"It says every family link resolves to this checkout."* |

Both edits replace a stale constant **inside** load-bearing prose and leave the rest intact: the "TOPOLOGY result, never an install-health verdict" framing, the restore-over-clone incident (106 files reverted, 111 upstream-deleted files resurrected, three green signals while every served command was stale), the content-check commands, and the instruction not to summarise the step as "command surface healthy".

**No script behaviour changed** - comment only. The `#756` verdict set (`ok | installed | drift | drift-missing | error`) and its exit codes are untouched.

A repository-wide search found no other instance of this stale count. Superficially similar numbers (`project-next-vendor: 16 files match contract`) are different facts that happen to share the digits and were left alone.

## Acceptance criteria

- [x] The literal count is dropped from Step 5c
- [x] The step quotes the helper's own always-current `families:` / `ok:` numbers (the issue's preferred option)
- [x] The #685 "topology, not health" paragraph survives intact

## Process

Implementation delegated to **Codex CLI** (`gpt-5.6-sol`) under an implementation-only execution fence, `--sandbox workspace-write`. No unexpected commits, pushes, or PRs. Claude Code review confirmed the incident narrative and contract block were preserved verbatim, and located the second instance in the script header that the issue does not name.

## Test plan

- `make verify` - 1791 tests, mypy across 186 source files, all repo checks
- `make skills-check`, `make codex-skills-check` - 75 skills in sync
- `bash -n scripts/cpp-commands-link.sh`, `git diff --check` clean

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYEwVQKrk3Wht1bHymUysu