### PR TITLE
fix(scaffold): prefer 'uv venv' for Python bootstrap and add a python3-venv advisory (Closes #759)

### DIFF
--- a/lib/cicd/bootstrap.py
+++ b/lib/cicd/bootstrap.py
@@ -1,11 +1,12 @@
 """Bootstrap dependency checker for the CI/CD runner.
 
-Detects admin-only bootstrap prerequisites (IAM roles, secrets provisioning,
-manual infrastructure steps) and blocks deploy/merge if they are not satisfied.
+Detects bootstrap prerequisites (IAM roles, secrets provisioning, manual
+infrastructure steps) and blocks deploy/merge if required checks are not
+satisfied. Advisory checks report findings without changing the verdict.
 
 Projects declare bootstrap dependencies in .claude/bootstrap.yaml. Each
-dependency has a check_command that exits 0 when satisfied. If any check
-fails, the gate blocks with a remediation message.
+dependency has a check_command that exits 0 when satisfied. If any required
+check fails, the gate blocks with a remediation message.
 
 Usage:
     python -m lib.cicd.bootstrap check [--project-root PATH]
@@ -34,6 +35,7 @@ class BootstrapDependency:
     check_command: str
     remediation: str
     timeout_seconds: int = 30
+    advisory: bool = False
 
     @classmethod
     def from_dict(cls, name: str, data: dict[str, Any]) -> BootstrapDependency:
@@ -43,6 +45,7 @@ class BootstrapDependency:
             check_command=data["check_command"],
             remediation=data.get("remediation", f"Run the bootstrap step for '{name}'"),
             timeout_seconds=data.get("timeout_seconds", 30),
+            advisory=data.get("advisory", False),
         )
 
 
@@ -85,6 +88,27 @@ class CheckResult:
     description: str = ""
     remediation: str = ""
     error: str = ""
+    advisory: bool = False
+
+
+def built_in_advisories(project_root: Path) -> list[BootstrapDependency]:
+    """Return built-in advisory checks that apply to the project."""
+    python_markers = ("pyproject.toml", "requirements.txt", "setup.py")
+    if not any((project_root / marker).is_file() for marker in python_markers):
+        return []
+
+    return [
+        BootstrapDependency(
+            name="python3-venv",
+            description="Python stdlib virtual environments require ensurepip",
+            check_command='python3 -c "import ensurepip"',
+            remediation=(
+                "Use `uv venv .venv` (preferred; uv is already a CPP prerequisite), "
+                "or run `apt install python3-venv` for the stdlib path."
+            ),
+            advisory=True,
+        )
+    ]
 
 
 def check_dependency(dep: BootstrapDependency, project_root: Path) -> CheckResult:
@@ -104,6 +128,7 @@ def check_dependency(dep: BootstrapDependency, project_root: Path) -> CheckResul
             description=dep.description,
             remediation=dep.remediation,
             error=proc.stderr.strip() if proc.returncode != 0 else "",
+            advisory=dep.advisory,
         )
     except subprocess.TimeoutExpired:
         return CheckResult(
@@ -112,6 +137,7 @@ def check_dependency(dep: BootstrapDependency, project_root: Path) -> CheckResul
             description=dep.description,
             remediation=dep.remediation,
             error=f"Check timed out after {dep.timeout_seconds}s",
+            advisory=dep.advisory,
         )
     except OSError as e:
         return CheckResult(
@@ -120,6 +146,7 @@ def check_dependency(dep: BootstrapDependency, project_root: Path) -> CheckResul
             description=dep.description,
             remediation=dep.remediation,
             error=str(e),
+            advisory=dep.advisory,
         )
 
 
@@ -130,14 +157,13 @@ def check_all(project_root: Path) -> tuple[bool, list[CheckResult]]:
         Tuple of (all_satisfied, results).
     """
     config = BootstrapConfig.load(project_root)
-    if config is None:
+    dependencies = list(config.dependencies) if config is not None else []
+    dependencies.extend(built_in_advisories(project_root))
+    if not dependencies:
         return True, []
 
-    if not config.dependencies:
-        return True, []
-
-    results = [check_dependency(dep, project_root) for dep in config.dependencies]
-    all_satisfied = all(r.satisfied for r in results)
+    results = [check_dependency(dep, project_root) for dep in dependencies]
+    all_satisfied = all(r.satisfied or r.advisory for r in results)
     return all_satisfied, results
 
 
@@ -153,19 +179,33 @@ def _print_report(passed: bool, results: list[CheckResult], project_root: Path) 
     """Print a human-readable report."""
     print(f"\n{BOLD}Bootstrap Dependency Check{NC}")
     print("================================================")
-    print(f"Config: {BLUE}{project_root / CONFIG_FILENAME}{NC}")
+    config_path = project_root / CONFIG_FILENAME
+    if config_path.exists():
+        print(f"Config: {BLUE}{config_path}{NC}")
+    else:
+        print(f"Config: {BLUE}none (only built-in advisories shown){NC}")
     print()
 
     if not results:
         print(f"{GREEN}No bootstrap dependencies configured.{NC}")
         return
 
-    satisfied_count = sum(1 for r in results if r.satisfied)
-    blocked_count = len(results) - satisfied_count
+    blocking_results = [r for r in results if not r.advisory]
+    advisory_results = [r for r in results if r.advisory]
+    satisfied_count = sum(1 for r in blocking_results if r.satisfied)
+    blocked_count = len(blocking_results) - satisfied_count
+    advisory_satisfied_count = sum(1 for r in advisory_results if r.satisfied)
+    advisory_warning_count = len(advisory_results) - advisory_satisfied_count
 
     for r in results:
         if r.satisfied:
-            print(f"{GREEN}ok{NC}    {r.name} - {r.description}")
+            advisory_label = " (advisory)" if r.advisory else ""
+            print(f"{GREEN}ok{NC}    {r.name}{advisory_label} - {r.description}")
+        elif r.advisory:
+            print(f"{YELLOW}WARN{NC}  {r.name} - {r.description}")
+            if r.error:
+                print(f"       {YELLOW}error:{NC} {r.error}")
+            print(f"       {YELLOW}fix:{NC}   {r.remediation}")
         else:
             print(f"{RED}BLOCK{NC} {r.name} - {r.description}")
             if r.error:
@@ -174,15 +214,26 @@ def _print_report(passed: bool, results: list[CheckResult], project_root: Path) 
 
     print()
     print("================================================")
-    if blocked_count > 0:
+    advisory_summary = ""
+    if advisory_results:
+        advisory_summary = (
+            f"; advisories: {advisory_satisfied_count}/{len(advisory_results)} satisfied, "
+            f"{advisory_warning_count} warning(s)"
+        )
+
+    if not passed:
         print(
             f"{RED}BLOCKED{NC}: {blocked_count} bootstrap prerequisite(s) not satisfied "
-            f"({satisfied_count}/{len(results)} passed)"
+            f"({satisfied_count}/{len(blocking_results)} blocking passed{advisory_summary})"
         )
         print()
         print(f"{BOLD}These require a manual bootstrap apply outside CI before deploying.{NC}")
     else:
-        print(f"{GREEN}ALL SATISFIED{NC}: {satisfied_count}/{len(results)} bootstrap prerequisites passed")
+        status = "PASSED" if advisory_warning_count else "ALL SATISFIED"
+        print(
+            f"{GREEN}{status}{NC}: {satisfied_count}/{len(blocking_results)} "
+            f"blocking prerequisites passed{advisory_summary}"
+        )
 
 
 def main(args: list[str] | None = None) -> int:
@@ -207,16 +258,16 @@ def main(args: list[str] | None = None) -> int:
     config = BootstrapConfig.load(project_root)
 
     if command == "list":
-        if config is None or not config.dependencies:
+        dependencies = list(config.dependencies) if config is not None else []
+        dependencies.extend(built_in_advisories(project_root))
+        if not dependencies:
             print("No bootstrap dependencies configured.")
             return 0
-        for dep in config.dependencies:
-            print(f"  {dep.name}: {dep.description}")
+        for dep in dependencies:
+            advisory_label = " (advisory)" if dep.advisory else ""
+            print(f"  {dep.name}{advisory_label}: {dep.description}")
             print(f"    check: {dep.check_command}")
             print(f"    fix:   {dep.remediation}")
-        return 0
-
-    if config is None:
         return 0
 
     passed, results = check_all(project_root)

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -427,13 +427,20 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
         _gate_step("typecheck", "mypy .", "mypy", 300),
     ],
     "deploy": [
+        # Keep these Python markers aligned with built_in_advisories() in
+        # bootstrap.py so applicable advisories are not skipped by the plan.
         StepDef(
             id="bootstrap_check",
             command="python3 -m lib.cicd.bootstrap check",
-            description="Check admin-only bootstrap dependencies",
+            description="Check bootstrap dependencies and built-in advisories",
             timeout_seconds=30,
             max_attempts=1,
-            skip_if="! [ -f .claude/bootstrap.yaml ]",
+            skip_if=(
+                "! [ -f .claude/bootstrap.yaml ] && "
+                "! [ -f pyproject.toml ] && "
+                "! [ -f requirements.txt ] && "
+                "! [ -f setup.py ]"
+            ),
             env={"PYTHONPATH": _CPP_ROOT},
         ),
         StepDef(

--- a/scripts/bootstrap-check.sh
+++ b/scripts/bootstrap-check.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# bootstrap-check.sh - Check admin-only bootstrap dependencies before deploy
+# bootstrap-check.sh - Check bootstrap dependencies and advisories before deploy
 # Part of Claude Power Pack (CPP)
 #
-# Thin wrapper that invokes the Python bootstrap checker. Projects declare
-# dependencies in .claude/bootstrap.yaml; each dependency has a check_command
-# that must exit 0 for the deploy to proceed.
+# Thin wrapper that invokes the Python bootstrap checker. Projects can declare
+# dependencies in .claude/bootstrap.yaml; blocking checks must exit 0 for the
+# deploy to proceed. Advisory findings are reported but never block.
 #
 # Usage:
 #   bootstrap-check.sh              # Check all dependencies
@@ -12,8 +12,8 @@
 #   bootstrap-check.sh --help       # Show help
 #
 # Exit codes:
-#   0 - All satisfied (or no config present)
-#   1 - One or more prerequisites not satisfied
+#   0 - All blocking checks satisfied; advisory findings may be present
+#   1 - One or more blocking prerequisites not satisfied
 #   2 - Usage error
 
 set -euo pipefail
@@ -23,21 +23,22 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 usage() {
     cat <<'EOF'
-bootstrap-check.sh - Check admin-only bootstrap dependencies
+bootstrap-check.sh - Check bootstrap dependencies and advisories
 
 Usage:
   bootstrap-check.sh              Check all bootstrap prerequisites
-  bootstrap-check.sh --list       List configured dependencies
+  bootstrap-check.sh --list       List dependencies and advisories
   bootstrap-check.sh --help       Show this help
 
 Config file: .claude/bootstrap.yaml
 
 Dependencies define a check_command (exits 0 when satisfied) and a
-remediation message shown when the check fails.
+remediation message shown when the check fails. Advisory findings are
+reported but never block.
 
 Exit codes:
-  0 - All satisfied (or no bootstrap.yaml present)
-  1 - One or more prerequisites not satisfied
+  0 - All blocking checks satisfied; advisory findings may be present
+  1 - One or more blocking prerequisites not satisfied
   2 - Usage error
 EOF
 }

--- a/templates/makefiles/python-pip.mk
+++ b/templates/makefiles/python-pip.mk
@@ -5,11 +5,11 @@
 #   /flow:deploy  → runs `make deploy`
 #   /flow:doctor  → reports which targets are available
 #
-# Uses pip with a virtual environment. Activate your venv first,
-# or adjust commands to use `python -m` prefix.
+# Uses pip with a virtual environment bootstrapped by `uv venv`. Activate your
+# venv first, or adjust commands to use `python -m` prefix.
 # Copy to your project root as "Makefile" and customize.
 
-.PHONY: lint test typecheck format build deploy clean verify troubleshoot venv ci-local
+.PHONY: lint test typecheck format build deploy clean verify troubleshoot venv venv-stdlib ci-local
 
 ## Quality gates (used by /flow:finish)
 
@@ -32,7 +32,15 @@ build:
 
 ## Virtual environment setup
 
+# `uv` is already a CPP prerequisite, so it is present wherever CPP works.
+# Debian/Ubuntu split ensurepip into python3-venv; a stdlib failure can leave a
+# half-built .venv without pip.
 venv:
+	uv venv .venv
+	uv pip install -r requirements.txt
+
+# Stdlib fallback: Debian/Ubuntu require `apt install python3-venv`.
+venv-stdlib:
 	python -m venv .venv
 	.venv/bin/pip install -r requirements.txt
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 import pytest
 
+import lib.cicd.bootstrap as bootstrap
 from lib.cicd.bootstrap import (
     BootstrapConfig,
     BootstrapDependency,
+    CheckResult,
+    built_in_advisories,
     check_all,
     check_dependency,
     main,
@@ -22,6 +25,17 @@ def tmp_project(tmp_path: Path) -> Path:
 def _write_config(project_root: Path, yaml_content: str) -> None:
     config_path = project_root / ".claude" / "bootstrap.yaml"
     config_path.write_text(yaml_content)
+
+
+def _failed_check(dep: BootstrapDependency, _project_root: Path) -> CheckResult:
+    return CheckResult(
+        name=dep.name,
+        satisfied=False,
+        description=dep.description,
+        remediation=dep.remediation,
+        error="Not available",
+        advisory=dep.advisory,
+    )
 
 
 class TestBootstrapConfig:
@@ -78,6 +92,22 @@ dependencies:
         assert config is not None
         assert len(config.dependencies) == 1
         assert config.dependencies[0].name == "good-dep"
+
+    def test_advisory_defaults_to_false(self, tmp_project: Path):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  required-dep:
+    description: Required dependency
+    check_command: "required-check"
+    remediation: "Install it"
+""",
+        )
+        config = BootstrapConfig.load(tmp_project)
+        assert config is not None
+        assert config.dependencies[0].advisory is False
 
 
 class TestCheckDependency:
@@ -193,6 +223,127 @@ dependencies: {}
         assert passed
         assert results == []
 
+    def test_failing_advisory_does_not_block(
+        self, tmp_project: Path, monkeypatch, capsys
+    ):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  optional-dep:
+    description: Optional dependency
+    check_command: "optional-check"
+    remediation: "Install it if needed"
+    advisory: true
+""",
+        )
+        monkeypatch.setattr(bootstrap, "check_dependency", _failed_check)
+
+        passed, results = check_all(tmp_project)
+
+        assert passed
+        assert len(results) == 1
+        assert not results[0].satisfied
+        assert results[0].advisory
+        assert main(["check", "--project-root", str(tmp_project)]) == 0
+        output = capsys.readouterr().out
+        assert "WARN" in output
+        assert "PASSED" in output
+        assert "BLOCKED" not in output
+
+    def test_failing_blocking_dependency_still_blocks(
+        self, tmp_project: Path, monkeypatch
+    ):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  required-dep:
+    description: Required dependency
+    check_command: "required-check"
+    remediation: "Install it"
+""",
+        )
+        monkeypatch.setattr(bootstrap, "check_dependency", _failed_check)
+
+        passed, results = check_all(tmp_project)
+
+        assert not passed
+        assert len(results) == 1
+        assert not results[0].advisory
+        assert main(["check", "--project-root", str(tmp_project)]) == 1
+
+    def test_failing_advisory_does_not_mask_blocking_failure(
+        self, tmp_project: Path, monkeypatch
+    ):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies:
+  optional-dep:
+    description: Optional dependency
+    check_command: "optional-check"
+    remediation: "Install it if needed"
+    advisory: true
+  required-dep:
+    description: Required dependency
+    check_command: "required-check"
+    remediation: "Install it"
+""",
+        )
+        monkeypatch.setattr(bootstrap, "check_dependency", _failed_check)
+
+        passed, results = check_all(tmp_project)
+
+        assert not passed
+        assert len(results) == 2
+        assert {result.advisory for result in results} == {False, True}
+        assert main(["check", "--project-root", str(tmp_project)]) == 1
+
+
+class TestBuiltInAdvisories:
+    @pytest.mark.parametrize("marker", ["pyproject.toml", "requirements.txt"])
+    def test_python_project_gets_python3_venv_advisory(
+        self, tmp_project: Path, marker: str
+    ):
+        (tmp_project / marker).write_text("")
+
+        advisories = built_in_advisories(tmp_project)
+
+        assert len(advisories) == 1
+        assert advisories[0].name == "python3-venv"
+        assert advisories[0].advisory
+        assert advisories[0].check_command == 'python3 -c "import ensurepip"'
+        assert "uv venv .venv" in advisories[0].remediation
+        assert "apt install python3-venv" in advisories[0].remediation
+
+    def test_non_python_project_gets_no_python_advisory(self, tmp_project: Path):
+        python_markers = ("pyproject.toml", "requirements.txt", "setup.py")
+        assert all(not (tmp_project / marker).exists() for marker in python_markers)
+
+        assert built_in_advisories(tmp_project) == []
+
+    def test_no_config_python_project_still_runs_advisory(
+        self, tmp_project: Path, monkeypatch, capsys
+    ):
+        assert BootstrapConfig.load(tmp_project) is None
+        (tmp_project / "pyproject.toml").write_text("")
+        monkeypatch.setattr(bootstrap, "check_dependency", _failed_check)
+
+        passed, results = check_all(tmp_project)
+
+        assert passed
+        assert [result.name for result in results] == ["python3-venv"]
+        assert not results[0].satisfied
+        assert results[0].advisory
+        assert main(["check", "--project-root", str(tmp_project)]) == 0
+        output = capsys.readouterr().out
+        assert "Config: \x1b[0;34mnone (only built-in advisories shown)" in output
+        assert str(tmp_project / ".claude" / "bootstrap.yaml") not in output
+
 
 class TestCLI:
     def test_check_no_config(self, tmp_project: Path, monkeypatch):
@@ -215,6 +366,26 @@ dependencies:
         )
         exit_code = main(["check"])
         assert exit_code == 0
+
+    def test_check_report_names_existing_config(
+        self, tmp_project: Path, capsys
+    ):
+        _write_config(
+            tmp_project,
+            """
+version: "1"
+dependencies: {}
+""",
+        )
+        config_path = tmp_project / ".claude" / "bootstrap.yaml"
+        assert config_path.exists()
+
+        exit_code = main(["check", "--project-root", str(tmp_project)])
+
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert f"Config: \x1b[0;34m{config_path}\x1b[0m" in output
+        assert "only built-in advisories shown" not in output
 
     def test_check_blocked(self, tmp_project: Path, monkeypatch):
         monkeypatch.chdir(tmp_project)
@@ -249,6 +420,19 @@ dependencies:
         assert exit_code == 0
         output = capsys.readouterr().out
         assert "my-dep" in output
+
+    def test_list_command_includes_built_in_advisory(
+        self, tmp_project: Path, capsys
+    ):
+        assert BootstrapConfig.load(tmp_project) is None
+        (tmp_project / "requirements.txt").write_text("")
+
+        exit_code = main(["list", "--project-root", str(tmp_project)])
+
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "python3-venv (advisory)" in output
+        assert "No bootstrap dependencies configured." not in output
 
     def test_project_root_flag(self, tmp_project: Path):
         _write_config(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -402,6 +403,43 @@ class TestStepDefinitionsSandboxAware:
         step = {s.id: s for s in BUILTIN_PLANS["deploy"]}["bootstrap_check"]
         assert step.command == "python3 -m lib.cicd.bootstrap check"
         assert step.env.get("PYTHONPATH") == _CPP_ROOT
+
+    @pytest.mark.skipif(shutil.which("sh") is None, reason="requires sh")
+    @pytest.mark.parametrize(
+        "marker", ["pyproject.toml", "requirements.txt", "setup.py"]
+    )
+    def test_deploy_bootstrap_check_runs_for_python_project_without_config(
+        self, tmp_project: Path, marker: str
+    ):
+        config_path = tmp_project / ".claude" / "bootstrap.yaml"
+        assert not config_path.exists()
+        (tmp_project / marker).write_text("")
+        step = ShellStep(
+            {s.id: s for s in BUILTIN_PLANS["deploy"]}["bootstrap_check"]
+        )
+
+        assert (
+            step.should_skip({"project_root": str(tmp_project), "env": {}}) is False
+        )
+
+    @pytest.mark.skipif(shutil.which("sh") is None, reason="requires sh")
+    def test_deploy_bootstrap_check_skips_without_config_or_python_markers(
+        self, tmp_project: Path
+    ):
+        relevant_files = (
+            ".claude/bootstrap.yaml",
+            "pyproject.toml",
+            "requirements.txt",
+            "setup.py",
+        )
+        assert all(not (tmp_project / path).exists() for path in relevant_files)
+        step = ShellStep(
+            {s.id: s for s in BUILTIN_PLANS["deploy"]}["bootstrap_check"]
+        )
+
+        assert (
+            step.should_skip({"project_root": str(tmp_project), "env": {}}) is True
+        )
 
     def test_deploy_security_scan_dehardcoded(self):
         step = {s.id: s for s in BUILTIN_PLANS["deploy"]}["security_scan"]


### PR DESCRIPTION
## Summary

CPP-scaffolded Python projects told the user to bootstrap with the stdlib venv module. The concrete instance in this repo is the `venv` target of `templates/makefiles/python-pip.mk`:

```make
venv:
	python -m venv .venv
	.venv/bin/pip install -r requirements.txt
```

On Debian and Ubuntu, `ensurepip` is split into a separate `python3-venv` package that is **not** installed by default. Where it is missing, that first line fails in a particularly unhelpful way - it exits non-zero, tells the user to reach for `sudo`, and leaves a **half-built `.venv`** behind with an interpreter but no `pip`:

```
$ python3 -m venv .venv
You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.

$ ./.venv/bin/pip install -r requirements.txt
/bin/bash: ./.venv/bin/pip: No such file or directory
```

The residue is the worst part: `.venv/` exists, so a retry or a follow-up step can look like it should work, and the second error names a missing `pip` rather than the actual cause. **The recipe above reproduces that exactly** - line 2 leaves the residue, line 3 then fails on the missing `pip`.

`uv` is already a CPP prerequisite - the quality-gate runner, `flow-finish-gate.sh`, and the deploy-verification path all invoke it, and `/cpp:init` checks for it. So on any host where CPP itself is functional, `uv venv` is guaranteed available and `python3 -m venv` is not. The scaffolding was recommending the less reliable of two tools that are both present.

## Part 1: `templates/makefiles/python-pip.mk`

- `venv` leads with `uv venv .venv` + `uv pip install -r requirements.txt`.
- `python -m venv` is **kept** as a documented `venv-stdlib` fallback carrying the `apt install python3-venv` note.
- A comment records why: `ensurepip` is a separate package there, the failure leaves a half-built `.venv`, and `uv` is already a prerequisite.
- Only the bootstrap changed. This template is for pip-managed projects, so the quality gates keep using `python -m <tool>`.

## Part 2: advisory checks

`scripts/bootstrap-check.sh` is a thin wrapper over `lib/cicd/bootstrap.py`, which treated every dependency as blocking. Advisory support was needed before the check could exist.

- `BootstrapDependency` / `CheckResult` gain an `advisory` flag, parsed from `.claude/bootstrap.yaml` like the other optional fields.
- `check_all` **excludes advisory failures from the verdict**, so an advisory can never change an exit code; `_print_report` renders them as `WARN` with a separate count instead of `BLOCK`.
- A built-in **`python3-venv`** advisory is emitted for any project root carrying `pyproject.toml`, `requirements.txt`, or `setup.py`. It checks the real gap - `python3 -c "import ensurepip"`, not a missing `venv` module - and names both routes in its remediation. It runs **even with no `bootstrap.yaml` at all**, which is the population that needs it; a Go or Node project never sees it.
- The report no longer prints a `Config:` path for a file that does not exist.

## Part 3: the gate that would have hidden it

`lib/cicd/steps.py`'s deploy-plan `bootstrap_check` step had `skip_if="! [ -f .claude/bootstrap.yaml ]"` - it skipped entirely whenever no config existed, which is **exactly** the population the new advisory targets. Left alone, the advisory would have been dead on arrival. Its `skip_if` now also runs the step for the Python markers, with a comment tying the two marker lists together, and its description no longer says "admin-only". The step still cannot block on an advisory.

## Acceptance criteria

- [x] Scaffolded setup leads with `uv venv .venv && uv pip install -r requirements.txt`, with `python3 -m venv` kept as a documented fallback plus the Debian/Ubuntu note
- [x] `python3-venv` added as an advisory (not blocking) check, so the gap is named before a user hits it

## Process

Implementation delegated to **Codex CLI** (`gpt-5.6-sol`) under an implementation-only execution fence, `--sandbox workspace-write`. No unexpected commits, pushes, or PRs.

**Claude Code review** found two defects, both fixed:
1. **The advisory was dead on arrival** in the deploy plan because of the `skip_if` above - the feature would have shipped invisible on every plain Python project.
2. Now that `main` no longer returns early when the config is absent, the report was naming a `.claude/bootstrap.yaml` path that does not exist, directly above an advisory the user did not configure.

## Test plan

- `make verify` - 1791 tests (14 new), mypy across 186 source files, binary-guard and negative-fixture contracts, all repo checks
- `make skills-check`, `make codex-skills-check` - 75 skills in sync
- `python -m lib.security gate flow_finish` - passed
- New coverage: advisory never blocks, blocking still blocks, a failing advisory does not mask a blocking failure, `advisory` defaults to False, the built-in fires per Python marker and not otherwise, it runs with no config at all, `list` labels it, and the deploy `skip_if` runs/skips correctly

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYEwVQKrk3Wht1bHymUysu