### PR TITLE
feat(drivers): halt the delegated drivers for approval before they delegate (Closes #774)

### DIFF
--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -1,16 +1,19 @@
 ---
-description: Full issue lifecycle delegated to Codex - worktree, implement, review, quality gates, PR
+description: Full issue lifecycle delegated to Codex - worktree, approve, implement, review, quality gates, PR
 allowed-tools: Bash(codex:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(mkdir:*), Bash(cd:*), Bash(pwd), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(make:*), Bash(sleep:*)
 ---
 
 # Codex Auto: Full Issue Lifecycle via Codex CLI
 
-Mirrors `/flow:auto` but delegates implementation (Step 3) to Codex CLI.
+Mirrors `/flow:auto` but delegates implementation (Step 4) to Codex CLI.
 Claude Code acts as supervisor/reviewer while Codex writes the code.
 
 ## Arguments
 
 - `ISSUE` (required): GitHub issue number (e.g., `42`)
+- `--yes` (optional, alias `--auto-approve`): skip the Step 3 approval pause for
+  unattended runs. The Step 2 plan report is still printed and approval is
+  recorded as auto-granted. There is no trailer-based equivalent (issue #775).
 
 ## Instructions
 
@@ -21,13 +24,14 @@ Report at the start:
 ```
 Codex Auto: Issue #<ISSUE> - Full Lifecycle
 
-Step 1/7: Start (create worktree and branch)
-Step 2/7: Analyze (understand issue, build Codex prompt)
-Step 3/7: Execute Codex (delegate implementation to Codex CLI)
-Step 4/7: Review (Claude reviews Codex's diff)
-Step 5/7: Quality Gates (lint, test, security - with fix loop)
-Step 6/7: Finish (commit, push, create PR)
-Step 7/7: Cleanup (optional merge + worktree removal)
+Step 1/8: Start (create worktree and branch)
+Step 2/8: Analyze (understand issue, build Codex prompt)
+Step 3/8: Approve (pre-implementation gate - stop and wait)
+Step 4/8: Execute Codex (delegate implementation to Codex CLI)
+Step 5/8: Review (Claude reviews Codex's diff)
+Step 6/8: Quality Gates (lint, test, security - with fix loop)
+Step 7/8: Finish (commit, push, create PR)
+Step 8/8: Cleanup (optional merge + worktree removal)
 
 Proceeding...
 ```
@@ -89,7 +93,7 @@ fi
 echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
 ```
 
-Report: `Step 1/7: Start complete - worktree at {path}, on branch {branch}`
+Report: `Step 1/8: Start complete - worktree at {path}, on branch {branch}`
 
 ---
 
@@ -119,7 +123,7 @@ Working from the worktree, analyze the issue and build a comprehensive prompt fo
 4. **Report the prompt to the user:**
 
 ```
-Step 2/7: Analysis Complete
+Step 2/8: Analysis Complete
 
 Issue #42: "Fix login redirect loop"
 
@@ -133,14 +137,46 @@ Codex Prompt Summary:
   - Scope: Modify src/auth/login.py, tests/test_auth.py, config/routes.py
   - Testing: make lint + make test available
 
-Proceeding to Codex execution...
+Awaiting approval (Step 3/8) - reply approve, revise, or abandon.
 ```
 
-Report: `Step 2/7: Analyze complete - Codex prompt built ({N} files referenced)`
+Report: `Step 2/8: Analyze complete - Codex prompt built ({N} files referenced)`
 
 ---
 
-### Step 3: Execute Codex - Delegate Implementation
+### Step 3: Approve - Pre-Implementation Gate
+
+**STOP HERE. This step ends the turn.**
+
+Step 2 printed the plan: the issue, its acceptance criteria, the files in scope,
+and the testing expectations. That report is not a checkpoint on its own - a
+report becomes a checkpoint only when something waits on it. Present it, then
+WAIT. Do not run `codex exec`, do not begin Step 4, and do not read "the
+plan looks right" as approval you are entitled to grant yourself.
+
+This is the only gate before code exists. Step 5 (Review) inspects a diff, which
+means Codex has already written it - a plan corrected here costs nothing, while
+a plan corrected there costs a rewrite. `/flow:auto` pauses at the equivalent
+boundary (its Step 3/9 ELI5 gate); this driver now matches it.
+
+Ask the reviewer for one of:
+
+- **approve** - proceed to Step 4 and invoke Codex.
+- **revise** - amend the plan or the prompt, re-report, and gate again.
+- **abandon** - stop the run; the worktree is left in place for inspection.
+
+**Unattended runs.** `--yes` (alias `--auto-approve`) on the invocation skips the
+pause. Print the Step 2 report anyway and record that approval was auto-granted.
+Only the caller who typed the command can pass it: there is deliberately NO
+trailer-based bypass here. A marker in an issue body or a commit message is
+written by whoever filed the issue, not by whoever is running the command, so it
+can never stand in for the reviewer's approval (issue #775).
+
+Report: `Step 3/8: Approve - {approved|auto-approved (--yes)|revised|abandoned}`
+
+---
+
+### Step 4: Execute Codex - Delegate Implementation
 
 Run Codex CLI in the worktree with **workspace-write** sandbox only (issue #735:
 `danger-full-access` gave Codex network access to push commits, open PRs, and
@@ -158,7 +194,7 @@ fi
 
 **Build the prompt with the mandatory execution fence (issue #735).** The fence
 MUST appear at the TOP of every prompt sent to Codex in this step and in the
-Step 5 fix loop - before the issue context, before the codebase summary,
+Step 6 fix loop - before the issue context, before the codebase summary,
 before any implementation instructions. It is non-negotiable and never omitted,
 even for trivial issues:
 
@@ -274,11 +310,11 @@ echo "Codex made changes to $FILES_CHANGED file(s): +$LINES_ADDED -$LINES_REMOVE
 
 If Codex made no changes, STOP and report.
 
-Report: `Step 3/7: Execute Codex complete - {N} files changed (+{added} -{removed})`
+Report: `Step 4/8: Execute Codex complete - {N} files changed (+{added} -{removed})`
 
 ---
 
-### Step 4: Review - Claude Reviews Codex's Diff
+### Step 5: Review - Claude Reviews Codex's Diff
 
 Cross-model review: Claude Code reviews what Codex wrote.
 
@@ -297,7 +333,7 @@ Cross-model review: Claude Code reviews what Codex wrote.
 3. **Report review findings:**
 
 ```
-Step 4/7: Review Complete
+Step 5/8: Review Complete
 
 Codex Diff Review:
   Files changed: 3
@@ -313,11 +349,11 @@ Proceeding to quality gates...
 
 If review finds CRITICAL issues that Codex cannot fix via re-prompt (e.g., fundamentally wrong approach), STOP and report. Offer to either re-prompt Codex or hand off to manual implementation.
 
-Report: `Step 4/7: Review complete - {PASS|N issues found}`
+Report: `Step 5/8: Review complete - {PASS|N issues found}`
 
 ---
 
-### Step 5: Quality Gates - Lint, Test, Security (with Fix Loop)
+### Step 6: Quality Gates - Lint, Test, Security (with Fix Loop)
 
 Run the deterministic quality gate runner:
 
@@ -344,7 +380,7 @@ If quality gates fail:
 
 1. **Extract the error output** from the failed step.
 2. **Build a fix prompt** for Codex with the error context. **The execution
-   fence from Step 3 MUST appear at the top of every fix prompt** (issue #735):
+   fence from Step 4 MUST appear at the top of every fix prompt** (issue #735):
    ```
    EXECUTION FENCE - MANDATORY CONSTRAINTS
    ========================================
@@ -368,7 +404,7 @@ If quality gates fail:
    Only change what is necessary to make the quality gates pass.
    ```
 3. **Re-execute Codex** with the fix prompt. **Use `--sandbox workspace-write`**
-   (same as Step 3 - never `danger-full-access` for delegated implementation):
+   (same as Step 4 - never `danger-full-access` for delegated implementation):
    ```bash
    codex exec \
        --json \
@@ -403,11 +439,11 @@ if [ "$RUNNER_EXIT" -ne 0 ]; then
 fi
 ```
 
-Report: `Step 5/7: Quality gates passed (attempt {N}/{MAX})`
+Report: `Step 6/8: Quality gates passed (attempt {N}/{MAX})`
 
 ---
 
-### Step 6: Finish - Commit, Push, Create PR
+### Step 7: Finish - Commit, Push, Create PR
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -435,11 +471,11 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
      - Test plan
      - `Closes #N`
 
-Report: `Step 6/7: Finish complete - PR #{N} created`
+Report: `Step 7/8: Finish complete - PR #{N} created`
 
 ---
 
-### Step 7: Cleanup (Optional)
+### Step 8: Cleanup (Optional)
 
 Ask the user if they want to merge and clean up now, or leave the PR for review:
 
@@ -450,7 +486,7 @@ PR #{N} created. What would you like to do?
   2. Leave for review (keep worktree, manual merge later)
 ```
 
-If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 6:
+If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 7:
 
 1. Squash-merge the PR
 2. Update local main
@@ -460,7 +496,7 @@ If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 6:
 
 If leave for review, report the PR URL and worktree location.
 
-Report: `Step 7/7: Cleanup complete - PR merged, worktree removed` or `Step 7/7: PR #{N} left for review`
+Report: `Step 8/8: Cleanup complete - PR merged, worktree removed` or `Step 8/8: PR #{N} left for review`
 
 ---
 
@@ -487,7 +523,7 @@ Codex Auto Complete
 At each step, if something fails:
 
 ```
-Codex Auto stopped at Step N/7: {Step Name}
+Codex Auto stopped at Step N/8: {Step Name}
 
   Failed: [description of what failed]
   Fix:    [actionable suggestion]
@@ -495,11 +531,12 @@ Codex Auto stopped at Step N/7: {Step Name}
   To resume manually:
     /flow:start {ISSUE}     (if step 1 failed)
     [investigate]            (if step 2 failed)
-    /codex:exec "<prompt>"   (if step 3 failed)
-    [review diff manually]   (if step 4 failed)
-    /flow:check              (if step 5 failed)
-    /flow:finish             (if step 6 failed)
-    /flow:merge              (if step 7 failed)
+    [approve or revise]      (if step 3 failed)
+    /codex:exec "<prompt>"   (if step 4 failed)
+    [review diff manually]   (if step 5 failed)
+    /flow:check              (if step 6 failed)
+    /flow:finish             (if step 7 failed)
+    /flow:merge              (if step 8 failed)
 ```
 
 Key failure scenarios:
@@ -507,17 +544,17 @@ Key failure scenarios:
   number, or `gh issue view` fails because the issue does not exist, stop. This
   is not a repair of `/codex:auto`; run
   `/codex:exec "<what you wanted to build>"` in the target directory instead
-- **Codex not installed:** Stop at step 3, suggest `npm install -g @openai/codex`
-- **Codex execution fails:** Stop at step 3, show last 20 lines of JSONL output
-- **Codex makes no changes:** Stop at step 3, suggest reviewing the prompt
-- **Review finds critical issues:** Stop at step 4, offer to re-prompt or hand off
-- **Quality gates fail after retries:** Stop at step 5, show error output
-- **Push/PR fails:** Stop at step 6, suggest manual resolution
+- **Codex not installed:** Stop at step 4, suggest `npm install -g @openai/codex`
+- **Codex execution fails:** Stop at step 4, show last 20 lines of JSONL output
+- **Codex makes no changes:** Stop at step 4, suggest reviewing the prompt
+- **Review finds critical issues:** Stop at step 5, offer to re-prompt or hand off
+- **Quality gates fail after retries:** Stop at step 6, show error output
+- **Push/PR fails:** Stop at step 7, suggest manual resolution
 
 ## Notes
 
 - Codex CLI runs with `--sandbox workspace-write` (issue #735: downgraded from `danger-full-access` to mechanically prevent network operations like `git push` and `gh pr create`)
-- Every Codex prompt (Step 3 implementation + Step 5 fix loop) carries the mandatory execution fence that explicitly prohibits commit/push/PR/merge and reading `.claude/commands/**` workflow files
+- Every Codex prompt (Step 4 implementation + Step 6 fix loop) carries the mandatory execution fence that explicitly prohibits commit/push/PR/merge and reading `.claude/commands/**` workflow files
 - Post-Step-3 overrun verification detects and remediates any fence/sandbox escape: unexpected commits are rolled back, unauthorized PRs are closed, and pushes are flagged
 - Defense in depth: the textual fence prevents intentional following of workflow files; the `workspace-write` sandbox mechanically blocks network operations; the overrun verification catches anything that slips through both
 - `--json` flag streams JSONL events for monitoring plan steps, diffs, and messages

--- a/.claude/commands/codex/help.md
+++ b/.claude/commands/codex/help.md
@@ -24,12 +24,13 @@ Cross-model implementation and review - Claude manages the workflow, Codex write
 Claude Code (supervisor)            Codex CLI (implementer)
   1. Read GH issue
   2. Create worktree + branch
-  3. Build prompt from issue     --> 4. codex exec --json -C <worktree>
-  5. Monitor JSONL stream        <-- 6. Plan, code, test
-  7. Review Codex's diff
-  8. Run quality gates (lint/test/security)
-  9. If gates fail, re-prompt   --> 10. Fix with error context (max 2 retries)
-  11. Commit, push, create PR
+  3. Build prompt from issue
+  4. GATE: stop for approval     --> 5. codex exec --json -C <worktree>
+  6. Monitor JSONL stream        <-- 7. Plan, code, test
+  8. Review Codex's diff
+  9. Run quality gates (lint/test/security)
+  10. If gates fail, re-prompt  --> 11. Fix with error context (max 2 retries)
+  12. Commit, push, create PR
 ```
 
 ## Quick Start
@@ -38,6 +39,8 @@ Choose by precondition, not task size:
 
 - `/codex:auto <ISSUE>` - an EXISTING repo with a FILED issue. Creates a
   worktree and runs the full lifecycle through review, quality gates, and PR.
+  It STOPS after the Step 2 plan report and waits for approval before Codex
+  writes anything (Step 3/8); pass `--yes` to skip that pause (issue #774).
 - `/codex:exec <PROMPT>` - anything else, including a brand-new empty
   directory. Runs in the current directory with no repo or issue required and
   no automatic commit.

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -1,11 +1,11 @@
 ---
-description: Full issue lifecycle delegated to a local Gemma model - worktree, implement, review, quality gates, PR
+description: Full issue lifecycle delegated to a local Gemma model - worktree, approve, implement, review, quality gates, PR
 allowed-tools: Bash(opencode:*), Bash(ollama:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(mkdir:*), Bash(cd:*), Bash(pwd), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(make:*), Bash(sleep:*)
 ---
 
 # Gemma Auto: Full Issue Lifecycle via Local Gemma Model
 
-Mirrors `/qwen:auto` but delegates implementation (Step 3) to a locally hosted
+Mirrors `/qwen:auto` but delegates implementation (Step 4) to a locally hosted
 Gemma 4 model served by Ollama, driven through the OpenCode harness
 (`opencode run` in headless mode). Claude Code acts as supervisor/reviewer while
 the local Gemma model writes the code. No cloud API key or per-token cost is
@@ -20,6 +20,9 @@ lane's M1 Max, and prefill 1,390 tok/s against 86 tok/s.
 ## Arguments
 
 - `ISSUE` (required): GitHub issue number (e.g., `42`)
+- `--yes` (optional, alias `--auto-approve`): skip the Step 3 approval pause for
+  unattended runs. The Step 2 plan report is still printed and approval is
+  recorded as auto-granted. There is no trailer-based equivalent (issue #775).
 
 ## Environment
 
@@ -40,13 +43,14 @@ Report at the start:
 ```
 Gemma Auto: Issue #<ISSUE> - Full Lifecycle
 
-Step 1/7: Start (create worktree and branch)
-Step 2/7: Analyze (understand issue, build Gemma prompt)
-Step 3/7: Execute Gemma (delegate implementation to local Gemma via OpenCode)
-Step 4/7: Review (Claude reviews Gemma's diff)
-Step 5/7: Quality Gates (lint, test, security - with fix loop)
-Step 6/7: Finish (commit, push, create PR)
-Step 7/7: Cleanup (optional merge + worktree removal)
+Step 1/8: Start (create worktree and branch)
+Step 2/8: Analyze (understand issue, build Gemma prompt)
+Step 3/8: Approve (pre-implementation gate - stop and wait)
+Step 4/8: Execute Gemma (delegate implementation to local Gemma via OpenCode)
+Step 5/8: Review (Claude reviews Gemma's diff)
+Step 6/8: Quality Gates (lint, test, security - with fix loop)
+Step 7/8: Finish (commit, push, create PR)
+Step 8/8: Cleanup (optional merge + worktree removal)
 
 Proceeding...
 ```
@@ -109,10 +113,10 @@ echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
 WORKTREE_ROOT=$(git rev-parse --show-toplevel)
 ```
 
-Capture `WORKTREE_ROOT` here: Step 3 passes it to `opencode --dir` explicitly
+Capture `WORKTREE_ROOT` here: Step 4 passes it to `opencode --dir` explicitly
 rather than trusting the inherited shell cwd, which drifts across tool calls.
 
-Report: `Step 1/7: Start complete - worktree at {path}, on branch {branch}`
+Report: `Step 1/8: Start complete - worktree at {path}, on branch {branch}`
 
 ---
 
@@ -153,11 +157,48 @@ Working from the worktree, analyze the issue and build a comprehensive prompt fo
 
 4. **Report the prompt to the user** (same format as `/qwen:auto` Step 2).
 
-Report: `Step 2/7: Analyze complete - Gemma prompt built ({N} files referenced)`
+Report: `Step 2/8: Analyze complete - Gemma prompt built ({N} files referenced)`
 
 ---
 
-### Step 3: Execute Gemma - Delegate Implementation
+### Step 3: Approve - Pre-Implementation Gate
+
+**STOP HERE. This step ends the turn.**
+
+Step 2 printed the plan: the issue, its acceptance criteria, the files in scope,
+and the testing expectations. That report is not a checkpoint on its own - a
+report becomes a checkpoint only when something waits on it. Present it, then
+WAIT. Do not run `opencode run`, do not begin Step 4, and do not read "the
+plan looks right" as approval you are entitled to grant yourself.
+
+This is the only gate before code exists. Step 5 (Review) inspects a diff, which
+means Gemma has already written it - a plan corrected here costs nothing, while
+a plan corrected there costs a rewrite. `/flow:auto` pauses at the equivalent
+boundary (its Step 3/9 ELI5 gate); this driver now matches it.
+
+Ask the reviewer for one of:
+
+- **approve** - proceed to Step 4 and invoke Gemma.
+- **revise** - amend the plan or the prompt, re-report, and gate again.
+- **abandon** - stop the run; the worktree is left in place for inspection.
+
+**This is not OpenCode's `--auto`.** That flag, in Step 4, governs tool approval
+INSIDE Gemma's own run. This gate is an orchestrator-level stop before that run
+begins: passing `--auto` never satisfies it, and `--yes` never changes how the
+model behaves once started.
+
+**Unattended runs.** `--yes` (alias `--auto-approve`) on the invocation skips the
+pause. Print the Step 2 report anyway and record that approval was auto-granted.
+Only the caller who typed the command can pass it: there is deliberately NO
+trailer-based bypass here. A marker in an issue body or a commit message is
+written by whoever filed the issue, not by whoever is running the command, so it
+can never stand in for the reviewer's approval (issue #775).
+
+Report: `Step 3/8: Approve - {approved|auto-approved (--yes)|revised|abandoned}`
+
+---
+
+### Step 4: Execute Gemma - Delegate Implementation
 
 Run the local Gemma model through the OpenCode harness against the worktree.
 
@@ -218,7 +259,7 @@ fi
 ```
 
 **Build the prompt with the mandatory execution fence.** The fence MUST appear
-at the TOP of every prompt sent to the model in this step and in the Step 5 fix
+at the TOP of every prompt sent to the model in this step and in the Step 6 fix
 loop - before the issue context, before the codebase summary, before any
 implementation instructions. It is non-negotiable and never omitted, even for
 trivial issues. A local model is MORE likely than Codex to wander into workflow
@@ -301,7 +342,7 @@ if [ "$GEMMA_EXIT" -ne 0 ]; then
 fi
 ```
 
-**Post-execution overrun verification.** Same checks as `/qwen:auto` Step 3
+**Post-execution overrun verification.** Same checks as `/qwen:auto` Step 4
 (issue #735). The permission profile should make these no-ops - run them anyway.
 They are the layer that catches a profile that was not loaded, a rule pattern
 that did not match what the model actually typed, or an OpenCode change to how
@@ -355,11 +396,11 @@ events and no `tool_use` events is the signature of the `/v1` tool-call-drop
 bug (ollama/ollama#14958) - run `/gemma:status`, whose Step 4 smoke test tests
 exactly that, before blaming the prompt.
 
-Report: `Step 3/7: Execute Gemma complete - {N} files changed (+{added} -{removed})`
+Report: `Step 4/8: Execute Gemma complete - {N} files changed (+{added} -{removed})`
 
 ---
 
-### Step 4: Review - Claude Reviews Gemma's Diff
+### Step 5: Review - Claude Reviews Gemma's Diff
 
 Cross-model review: Claude Code reviews what the local Gemma model wrote.
 **This step carries more weight than in `/codex:auto`** - a local 31B model
@@ -377,17 +418,17 @@ Review the diff line by line, not just structurally.
    - Completeness: Are all acceptance criteria addressed?
    - Test coverage: Are tests updated or added?
 
-3. **Report review findings** (same format as `/qwen:auto` Step 4).
+3. **Report review findings** (same format as `/qwen:auto` Step 5).
 
 If review finds CRITICAL issues that a re-prompt cannot fix (fundamentally
 wrong approach), STOP and report. Offer to re-prompt Gemma, escalate to
 `/qwen:auto` or `/codex:auto`, or hand off to manual implementation.
 
-Report: `Step 4/7: Review complete - {PASS|N issues found}`
+Report: `Step 5/8: Review complete - {PASS|N issues found}`
 
 ---
 
-### Step 5: Quality Gates - Lint, Test, Security (with Fix Loop)
+### Step 6: Quality Gates - Lint, Test, Security (with Fix Loop)
 
 Run the deterministic quality gate runner:
 
@@ -414,7 +455,7 @@ If quality gates fail:
 
 1. **Extract the error output** from the failed step.
 2. **Build a fix prompt** with the error context. **The execution fence from
-   Step 3 MUST appear at the top of every fix prompt.** After the fence:
+   Step 4 MUST appear at the top of every fix prompt.** After the fence:
    ```
    The following quality gate failed after your implementation:
 
@@ -423,18 +464,18 @@ If quality gates fail:
    Fix the issues while preserving the original implementation intent.
    Only change what is necessary to make the quality gates pass.
    ```
-3. **Re-execute** with the same invocation as Step 3 (same `--agent`, `--dir`,
+3. **Re-execute** with the same invocation as Step 4 (same `--agent`, `--dir`,
    and provider flags), teeing to `/tmp/gemma-fix-${ISSUE_NUM}-${RETRY}.jsonl`.
 4. **Re-run quality gates.**
 5. If still failing after 2 retries, STOP and report. Offer escalation:
    re-run the remaining fix loop under `/codex:auto` (frontier model) or fix
    manually.
 
-Report: `Step 5/7: Quality gates passed (attempt {N}/{MAX})`
+Report: `Step 6/8: Quality gates passed (attempt {N}/{MAX})`
 
 ---
 
-### Step 6: Finish - Commit, Push, Create PR
+### Step 7: Finish - Commit, Push, Create PR
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -455,11 +496,11 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
    - Test plan
    - `Closes #N`
 
-Report: `Step 6/7: Finish complete - PR #{N} created`
+Report: `Step 7/8: Finish complete - PR #{N} created`
 
 ---
 
-### Step 7: Cleanup (Optional)
+### Step 8: Cleanup (Optional)
 
 Ask the user if they want to merge and clean up now, or leave the PR for review.
 If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 7:
@@ -470,7 +511,7 @@ If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 7:
 4. Remove worktree and branch
 5. Close issue if still open
 
-Report: `Step 7/7: Cleanup complete - PR merged, worktree removed` or `Step 7/7: PR #{N} left for review`
+Report: `Step 8/8: Cleanup complete - PR merged, worktree removed` or `Step 8/8: PR #{N} left for review`
 
 ---
 
@@ -497,7 +538,7 @@ Gemma Auto Complete
 At each step, if something fails:
 
 ```
-Gemma Auto stopped at Step N/7: {Step Name}
+Gemma Auto stopped at Step N/8: {Step Name}
 
   Failed: [description of what failed]
   Fix:    [actionable suggestion]
@@ -505,11 +546,12 @@ Gemma Auto stopped at Step N/7: {Step Name}
   To resume manually:
     /flow:start {ISSUE}      (if step 1 failed)
     [investigate]            (if step 2 failed)
-    /gemma:exec "<prompt>"   (if step 3 failed)
-    [review diff manually]   (if step 4 failed)
-    /flow:check              (if step 5 failed)
-    /flow:finish             (if step 6 failed)
-    /flow:merge              (if step 7 failed)
+    [approve or revise]      (if step 3 failed)
+    /gemma:exec "<prompt>"   (if step 4 failed)
+    [review diff manually]   (if step 5 failed)
+    /flow:check              (if step 6 failed)
+    /flow:finish             (if step 7 failed)
+    /flow:merge              (if step 8 failed)
 ```
 
 Key failure scenarios:
@@ -517,13 +559,13 @@ Key failure scenarios:
   number, or `gh issue view` fails because the issue does not exist, stop. This
   is not a repair of `/gemma:auto`; run
   `/gemma:exec "<what you wanted to build>"` in the target directory instead
-- **OpenCode CLI not installed:** Stop at step 3; it is required as the harness (no cloud API key is used)
-- **Agent profile missing:** Stop at step 3; the mechanical fence is mandatory, install it from `templates/opencode-gemma.json` or via `/cpp:init` Tier 7
-- **Ollama unreachable / model missing:** Stop at step 3; run `/gemma:status` to diagnose. On the reference server this can mean another VM holds the GPU claim
-- **Execution fails or stalls:** Stop at step 3, show last 20 lines of JSONL output
-- **Model makes no changes:** Stop at step 3; if the stream has no `tool_use` events at all, suspect the `/v1` tool-call-drop bug before the prompt - `/gemma:status` Step 4 tests for it
-- **Review finds critical issues:** Stop at step 4; offer re-prompt, escalation, or manual hand-off
-- **Quality gates fail after retries:** Stop at step 5; offer escalation to `/codex:auto`
+- **OpenCode CLI not installed:** Stop at step 4; it is required as the harness (no cloud API key is used)
+- **Agent profile missing:** Stop at step 4; the mechanical fence is mandatory, install it from `templates/opencode-gemma.json` or via `/cpp:init` Tier 7
+- **Ollama unreachable / model missing:** Stop at step 4; run `/gemma:status` to diagnose. On the reference server this can mean another VM holds the GPU claim
+- **Execution fails or stalls:** Stop at step 4, show last 20 lines of JSONL output
+- **Model makes no changes:** Stop at step 4; if the stream has no `tool_use` events at all, suspect the `/v1` tool-call-drop bug before the prompt - `/gemma:status` Step 4 tests for it
+- **Review finds critical issues:** Stop at step 5; offer re-prompt, escalation, or manual hand-off
+- **Quality gates fail after retries:** Stop at step 6; offer escalation to `/codex:auto`
 
 ## Notes
 

--- a/.claude/commands/gemma/help.md
+++ b/.claude/commands/gemma/help.md
@@ -24,12 +24,13 @@ privacy, and available to every machine on the tailnet/LAN.
 Claude Code (supervisor)            Local Gemma 4 via OpenCode harness
   1. Read GH issue
   2. Create worktree + branch
-  3. Build prompt from issue     --> 4. opencode run --format json
-  5. Monitor JSONL stream        <--    -m gemma-ollama/gemma4-code (served by Ollama)
-  7. Review Gemma's diff               6. Plan, code, test (25-39 tok/s decode)
-  8. Run quality gates (lint/test/security)
-  9. If gates fail, re-prompt   --> 10. Fix with error context (max 2 retries)
-  11. Commit, push, create PR
+  3. Build prompt from issue
+  4. GATE: stop for approval     --> 5. opencode run --format json
+  6. Monitor JSONL stream        <--    -m gemma-ollama/gemma4-code (served by Ollama)
+  8. Review Gemma's diff               7. Plan, code, test (25-39 tok/s decode)
+  9. Run quality gates (lint/test/security)
+  10. If gates fail, re-prompt  --> 11. Fix with error context (max 2 retries)
+  12. Commit, push, create PR
 ```
 
 ## Serving Stack
@@ -191,6 +192,8 @@ Choose by precondition, not task size:
 
 - `/gemma:auto <ISSUE>` - an EXISTING repo with a FILED issue. Creates a
   worktree and runs the full lifecycle through review, quality gates, and PR.
+  It STOPS after the Step 2 plan report and waits for approval before the model
+  writes anything (Step 3/8); pass `--yes` to skip that pause (issue #774).
 - `/gemma:exec <PROMPT>` - anything else, including a brand-new empty
   directory. Runs in the current directory with no repo or issue required and
   no automatic commit.

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -1,11 +1,11 @@
 ---
-description: Full issue lifecycle delegated to a local Qwen model - worktree, implement, review, quality gates, PR
+description: Full issue lifecycle delegated to a local Qwen model - worktree, approve, implement, review, quality gates, PR
 allowed-tools: Bash(qwen:*), Bash(ollama:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(curl:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(mkdir:*), Bash(cd:*), Bash(pwd), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(test:*), Bash(make:*), Bash(sleep:*)
 ---
 
 # Qwen Auto: Full Issue Lifecycle via Local Qwen Model
 
-Mirrors `/codex:auto` but delegates implementation (Step 3) to a locally hosted
+Mirrors `/codex:auto` but delegates implementation (Step 4) to a locally hosted
 Qwen model served by Ollama, driven through the Qwen Code CLI harness
 (`qwen` in headless mode; the Codex CLI harness was retired in issue #745).
 Claude Code acts as supervisor/reviewer while the local Qwen model writes the
@@ -14,6 +14,9 @@ code. No cloud API key or per-token cost is involved.
 ## Arguments
 
 - `ISSUE` (required): GitHub issue number (e.g., `42`)
+- `--yes` (optional, alias `--auto-approve`): skip the Step 3 approval pause for
+  unattended runs. The Step 2 plan report is still printed and approval is
+  recorded as auto-granted. There is no trailer-based equivalent (issue #775).
 
 ## Environment
 
@@ -33,13 +36,14 @@ Report at the start:
 ```
 Qwen Auto: Issue #<ISSUE> - Full Lifecycle
 
-Step 1/7: Start (create worktree and branch)
-Step 2/7: Analyze (understand issue, build Qwen prompt)
-Step 3/7: Execute Qwen (delegate implementation to local Qwen via Qwen Code CLI)
-Step 4/7: Review (Claude reviews Qwen's diff)
-Step 5/7: Quality Gates (lint, test, security - with fix loop)
-Step 6/7: Finish (commit, push, create PR)
-Step 7/7: Cleanup (optional merge + worktree removal)
+Step 1/8: Start (create worktree and branch)
+Step 2/8: Analyze (understand issue, build Qwen prompt)
+Step 3/8: Approve (pre-implementation gate - stop and wait)
+Step 4/8: Execute Qwen (delegate implementation to local Qwen via Qwen Code CLI)
+Step 5/8: Review (Claude reviews Qwen's diff)
+Step 6/8: Quality Gates (lint, test, security - with fix loop)
+Step 7/8: Finish (commit, push, create PR)
+Step 8/8: Cleanup (optional merge + worktree removal)
 
 Proceeding...
 ```
@@ -101,7 +105,7 @@ fi
 echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
 ```
 
-Report: `Step 1/7: Start complete - worktree at {path}, on branch {branch}`
+Report: `Step 1/8: Start complete - worktree at {path}, on branch {branch}`
 
 ---
 
@@ -139,11 +143,43 @@ Working from the worktree, analyze the issue and build a comprehensive prompt fo
 
 4. **Report the prompt to the user** (same format as `/codex:auto` Step 2).
 
-Report: `Step 2/7: Analyze complete - Qwen prompt built ({N} files referenced)`
+Report: `Step 2/8: Analyze complete - Qwen prompt built ({N} files referenced)`
 
 ---
 
-### Step 3: Execute Qwen - Delegate Implementation
+### Step 3: Approve - Pre-Implementation Gate
+
+**STOP HERE. This step ends the turn.**
+
+Step 2 printed the plan: the issue, its acceptance criteria, the files in scope,
+and the testing expectations. That report is not a checkpoint on its own - a
+report becomes a checkpoint only when something waits on it. Present it, then
+WAIT. Do not run the `qwen` harness, do not begin Step 4, and do not read "the
+plan looks right" as approval you are entitled to grant yourself.
+
+This is the only gate before code exists. Step 5 (Review) inspects a diff, which
+means Qwen has already written it - a plan corrected here costs nothing, while
+a plan corrected there costs a rewrite. `/flow:auto` pauses at the equivalent
+boundary (its Step 3/9 ELI5 gate); this driver now matches it.
+
+Ask the reviewer for one of:
+
+- **approve** - proceed to Step 4 and invoke Qwen.
+- **revise** - amend the plan or the prompt, re-report, and gate again.
+- **abandon** - stop the run; the worktree is left in place for inspection.
+
+**Unattended runs.** `--yes` (alias `--auto-approve`) on the invocation skips the
+pause. Print the Step 2 report anyway and record that approval was auto-granted.
+Only the caller who typed the command can pass it: there is deliberately NO
+trailer-based bypass here. A marker in an issue body or a commit message is
+written by whoever filed the issue, not by whoever is running the command, so it
+can never stand in for the reviewer's approval (issue #775).
+
+Report: `Step 3/8: Approve - {approved|auto-approved (--yes)|revised|abandoned}`
+
+---
+
+### Step 4: Execute Qwen - Delegate Implementation
 
 Run the local Qwen model through the Qwen Code CLI harness in the worktree.
 When the Ollama server is local (localhost / 127.0.0.1 / ::1), the harness runs
@@ -208,7 +244,7 @@ fi
 ```
 
 **Build the prompt with the mandatory execution fence.** The fence MUST appear
-at the TOP of every prompt sent to the model in this step and in the Step 5 fix
+at the TOP of every prompt sent to the model in this step and in the Step 6 fix
 loop - before the issue context, before the codebase summary, before any
 implementation instructions. It is non-negotiable and never omitted, even for
 trivial issues. A local model is MORE likely than Codex to wander into workflow
@@ -293,7 +329,7 @@ if [ "$QWEN_EXIT" -ne 0 ]; then
 fi
 ```
 
-**Post-execution overrun verification.** Same checks as `/codex:auto` Step 3
+**Post-execution overrun verification.** Same checks as `/codex:auto` Step 4
 (issue #735) - verify the model did not escape its implementation-only boundary:
 
 ```bash
@@ -335,11 +371,11 @@ git diff --stat | tail -1
 
 If the model made no changes, STOP and report.
 
-Report: `Step 3/7: Execute Qwen complete - {N} files changed (+{added} -{removed})`
+Report: `Step 4/8: Execute Qwen complete - {N} files changed (+{added} -{removed})`
 
 ---
 
-### Step 4: Review - Claude Reviews Qwen's Diff
+### Step 5: Review - Claude Reviews Qwen's Diff
 
 Cross-model review: Claude Code reviews what the local Qwen model wrote.
 **This step carries more weight than in `/codex:auto`** - a local 27B model
@@ -357,17 +393,17 @@ Review the diff line by line, not just structurally.
    - Completeness: Are all acceptance criteria addressed?
    - Test coverage: Are tests updated or added?
 
-3. **Report review findings** (same format as `/codex:auto` Step 4).
+3. **Report review findings** (same format as `/codex:auto` Step 5).
 
 If review finds CRITICAL issues that a re-prompt cannot fix (fundamentally
 wrong approach), STOP and report. Offer to re-prompt Qwen, escalate to
 `/codex:auto`, or hand off to manual implementation.
 
-Report: `Step 4/7: Review complete - {PASS|N issues found}`
+Report: `Step 5/8: Review complete - {PASS|N issues found}`
 
 ---
 
-### Step 5: Quality Gates - Lint, Test, Security (with Fix Loop)
+### Step 6: Quality Gates - Lint, Test, Security (with Fix Loop)
 
 Run the deterministic quality gate runner:
 
@@ -394,7 +430,7 @@ If quality gates fail:
 
 1. **Extract the error output** from the failed step.
 2. **Build a fix prompt** with the error context. **The execution fence from
-   Step 3 MUST appear at the top of every fix prompt.** After the fence:
+   Step 4 MUST appear at the top of every fix prompt.** After the fence:
    ```
    The following quality gate failed after your implementation:
 
@@ -403,18 +439,18 @@ If quality gates fail:
    Fix the issues while preserving the original implementation intent.
    Only change what is necessary to make the quality gates pass.
    ```
-3. **Re-execute** with the same invocation as Step 3 (same sandbox, same
+3. **Re-execute** with the same invocation as Step 4 (same sandbox, same
    provider flags), teeing to `/tmp/qwen-fix-${ISSUE_NUM}-${RETRY}.jsonl`.
 4. **Re-run quality gates.**
 5. If still failing after 2 retries, STOP and report. Offer escalation:
    re-run the remaining fix loop under `/codex:auto` (frontier model) or fix
    manually.
 
-Report: `Step 5/7: Quality gates passed (attempt {N}/{MAX})`
+Report: `Step 6/8: Quality gates passed (attempt {N}/{MAX})`
 
 ---
 
-### Step 6: Finish - Commit, Push, Create PR
+### Step 7: Finish - Commit, Push, Create PR
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -435,14 +471,14 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
    - Test plan
    - `Closes #N`
 
-Report: `Step 6/7: Finish complete - PR #{N} created`
+Report: `Step 7/8: Finish complete - PR #{N} created`
 
 ---
 
-### Step 7: Cleanup (Optional)
+### Step 8: Cleanup (Optional)
 
 Ask the user if they want to merge and clean up now, or leave the PR for review.
-If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 6:
+If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 7:
 
 1. Squash-merge the PR
 2. Update local main
@@ -450,7 +486,7 @@ If merge now, follow the same merge/cleanup pattern as `/flow:auto` Step 6:
 4. Remove worktree and branch
 5. Close issue if still open
 
-Report: `Step 7/7: Cleanup complete - PR merged, worktree removed` or `Step 7/7: PR #{N} left for review`
+Report: `Step 8/8: Cleanup complete - PR merged, worktree removed` or `Step 8/8: PR #{N} left for review`
 
 ---
 
@@ -476,7 +512,7 @@ Qwen Auto Complete
 At each step, if something fails:
 
 ```
-Qwen Auto stopped at Step N/7: {Step Name}
+Qwen Auto stopped at Step N/8: {Step Name}
 
   Failed: [description of what failed]
   Fix:    [actionable suggestion]
@@ -484,11 +520,12 @@ Qwen Auto stopped at Step N/7: {Step Name}
   To resume manually:
     /flow:start {ISSUE}      (if step 1 failed)
     [investigate]            (if step 2 failed)
-    /qwen:exec "<prompt>"    (if step 3 failed)
-    [review diff manually]   (if step 4 failed)
-    /flow:check              (if step 5 failed)
-    /flow:finish             (if step 6 failed)
-    /flow:merge              (if step 7 failed)
+    [approve or revise]      (if step 3 failed)
+    /qwen:exec "<prompt>"    (if step 4 failed)
+    [review diff manually]   (if step 5 failed)
+    /flow:check              (if step 6 failed)
+    /flow:finish             (if step 7 failed)
+    /flow:merge              (if step 8 failed)
 ```
 
 Key failure scenarios:
@@ -496,12 +533,12 @@ Key failure scenarios:
   number, or `gh issue view` fails because the issue does not exist, stop. This
   is not a repair of `/qwen:auto`; run
   `/qwen:exec "<what you wanted to build>"` in the target directory instead
-- **Qwen Code CLI not installed:** Stop at step 3; it is required as the harness (no cloud API key is used)
-- **Ollama unreachable / model missing:** Stop at step 3; run `/qwen:status` to diagnose
-- **Execution fails or stalls:** Stop at step 3, show last 20 lines of JSONL output
-- **Model makes no changes:** Stop at step 3; tighten the prompt or escalate to `/codex:auto`
-- **Review finds critical issues:** Stop at step 4; offer re-prompt, escalation, or manual hand-off
-- **Quality gates fail after retries:** Stop at step 5; offer escalation to `/codex:auto`
+- **Qwen Code CLI not installed:** Stop at step 4; it is required as the harness (no cloud API key is used)
+- **Ollama unreachable / model missing:** Stop at step 4; run `/qwen:status` to diagnose
+- **Execution fails or stalls:** Stop at step 4, show last 20 lines of JSONL output
+- **Model makes no changes:** Stop at step 4; tighten the prompt or escalate to `/codex:auto`
+- **Review finds critical issues:** Stop at step 5; offer re-prompt, escalation, or manual hand-off
+- **Quality gates fail after retries:** Stop at step 6; offer escalation to `/codex:auto`
 
 ## Notes
 

--- a/.claude/commands/qwen/help.md
+++ b/.claude/commands/qwen/help.md
@@ -24,12 +24,13 @@ and available to every machine on the tailnet/LAN.
 Claude Code (supervisor)            Local Qwen via Qwen Code CLI harness
   1. Read GH issue
   2. Create worktree + branch
-  3. Build prompt from issue     --> 4. qwen --output-format stream-json
-  5. Monitor JSONL stream        <--    -m qwen3.8-code:latest (served by Ollama)
-  7. Review Qwen's diff                6. Plan, code, test (~15-20 tok/s locally)
-  8. Run quality gates (lint/test/security)
-  9. If gates fail, re-prompt   --> 10. Fix with error context (max 2 retries)
-  11. Commit, push, create PR
+  3. Build prompt from issue
+  4. GATE: stop for approval     --> 5. qwen --output-format stream-json
+  6. Monitor JSONL stream        <--    -m qwen3.8-code:latest (served by Ollama)
+  8. Review Qwen's diff                7. Plan, code, test (~15-20 tok/s locally)
+  9. Run quality gates (lint/test/security)
+  10. If gates fail, re-prompt  --> 11. Fix with error context (max 2 retries)
+  12. Commit, push, create PR
 ```
 
 ## Serving Stack
@@ -143,6 +144,8 @@ Choose by precondition, not task size:
 
 - `/qwen:auto <ISSUE>` - an EXISTING repo with a FILED issue. Creates a
   worktree and runs the full lifecycle through review, quality gates, and PR.
+  It STOPS after the Step 2 plan report and waits for approval before the model
+  writes anything (Step 3/8); pass `--yes` to skip that pause (issue #774).
 - `/qwen:exec <PROMPT>` - anything else, including a brand-new empty
   directory. Runs in the current directory with no repo or issue required and
   no automatic commit.

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -228,14 +228,15 @@ qualifiers such as `/qa:test` being single-session) are not lost.
 - `/cicd:infra-pipeline` - Generate per-tier CI/CD pipelines with approval gates
 ### Codex Orchestration
 
-- `/codex:auto <ISSUE>` - Full issue lifecycle delegated to Codex CLI (worktree, implement, review, quality gates, PR)
+- `/codex:auto <ISSUE>` - Full issue lifecycle delegated to Codex CLI (8 steps: worktree, approve, implement, review, quality gates, PR)
 - `/codex:exec <PROMPT>` - One-shot Codex execution in current directory with JSONL monitoring
 - `/codex:ask <QUESTION>` - Delegate a read-only question to Codex and relay its answer (read-only by default; network opt-in on explicit request)
 - `/codex:status` - Check Codex CLI installation, config, and readiness
 - `/codex:help` - Codex commands overview
+- Pre-implementation gate (issue #774): all three delegated drivers - `/codex:auto`, `/qwen:auto`, `/gemma:auto` - STOP at `Step 3/8: Approve` after reporting the plan and wait for approval before invoking the model CLI. Before #774 each printed a plan that read exactly like a checkpoint and then delegated in the same turn; because their Review step inspects a diff, that boundary is the only point at which anything can be caught before code exists. Found on a six-worker kyle orchestration wave where three workers described the boundary as a halt it did not have. `--yes` (alias `--auto-approve`) is the only bypass, and it is deliberately flag-only: no `eli5: auto-approve`-style trailer is honored, since a marker in an issue body or commit message is written by the filer rather than the invoker (the #775 hazard, not propagated). `tests/test_delegated_driver_gates.py` pins the gate, the ordering, the escape hatch, and the absence of a trailer bypass in all three drivers.
 ### Local Qwen Orchestration (Tier 6, optional)
 
-- `/qwen:auto <ISSUE>` - Full issue lifecycle delegated to a locally hosted Qwen model (Ollama-served, driven through the Qwen Code CLI harness in headless stream-json mode; no cloud API key or per-token cost)
+- `/qwen:auto <ISSUE>` - Full issue lifecycle (8 steps, gated at Step 3/8) delegated to a locally hosted Qwen model (Ollama-served, driven through the Qwen Code CLI harness in headless stream-json mode; no cloud API key or per-token cost)
 - `/qwen:exec <PROMPT>` - One-shot local Qwen execution in current directory with JSONL monitoring (Seatbelt/Docker sandbox, yolo approval, wall-time budget)
 - `/qwen:status` - Check the Ollama server, model presence, network exposure, and Qwen Code harness readiness
 - `/qwen:help` - Qwen commands overview, serving-stack recipe, thinking-token guidance, and remote-access setup
@@ -243,7 +244,7 @@ qualifiers such as `/qa:test` being single-session) are not lost.
 
 ### Local Gemma Orchestration (Tier 7, optional)
 
-- `/gemma:auto <ISSUE>` - Full issue lifecycle delegated to a locally hosted Gemma 4 model (Ollama-served on a GPU box, driven through the OpenCode harness in headless `--format json` mode; no cloud API key or per-token cost)
+- `/gemma:auto <ISSUE>` - Full issue lifecycle (8 steps, gated at Step 3/8) delegated to a locally hosted Gemma 4 model (Ollama-served on a GPU box, driven through the OpenCode harness in headless `--format json` mode; no cloud API key or per-token cost)
 - `/gemma:exec <PROMPT>` - One-shot local Gemma execution in the current directory with JSONL monitoring (explicit `--dir`, `--auto` approval, wall-time budget)
 - `/gemma:status` - Check the Ollama server, model presence and GPU residency, OpenCode harness, provider resolution, the `gemma-implementer` agent profile, and a real tool-calling smoke test
 - `/gemma:help` - Gemma commands overview, serving-stack recipe, the native-API rationale, the mechanical-fence design, and remote-access setup

--- a/tests/test_delegated_driver_gates.py
+++ b/tests/test_delegated_driver_gates.py
@@ -1,0 +1,138 @@
+"""Pin: the delegated drivers halt before delegating (issue #774).
+
+`/codex:auto`, `/qwen:auto` and `/gemma:auto` each printed a Step 2 plan report -
+issue, acceptance criteria, files in scope, testing expectations - and then fell
+straight into delegating implementation in the same turn. The report reads
+exactly like a checkpoint and was not one: a grep for
+`approv|confirm|wait for|pause|before proceeding|halt` between the Step 2 and
+Step 3 headings returned nothing in any of the three, while `/flow:auto` genuinely
+pauses at the equivalent boundary.
+
+There is no later recovery. Each driver's Review step inspects a DIFF, which only
+exists after the model has written it, so the Step 2 -> delegate boundary is the
+only moment before code exists. Found on a six-worker kyle orchestration wave:
+three workers described the boundary as a halt it did not have, and two were
+running `/codex:auto` under a policy that assumed one.
+
+These are prompt documents, so the document is the enforceable layer - which is
+what makes this test the mechanism rather than the discipline it replaces. A
+future editor cannot delete the halt, reorder it after the delegation, drop the
+invoker-controlled escape hatch, or introduce the trailer-shaped bypass that
+issue #775 is open about, without turning one of these red.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS = ROOT / ".claude" / "commands"
+
+#: driver family -> (gate heading, delegation heading, the CLI it must not reach early)
+DRIVERS = {
+    "codex": ("### Step 3: Approve", "### Step 4: Execute Codex", "codex exec"),
+    "qwen": ("### Step 3: Approve", "### Step 4: Execute Qwen", "qwen"),
+    "gemma": ("### Step 3: Approve", "### Step 4: Execute Gemma", "opencode run"),
+}
+
+#: A trailer bypass is read from the issue body or HEAD commit - written by the
+#: filer, not the invoker - so it can never stand in for reviewer approval (#775).
+TRAILER_BYPASS = re.compile(r"auto-approve\s+trailer|trailer\s+in the issue body", re.IGNORECASE)
+
+
+def _driver(family: str) -> str:
+    return (COMMANDS / family / "auto.md").read_text(encoding="utf-8")
+
+
+def _section(text: str, start: str, end: str) -> str:
+    lines = text.splitlines()
+    first = next(index for index, line in enumerate(lines) if line.startswith(start))
+    last = next(index for index, line in enumerate(lines) if line.startswith(end))
+    assert first < last, f"{start!r} must precede {end!r}"
+    return "\n".join(lines[first:last])
+
+
+@pytest.mark.parametrize("family", sorted(DRIVERS), ids=sorted(DRIVERS))
+def test_gate_sits_between_the_plan_report_and_the_delegation(family: str) -> None:
+    gate_heading, delegate_heading, _ = DRIVERS[family]
+    text = _driver(family)
+    lines = text.splitlines()
+
+    analyze = next(i for i, line in enumerate(lines) if line.startswith("### Step 2: Analyze"))
+    gate = next(i for i, line in enumerate(lines) if line.startswith(gate_heading))
+    delegate = next(i for i, line in enumerate(lines) if line.startswith(delegate_heading))
+
+    assert analyze < gate < delegate, (
+        f"{family}/auto.md: the approval gate must sit strictly between the Step 2 plan "
+        f"report and the delegation step (issue #774); found Analyze@{analyze}, "
+        f"gate@{gate}, delegate@{delegate}"
+    )
+
+
+@pytest.mark.parametrize("family", sorted(DRIVERS), ids=sorted(DRIVERS))
+def test_gate_halts_rather_than_merely_announcing(family: str) -> None:
+    gate_heading, delegate_heading, cli = DRIVERS[family]
+    section = _section(_driver(family), gate_heading, delegate_heading)
+
+    assert "STOP HERE" in section, f"{family}: the gate must say STOP, not describe a boundary"
+    assert "ends the turn" in section, f"{family}: the gate must end the turn, not continue"
+    assert "WAIT" in section, f"{family}: the gate must wait for the reviewer"
+    assert cli in section, (
+        f"{family}: the gate must name {cli!r} as the thing it withholds - a halt that does "
+        "not name what it is stopping is advice, not a gate"
+    )
+    for verdict in ("approve", "revise", "abandon"):
+        assert f"**{verdict}**" in section, f"{family}: the gate must offer the {verdict!r} verdict"
+
+
+@pytest.mark.parametrize("family", sorted(DRIVERS), ids=sorted(DRIVERS))
+def test_the_plan_report_no_longer_promises_to_proceed(family: str) -> None:
+    gate_heading = DRIVERS[family][0]
+    text = _driver(family)
+    lines = text.splitlines()
+    gate = next(i for i, line in enumerate(lines) if line.startswith(gate_heading))
+    before_gate = "\n".join(lines[:gate])
+
+    # codex/auto.md's Step 2 report template used to end "Proceeding to Codex
+    # execution..." - the single line that most made a report look like consent.
+    assert not re.search(r"Proceeding to \w+ execution", before_gate), (
+        f"{family}/auto.md: nothing before the approval gate may announce that execution "
+        "is about to proceed (issue #774)"
+    )
+
+
+@pytest.mark.parametrize("family", sorted(DRIVERS), ids=sorted(DRIVERS))
+def test_only_an_invoker_typed_flag_skips_the_gate(family: str) -> None:
+    text = _driver(family)
+
+    assert "`--yes` (optional, alias `--auto-approve`)" in text, (
+        f"{family}/auto.md: the gate needs an invoker-controlled escape hatch, or unattended "
+        "callers are broken by it"
+    )
+    assert not TRAILER_BYPASS.search(text) or "no trailer-based" in text.casefold() or "NO\ntrailer-based" in text, (
+        f"{family}/auto.md: a trailer bypass would let the issue filer approve on the "
+        "invoker's behalf (the #775 hazard) - do not propagate it here"
+    )
+
+
+@pytest.mark.parametrize("family", sorted(DRIVERS), ids=sorted(DRIVERS))
+def test_step_numbering_is_internally_consistent(family: str) -> None:
+    text = _driver(family)
+
+    # The renumber to 8 must be total: a leftover /7 means some report line still
+    # tells the user a step count the driver no longer has.
+    assert "/7:" not in text, f"{family}/auto.md: leftover 7-step reference after the #774 renumber"
+    for step in range(1, 9):
+        assert f"Step {step}/8" in text, f"{family}/auto.md: no report line for Step {step}/8"
+
+
+def test_flow_auto_still_pauses_at_its_own_gate() -> None:
+    # The parity claim these drivers now make is only true while flow:auto's gate
+    # exists; if it is ever removed, this pin must fail rather than quietly rot.
+    text = (COMMANDS / "flow" / "auto.md").read_text(encoding="utf-8")
+
+    assert "pause and wait for reviewer approval" in text
+    assert "Step 3/9: ELI5" in text


### PR DESCRIPTION
## Summary

`/codex:auto`, `/qwen:auto` and `/gemma:auto` each printed a Step 2 plan report - issue, acceptance criteria, files in scope, testing expectations - and then delegated implementation **in the same turn**. Re-verified against the tree before writing anything: grepping `approv|confirm|wait for|pause|before proceeding|halt` between the Step 2 and Step 3 headings returned nothing in any of the three, and `codex/auto.md`'s report template literally ended `Proceeding to Codex execution...`. `/flow:auto` genuinely pauses at the equivalent boundary; these three did not.

There was no later recovery. Each driver's Review step inspects a **diff**, which only exists once the model has written it - so the Step 2 → delegate boundary is the only moment before code exists. Found on a six-worker kyle orchestration wave where three workers described that boundary as a halt it did not have, and two were running `/codex:auto` under a policy that assumed one.

## What changed

**The gate is a first-class step.** 7 steps become 8, with `Step 3/8: Approve` between Analyze and Execute. It says STOP, ends the turn, names the CLI it is withholding (`codex exec` / the `qwen` harness / `opencode run`), and offers **approve** / **revise** / **abandon**.

The renumber is total: every later step heading, every `Step N/7` report line, the manual-resume ladder, the failure-scenario list, and the internal cross-references (`fence from Step 3` → `Step 4`, `Step 5 fix loop` → `Step 6`, …). References to **other** commands' numbering (`/flow:auto`, `/gemma:status`) are deliberately frozen and left alone.

**One bypass, invoker-controlled.** `--yes` (alias `--auto-approve`) skips the pause; the plan report still prints and approval is recorded as auto-granted. No `eli5: auto-approve`-style trailer is honored here on purpose: a marker in an issue body or commit message is written by whoever *filed* the issue, not by whoever is *running* the command. That is the open #775 hazard, and this change does not spread it to three more commands.

`/gemma:auto` additionally spells out that this gate is **not** OpenCode's `--auto` flag - that governs tool approval inside Gemma's own run, which the issue explicitly asked not to be conflated.

## The test is the mechanism

The issue's own words: the current mitigation "is discipline, not mechanism." These are prompt documents, so the document is the enforceable layer. `tests/test_delegated_driver_gates.py` (16 cases) pins:

- the gate exists and sits **strictly between** the plan report and the delegation step
- it halts rather than announcing: `STOP HERE`, `ends the turn`, `WAIT`, names the withheld CLI, offers all three verdicts
- nothing before the gate promises to proceed (the old `Proceeding to Codex execution` line)
- the `--yes` escape is documented, and no trailer bypass is introduced
- the renumber is complete: no leftover `/7`, and a report line exists for every `Step 1/8` … `Step 8/8`
- `/flow:auto` still pauses at its own Step 3/9 gate, so the parity claim these drivers now make cannot rot silently

**Verified non-vacuous:** run against the pre-change documents (`git show HEAD:…`), all three fail it - no gate, no `--yes`, leftover `/7`, and codex's proceeding line.

## Adjacent correction

`/codex:auto` and `/qwen:auto` both pointed at "`/flow:auto` Step 6" for the merge/cleanup pattern. That is flow:auto's *Finish* step; its merge is Step 7, as `/gemma:auto` already said. Corrected in passing, since this commit is otherwise entirely about step-reference accuracy in these files.

## Test plan

- Full gate green on the branch: ruff, mypy (189 source files), **1886 passed / 0 skipped**, security scan.
- `python3 scripts/codex-skill-sync.py --check` → 75 skills in sync; no mirror regeneration needed, since codex/qwen/gemma are in `UNPACKAGED_FAMILIES`.
- Help documents and `docs/commands-reference.md` updated to describe the gate rather than the old 7-step flow.

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019E2oDfccpasGsTYs74XWZG