### PR TITLE
fix(cicd): aggregate every test invocation in a step, and locate security findings

### DIFF
--- a/lib/cicd/outcomes.py
+++ b/lib/cicd/outcomes.py
@@ -30,6 +30,15 @@ class SuiteOutcome:
     skipped: int = 0
     errors: int = 0
     framework: str = "unknown"
+    # How many summaries were aggregated into these counts, and how many of
+    # them executed nothing (kyle issue #838). A step whose command runs the
+    # runner more than once - `make test` invoking pytest for two disjoint
+    # suites - produces one summary per invocation, and the TOTAL can look
+    # healthy while one invocation collected zero. Summing without these would
+    # report an honest number and leave #621's guard exactly as blind as the
+    # last-wins behaviour did.
+    invocations: int = 1
+    empty_invocations: int = 0
 
     @property
     def executed(self) -> int:
@@ -45,6 +54,18 @@ class SuiteOutcome:
         nothing at all, so even the skip count is zero).
         """
         return self.executed == 0
+
+    @property
+    def any_invocation_empty(self) -> bool:
+        """True when some invocation executed nothing, even if others did.
+
+        ``nothing_ran`` asks about the total, which is the right question for
+        a single invocation and the wrong one for several: two suites where
+        the first collects zero and the second passes 102 total 102, so the
+        total ran something and the #621 warning stays silent about a half of
+        the gate that proved nothing (kyle issue #838).
+        """
+        return self.empty_invocations > 0
 
     def summary(self) -> str:
         """Human-readable count summary, e.g. ``312 passed, 66 skipped``."""
@@ -64,6 +85,8 @@ class SuiteOutcome:
             "errors": self.errors,
             "executed": self.executed,
             "framework": self.framework,
+            "invocations": self.invocations,
+            "empty_invocations": self.empty_invocations,
         }
 
 
@@ -115,25 +138,61 @@ def parse_suite_outcome(text: str) -> Optional[SuiteOutcome]:
     """Parse a test runner's summary out of captured step output.
 
     Returns None when no recognizable summary is present - the caller then
-    reports exactly what it reported before this module existed. The LAST
-    matching summary wins, so a ``make test`` target that runs several suites
-    reports its final one rather than an early partial.
+    reports exactly what it reported before this module existed.
+
+    EVERY recognized summary is aggregated, not just the last one. This used
+    to keep the last, reasoning that a target running several suites should
+    report its final one "rather than an early partial" - which is right for a
+    partial or a re-run of a subset, and wrong for two DISJOINT suites, a
+    shape that reasoning did not cover. kyle's ``make test`` runs pytest twice
+    (non-Playwright, then Playwright), so a gate over 4,153 executed tests
+    reported 103 and discarded 97.5% of the run (kyle issue #838).
+
+    The #769 failed-id re-run is unaffected: it runs as a SEPARATE
+    ``step.execute`` with its own captured output, so it is never in the same
+    text as the run it re-runs and cannot be double-counted here.
     """
     if not text:
         return None
     lines = text.splitlines()
-    # Order matters only in that each parser scans independently; the last
-    # recognized summary across all of them (by line position) is returned.
-    best: Optional[tuple[int, SuiteOutcome]] = None
+    # Each parser scans independently; per line the last recognized summary
+    # wins, which preserves the previous precedence for a single summary.
+    parsed: list[SuiteOutcome] = []
     for idx, line in enumerate(lines):
-        for parsed in (
+        found: Optional[SuiteOutcome] = None
+        for candidate in (
             _parse_pytest_line(line),
             _parse_jest_line(line),
             _parse_unittest_line(line, lines, idx),
         ):
-            if parsed is not None:
-                best = (idx, parsed)
-    return best[1] if best else None
+            if candidate is not None:
+                found = candidate
+        if found is not None:
+            parsed.append(found)
+    if not parsed:
+        return None
+    return _aggregate(parsed)
+
+
+def _aggregate(outcomes: list[SuiteOutcome]) -> SuiteOutcome:
+    """Sum several summaries into one, keeping how many ran nothing.
+
+    A single summary passes through with its counts untouched; it simply
+    reports ``invocations=1``, and ``empty_invocations=1`` when it is #621's
+    original "exited 0 having executed nothing" case.
+    """
+    frameworks = {outcome.framework for outcome in outcomes}
+    return SuiteOutcome(
+        passed=sum(outcome.passed for outcome in outcomes),
+        failed=sum(outcome.failed for outcome in outcomes),
+        skipped=sum(outcome.skipped for outcome in outcomes),
+        errors=sum(outcome.errors for outcome in outcomes),
+        # One framework per step is the norm; "mixed" is honest rather than
+        # silently attributing a jest run's tests to pytest.
+        framework=outcomes[-1].framework if len(frameworks) == 1 else "mixed",
+        invocations=len(outcomes),
+        empty_invocations=sum(1 for outcome in outcomes if outcome.nothing_ran),
+    )
 
 
 def _parse_pytest_line(line: str) -> Optional[SuiteOutcome]:

--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -315,6 +315,26 @@ class DeterministicRunner:
                         f"  [{idx + 1}/{len(step_defs)}] {step.id}: "
                         f"SUCCESS - NO TESTS RAN{qualifier}"
                     )
+                elif outcome is not None and outcome.any_invocation_empty:
+                    # The same hole as above, hidden by an aggregate (kyle
+                    # issue #838). A step running the runner more than once -
+                    # `make test` invoking pytest for two disjoint suites -
+                    # can have one invocation collect nothing while the total
+                    # looks healthy, so `nothing_ran` is False and the warning
+                    # above stays silent about a half of the gate that proved
+                    # nothing. Summing the counts makes the NUMBER honest and
+                    # does not restore the guard; this does.
+                    warnings.append(
+                        f"{step.id}: {outcome.empty_invocations} of "
+                        f"{outcome.invocations} test invocations executed NO tests "
+                        f"({outcome.summary()} across all of them) - part of this "
+                        "gate proved nothing about the change"
+                    )
+                    self._log(
+                        f"  [{idx + 1}/{len(step_defs)}] {step.id}: "
+                        f"SUCCESS - {outcome.empty_invocations} OF "
+                        f"{outcome.invocations} INVOCATIONS RAN NO TESTS{qualifier}"
+                    )
                 else:
                     self._log(f"  [{idx + 1}/{len(step_defs)}] {step.id}: SUCCESS{qualifier}")
                 state.mark_step_success(idx, result.output, tests=outcome_dict)

--- a/lib/security/orchestrator.py
+++ b/lib/security/orchestrator.py
@@ -7,7 +7,7 @@ Provides quick, standard, and deep scan modes.
 from __future__ import annotations
 
 from .config import SecurityConfig
-from .models import ScanResult
+from .models import Finding, ScanResult
 from .modules import debug_flags, env_files, gitignore, gitleaks, npm_audit, permissions, pip_audit, secrets
 
 
@@ -84,6 +84,26 @@ def scan_deep(project_root: str, config: SecurityConfig | None = None) -> ScanRe
     return result
 
 
+def _gate_message(finding: Finding) -> str:
+    """One gate line for *finding*, with enough to act on it (kyle #838).
+
+    Severity and title alone cannot be triaged: five identical HIGH lines for
+    "Hardcoded password in source code" leave a reader unable to tell a real
+    one from a known-ignorable one without re-deriving the scan, so a genuine
+    finding hides among them. The location was never missing - ``Finding``
+    carries ``file_path``/``line_number`` and the scanners populate them - it
+    was simply not printed.
+
+    ``raw_match`` is deliberately NOT included. It may be the secret itself,
+    which is why the model carries ``mask_secret``, and these messages land in
+    shared logs and PR bodies. The location is enough to go and look.
+    """
+    parts = [f"{finding.severity.icon} {finding.severity.label}: {finding.title}"]
+    if finding.location:
+        parts.append(f"at {finding.location}")
+    return " ".join(parts) + f" [{finding.id}]"
+
+
 def check_gate(result: ScanResult, gate_name: str, config: SecurityConfig | None = None) -> tuple[bool, list[str]]:
     """Check if scan results pass a flow gate.
 
@@ -109,14 +129,10 @@ def check_gate(result: ScanResult, gate_name: str, config: SecurityConfig | None
 
     for finding in result.findings:
         if finding.severity in gate.block_on:
-            messages.append(
-                f"BLOCKED: {finding.severity.icon} {finding.severity.label}: {finding.title}"
-            )
+            messages.append(f"BLOCKED: {_gate_message(finding)}")
             blocked = True
         elif finding.severity in gate.warn_on:
-            messages.append(
-                f"WARNING: {finding.severity.icon} {finding.severity.label}: {finding.title}"
-            )
+            messages.append(f"WARNING: {_gate_message(finding)}")
 
     return not blocked, messages
 

--- a/tests/test_cicd_outcomes.py
+++ b/tests/test_cicd_outcomes.py
@@ -98,8 +98,18 @@ class TestPytestParsing:
         assert out.failed == 1  # xfailed ran and failed as expected
         assert not out.nothing_ran
 
-    def test_last_summary_wins(self) -> None:
-        # A `make test` target that runs two suites reports the final one.
+    def test_summaries_from_two_suites_are_summed(self) -> None:
+        """CONTRACT CHANGE (kyle issue #838). This test previously asserted
+        the opposite - "a `make test` target that runs two suites reports the
+        final one" - and that was the defect, pinned as intent: kyle's target
+        runs pytest twice, so a gate over 4,153 tests reported 103.
+
+        The old docstring in outcomes.py defended last-wins against "an early
+        partial", which is a different scenario from the one this test used.
+        Where a partial genuinely occurs - the #769 failed-id re-run - it runs
+        as a separate `step.execute` with its own output, so it is never in
+        the same text and cannot be double-counted by summing here.
+        """
         text = "\n".join(
             [
                 "=== 10 passed in 1.00s ===",
@@ -109,8 +119,9 @@ class TestPytestParsing:
         )
         out = parse_suite_outcome(text)
         assert out is not None
-        assert out.passed == 4
+        assert out.passed == 14
         assert out.skipped == 2
+        assert out.invocations == 2
 
     def test_summary_embedded_in_full_output(self) -> None:
         text = (
@@ -258,3 +269,124 @@ class TestStepGating:
         step = ShellStep(StepDef(id="test", command="make test"))
         outcome = step._parse_tests("", "== 1 passed, 9 skipped in 1.0s ==")
         assert outcome == SuiteOutcome(passed=1, skipped=9, framework="pytest")
+
+
+class TestMultipleInvocationsInOneStep:
+    """A step whose command runs pytest more than once (kyle issue #838).
+
+    `make test` in kyle runs two disjoint pytest invocations - non-Playwright,
+    then Playwright - inside one Make target. The parser kept only the last
+    summary, so a gate over 4,153 executed tests reported 103: the Playwright
+    half, with the other 97.5% silently discarded.
+
+    The existing last-wins behaviour is NOT an oversight, it is scoped. Its
+    comment reasons about "an early partial", and for a partial or a re-run of
+    a subset last-wins is correct - summing those would double-count. Two
+    DISJOINT suites is a shape that reasoning did not cover.
+
+    The #769 failed-id re-run stays correct for the same reason it always was:
+    it happens in a SEPARATE `step.execute` with its own captured output
+    (`runner.py`), so aggregating within one output cannot absorb it.
+    """
+
+    TWO_SUITES = """Running non-Playwright tests...
+============ 4051 passed, 1 skipped, 954 warnings in 284.73s (0:04:44) ============
+Running Playwright tests...
+============ 102 passed, 1 xpassed in 156.66s (0:02:36) ============
+"""
+
+    ONE_INVOCATION_RAN_NOTHING = """Running non-Playwright tests...
+============ no tests ran in 0.31s ============
+Running Playwright tests...
+============ 102 passed in 156.66s ============
+"""
+
+    def test_disjoint_suites_are_summed_not_replaced(self) -> None:
+        outcome = parse_suite_outcome(self.TWO_SUITES)
+
+        assert outcome is not None
+        # 4051 + 102 + 1 xpassed: xpassed executed and passed (#621's rule).
+        assert outcome.passed == 4154
+        assert outcome.skipped == 1
+        assert outcome.executed == 4154
+        assert outcome.invocations == 2
+
+    def test_an_empty_invocation_is_reported_even_when_the_total_is_healthy(
+        self,
+    ) -> None:
+        """THE criterion for kyle #838, and the reason summing is not enough.
+
+        One invocation collects nothing, the other passes 102. The TOTAL ran
+        something, so `nothing_ran` is False and the #621 warning does not
+        fire - which is exactly the blindness that issue exists to prevent,
+        surviving inside the aggregate that was supposed to fix it.
+
+        This test fails against a correctly-summing implementation, not only
+        against the old last-wins one. That is deliberate: aggregation alone
+        would report the honest total, pass a test asserting the honest total,
+        look complete, and leave the guard as blind as it is today.
+        """
+        outcome = parse_suite_outcome(self.ONE_INVOCATION_RAN_NOTHING)
+
+        assert outcome is not None
+        assert outcome.executed == 102
+        assert outcome.nothing_ran is False
+        assert outcome.invocations == 2
+        assert outcome.empty_invocations == 1
+        assert outcome.any_invocation_empty is True
+
+    def test_a_single_invocation_is_unchanged(self) -> None:
+        """The overwhelmingly common shape must be untouched."""
+        outcome = parse_suite_outcome("==== 312 passed, 66 skipped in 55.69s ====")
+
+        assert outcome is not None
+        assert outcome.passed == 312
+        assert outcome.invocations == 1
+        assert outcome.empty_invocations == 0
+        assert outcome.any_invocation_empty is False
+
+    def test_a_lone_empty_invocation_still_reads_as_nothing_ran(self) -> None:
+        """#621's original case keeps its original answer."""
+        outcome = parse_suite_outcome("==== no tests ran in 0.01s ====")
+
+        assert outcome is not None
+        assert outcome.nothing_ran is True
+        assert outcome.invocations == 1
+        assert outcome.empty_invocations == 1
+
+
+class TestVerdictIsIndependentOfCounts:
+    """The blast-radius guarantee, demonstrated rather than asserted in prose.
+
+    This module's contract is that it "changes what a step REPORTS, never
+    whether it passed". CPP is the tooling every session's gate runs through,
+    so the question a reviewer actually needs answered is whether a parsing
+    change can turn a red green. It cannot: status comes from the exit code
+    and nothing else, and these pin that for the multi-invocation output whose
+    parsing this change alters.
+    """
+
+    TWO_SUITES = (
+        "printf '%s\\n' "
+        "'==== 4051 passed in 284.73s ====' "
+        "'==== 102 passed in 156.66s ===='; exit "
+    )
+
+    def test_zero_exit_is_success_with_counts_parsed(self) -> None:
+        step = ShellStep(StepDef(id="test", command=self.TWO_SUITES + "0"))
+
+        result = step.execute({"project_root": "/tmp"})
+
+        assert result.success
+        assert result.tests is not None
+        assert result.tests.passed == 4153
+
+    def test_nonzero_exit_is_failure_with_the_same_counts_parsed(self) -> None:
+        """Same output, same counts, opposite verdict - decided by exit code."""
+        step = ShellStep(StepDef(id="test", command=self.TWO_SUITES + "1"))
+
+        result = step.execute({"project_root": "/tmp"})
+
+        assert not result.success
+        assert result.tests is not None
+        assert result.tests.passed == 4153

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -851,6 +851,17 @@ class TestSkippedSuiteReporting:
         silent - while half the gate proved nothing. Summing the summaries
         alone does not fix it: the honest total is still 102 and still not
         zero. The guard has to know that an INVOCATION was empty.
+
+        DO NOT DELETE THIS AS REDUNDANT WITH THE AGGREGATION TESTS. It is the
+        only thing separating this fix from the simplification a reviewer
+        would reasonably propose - "just sum the summaries". It was observed
+        red TWICE during development: once against the old last-wins parser,
+        and again after aggregation was working correctly, where the counts
+        were already right (`invocations: 2, empty_invocations: 1`) and
+        `warnings` was still empty. That second red is the whole point. An
+        aggregate-only implementation reports 4,218 honestly, passes every
+        other test in this file, looks complete, and ships #621's guard as
+        blind as it was before any of this.
         """
         log = StringIO()
         runner = DeterministicRunner(project_root=tmp_project, output=log)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -827,6 +827,11 @@ class TestSkippedSuiteReporting:
             "errors": 0,
             "executed": 312,
             "framework": "pytest",
+            # Additive (kyle issue #838): one summary parsed, none of them
+            # empty. The gate helper reads this dict, so the shape is pinned
+            # here deliberately rather than left to drift.
+            "invocations": 1,
+            "empty_invocations": 0,
         }
         # Some tests DID run, so this is a real green - no warning, no
         # "WITH WARNINGS" banner, but the counts are visible either way.
@@ -834,6 +839,38 @@ class TestSkippedSuiteReporting:
         text = log.getvalue()
         assert "test: SUCCESS (312 passed, 66 skipped)" in text
         assert "completed successfully" in text
+
+    def test_an_empty_invocation_warns_even_when_the_total_ran(
+        self, tmp_project: Path
+    ):
+        """A step running the runner TWICE, where one invocation collected
+        nothing (kyle issue #838).
+
+        This is the case #621's guard exists for and could not see. The total
+        executed 102, so `nothing_ran` is False and the original warning stays
+        silent - while half the gate proved nothing. Summing the summaries
+        alone does not fix it: the honest total is still 102 and still not
+        zero. The guard has to know that an INVOCATION was empty.
+        """
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+
+        result = runner.run(
+            "check",
+            step_defs=self._steps(
+                "== no tests ran in 0.01s ==\n== 102 passed in 5.00s =="
+            ),
+        )
+
+        assert result.success
+        assert result.tests["test"]["executed"] == 102
+        assert result.tests["test"]["invocations"] == 2
+        assert result.tests["test"]["empty_invocations"] == 1
+        assert result.warnings, (
+            "an invocation that executed nothing must be reported even when "
+            "the step's total is healthy (kyle issue #838)"
+        )
+        assert "1 of 2" in result.warnings[0]
 
     def test_suite_that_skips_nothing_is_unchanged(self, tmp_project: Path):
         log = StringIO()

--- a/tests/test_security_scanners.py
+++ b/tests/test_security_scanners.py
@@ -207,6 +207,80 @@ class TestCheckGate:
         assert passed is True
         assert len(messages) == 0
 
+    def test_findings_carry_their_location(self) -> None:
+        """A gate message must say WHERE (kyle issue #838).
+
+        The gate emitted five HIGH "Hardcoded password in source code" lines
+        with no file, no line and no id, which cannot be triaged: a reader
+        cannot separate a real finding from a known-ignorable one without
+        re-deriving the whole scan. The location was never missing - `Finding`
+        carries `file_path` and `line_number` and exposes `location`, and the
+        secrets scanner populates both - it was discarded when the message was
+        built.
+
+        Consequence of leaving it: a genuine HIGH arrives in a list of five
+        indistinguishable ones, and the only way to spot it is to already know
+        which five to ignore. That is alert fatigue with a mechanism, on a
+        security gate.
+        """
+        result = ScanResult(findings=[
+            Finding(
+                id="HARDCODED_PASSWORD",
+                severity=Severity.HIGH,
+                title="Hardcoded password in source code",
+                file_path="config/settings.py",
+                line_number=372,
+            ),
+        ])
+        config = SecurityConfig._defaults()
+
+        passed, messages = check_gate(result, "flow_finish", config)
+
+        assert passed is True
+        assert len(messages) == 1
+        assert "config/settings.py:372" in messages[0]
+        assert "HARDCODED_PASSWORD" in messages[0]
+
+    def test_a_finding_without_a_location_still_reads_cleanly(self) -> None:
+        """`location` is empty for a finding with no file - a scanner that
+        reports a project-wide condition. The message must not grow a dangling
+        separator or an empty pair of brackets for it."""
+        result = ScanResult(findings=[
+            Finding(id="NO_GITIGNORE", severity=Severity.HIGH, title="No .gitignore"),
+        ])
+        config = SecurityConfig._defaults()
+
+        _, messages = check_gate(result, "flow_finish", config)
+
+        assert messages == [
+            "WARNING: \U0001f7e1 HIGH: No .gitignore [NO_GITIGNORE]"
+        ]
+
+    def test_the_matched_text_is_never_printed(self) -> None:
+        """Locations yes, secrets no (kyle issue #838).
+
+        `raw_match` may BE the secret - the model carries `mask_secret` for
+        exactly that reason - and gate messages land in shared logs, PR bodies
+        and terminal scrollback. Untriageable-but-safe beats triageable-and-
+        leaked, and the location alone is enough to go and look.
+        """
+        result = ScanResult(findings=[
+            Finding(
+                id="HARDCODED_PASSWORD",
+                severity=Severity.HIGH,
+                title="Hardcoded password in source code",
+                file_path="app/config.py",
+                line_number=9,
+                raw_match='password = "hunter2-actual-secret"',
+            ),
+        ])
+        config = SecurityConfig._defaults()
+
+        _, messages = check_gate(result, "flow_finish", config)
+
+        assert "hunter2-actual-secret" not in messages[0]
+        assert "app/config.py:9" in messages[0]
+
     def test_block_on_critical(self) -> None:
         result = ScanResult(findings=[
             Finding(id="A", severity=Severity.CRITICAL, title="Critical issue"),


### PR DESCRIPTION
Two defects in one gate, same shape: **the gate reported things that could not be acted on.** Reported in cooneycw/kyle#838, where the fix turned out not to belong — both halves are here, and kyle needs no change.

> **DO NOT PULL THIS INTO `~/Projects/claude-power-pack` AFTER MERGING.** That checkout is read *live* by every running gate (`flow-finish-gate.sh` resolves `CPP_DIR` to it and runs `uv run --project "$CPP_DIR" python -m lib.cicd`; `lib` is not installed anywhere, and `~/.claude/scripts/flow-finish-gate.sh` is itself a symlink into it). Merging changes nothing for the fleet; the **pull** is the moment the instrument changes under everyone, mid-run. That step is sequenced by the run's orchestrator, when no gate is executing.

## 1. The test count omitted most of the run

`parse_suite_outcome` kept only the **last** summary in a step's output. kyle's `make test` runs pytest twice — non-Playwright, then Playwright — inside one Make target, so only the second invocation's numbers survived.

Measured on kyle, before and after, same tree:

| | reported |
|---|---|
| before | **103** |
| after | **4,218** (`invocations: 2`) |

Under-reported by 97.5%. Exit codes were never affected — `status` is captured from both invocations — so this was a reading defect, not a correctness one. But "103 passed" on a 4,000-test repo either looks like a catastrophic collection failure or gets waved through, and both readings are wrong.

**The previous behaviour was scoped, not an oversight**, and it matters that a reader understands which. Its comment reasoned about *"an early partial"*, and for a partial — or a re-run of a subset — last-wins is correct; summing those would double-count. Two *disjoint* suites is a shape that reasoning did not cover. The #769 failed-id re-run stays correct for a structural reason, checked before proposing the sum: it runs as a **separate `step.execute`** with its own captured output, so it is never in the same text and cannot be absorbed here.

One existing test asserted the old behaviour with the comment *"a `make test` target that runs two suites reports the final one"* — the defect pinned as intent. It is updated deliberately, with the reasoning above recorded in it.

## 2. Summing alone would have left #621's guard blind

**This is why the change is not simply "sum the summaries", and it is what a reviewer would otherwise suggest simplifying it to.**

The #621 warning — the guard against a test step exiting 0 having executed nothing — fires on `nothing_ran`, computed from these same counts. Consider one invocation collecting zero and the other passing 102:

- Old: reported 102, `nothing_ran` False → silent.
- **Summed only: reported 102, `nothing_ran` False → still silent.**
- Now: `invocations: 2`, `empty_invocations: 1` → warned.

An aggregate-only fix would report the honest total, pass a test asserting the honest total, look complete, and leave the guard exactly as blind as it is today — the ticket's own subject reappearing inside its repair. `tests/test_runner.py::test_an_empty_invocation_warns_even_when_the_total_ran` is written to fail against that version, not only against the old one.

## 3. Security findings that could not be triaged

The gate emitted HIGH findings as severity + title only:

```
WARNING: 🟡 HIGH: Hardcoded password in source code   (x5)
```

The location was never missing — `Finding` carries `file_path`/`line_number` and exposes `location`, and the scanners populate both — it was discarded when the message was built. Now:

```
WARNING: 🟡 HIGH: Hardcoded password in source code at core/deploy_checks.py:78 [HARDCODED_PASSWORD]
```

**The located output immediately corrected the ticket's own reading of these findings**, which is the tightest available demonstration of why this matters. The ticket inferred, reasonably, that one finding was `config/settings.py`'s #716 fix being flagged for a literal quoted in its docstring. Running the located gate on the current tree, that finding is **not present at all**, and the one non-test finding is `core/deploy_checks.py:78` — `LEGACY_DB_PASSWORD = "kyle_dev_password"`, the *detector constant* for the `kyle.E003` deploy check that refuses to start on the compose dev password. A known-ignorable, and previously indistinguishable from a real one. The ticket's author could not have known that: they said so, and said the reason was that the findings carry no locations.

`raw_match` is deliberately **excluded**. It may be the secret itself — which is why the model carries `mask_secret` — and these lines land in shared logs, PR bodies and terminal scrollback. Untriageable-but-safe beats triageable-and-leaked; the location is enough to go and look.

## Blast radius, and why it is contained

CPP is the tooling every session's gate runs through, and five workers are gating in parallel on a deadline. The guarantee is the module's own documented contract:

> It is deliberately read-only and advisory: it changes what a step REPORTS, never whether it passed.

`TestVerdictIsIndependentOfCounts` makes that a **demonstrated property rather than an intention**: the same two-invocation output with exit 0 and exit 1 produces SUCCESS and FAILURE respectively, with identical parsed counts in both. If parsing cannot move a verdict, the worst case of a bug here is a wrong number — which is where we already are.

## Verification

- CPP: **2,183 tests pass**, ruff clean, mypy clean on 194 files.
- kyle's **full finish gate** run against this branch via `FLOW_GATE_CPP_DIR`, with the shared checkout untouched: `FLOW_FINISH_GATE: ok`, `"passed": 4218, "invocations": 2, "empty_invocations": 0`, and eight located security findings.
- Every new test observed red first, including the two that must fail against a *correctly-summing* implementation rather than only against today's code.

Reported in cooneycw/kyle#838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWsxq28mDuRZx4QUHqZtrw
