### PR TITLE
fix(cicd): mark a step whose result was carried from an earlier run

### DIFF
--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any, Optional, TextIO
 
 from .outcomes import parse_failed_node_ids
-from .state import RunState
+from .state import RunState, StepStatus
 from .steps import GATE_STEP_IDS, ShellStep, StepDef, get_plan_steps
 
 # Variables the runner launcher injects (or a parent venv leaks) that must NOT
@@ -133,6 +133,17 @@ class RunResult:
     # re-run that passed is a DIFFERENT qualification and must not borrow #621's
     # sentence.
     reruns: list[dict[str, Any]] = field(default_factory=list)
+    # Step ids whose result was earned in an EARLIER invocation and carried
+    # into this one by a resume (issue #838 follow-up). Its own channel and not
+    # a `warning`: nothing is wrong, but the reader must be able to tell a
+    # result just earned from one merely remembered. Captured on the RESULT
+    # rather than read back from state, because the state file is deleted on
+    # success - which is exactly why the old `step_details` block could never
+    # have shown this on the green path it matters most on.
+    carried_from_previous_run: list[str] = field(default_factory=list)
+    # Full per-step detail, captured BEFORE the success cleanup removes the
+    # state file so a green run can report it at all.
+    step_details: list[dict[str, Any]] = field(default_factory=list)
     # Step ids that skip_if-skipped this run (issue #628). A skipped GATE step
     # (lint/test/typecheck) means the gate verified nothing about the change, so
     # flow-finish-gate.sh reads this to report `warn` and NAME the skipped gates
@@ -192,6 +203,7 @@ class DeterministicRunner:
         existing = RunState.find_latest(plan_name, self.project_root)
         if existing:
             self._log(f"Resuming failed run {existing.run_id} from step {existing.current_index + 1}")
+            self._warn_carried_over(existing)
             return self._execute(existing, step_defs)
 
         # Load step definitions
@@ -225,6 +237,7 @@ class DeterministicRunner:
             )
 
         self._log(f"Resuming run {run_id} from step {state.current_index + 1}")
+        self._warn_carried_over(state)
         # Reset state to running for resume
         state.status = "running"
 
@@ -238,8 +251,42 @@ class DeterministicRunner:
         state = RunState.load(run_id, self.project_root)
         return state.summary()
 
+    def _warn_carried_over(self, state: RunState) -> None:
+        """Name the steps this invocation will NOT execute (issue #838 follow-up).
+
+        A resumed run starts at ``current_index``, so every earlier step keeps
+        the result it earned in a previous invocation - against a tree that may
+        since have changed, because the usual reason to resume is that
+        something was fixed. Those results are still reported, and until this
+        warning they were reported in exactly the form of a step that had just
+        run.
+
+        Observed twice on one day: a cached ``test: SUCCESS (103 passed)`` on a
+        run where pytest was never invoked, and a cached ``lint: SUCCESS`` for a
+        tree whose linted source had been edited between the two runs. Both were
+        caught by out-of-band knowledge - grepping for "Resuming" and counting
+        pytest invocations, and remembering a hand-run ``make lint`` - neither of
+        which is a property of the output.
+        """
+        carried = [
+            record.step_id
+            for record in state.step_records[: state.current_index]
+            if record.status not in (StepStatus.PENDING, StepStatus.SKIPPED)
+        ]
+        if not carried:
+            return
+        self._log(
+            f"  NOTE: {len(carried)} step(s) will NOT run in this invocation "
+            f"and keep their earlier result: {', '.join(carried)}. "
+            "If the tree changed since that run, those results are stale - "
+            "they are marked carried_from_previous_run in step_details."
+        )
+
     def _execute(self, state: RunState, step_defs: Optional[list[StepDef]] = None) -> RunResult:
         """Execute steps from the current state index."""
+        # Where THIS invocation began, so the summary can distinguish a result
+        # earned now from one carried over (issue #838 follow-up).
+        executed_from = state.current_index
         if step_defs is None:
             step_defs = get_plan_steps(state.plan_name, project_root=str(self.project_root))
 
@@ -260,6 +307,7 @@ class DeterministicRunner:
         }
 
         completed = state.current_index
+        self._executed_from = executed_from
         tests: dict[str, dict[str, Any]] = {}
         warnings: list[str] = []
         reruns: list[dict[str, Any]] = []
@@ -487,11 +535,32 @@ class DeterministicRunner:
         else:
             self._log(f"Plan '{state.plan_name}' completed successfully ({completed}/{len(step_defs)} steps)")
 
+        # Capture the per-step detail BEFORE cleanup deletes the state file.
+        # Order matters and is the whole point: reading it afterwards raises
+        # FileNotFoundError, which is why `step_details` was previously
+        # failure-only and why a resumed GREEN run could not say which of its
+        # steps had actually run.
+        success_details = state.summary(executed_from=executed_from)["steps"]
+        success_carried = [
+            entry["id"]
+            for entry in success_details
+            if entry.get("carried_from_previous_run")
+        ]
+        if success_carried:
+            self._log(
+                f"  NOTE: this run succeeded, but {len(success_carried)} step(s) "
+                f"kept a result from an earlier invocation: "
+                f"{', '.join(success_carried)}. If the tree changed since, those "
+                "results do not describe it."
+            )
+
         # Clean up state file on success
         state.cleanup(self.project_root)
 
         return RunResult(
             success=True,
+            step_details=success_details,
+            carried_from_previous_run=success_carried,
             run_id=state.run_id,
             plan_name=state.plan_name,
             steps_completed=completed,
@@ -531,13 +600,33 @@ def run_plan(
         # Structured output for LLM consumption
         output = result.to_dict()
 
-        # Include step details from state if run failed
-        if not result.success:
+        # Include step details from state. Emitted on SUCCESS as well as
+        # failure (issue #838 follow-up): the carried-over marking added below
+        # matters most on a GREEN resumed run, which is exactly the case the
+        # old `if not result.success` guard excluded. A resumed success that
+        # cannot show which of its steps actually ran this time is the report
+        # that misleads - a failure is already being read carefully.
+        if result.step_details:
+            # Success path: captured before cleanup removed the state file.
+            output["step_details"] = result.step_details
+        else:
+            # Failure path: the state file survives, so read it back and mark
+            # carried-over steps the same way.
             try:
                 state = RunState.load(result.run_id, root)
-                output["step_details"] = state.summary()["steps"]
+                executed_from = getattr(runner, "_executed_from", None)
+                output["step_details"] = state.summary(
+                    executed_from=executed_from
+                )["steps"]
             except FileNotFoundError:
                 pass
+        carried = [
+            entry["id"]
+            for entry in output.get("step_details", [])
+            if entry.get("carried_from_previous_run")
+        ]
+        if carried:
+            output["carried_from_previous_run"] = carried
 
         print(json.dumps(output, indent=2))
 

--- a/lib/cicd/state.py
+++ b/lib/cicd/state.py
@@ -214,11 +214,26 @@ class RunState:
                 continue
         return None
 
-    def summary(self) -> dict[str, Any]:
-        """Return a summary suitable for JSON output to the LLM."""
+    def summary(self, executed_from: Optional[int] = None) -> dict[str, Any]:
+        """Return a summary suitable for JSON output to the LLM.
+
+        ``executed_from`` is the step index the CURRENT invocation started at
+        (issue #838 follow-up). Records before it were produced by an earlier
+        invocation and are carried over: their command did not run this time,
+        and the tree may have changed since it did. Without the distinction a
+        carried-over ``success`` renders identically to one just earned, which
+        is how a stale ``lint: SUCCESS`` was reported for a tree whose lint
+        input had been edited between the two runs.
+        """
         steps_summary = []
-        for r in self.step_records:
+        for index, r in enumerate(self.step_records):
             entry: dict[str, Any] = {"id": r.step_id, "status": r.status.value}
+            if executed_from is not None and index < executed_from:
+                # Only meaningful for a record that HAS a result; a pending
+                # step before the resume point has nothing to be stale about.
+                if r.status not in (StepStatus.PENDING, StepStatus.SKIPPED):
+                    entry["executed_in_this_run"] = False
+                    entry["carried_from_previous_run"] = True
             if r.tests:
                 # A green test step whose suite executed nothing is the #621
                 # false green - carry the counts so the summary can say so.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1026,3 +1026,103 @@ class TestSkippedGateReporting:
         text = log.getvalue()
         assert "SKIPPED GATES: typecheck" in text
         assert "#621" in text
+
+
+class TestResumedRunReportsWhatActuallyRan:
+    """The runner must record where THIS invocation began (issue #838 f/u).
+
+    ``TestCarriedOverStepsAreMarked`` in test_runner_state.py pins the summary
+    rendering; this pins the half that feeds it. Without ``_executed_from`` the
+    marking has nothing to key on, so both are needed and neither is redundant:
+    a summary that can mark correctly, given a number nobody supplies, marks
+    nothing.
+    """
+
+    def test_a_resumed_run_records_the_step_it_started_at(self, tmp_project: Path):
+        steps = [
+            StepDef(id="lint", command="echo 'lint ok'", timeout_seconds=30),
+            StepDef(id="bad_step", command="exit 1", timeout_seconds=30),
+        ]
+        runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+        first = runner.run("check", step_defs=steps)
+        assert not first.success
+
+        fixed = [
+            StepDef(id="lint", command="echo 'lint ok'", timeout_seconds=30),
+            StepDef(id="bad_step", command="echo 'fixed'", timeout_seconds=30),
+        ]
+        second = runner.run("check", step_defs=fixed)
+        assert second.success
+
+        # The resume began at step 2 (index 1), so lint did NOT run this time.
+        assert runner._executed_from == 1
+
+        # Read from the RESULT, not from state: a successful run deletes its
+        # state file, which is precisely why this detail has to be captured
+        # before cleanup rather than loaded back afterwards.
+        assert second.carried_from_previous_run == ["lint"]
+        lint = second.step_details[0]
+        assert lint["status"] == "success"
+        assert lint["carried_from_previous_run"] is True, (
+            "lint succeeded in the FIRST invocation and was not re-run here. "
+            "Reporting it identically to a step that just passed is how a "
+            "stale lint result was carried across a tree change (#838 f/u)."
+        )
+
+    def test_the_state_file_is_gone_on_success_so_detail_must_be_captured(
+        self, tmp_project: Path
+    ):
+        """Pins WHY the capture happens before cleanup.
+
+        This is the constraint that made the obvious implementation - read the
+        state back in run_plan and annotate it - a silent no-op on exactly the
+        green resumed run it was written for. Without this test the next person
+        reverts the capture as redundant and the feature quietly stops working
+        on the success path while every unit test still passes.
+        """
+        steps = [StepDef(id="only", command="echo ok", timeout_seconds=30)]
+        runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+        result = runner.run("check", step_defs=steps)
+        assert result.success
+
+        with pytest.raises(FileNotFoundError):
+            RunState.load(result.run_id, tmp_project)
+        assert result.step_details, (
+            "a successful run must carry its own step detail - there is no "
+            "state file left to read it from"
+        )
+
+    def test_a_fresh_run_starts_at_zero_and_marks_nothing(self, tmp_project: Path):
+        """The guard rail: every step of a from-scratch run really did run."""
+        steps = [StepDef(id="only", command="echo ok", timeout_seconds=30)]
+        runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+        result = runner.run("check", step_defs=steps)
+        assert result.success
+        assert runner._executed_from == 0
+        assert result.carried_from_previous_run == []
+        for entry in result.step_details:
+            assert "carried_from_previous_run" not in entry
+
+    def test_the_resume_names_the_steps_it_will_not_run(self, tmp_project: Path):
+        """The human half. The JSON marking serves a reader parsing it; the log
+        line serves the far more common reader who is watching the gate scroll
+        past and has no reason to suspect anything."""
+        steps = [
+            StepDef(id="lint", command="echo 'lint ok'", timeout_seconds=30),
+            StepDef(id="bad_step", command="exit 1", timeout_seconds=30),
+        ]
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+        runner.run("check", step_defs=steps)
+
+        fixed = [
+            StepDef(id="lint", command="echo 'lint ok'", timeout_seconds=30),
+            StepDef(id="bad_step", command="echo 'fixed'", timeout_seconds=30),
+        ]
+        resume_log = StringIO()
+        runner2 = DeterministicRunner(project_root=tmp_project, output=resume_log)
+        runner2.run("check", step_defs=fixed)
+
+        text = resume_log.getvalue()
+        assert "will NOT run in this invocation" in text
+        assert "lint" in text

--- a/tests/test_runner_state.py
+++ b/tests/test_runner_state.py
@@ -160,3 +160,80 @@ class TestRunState:
         assert loaded.step_records[1].status == StepStatus.FAILED
         assert loaded.step_records[1].error == "deploy error"
         assert loaded.current_index == 1  # step 0 succeeded (advancing to 1), step 1 failed
+
+
+class TestCarriedOverStepsAreMarked:
+    """A resumed run must not render a carried-over step like a fresh one.
+
+    Issue #838 follow-up. A resume starts at ``current_index``, so every
+    earlier step keeps the result it earned in a PREVIOUS invocation - against
+    a tree that has usually changed, because fixing something is the normal
+    reason to resume. Until this marking, those results were reported in
+    exactly the form of a step that had just run.
+
+    Observed twice on one day, in opposite registers:
+
+    * a cached ``test: SUCCESS (103 passed)`` on a run where pytest was never
+      invoked at all, and
+    * a cached ``lint: SUCCESS`` for a tree whose linted source had been
+      edited between the two runs - the quieter one, because the suite really
+      did re-execute and only the lint result was stale.
+
+    Both were caught by out-of-band knowledge: grepping line 1 for "Resuming"
+    and counting pytest invocations, and remembering a hand-run ``make lint``.
+    Neither is a property of the output, which is what these tests fix.
+    """
+
+    def _failed_at_second_step(self) -> RunState:
+        state = RunState.create("finish", ["lint", "test", "typecheck"])
+        state.mark_step_success(0, "ruff ok", tests={"passed": 12, "executed": 12})
+        state.mark_step_running(1)
+        state.mark_step_failed(1, error="boom", exit_code=1)
+        return state
+
+    def test_a_carried_step_is_marked_when_the_run_resumed_past_it(self):
+        state = self._failed_at_second_step()
+        lint = state.summary(executed_from=1)["steps"][0]
+        assert lint["carried_from_previous_run"] is True
+        assert lint["executed_in_this_run"] is False
+
+    def test_a_step_executed_in_this_invocation_is_not_marked(self):
+        """The other direction, and the one that keeps the marking meaningful.
+
+        A marking that appeared on every step would be noise, and a reader who
+        learns to ignore it is worse off than one who never had it.
+        """
+        state = self._failed_at_second_step()
+        steps = state.summary(executed_from=1)["steps"]
+        assert "carried_from_previous_run" not in steps[1]
+        assert "executed_in_this_run" not in steps[1]
+
+    def test_a_fresh_run_marks_nothing(self):
+        """executed_from=0 is a run that started at the beginning."""
+        state = self._failed_at_second_step()
+        for entry in state.summary(executed_from=0)["steps"]:
+            assert "carried_from_previous_run" not in entry
+
+    def test_omitting_executed_from_is_unchanged(self):
+        """Callers that do not know where the invocation began keep the old
+        shape exactly - the marking is additive, never a silent rewrite."""
+        state = self._failed_at_second_step()
+        for entry in state.summary()["steps"]:
+            assert "carried_from_previous_run" not in entry
+            assert "executed_in_this_run" not in entry
+
+    def test_a_pending_step_before_the_resume_point_is_not_called_carried(self):
+        """Nothing to be stale about.
+
+        A pending or skipped record before the resume index has no result, so
+        marking it 'carried' would assert a previous execution that never
+        happened - a false claim in the direction of more confidence, which is
+        the direction that matters.
+        """
+        state = RunState.create("finish", ["lint", "test", "typecheck"])
+        state.mark_step_skipped(0)
+        state.mark_step_running(1)
+        state.mark_step_failed(1, error="boom", exit_code=1)
+        entry = state.summary(executed_from=1)["steps"][0]
+        assert entry["status"] == StepStatus.SKIPPED.value
+        assert "carried_from_previous_run" not in entry


### PR DESCRIPTION
## The defect

A resumed run reported steps it had **not executed** in exactly the form of steps it had.

Three sessions found this independently, on different days, in different repo states:

| log | line 1 | pytest invocations | marker |
|---|---|---|---|
| `gate846b` (#846, yesterday) | `Resuming ... from step 3` | **0** | `ok` |
| a0's run (today) | `Resuming ... from step 3` | **0** | `ok` |
| `gate4` (today) | `Resuming ... from step 2` | 2 (real) | `ok` |

The first two are the loud version — a green covering a tree that predated the fix, with pytest never invoked at all. **The third is the quiet one, and it is worse for being quiet**: the suite genuinely re-ran and only the *lint* result was stale, for a file the fix had just edited.

All three were caught by knowledge that lives outside the output — grepping line 1 for `Resuming`, counting pytest invocations, remembering a hand-run `make lint`. None of that is a property of the report, and the next person does not have it.

## It is the normal loop, not an edge case

From one session's full audit: **one instance in eleven runs**, appearing exactly when a failed run was retried after a fix.

That is the ordinary workflow. A lint or typecheck failure is almost always repaired by editing a source file — and the tests that would exercise that edit live in the step the resume skips. The more ordinary your workflow, the more likely you hit it.

## The fix

A carried-over step now says so:

```diff
- {"id": "lint", "status": "success", "tests": {...}}
+ {"id": "lint", "status": "success", "executed_in_this_run": false,
+  "carried_from_previous_run": true, "tests": {...}}
```

plus a log line at resume naming the steps that will **not** run, and a second at the end when a *successful* run kept carried results.

### The ordering is the fix, not an implementation detail

`step_details` was previously emitted **only on failure**, and the obvious repair — read the state back in `run_plan` and annotate it — is a **silent no-op on the green path**, because a successful run deletes its state file. I wrote that version first; the end-to-end test is what caught it.

So the detail is captured *before* cleanup and carried on the result. The old guard withheld it precisely where it was needed: **a red run is already read carefully, a green one is not.** A test pins the constraint (`test_the_state_file_is_gone_on_success_so_detail_must_be_captured`) so the capture is not later reverted as redundant — without it, the next person removes it and the feature quietly stops working on the success path while every unit test still passes.

## This is half of a pair — please don't merge one and consider it closed

Neither half alone makes the summary trustworthy:

- **cpp#806** fixed the **count**. `parse_suite_outcome` kept only the last summary, so `make test`'s two pytest invocations reported the second as the whole run: `103 passed` against a real 4,282 + 102. That was wrong on *every* run, cached or fresh.
- **This PR** fixes whether the step **ran at all**.

A reader needs both to tell a full run from a partial one, and either from a remembered one.

## Tests

Nine, split across the two halves they pin — the summary rendering (`test_runner_state.py`) and the runner that feeds it (`test_runner.py`). A summary that can mark correctly, given a number nobody supplies, marks nothing.

Confirmed to **fail without the fix** (4 of 5 in the state suite; the fifth is the backward-compatibility guard rail, correctly passing either way — omitting `executed_from` must keep the old shape exactly, so the marking is additive and never a silent rewrite).

Both directions are pinned: a carried step is marked, a step executed *this* invocation is **not**, and a pending/skipped record before the resume point is not called "carried" — it has no result, so claiming one would be a false statement in the direction of more confidence.

## Gate

**`make verify`** — CPP's real nine-target gate, not `flow-finish-gate`, which runs three of the nine. All nine confirmed *executed* rather than inferred from exit 0:

```
ruff check .          passed          binary-guards         ok
pytest                2192 passed     negative-fixture      ok
mypy .                194 files       claude-md-budget      ok - 1187/2000 words
                                      claude-md-links       ok
                                      claude-md-behavior    ok
                                      project-next-vendor   16 files, contract v1.3
```

Run from a worktree, never the live checkout — that checkout is what every session's `~/.claude/scripts` resolves into, so editing it changes gates under running gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zji5qgFeVaffLwDKRMXp