### PR TITLE
fix(flow-finish-gate): name the gates that ran, and see a larger one (Closes #808)

### DIFF
--- a/codex/skills/flow-auto/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-auto/scripts/flow-finish-gate.sh
@@ -252,6 +252,13 @@ echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback.
 RAN=0
 FAILED=0
 SKIPPED_GATES=""
+# What actually executed, and by which route (issue #808). The marker alone
+# cannot distinguish a repo where this fallback IS the gate from one where it
+# is a fraction of it, and a reader should not have to infer coverage from an
+# absence of complaints.
+RAN_GATES=""
+UNRUN_AGGREGATE=""
+AGGREGATE_TARGET=""
 RERUN_PASSED_IDS=""
 UV_OK=0
 command -v uv >/dev/null 2>&1 && UV_OK=1
@@ -279,6 +286,7 @@ run_fallback_gate() {
     local id="$1" uvargs="$2" token="$3"
     if grep -q "^${id}:" Makefile 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'make ${id}'"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }make ${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -305,6 +313,7 @@ run_fallback_gate() {
         RAN=1
     elif [[ "$UV_OK" -eq 1 ]] && grep -q "${token}" pyproject.toml 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'uv run --extra dev ${uvargs}' (no '${id}' Makefile target)"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }uv:${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -337,6 +346,55 @@ run_fallback_gate() {
     fi
 }
 
+# Find a Makefile target whose prerequisites are a SUPERSET of the three gates
+# this fallback knows (issue #808). Such a target is the repo's real gate, and
+# running three of its nine prerequisites while reporting `ok` is a true
+# statement about a fraction of the gate presented as a verdict on the tree.
+#
+# Derived from the Makefile rather than a hardcoded name like `verify` or
+# `check`: a list of names someone has to remember to extend is the enumeration
+# this whole ticket is about. The test is structural - does a target depend on
+# at least two of lint/test/typecheck AND on something else we did not run.
+#
+# Line continuations are joined first: this repo's own `verify` spans four
+# lines, so a line-at-a-time scan would see one prerequisite and miss five.
+detect_aggregate_gate() {
+    [[ -f Makefile ]] || return 0
+    awk '
+        # Join backslash continuations into one logical line.
+        { line = line $0
+          if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
+          print line; line = "" }
+        END { if (line != "") print line }
+    ' Makefile 2>/dev/null | awk -F: '
+        # Special targets (.PHONY, .DEFAULT_GOAL) list gate names as DATA, not
+        # as prerequisites - .PHONY names every phony target in the file, so it
+        # trivially "depends on" lint, test and typecheck and matched first.
+        # Caught by running the detector against this repo rather than a
+        # fixture: the real Makefile has a .PHONY line and a synthetic one
+        # would not have.
+        /^\./ { next }
+        /^[a-zA-Z0-9_-]+[[:space:]]*:[^=]/ {
+            target = $1
+            gsub(/[[:space:]]/, "", target)
+            deps = $2
+            known = 0; extra = ""
+            n = split(deps, parts, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) {
+                d = parts[i]
+                if (d == "") continue
+                if (d == "lint" || d == "test" || d == "typecheck") { known++ }
+                else { extra = extra (extra == "" ? "" : " ") d }
+            }
+            # Two of the three, plus at least one we would not have run.
+            if (known >= 2 && extra != "") {
+                print target "\t" extra
+                exit
+            }
+        }
+    '
+}
+
 if [[ -f Makefile || -f pyproject.toml ]]; then
     run_fallback_gate lint "ruff check ." "ruff"
     run_fallback_gate test "pytest" "pytest"
@@ -344,6 +402,22 @@ if [[ -f Makefile || -f pyproject.toml ]]; then
     # runs it too - otherwise a repo that degrades here gets the same
     # local-green-then-CI-red the runner plan had before #617.
     run_fallback_gate typecheck "mypy ." "mypy"
+fi
+
+# Report what actually executed, before any verdict (issue #808). A reader
+# should be able to see the coverage rather than infer it from the absence of a
+# complaint.
+if [[ -n "$RAN_GATES" ]]; then
+    echo "flow-finish-gate: gates executed: $RAN_GATES"
+fi
+
+# Does this repo define a larger gate we did not run?
+if [[ "$RAN" -gt 0 ]]; then
+    _aggregate="$(detect_aggregate_gate)"
+    if [[ -n "$_aggregate" ]]; then
+        AGGREGATE_TARGET="${_aggregate%%$'\t'*}"
+        UNRUN_AGGREGATE="${_aggregate#*$'\t'}"
+    fi
 fi
 
 if [[ "$RAN" -eq 0 && -z "$SKIPPED_GATES" ]]; then
@@ -366,6 +440,14 @@ fi
 if [[ -n "$SKIPPED_GATES" ]]; then
     echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no runnable tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
     verdict "warn (skipped gates: $SKIPPED_GATES)"
+    exit 0
+fi
+if [[ -n "$UNRUN_AGGREGATE" ]]; then
+    # Same sentence as #628's, for the same reason: this gate proved nothing
+    # about those checks. The difference is only how they came to be unrun -
+    # #628's could not run, these were never looked for.
+    echo "WARNING: this repo's 'make $AGGREGATE_TARGET' also runs: $UNRUN_AGGREGATE. Those did NOT run here - the fallback knows only lint/test/typecheck. This gate proved nothing about them; run 'make $AGGREGATE_TARGET' for the repo's full gate (issue #808)." >&2
+    verdict "warn (not run by fallback: $UNRUN_AGGREGATE)"
     exit 0
 fi
 if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/codex/skills/flow-check/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-check/scripts/flow-finish-gate.sh
@@ -252,6 +252,13 @@ echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback.
 RAN=0
 FAILED=0
 SKIPPED_GATES=""
+# What actually executed, and by which route (issue #808). The marker alone
+# cannot distinguish a repo where this fallback IS the gate from one where it
+# is a fraction of it, and a reader should not have to infer coverage from an
+# absence of complaints.
+RAN_GATES=""
+UNRUN_AGGREGATE=""
+AGGREGATE_TARGET=""
 RERUN_PASSED_IDS=""
 UV_OK=0
 command -v uv >/dev/null 2>&1 && UV_OK=1
@@ -279,6 +286,7 @@ run_fallback_gate() {
     local id="$1" uvargs="$2" token="$3"
     if grep -q "^${id}:" Makefile 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'make ${id}'"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }make ${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -305,6 +313,7 @@ run_fallback_gate() {
         RAN=1
     elif [[ "$UV_OK" -eq 1 ]] && grep -q "${token}" pyproject.toml 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'uv run --extra dev ${uvargs}' (no '${id}' Makefile target)"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }uv:${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -337,6 +346,55 @@ run_fallback_gate() {
     fi
 }
 
+# Find a Makefile target whose prerequisites are a SUPERSET of the three gates
+# this fallback knows (issue #808). Such a target is the repo's real gate, and
+# running three of its nine prerequisites while reporting `ok` is a true
+# statement about a fraction of the gate presented as a verdict on the tree.
+#
+# Derived from the Makefile rather than a hardcoded name like `verify` or
+# `check`: a list of names someone has to remember to extend is the enumeration
+# this whole ticket is about. The test is structural - does a target depend on
+# at least two of lint/test/typecheck AND on something else we did not run.
+#
+# Line continuations are joined first: this repo's own `verify` spans four
+# lines, so a line-at-a-time scan would see one prerequisite and miss five.
+detect_aggregate_gate() {
+    [[ -f Makefile ]] || return 0
+    awk '
+        # Join backslash continuations into one logical line.
+        { line = line $0
+          if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
+          print line; line = "" }
+        END { if (line != "") print line }
+    ' Makefile 2>/dev/null | awk -F: '
+        # Special targets (.PHONY, .DEFAULT_GOAL) list gate names as DATA, not
+        # as prerequisites - .PHONY names every phony target in the file, so it
+        # trivially "depends on" lint, test and typecheck and matched first.
+        # Caught by running the detector against this repo rather than a
+        # fixture: the real Makefile has a .PHONY line and a synthetic one
+        # would not have.
+        /^\./ { next }
+        /^[a-zA-Z0-9_-]+[[:space:]]*:[^=]/ {
+            target = $1
+            gsub(/[[:space:]]/, "", target)
+            deps = $2
+            known = 0; extra = ""
+            n = split(deps, parts, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) {
+                d = parts[i]
+                if (d == "") continue
+                if (d == "lint" || d == "test" || d == "typecheck") { known++ }
+                else { extra = extra (extra == "" ? "" : " ") d }
+            }
+            # Two of the three, plus at least one we would not have run.
+            if (known >= 2 && extra != "") {
+                print target "\t" extra
+                exit
+            }
+        }
+    '
+}
+
 if [[ -f Makefile || -f pyproject.toml ]]; then
     run_fallback_gate lint "ruff check ." "ruff"
     run_fallback_gate test "pytest" "pytest"
@@ -344,6 +402,22 @@ if [[ -f Makefile || -f pyproject.toml ]]; then
     # runs it too - otherwise a repo that degrades here gets the same
     # local-green-then-CI-red the runner plan had before #617.
     run_fallback_gate typecheck "mypy ." "mypy"
+fi
+
+# Report what actually executed, before any verdict (issue #808). A reader
+# should be able to see the coverage rather than infer it from the absence of a
+# complaint.
+if [[ -n "$RAN_GATES" ]]; then
+    echo "flow-finish-gate: gates executed: $RAN_GATES"
+fi
+
+# Does this repo define a larger gate we did not run?
+if [[ "$RAN" -gt 0 ]]; then
+    _aggregate="$(detect_aggregate_gate)"
+    if [[ -n "$_aggregate" ]]; then
+        AGGREGATE_TARGET="${_aggregate%%$'\t'*}"
+        UNRUN_AGGREGATE="${_aggregate#*$'\t'}"
+    fi
 fi
 
 if [[ "$RAN" -eq 0 && -z "$SKIPPED_GATES" ]]; then
@@ -366,6 +440,14 @@ fi
 if [[ -n "$SKIPPED_GATES" ]]; then
     echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no runnable tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
     verdict "warn (skipped gates: $SKIPPED_GATES)"
+    exit 0
+fi
+if [[ -n "$UNRUN_AGGREGATE" ]]; then
+    # Same sentence as #628's, for the same reason: this gate proved nothing
+    # about those checks. The difference is only how they came to be unrun -
+    # #628's could not run, these were never looked for.
+    echo "WARNING: this repo's 'make $AGGREGATE_TARGET' also runs: $UNRUN_AGGREGATE. Those did NOT run here - the fallback knows only lint/test/typecheck. This gate proved nothing about them; run 'make $AGGREGATE_TARGET' for the repo's full gate (issue #808)." >&2
+    verdict "warn (not run by fallback: $UNRUN_AGGREGATE)"
     exit 0
 fi
 if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/codex/skills/flow-finish/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-finish/scripts/flow-finish-gate.sh
@@ -252,6 +252,13 @@ echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback.
 RAN=0
 FAILED=0
 SKIPPED_GATES=""
+# What actually executed, and by which route (issue #808). The marker alone
+# cannot distinguish a repo where this fallback IS the gate from one where it
+# is a fraction of it, and a reader should not have to infer coverage from an
+# absence of complaints.
+RAN_GATES=""
+UNRUN_AGGREGATE=""
+AGGREGATE_TARGET=""
 RERUN_PASSED_IDS=""
 UV_OK=0
 command -v uv >/dev/null 2>&1 && UV_OK=1
@@ -279,6 +286,7 @@ run_fallback_gate() {
     local id="$1" uvargs="$2" token="$3"
     if grep -q "^${id}:" Makefile 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'make ${id}'"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }make ${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -305,6 +313,7 @@ run_fallback_gate() {
         RAN=1
     elif [[ "$UV_OK" -eq 1 ]] && grep -q "${token}" pyproject.toml 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'uv run --extra dev ${uvargs}' (no '${id}' Makefile target)"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }uv:${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -337,6 +346,55 @@ run_fallback_gate() {
     fi
 }
 
+# Find a Makefile target whose prerequisites are a SUPERSET of the three gates
+# this fallback knows (issue #808). Such a target is the repo's real gate, and
+# running three of its nine prerequisites while reporting `ok` is a true
+# statement about a fraction of the gate presented as a verdict on the tree.
+#
+# Derived from the Makefile rather than a hardcoded name like `verify` or
+# `check`: a list of names someone has to remember to extend is the enumeration
+# this whole ticket is about. The test is structural - does a target depend on
+# at least two of lint/test/typecheck AND on something else we did not run.
+#
+# Line continuations are joined first: this repo's own `verify` spans four
+# lines, so a line-at-a-time scan would see one prerequisite and miss five.
+detect_aggregate_gate() {
+    [[ -f Makefile ]] || return 0
+    awk '
+        # Join backslash continuations into one logical line.
+        { line = line $0
+          if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
+          print line; line = "" }
+        END { if (line != "") print line }
+    ' Makefile 2>/dev/null | awk -F: '
+        # Special targets (.PHONY, .DEFAULT_GOAL) list gate names as DATA, not
+        # as prerequisites - .PHONY names every phony target in the file, so it
+        # trivially "depends on" lint, test and typecheck and matched first.
+        # Caught by running the detector against this repo rather than a
+        # fixture: the real Makefile has a .PHONY line and a synthetic one
+        # would not have.
+        /^\./ { next }
+        /^[a-zA-Z0-9_-]+[[:space:]]*:[^=]/ {
+            target = $1
+            gsub(/[[:space:]]/, "", target)
+            deps = $2
+            known = 0; extra = ""
+            n = split(deps, parts, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) {
+                d = parts[i]
+                if (d == "") continue
+                if (d == "lint" || d == "test" || d == "typecheck") { known++ }
+                else { extra = extra (extra == "" ? "" : " ") d }
+            }
+            # Two of the three, plus at least one we would not have run.
+            if (known >= 2 && extra != "") {
+                print target "\t" extra
+                exit
+            }
+        }
+    '
+}
+
 if [[ -f Makefile || -f pyproject.toml ]]; then
     run_fallback_gate lint "ruff check ." "ruff"
     run_fallback_gate test "pytest" "pytest"
@@ -344,6 +402,22 @@ if [[ -f Makefile || -f pyproject.toml ]]; then
     # runs it too - otherwise a repo that degrades here gets the same
     # local-green-then-CI-red the runner plan had before #617.
     run_fallback_gate typecheck "mypy ." "mypy"
+fi
+
+# Report what actually executed, before any verdict (issue #808). A reader
+# should be able to see the coverage rather than infer it from the absence of a
+# complaint.
+if [[ -n "$RAN_GATES" ]]; then
+    echo "flow-finish-gate: gates executed: $RAN_GATES"
+fi
+
+# Does this repo define a larger gate we did not run?
+if [[ "$RAN" -gt 0 ]]; then
+    _aggregate="$(detect_aggregate_gate)"
+    if [[ -n "$_aggregate" ]]; then
+        AGGREGATE_TARGET="${_aggregate%%$'\t'*}"
+        UNRUN_AGGREGATE="${_aggregate#*$'\t'}"
+    fi
 fi
 
 if [[ "$RAN" -eq 0 && -z "$SKIPPED_GATES" ]]; then
@@ -366,6 +440,14 @@ fi
 if [[ -n "$SKIPPED_GATES" ]]; then
     echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no runnable tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
     verdict "warn (skipped gates: $SKIPPED_GATES)"
+    exit 0
+fi
+if [[ -n "$UNRUN_AGGREGATE" ]]; then
+    # Same sentence as #628's, for the same reason: this gate proved nothing
+    # about those checks. The difference is only how they came to be unrun -
+    # #628's could not run, these were never looked for.
+    echo "WARNING: this repo's 'make $AGGREGATE_TARGET' also runs: $UNRUN_AGGREGATE. Those did NOT run here - the fallback knows only lint/test/typecheck. This gate proved nothing about them; run 'make $AGGREGATE_TARGET' for the repo's full gate (issue #808)." >&2
+    verdict "warn (not run by fallback: $UNRUN_AGGREGATE)"
     exit 0
 fi
 if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/codex/skills/flow-merge/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-merge/scripts/flow-finish-gate.sh
@@ -252,6 +252,13 @@ echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback.
 RAN=0
 FAILED=0
 SKIPPED_GATES=""
+# What actually executed, and by which route (issue #808). The marker alone
+# cannot distinguish a repo where this fallback IS the gate from one where it
+# is a fraction of it, and a reader should not have to infer coverage from an
+# absence of complaints.
+RAN_GATES=""
+UNRUN_AGGREGATE=""
+AGGREGATE_TARGET=""
 RERUN_PASSED_IDS=""
 UV_OK=0
 command -v uv >/dev/null 2>&1 && UV_OK=1
@@ -279,6 +286,7 @@ run_fallback_gate() {
     local id="$1" uvargs="$2" token="$3"
     if grep -q "^${id}:" Makefile 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'make ${id}'"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }make ${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -305,6 +313,7 @@ run_fallback_gate() {
         RAN=1
     elif [[ "$UV_OK" -eq 1 ]] && grep -q "${token}" pyproject.toml 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'uv run --extra dev ${uvargs}' (no '${id}' Makefile target)"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }uv:${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -337,6 +346,55 @@ run_fallback_gate() {
     fi
 }
 
+# Find a Makefile target whose prerequisites are a SUPERSET of the three gates
+# this fallback knows (issue #808). Such a target is the repo's real gate, and
+# running three of its nine prerequisites while reporting `ok` is a true
+# statement about a fraction of the gate presented as a verdict on the tree.
+#
+# Derived from the Makefile rather than a hardcoded name like `verify` or
+# `check`: a list of names someone has to remember to extend is the enumeration
+# this whole ticket is about. The test is structural - does a target depend on
+# at least two of lint/test/typecheck AND on something else we did not run.
+#
+# Line continuations are joined first: this repo's own `verify` spans four
+# lines, so a line-at-a-time scan would see one prerequisite and miss five.
+detect_aggregate_gate() {
+    [[ -f Makefile ]] || return 0
+    awk '
+        # Join backslash continuations into one logical line.
+        { line = line $0
+          if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
+          print line; line = "" }
+        END { if (line != "") print line }
+    ' Makefile 2>/dev/null | awk -F: '
+        # Special targets (.PHONY, .DEFAULT_GOAL) list gate names as DATA, not
+        # as prerequisites - .PHONY names every phony target in the file, so it
+        # trivially "depends on" lint, test and typecheck and matched first.
+        # Caught by running the detector against this repo rather than a
+        # fixture: the real Makefile has a .PHONY line and a synthetic one
+        # would not have.
+        /^\./ { next }
+        /^[a-zA-Z0-9_-]+[[:space:]]*:[^=]/ {
+            target = $1
+            gsub(/[[:space:]]/, "", target)
+            deps = $2
+            known = 0; extra = ""
+            n = split(deps, parts, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) {
+                d = parts[i]
+                if (d == "") continue
+                if (d == "lint" || d == "test" || d == "typecheck") { known++ }
+                else { extra = extra (extra == "" ? "" : " ") d }
+            }
+            # Two of the three, plus at least one we would not have run.
+            if (known >= 2 && extra != "") {
+                print target "\t" extra
+                exit
+            }
+        }
+    '
+}
+
 if [[ -f Makefile || -f pyproject.toml ]]; then
     run_fallback_gate lint "ruff check ." "ruff"
     run_fallback_gate test "pytest" "pytest"
@@ -344,6 +402,22 @@ if [[ -f Makefile || -f pyproject.toml ]]; then
     # runs it too - otherwise a repo that degrades here gets the same
     # local-green-then-CI-red the runner plan had before #617.
     run_fallback_gate typecheck "mypy ." "mypy"
+fi
+
+# Report what actually executed, before any verdict (issue #808). A reader
+# should be able to see the coverage rather than infer it from the absence of a
+# complaint.
+if [[ -n "$RAN_GATES" ]]; then
+    echo "flow-finish-gate: gates executed: $RAN_GATES"
+fi
+
+# Does this repo define a larger gate we did not run?
+if [[ "$RAN" -gt 0 ]]; then
+    _aggregate="$(detect_aggregate_gate)"
+    if [[ -n "$_aggregate" ]]; then
+        AGGREGATE_TARGET="${_aggregate%%$'\t'*}"
+        UNRUN_AGGREGATE="${_aggregate#*$'\t'}"
+    fi
 fi
 
 if [[ "$RAN" -eq 0 && -z "$SKIPPED_GATES" ]]; then
@@ -366,6 +440,14 @@ fi
 if [[ -n "$SKIPPED_GATES" ]]; then
     echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no runnable tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
     verdict "warn (skipped gates: $SKIPPED_GATES)"
+    exit 0
+fi
+if [[ -n "$UNRUN_AGGREGATE" ]]; then
+    # Same sentence as #628's, for the same reason: this gate proved nothing
+    # about those checks. The difference is only how they came to be unrun -
+    # #628's could not run, these were never looked for.
+    echo "WARNING: this repo's 'make $AGGREGATE_TARGET' also runs: $UNRUN_AGGREGATE. Those did NOT run here - the fallback knows only lint/test/typecheck. This gate proved nothing about them; run 'make $AGGREGATE_TARGET' for the repo's full gate (issue #808)." >&2
+    verdict "warn (not run by fallback: $UNRUN_AGGREGATE)"
     exit 0
 fi
 if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/scripts/flow-finish-gate.sh
+++ b/scripts/flow-finish-gate.sh
@@ -252,6 +252,13 @@ echo "NOTE: deterministic runner unavailable ($REASON); using Makefile fallback.
 RAN=0
 FAILED=0
 SKIPPED_GATES=""
+# What actually executed, and by which route (issue #808). The marker alone
+# cannot distinguish a repo where this fallback IS the gate from one where it
+# is a fraction of it, and a reader should not have to infer coverage from an
+# absence of complaints.
+RAN_GATES=""
+UNRUN_AGGREGATE=""
+AGGREGATE_TARGET=""
 RERUN_PASSED_IDS=""
 UV_OK=0
 command -v uv >/dev/null 2>&1 && UV_OK=1
@@ -279,6 +286,7 @@ run_fallback_gate() {
     local id="$1" uvargs="$2" token="$3"
     if grep -q "^${id}:" Makefile 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'make ${id}'"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }make ${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -305,6 +313,7 @@ run_fallback_gate() {
         RAN=1
     elif [[ "$UV_OK" -eq 1 ]] && grep -q "${token}" pyproject.toml 2>/dev/null; then
         echo "flow-finish-gate: running fallback gate 'uv run --extra dev ${uvargs}' (no '${id}' Makefile target)"
+        RAN_GATES="${RAN_GATES:+$RAN_GATES }uv:${id}"
         if [[ "$id" == "test" && "$RERUN_ENABLED" == "1" ]]; then
             local first_output gate_exit failed_ids failed_count
             first_output=$(mktemp "${TMPDIR:-/tmp}/flow-finish-gate-test.XXXXXX")
@@ -337,6 +346,55 @@ run_fallback_gate() {
     fi
 }
 
+# Find a Makefile target whose prerequisites are a SUPERSET of the three gates
+# this fallback knows (issue #808). Such a target is the repo's real gate, and
+# running three of its nine prerequisites while reporting `ok` is a true
+# statement about a fraction of the gate presented as a verdict on the tree.
+#
+# Derived from the Makefile rather than a hardcoded name like `verify` or
+# `check`: a list of names someone has to remember to extend is the enumeration
+# this whole ticket is about. The test is structural - does a target depend on
+# at least two of lint/test/typecheck AND on something else we did not run.
+#
+# Line continuations are joined first: this repo's own `verify` spans four
+# lines, so a line-at-a-time scan would see one prerequisite and miss five.
+detect_aggregate_gate() {
+    [[ -f Makefile ]] || return 0
+    awk '
+        # Join backslash continuations into one logical line.
+        { line = line $0
+          if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
+          print line; line = "" }
+        END { if (line != "") print line }
+    ' Makefile 2>/dev/null | awk -F: '
+        # Special targets (.PHONY, .DEFAULT_GOAL) list gate names as DATA, not
+        # as prerequisites - .PHONY names every phony target in the file, so it
+        # trivially "depends on" lint, test and typecheck and matched first.
+        # Caught by running the detector against this repo rather than a
+        # fixture: the real Makefile has a .PHONY line and a synthetic one
+        # would not have.
+        /^\./ { next }
+        /^[a-zA-Z0-9_-]+[[:space:]]*:[^=]/ {
+            target = $1
+            gsub(/[[:space:]]/, "", target)
+            deps = $2
+            known = 0; extra = ""
+            n = split(deps, parts, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) {
+                d = parts[i]
+                if (d == "") continue
+                if (d == "lint" || d == "test" || d == "typecheck") { known++ }
+                else { extra = extra (extra == "" ? "" : " ") d }
+            }
+            # Two of the three, plus at least one we would not have run.
+            if (known >= 2 && extra != "") {
+                print target "\t" extra
+                exit
+            }
+        }
+    '
+}
+
 if [[ -f Makefile || -f pyproject.toml ]]; then
     run_fallback_gate lint "ruff check ." "ruff"
     run_fallback_gate test "pytest" "pytest"
@@ -344,6 +402,22 @@ if [[ -f Makefile || -f pyproject.toml ]]; then
     # runs it too - otherwise a repo that degrades here gets the same
     # local-green-then-CI-red the runner plan had before #617.
     run_fallback_gate typecheck "mypy ." "mypy"
+fi
+
+# Report what actually executed, before any verdict (issue #808). A reader
+# should be able to see the coverage rather than infer it from the absence of a
+# complaint.
+if [[ -n "$RAN_GATES" ]]; then
+    echo "flow-finish-gate: gates executed: $RAN_GATES"
+fi
+
+# Does this repo define a larger gate we did not run?
+if [[ "$RAN" -gt 0 ]]; then
+    _aggregate="$(detect_aggregate_gate)"
+    if [[ -n "$_aggregate" ]]; then
+        AGGREGATE_TARGET="${_aggregate%%$'\t'*}"
+        UNRUN_AGGREGATE="${_aggregate#*$'\t'}"
+    fi
 fi
 
 if [[ "$RAN" -eq 0 && -z "$SKIPPED_GATES" ]]; then
@@ -366,6 +440,14 @@ fi
 if [[ -n "$SKIPPED_GATES" ]]; then
     echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no runnable tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
     verdict "warn (skipped gates: $SKIPPED_GATES)"
+    exit 0
+fi
+if [[ -n "$UNRUN_AGGREGATE" ]]; then
+    # Same sentence as #628's, for the same reason: this gate proved nothing
+    # about those checks. The difference is only how they came to be unrun -
+    # #628's could not run, these were never looked for.
+    echo "WARNING: this repo's 'make $AGGREGATE_TARGET' also runs: $UNRUN_AGGREGATE. Those did NOT run here - the fallback knows only lint/test/typecheck. This gate proved nothing about them; run 'make $AGGREGATE_TARGET' for the repo's full gate (issue #808)." >&2
+    verdict "warn (not run by fallback: $UNRUN_AGGREGATE)"
     exit 0
 fi
 if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/tests/test_flow_finish_gate.py
+++ b/tests/test_flow_finish_gate.py
@@ -657,3 +657,109 @@ def test_runner_skipped_non_gate_still_ok(tmp_path: Path) -> None:
     assert proc.returncode == 0
     assert "FLOW_FINISH_GATE: ok" in proc.stdout
     assert "warn" not in proc.stdout
+
+
+# ── Naming what ran, and seeing a larger gate (issue #808) ──────────────────
+#
+# The fallback runs lint/test/typecheck. A repo whose real gate is a larger
+# aggregate target - this repository's own `make verify` is nine - gets three
+# of nine run and reported `ok`: a true statement about a fraction of the gate,
+# presented as a verdict on the tree. That is the same shape as the `skipped`
+# case above, one level in, and it sits inside the instrument everything else
+# trusts.
+#
+# The threshold is deliberately unchanged. `skipped` keeps its exit code and a
+# repo where the fallback IS the gate still reports `ok`; what changes is that
+# the report now says which targets ran and which the repo expected.
+
+
+@requires_bash
+def test_fallback_names_the_gates_it_ran(tmp_path: Path) -> None:
+    """Coverage should be readable, not inferred from an absence of complaint."""
+    (tmp_path / "Makefile").write_text(
+        "lint:\n\ttrue\ntest:\n\ttrue\ntypecheck:\n\ttrue\n"
+    )
+    proc, _ = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=0)
+    assert proc.returncode == 0
+    assert "gates executed: make lint make test make typecheck" in proc.stdout
+
+
+@requires_bash
+def test_an_aggregate_gate_the_fallback_cannot_run_is_a_warn(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text(
+        "lint:\n\ttrue\n"
+        "test:\n\ttrue\n"
+        "typecheck:\n\ttrue\n"
+        "extra-check:\n\ttrue\n"
+        "verify: lint test typecheck extra-check\n"
+    )
+    proc, bindir = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=0)
+    assert proc.returncode == 0
+    assert "FLOW_FINISH_GATE: warn" in proc.stdout
+    assert "FLOW_FINISH_GATE: ok" not in proc.stdout
+    assert "extra-check" in proc.stdout
+    assert "make verify" in proc.stdout
+    # The three it knows still ran - this is a reporting change, not a refusal.
+    argv = (bindir / "make.log").read_text().splitlines()
+    assert argv == ["lint", "test", "typecheck"]
+
+
+@requires_bash
+def test_a_repo_where_the_fallback_is_the_gate_is_still_ok(tmp_path: Path) -> None:
+    """The guard rail. Without it, "warn on an aggregate" is satisfiable by
+    warning on everything, which would train readers to ignore the warning -
+    strictly worse than not having it."""
+    (tmp_path / "Makefile").write_text(
+        "lint:\n\ttrue\ntest:\n\ttrue\ntypecheck:\n\ttrue\n"
+    )
+    proc, _ = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=0)
+    assert "FLOW_FINISH_GATE: ok" in proc.stdout
+    assert "not run by fallback" not in proc.stdout
+
+
+@requires_bash
+def test_a_phony_declaration_is_not_mistaken_for_an_aggregate(tmp_path: Path) -> None:
+    """.PHONY lists gate names as DATA, not as prerequisites.
+
+    Found by running the detector against this repository rather than a
+    fixture: .PHONY names every phony target, so it trivially 'depends on'
+    lint, test and typecheck and matched before `verify` did. A synthetic
+    Makefile without a .PHONY line would never have shown it.
+    """
+    (tmp_path / "Makefile").write_text(
+        ".PHONY: lint test typecheck docs clean\n"
+        "lint:\n\ttrue\ntest:\n\ttrue\ntypecheck:\n\ttrue\n"
+    )
+    proc, _ = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=0)
+    assert "FLOW_FINISH_GATE: ok" in proc.stdout
+    assert "docs" not in proc.stdout
+    assert "clean" not in proc.stdout
+
+
+@requires_bash
+def test_a_multi_line_aggregate_is_detected(tmp_path: Path) -> None:
+    """This repo's own `verify` spans four continuation lines, so a
+    line-at-a-time scan would see one prerequisite and miss five."""
+    (tmp_path / "Makefile").write_text(
+        "lint:\n\ttrue\n"
+        "test:\n\ttrue\n"
+        "typecheck:\n\ttrue\n"
+        "alpha-check:\n\ttrue\n"
+        "beta-check:\n\ttrue\n"
+        "verify: lint test typecheck \\\n\talpha-check \\\n\tbeta-check\n"
+    )
+    proc, _ = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=0)
+    assert "FLOW_FINISH_GATE: warn" in proc.stdout
+    assert "alpha-check" in proc.stdout
+    assert "beta-check" in proc.stdout
+
+
+@requires_bash
+def test_the_skipped_threshold_is_unchanged(tmp_path: Path) -> None:
+    """Explicitly pinned, because this ticket's scope excluded it: a repo with
+    no gate targets still reports `skipped` at exit 0. Changing that is the
+    oscillation-prone class and was ruled out, so a later reader should see it
+    asserted rather than assume it drifted."""
+    proc, _ = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=None)
+    assert proc.returncode == 0
+    assert "FLOW_FINISH_GATE: skipped" in proc.stdout


### PR DESCRIPTION
## The defect

The Makefile fallback runs `lint`, `test` and `typecheck`. **This repository's own gate is nine targets:**

```
verify: lint test typecheck binary-guards-check negative-fixture-check \
        claude-md-budget-check claude-md-links-check \
        claude-md-behavior-check project-next-check
```

So the fallback ran **three of nine** and reported `ok` — a true statement about a third of the gate, presented as a verdict on the tree.

It is the same shape as the silent `skipped` case one level in: an instrument whose output is literally true (*the steps I ran passed*) answering a narrower question than the one asked (*does this tree pass*). Here it sits inside the gate, which is the thing everything else trusts. Any worker running `flow:auto` against this repo was under-gating it, with nothing in the output to say so.

## Two reporting changes, no threshold change

**1. Name the targets that ran.**

```
flow-finish-gate: gates executed: make lint make test make typecheck
```

Coverage becomes readable rather than inferred from the absence of a complaint.

**2. Detect an aggregate gate the fallback cannot run.**

```
WARNING: this repo's 'make verify' also runs: binary-guards-check
negative-fixture-check claude-md-budget-check claude-md-links-check
claude-md-behavior-check project-next-check. Those did NOT run here - the
fallback knows only lint/test/typecheck. This gate proved nothing about them.
FLOW_FINISH_GATE: warn (not run by fallback: ...)
```

This reuses **#628's existing sentence**, because it is the same claim — *this gate proved nothing about those checks*. Only how they came to be unrun differs: #628's could not run, these were never looked for. The mechanism already existed; it simply did not look for this case.

## The threshold is deliberately untouched

Ruled out of scope, and pinned by a test so a later reader sees it asserted rather than assuming it drifted:

- a repo with **no** gate targets still reports `skipped` at exit `0`
- a repo where the fallback **is** the gate still reports `ok`

That second guard rail matters more than it looks. "Warn on an aggregate" is trivially satisfiable by warning on *everything* — which would train readers to ignore the warning, strictly worse than not having it.

## The aggregate is derived, not listed

The detector asks a structural question — *does a target depend on at least two of lint/test/typecheck **and** on something else we did not run* — rather than matching names like `verify` or `check`. A name list is exactly the enumeration this ticket is about, one level up.

## Two things I got wrong first

Both found by running the detector against **this repository** rather than a fixture, which is the argument for doing that:

1. **`.PHONY` lists gate names as data, not prerequisites.** It names every phony target, so it trivially "depends on" lint, test and typecheck — and matched *before* `verify` did. A synthetic Makefile without a `.PHONY` line would never have shown it.
2. **`verify` spans four continuation lines here**, so a line-at-a-time scan saw one prerequisite and missed five.

Both are pinned by tests.

## Gate

**`make verify`** — all nine targets confirmed *executed*, not inferred from exit 0: ruff, **2189 pytest**, mypy over 194 files, binary-guards, negative-fixture, claude-md-budget/links/behavior, project-next-vendor.

Generated Codex skill copies re-synced (#506) — the bundled-copy parity test caught the drift, which is the check working.

## Provenance

Filed as #808 rather than transferred from the private downstream repo that found it: GitHub refuses private→public transfers, and copying a private issue body into a public repository is a disclosure decision rather than a mechanical move. The defect reproduces entirely within this repo.

Closes #808
