### PR TITLE
fix(cicd): report a timed-out step as a timeout, not a failure (Closes #812)

### DIFF
--- a/codex/skills/flow-auto/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-auto/scripts/flow-finish-gate.sh
@@ -212,6 +212,14 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
             in_entry = 0
         }
     ' "$RUNNER_JSON" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+    # A step killed by its own budget is NOT a step that failed (issue #812).
+    # The runner emits it as a distinct top-level field; read it before the
+    # JSON is removed. Anchored on the field name rather than on the error
+    # prose, which is the string-matching that would drift.
+    TIMED_OUT_STEP=$(sed -n 's/^  "timed_out_step": "\([^"]*\)",\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
+    TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -238,6 +246,20 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         fi
         verdict ok
         exit 0
+    fi
+    if [[ -n "$TIMED_OUT_STEP" ]]; then
+        # Distinguished from a test failure deliberately. A reader told
+        # "FAILED" debugs a suite that never finished; the useful facts are
+        # that the step ran out of budget, that this says NOTHING about
+        # whether it would have passed, and how to give it more. Still exit 1:
+        # an unfinished gate has not shown the tree is good.
+        echo "TIMEOUT: step '$TIMED_OUT_STEP' was killed after ${TIMED_OUT_AFTER:-its}s - it did NOT fail, it did not finish." >&2
+        echo "  This proves nothing about the tree either way. Do not triage the tests; they were still running." >&2
+        echo "  A suite grows every merge and no constant tracks that, so this budget will need raising again:" >&2
+        echo "        CPP_GATE_TEST_TIMEOUT=<seconds> <re-run the gate>" >&2
+        echo "  If it times out at a budget far above the suite's real cost, suspect a hang rather than growth (issue #812)." >&2
+        verdict "fail (timeout: $TIMED_OUT_STEP after ${TIMED_OUT_AFTER:-?}s)"
+        exit 1
     fi
     verdict fail
     exit 1

--- a/codex/skills/flow-check/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-check/scripts/flow-finish-gate.sh
@@ -212,6 +212,14 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
             in_entry = 0
         }
     ' "$RUNNER_JSON" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+    # A step killed by its own budget is NOT a step that failed (issue #812).
+    # The runner emits it as a distinct top-level field; read it before the
+    # JSON is removed. Anchored on the field name rather than on the error
+    # prose, which is the string-matching that would drift.
+    TIMED_OUT_STEP=$(sed -n 's/^  "timed_out_step": "\([^"]*\)",\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
+    TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -238,6 +246,20 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         fi
         verdict ok
         exit 0
+    fi
+    if [[ -n "$TIMED_OUT_STEP" ]]; then
+        # Distinguished from a test failure deliberately. A reader told
+        # "FAILED" debugs a suite that never finished; the useful facts are
+        # that the step ran out of budget, that this says NOTHING about
+        # whether it would have passed, and how to give it more. Still exit 1:
+        # an unfinished gate has not shown the tree is good.
+        echo "TIMEOUT: step '$TIMED_OUT_STEP' was killed after ${TIMED_OUT_AFTER:-its}s - it did NOT fail, it did not finish." >&2
+        echo "  This proves nothing about the tree either way. Do not triage the tests; they were still running." >&2
+        echo "  A suite grows every merge and no constant tracks that, so this budget will need raising again:" >&2
+        echo "        CPP_GATE_TEST_TIMEOUT=<seconds> <re-run the gate>" >&2
+        echo "  If it times out at a budget far above the suite's real cost, suspect a hang rather than growth (issue #812)." >&2
+        verdict "fail (timeout: $TIMED_OUT_STEP after ${TIMED_OUT_AFTER:-?}s)"
+        exit 1
     fi
     verdict fail
     exit 1

--- a/codex/skills/flow-finish/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-finish/scripts/flow-finish-gate.sh
@@ -212,6 +212,14 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
             in_entry = 0
         }
     ' "$RUNNER_JSON" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+    # A step killed by its own budget is NOT a step that failed (issue #812).
+    # The runner emits it as a distinct top-level field; read it before the
+    # JSON is removed. Anchored on the field name rather than on the error
+    # prose, which is the string-matching that would drift.
+    TIMED_OUT_STEP=$(sed -n 's/^  "timed_out_step": "\([^"]*\)",\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
+    TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -238,6 +246,20 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         fi
         verdict ok
         exit 0
+    fi
+    if [[ -n "$TIMED_OUT_STEP" ]]; then
+        # Distinguished from a test failure deliberately. A reader told
+        # "FAILED" debugs a suite that never finished; the useful facts are
+        # that the step ran out of budget, that this says NOTHING about
+        # whether it would have passed, and how to give it more. Still exit 1:
+        # an unfinished gate has not shown the tree is good.
+        echo "TIMEOUT: step '$TIMED_OUT_STEP' was killed after ${TIMED_OUT_AFTER:-its}s - it did NOT fail, it did not finish." >&2
+        echo "  This proves nothing about the tree either way. Do not triage the tests; they were still running." >&2
+        echo "  A suite grows every merge and no constant tracks that, so this budget will need raising again:" >&2
+        echo "        CPP_GATE_TEST_TIMEOUT=<seconds> <re-run the gate>" >&2
+        echo "  If it times out at a budget far above the suite's real cost, suspect a hang rather than growth (issue #812)." >&2
+        verdict "fail (timeout: $TIMED_OUT_STEP after ${TIMED_OUT_AFTER:-?}s)"
+        exit 1
     fi
     verdict fail
     exit 1

--- a/codex/skills/flow-merge/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-merge/scripts/flow-finish-gate.sh
@@ -212,6 +212,14 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
             in_entry = 0
         }
     ' "$RUNNER_JSON" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+    # A step killed by its own budget is NOT a step that failed (issue #812).
+    # The runner emits it as a distinct top-level field; read it before the
+    # JSON is removed. Anchored on the field name rather than on the error
+    # prose, which is the string-matching that would drift.
+    TIMED_OUT_STEP=$(sed -n 's/^  "timed_out_step": "\([^"]*\)",\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
+    TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -238,6 +246,20 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         fi
         verdict ok
         exit 0
+    fi
+    if [[ -n "$TIMED_OUT_STEP" ]]; then
+        # Distinguished from a test failure deliberately. A reader told
+        # "FAILED" debugs a suite that never finished; the useful facts are
+        # that the step ran out of budget, that this says NOTHING about
+        # whether it would have passed, and how to give it more. Still exit 1:
+        # an unfinished gate has not shown the tree is good.
+        echo "TIMEOUT: step '$TIMED_OUT_STEP' was killed after ${TIMED_OUT_AFTER:-its}s - it did NOT fail, it did not finish." >&2
+        echo "  This proves nothing about the tree either way. Do not triage the tests; they were still running." >&2
+        echo "  A suite grows every merge and no constant tracks that, so this budget will need raising again:" >&2
+        echo "        CPP_GATE_TEST_TIMEOUT=<seconds> <re-run the gate>" >&2
+        echo "  If it times out at a budget far above the suite's real cost, suspect a hang rather than growth (issue #812)." >&2
+        verdict "fail (timeout: $TIMED_OUT_STEP after ${TIMED_OUT_AFTER:-?}s)"
+        exit 1
     fi
     verdict fail
     exit 1

--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -27,7 +27,13 @@ from typing import Any, Optional, TextIO
 
 from .outcomes import parse_failed_node_ids
 from .state import RunState, StepStatus
-from .steps import GATE_STEP_IDS, ShellStep, StepDef, get_plan_steps
+from .steps import (
+    GATE_STEP_IDS,
+    TIMEOUT_EXIT_CODE,
+    ShellStep,
+    StepDef,
+    get_plan_steps,
+)
 
 # Variables the runner launcher injects (or a parent venv leaks) that must NOT
 # reach child step processes: PYTHONPATH is added so ``python -m lib.cicd`` can
@@ -133,6 +139,12 @@ class RunResult:
     # re-run that passed is a DIFFERENT qualification and must not borrow #621's
     # sentence.
     reruns: list[dict[str, Any]] = field(default_factory=list)
+    # A step killed by its own budget rather than by failing (issue #812).
+    # exit 124 is already distinguishable and was being flattened into "the
+    # step failed", which sends a reader to debug a suite that never finished.
+    # Carried as its own channel so the difference survives to the report.
+    timed_out_step: Optional[str] = None
+    timed_out_after: Optional[int] = None
     # Step ids whose result was earned in an EARLIER invocation and carried
     # into this one by a resume (issue #838 follow-up). Its own channel and not
     # a `warning`: nothing is wrong, but the reader must be able to tell a
@@ -170,6 +182,13 @@ class RunResult:
             d["reruns"] = self.reruns
         if self.skipped_steps:
             d["skipped"] = self.skipped_steps
+        # The gate parses this JSON, so a field that never reaches it cannot be
+        # acted on however carefully it was set (issue #812). Emitted at the top
+        # level and keyed by name so the shell reader anchors on the field
+        # rather than on error prose, which drifts.
+        if self.timed_out_step:
+            d["timed_out_step"] = self.timed_out_step
+            d["timed_out_after"] = self.timed_out_after
         return d
 
 
@@ -389,13 +408,32 @@ class DeterministicRunner:
                 state.save(self.project_root)
                 completed = idx + 1
             else:
-                self._log(
-                    f"  [{idx + 1}/{len(step_defs)}] {step.id}: "
-                    f"FAILED (exit {result.exit_code}){qualifier}"
-                )
+                # A step killed by its own budget is not a step that failed
+                # (issue #812). Saying FAILED sends the reader to debug a
+                # suite that never finished, and the #769 targeted re-run
+                # below is meaningless for it: there are no failed ids to
+                # re-run, only an unfinished run.
+                timed_out = result.exit_code == TIMEOUT_EXIT_CODE
+                if timed_out:
+                    budget = step_def.timeout_seconds
+                    self._log(
+                        f"  [{idx + 1}/{len(step_defs)}] {step.id}: "
+                        f"TIMED OUT after {budget}s (exit "
+                        f"{TIMEOUT_EXIT_CODE}) - the step did not finish, so "
+                        f"this says NOTHING about whether it would have "
+                        f"passed. Raise the budget with "
+                        f"CPP_GATE_TEST_TIMEOUT=<seconds> if the suite has "
+                        f"simply outgrown it."
+                    )
+                else:
+                    self._log(
+                        f"  [{idx + 1}/{len(step_defs)}] {step.id}: "
+                        f"FAILED (exit {result.exit_code}){qualifier}"
+                    )
                 failed_ids: list[str] = []
                 if (
                     self.rerun_failed
+                    and not timed_out
                     and step.is_test_step()
                     and outcome is not None
                     and outcome.framework == "pytest"
@@ -477,6 +515,10 @@ class DeterministicRunner:
                     steps_completed=completed,
                     steps_total=len(step_defs),
                     failed_step=step.id,
+                    timed_out_step=step.id if timed_out else None,
+                    timed_out_after=(
+                        step_def.timeout_seconds if timed_out else None
+                    ),
                     error=result.error or result.output,
                     tests=tests,
                     warnings=warnings,

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -78,6 +78,11 @@ class StepResult:
         return self.status == StepStatus.SUCCESS
 
 
+#: The exit code a killed-by-timeout step reports. Named rather than repeated
+#: as a bare 124, so the producer here and the consumers in runner.py and
+#: flow-finish-gate.sh agree by reference instead of by coincidence.
+TIMEOUT_EXIT_CODE = 124
+
 @dataclass
 class StepDef:
     """Definition of a step from the task manifest or built-in plan.
@@ -288,7 +293,7 @@ class ShellStep:
             timeout_msg = f"Step timed out after {self.timeout_seconds}s"
             return StepResult(
                 status=StepStatus.FAILED,
-                exit_code=124,  # standard timeout exit code
+                exit_code=TIMEOUT_EXIT_CODE,
                 output=output,
                 error=f"{error}\n{timeout_msg}".strip() if error else timeout_msg,
                 tests=tests,
@@ -359,6 +364,36 @@ class ShellStep:
 GATE_STEP_IDS = frozenset({"lint", "test", "typecheck"})
 
 
+#: Default budget for the whole `test` STEP - not for one pytest invocation.
+#: A step runs a command, and that command may run pytest several times: kyle's
+#: `make test` deliberately runs two (non-Playwright, then Playwright) to avoid
+#: an event-loop leak between pytest-asyncio and pytest-playwright. A budget
+#: sized by watching one invocation is therefore wrong by construction, which is
+#: how 600s came to be under the real cost (issue #812): the first invocation
+#: alone took 457s and the second needed ~160s more, so the step was killed at
+#: 91% of the second and reported FAILED on a suite that would have passed.
+#:
+#: This number WILL be wrong again. A suite grows every merge and no constant
+#: tracks that, which is why the substantive half of #812's fix is that a
+#: timeout is now REPORTED as a timeout rather than flattened into a test
+#: failure - a reader can tell "ran out of budget" from "the tree is broken",
+#: and the message says how to raise it.
+DEFAULT_TEST_STEP_TIMEOUT = 1800
+
+
+def _test_step_timeout() -> int:
+    """Budget for the test step, overridable without a code change (#812).
+
+    Read at plan-construction time so an operator whose suite has outgrown the
+    default can raise it for one run - the alternative is editing this file,
+    which nobody does mid-incident and which does not survive an update.
+    """
+    raw = os.environ.get("CPP_GATE_TEST_TIMEOUT", "").strip()
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    return DEFAULT_TEST_STEP_TIMEOUT
+
+
 def _gate_step(
     step_id: str, uv_tool: str, pyproject_token: str, timeout_seconds: int
 ) -> "StepDef":
@@ -409,7 +444,7 @@ def _gate_step(
 BUILTIN_PLANS: dict[str, list[StepDef]] = {
     "finish": [
         _gate_step("lint", "ruff check .", "ruff", 300),
-        _gate_step("test", "pytest", "pytest", 600),
+        _gate_step("test", "pytest", "pytest", _test_step_timeout()),
         _gate_step("typecheck", "mypy .", "mypy", 300),
         StepDef(
             id="security_scan",
@@ -423,7 +458,7 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
     ],
     "check": [
         _gate_step("lint", "ruff check .", "ruff", 300),
-        _gate_step("test", "pytest", "pytest", 600),
+        _gate_step("test", "pytest", "pytest", _test_step_timeout()),
         _gate_step("typecheck", "mypy .", "mypy", 300),
     ],
     "deploy": [

--- a/scripts/flow-finish-gate.sh
+++ b/scripts/flow-finish-gate.sh
@@ -212,6 +212,14 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
             in_entry = 0
         }
     ' "$RUNNER_JSON" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+    # A step killed by its own budget is NOT a step that failed (issue #812).
+    # The runner emits it as a distinct top-level field; read it before the
+    # JSON is removed. Anchored on the field name rather than on the error
+    # prose, which is the string-matching that would drift.
+    TIMED_OUT_STEP=$(sed -n 's/^  "timed_out_step": "\([^"]*\)",\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
+    TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
+        "$RUNNER_JSON" 2>/dev/null | head -1)
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -238,6 +246,20 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         fi
         verdict ok
         exit 0
+    fi
+    if [[ -n "$TIMED_OUT_STEP" ]]; then
+        # Distinguished from a test failure deliberately. A reader told
+        # "FAILED" debugs a suite that never finished; the useful facts are
+        # that the step ran out of budget, that this says NOTHING about
+        # whether it would have passed, and how to give it more. Still exit 1:
+        # an unfinished gate has not shown the tree is good.
+        echo "TIMEOUT: step '$TIMED_OUT_STEP' was killed after ${TIMED_OUT_AFTER:-its}s - it did NOT fail, it did not finish." >&2
+        echo "  This proves nothing about the tree either way. Do not triage the tests; they were still running." >&2
+        echo "  A suite grows every merge and no constant tracks that, so this budget will need raising again:" >&2
+        echo "        CPP_GATE_TEST_TIMEOUT=<seconds> <re-run the gate>" >&2
+        echo "  If it times out at a budget far above the suite's real cost, suspect a hang rather than growth (issue #812)." >&2
+        verdict "fail (timeout: $TIMED_OUT_STEP after ${TIMED_OUT_AFTER:-?}s)"
+        exit 1
     fi
     verdict fail
     exit 1

--- a/tests/test_flow_finish_gate.py
+++ b/tests/test_flow_finish_gate.py
@@ -39,13 +39,26 @@ requires_bash = pytest.mark.skipif(
 )
 
 
-def _make_stub(bindir: Path, name: str, exit_code: int = 0) -> Path:
-    """An executable PATH shim that logs its argv and exits ``exit_code``."""
+def _make_stub(
+    bindir: Path, name: str, exit_code: int = 0, stdout: str = ""
+) -> Path:
+    """An executable PATH shim that logs its argv and exits ``exit_code``.
+
+    ``stdout`` lets a stub emit a payload the helper then parses - the runner
+    path reads the runner's JSON from STDOUT via ``tee``, so a test that writes
+    a JSON file somewhere is testing nothing (issue #812).
+    """
     log = bindir / f"{name}.log"
     stub = bindir / name
+    payload = ""
+    if stdout:
+        out_file = bindir / f"{name}.stdout"
+        out_file.write_text(stdout)
+        payload = f'cat "{out_file}"\n'
     stub.write_text(
         "#!/usr/bin/env bash\n"
         f'echo "$@" >> "{log}"\n'
+        f"{payload}"
         f"exit {exit_code}\n"
     )
     stub.chmod(0o755)
@@ -59,12 +72,13 @@ def _run(
     uv_exit: int | None = 0,
     make_exit: int | None = None,
     cwd: Path | None = None,
+    uv_stdout: str = "",
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run the helper with stubbed uv/make; returns (proc, stub bin dir)."""
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
     if uv_exit is not None:
-        _make_stub(bindir, "uv", uv_exit)
+        _make_stub(bindir, "uv", uv_exit, stdout=uv_stdout)
     if make_exit is not None:
         _make_stub(bindir, "make", make_exit)
     env = os.environ.copy()
@@ -763,3 +777,46 @@ def test_the_skipped_threshold_is_unchanged(tmp_path: Path) -> None:
     proc, _ = _run(tmp_path, cpp_dir="", uv_exit=None, make_exit=None)
     assert proc.returncode == 0
     assert "FLOW_FINISH_GATE: skipped" in proc.stdout
+
+
+# ── A timeout is reported as a timeout (issue #812) ─────────────────────────
+#
+# The runner emits `timed_out_step` / `timed_out_after` at the top level of its
+# JSON; the gate must surface that rather than flattening it into a bare
+# `fail`. Still exit 1 - an unfinished gate has not shown the tree is good -
+# but the reader has to be able to tell "ran out of budget" from "the tree is
+# broken", because only one of those is worth triaging.
+
+
+@requires_bash
+def test_a_runner_timeout_is_surfaced_as_a_timeout(tmp_path: Path) -> None:
+    cpp = _fake_cpp(tmp_path)
+    runner_json = (
+        '{\n'
+        '  "success": false,\n'
+        '  "failed_step": "test",\n'
+        '  "timed_out_step": "test",\n'
+        '  "timed_out_after": 600\n'
+        '}\n'
+    )
+    proc, _ = _run(tmp_path, cpp_dir=str(cpp), uv_exit=1, uv_stdout=runner_json)
+    assert proc.returncode == 1
+    assert "FLOW_FINISH_GATE: fail (timeout: test after 600s)" in proc.stdout
+    assert "did NOT fail, it did not finish" in proc.stdout
+    assert "CPP_GATE_TEST_TIMEOUT" in proc.stdout, (
+        "the message must say how to raise the budget - the number will be "
+        "wrong again as the suite grows, and a reader mid-incident should not "
+        "have to find that out from the source"
+    )
+
+
+@requires_bash
+def test_an_ordinary_failure_is_still_a_bare_fail(tmp_path: Path) -> None:
+    """The guard rail: a change that called every failure a timeout would pass
+    the test above while destroying the distinction it exists for."""
+    cpp = _fake_cpp(tmp_path)
+    runner_json = '{\n  "success": false,\n  "failed_step": "test"\n}\n'
+    proc, _ = _run(tmp_path, cpp_dir=str(cpp), uv_exit=1, uv_stdout=runner_json)
+    assert proc.returncode == 1
+    assert "FLOW_FINISH_GATE: fail" in proc.stdout
+    assert "timeout" not in proc.stdout.lower()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1126,3 +1126,116 @@ class TestResumedRunReportsWhatActuallyRan:
         text = resume_log.getvalue()
         assert "will NOT run in this invocation" in text
         assert "lint" in text
+
+
+class TestATimeoutIsNotAFailure:
+    """A step killed by its budget must not report as a step that failed (#812).
+
+    Measured cause: the `test` step's budget was 600s while kyle's `make test`
+    needed ~620s — the first pytest invocation alone took 457s and the
+    Playwright half another ~160s. The step was killed at 91% of the second and
+    reported FAILED, so the gate said a suite was broken when it had simply not
+    finished. Someone triaging that debugs tests that were still running.
+
+    Note the budget is per STEP, not per invocation: one step's command may run
+    pytest several times, and a number sized by watching one of them is wrong by
+    construction. That is how 600 came to be under the real cost.
+
+    Raising the number does not fix this - it only moves the cliff, because a
+    suite grows every merge and no constant tracks that. What fixes it is that
+    the two outcomes are now distinguishable.
+    """
+
+    def test_a_timed_out_step_is_reported_as_a_timeout_not_a_failure(
+        self, tmp_project: Path
+    ):
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+        result = runner.run(
+            "check",
+            step_defs=[StepDef(id="test", command="sleep 5", timeout_seconds=1)],
+        )
+        assert not result.success
+        assert result.timed_out_step == "test"
+        assert result.timed_out_after == 1
+
+        text = log.getvalue()
+        assert "TIMED OUT" in text
+        assert "FAILED (exit" not in text, (
+            "reporting a timeout as FAILED is the defect - it sends a reader to "
+            "debug a suite that never finished (#812)"
+        )
+
+    def test_the_timeout_reaches_the_json_the_gate_parses(self, tmp_project: Path):
+        """A field that never reaches the report cannot be acted on, however
+        carefully it was set. `to_dict` is the gate's only view of the run, and
+        omitting it there was a real bug in the first draft of this change."""
+        runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+        result = runner.run(
+            "check",
+            step_defs=[StepDef(id="test", command="sleep 5", timeout_seconds=1)],
+        )
+        payload = result.to_dict()
+        assert payload["timed_out_step"] == "test"
+        assert payload["timed_out_after"] == 1
+
+    def test_a_genuine_failure_is_still_a_failure(self, tmp_project: Path):
+        """The guard rail. A change that called everything a timeout would pass
+        the assertions above while destroying the distinction they exist for."""
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+        result = runner.run(
+            "check",
+            step_defs=[StepDef(id="test", command="exit 1", timeout_seconds=30)],
+        )
+        assert not result.success
+        assert result.timed_out_step is None
+        assert "timed_out_step" not in result.to_dict()
+        assert "FAILED (exit 1)" in log.getvalue()
+        assert "TIMED OUT" not in log.getvalue()
+
+    def test_the_targeted_rerun_does_not_fire_for_a_timeout(self, tmp_project: Path):
+        """#769 re-runs a step against only its FAILED ids. A timed-out step has
+        no failed ids - it has an unfinished run - so re-running it burns the
+        budget again and can only time out a second time."""
+        log = StringIO()
+        runner = DeterministicRunner(
+            project_root=tmp_project, output=log, rerun_failed=True
+        )
+        runner.run(
+            "check",
+            step_defs=[StepDef(id="test", command="sleep 5", timeout_seconds=1)],
+        )
+        assert "RE-RUNNING" not in log.getvalue()
+
+
+class TestTestStepBudgetIsConfigurable:
+    """The budget must be raisable without editing the source (#812).
+
+    Nobody edits a vendored file mid-incident, and an edit does not survive an
+    update. The number will be wrong again as the suite grows, so the escape
+    hatch is part of the fix rather than a convenience.
+    """
+
+    def test_the_env_override_is_used(self, monkeypatch):
+        from lib.cicd.steps import _test_step_timeout
+
+        monkeypatch.setenv("CPP_GATE_TEST_TIMEOUT", "42")
+        assert _test_step_timeout() == 42
+
+    def test_a_nonsense_override_falls_back_rather_than_crashing(self, monkeypatch):
+        """Fail-safe, not fail-closed: a typo'd budget must not stop the gate
+        running, and must not silently become zero (which would time out
+        instantly and look like a hung suite)."""
+        from lib.cicd.steps import DEFAULT_TEST_STEP_TIMEOUT, _test_step_timeout
+
+        for bad in ("not-a-number", "", "0", "-5"):
+            monkeypatch.setenv("CPP_GATE_TEST_TIMEOUT", bad)
+            assert _test_step_timeout() == DEFAULT_TEST_STEP_TIMEOUT
+
+    def test_the_default_exceeds_the_cost_that_caused_this_issue(self):
+        """600s was already under the ~620s the suite needed when #812 was
+        filed. A default that is wrong on the day it ships is the bug."""
+        from lib.cicd.steps import DEFAULT_TEST_STEP_TIMEOUT
+
+        assert DEFAULT_TEST_STEP_TIMEOUT > 620


### PR DESCRIPTION
## The defect

The gate's `test` step budget was **600s**; kyle's `make test` needs **~620s**. The step was killed at 91% of its second pytest invocation and reported `FAILED`, so the gate said a suite was broken when it had simply **not finished**.

Someone triaging that debugs tests that were still running. It cost real time during a fleet-outage investigation, where the manufactured errors had to be excluded by hand before the actual question could be answered.

## Raising the number is the smaller half and does not fix it

A suite grows every merge and no constant tracks that, so **whatever number is chosen is wrong again later**. What fixes it is that the two outcomes are now distinguishable:

```
before   [2/4] test: FAILED (exit 124)

after    [2/4] test: TIMED OUT after 600s (exit 124) - the step did not
         finish, so this says NOTHING about whether it would have passed.
         Raise the budget with CPP_GATE_TEST_TIMEOUT=<seconds> ...
```

and at the gate:

```
TIMEOUT: step 'test' was killed after 600s - it did NOT fail, it did not finish.
  This proves nothing about the tree either way. Do not triage the tests; they were still running.
  A suite grows every merge and no constant tracks that, so this budget will need raising again:
        CPP_GATE_TEST_TIMEOUT=<seconds> <re-run the gate>
  If it times out at a budget far above the suite's real cost, suspect a hang rather than growth.
FLOW_FINISH_GATE: fail (timeout: test after 600s)
```

`exit 124` was **already** a distinguishable signal. The runner and the gate were both flattening it. Still exit 1 — an unfinished gate has not shown the tree is good — but the reader can now tell *ran out of budget* from *the tree is broken*.

## The budget is per STEP, not per invocation

That is how 600 came to be under the real cost. One step's command may run pytest several times — kyle's `make test` deliberately runs two, to avoid an event-loop leak between `pytest-asyncio` and `pytest-playwright`. **A number sized by watching one invocation is wrong by construction.**

Default is now **1800** (above the ~620s that caused this) and overridable with `CPP_GATE_TEST_TIMEOUT`, because nobody edits a vendored file mid-incident and an edit does not survive an update. A nonsense or zero value falls back to the default rather than becoming an instant timeout that looks like a hang.

## The #769 re-run no longer fires for a timeout

It re-runs a step against only its **failed ids**. A timed-out step has none — it has an unfinished run — so re-running it burns the budget again and can only time out a second time.

## Two bugs caught by running the change rather than reading it

1. **The new fields were absent from `to_dict()`.** The gate parses that JSON, so the fields could never have reached it however carefully they were set. The whole change would have been inert.
2. **My first gate test asserted a JSON file the gate does not read** — the runner's output is captured from **stdout** via `tee`. The test passed nothing and proved nothing.

Both are now pinned: one test asserts the field reaches `to_dict()`, and the stub builder grew a `stdout` parameter so gate tests drive the real path.

## Three defects, three directions

This is the third defect found in this instrument, and they do **not** all point the same way:

| defect | direction |
|---|---|
| stale-run resume (cpp#807) | **over**-reports success |
| test under-count (cpp#806) | **under**-reports scope |
| this one | **over**-reports failure |

Worth stating because a reader who has only seen the false-green fixes will assume the corrections all push toward strictness.

**Triage note worth having before debugging any red gate:** check whether the failures reproduce under a bare `make test` first.

## Tests

Nine new. Both directions pinned — a genuine failure is still a bare `FAILED`, and a change that called everything a timeout would pass the timeout assertions while destroying the distinction they exist for.

## Gate

`make verify` — all nine targets confirmed executed: ruff, **2211 pytest**, mypy over 194 files, binary-guards, negative-fixture, claude-md-budget/links/behavior, project-next-vendor. Generated Codex copies re-synced (#506) — the parity test caught the drift, which is the check working.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zji5qgFeVaffLwDKRMXp
