### PR TITLE
fix(cicd): discard a resumable run when the tree changed since it failed (Closes #804)

### DIFF
--- a/codex/skills/flow-auto/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-auto/scripts/flow-finish-gate.sh
@@ -45,7 +45,12 @@
 #           or a test step exited 0 having executed no tests
 #           (issue #621), OR a failed test was re-run against only
 #           its failed ids and PASSED (issue #769 - `warn (rerun
-#           passed: ...)`). Every qualification names the reason.
+#           passed: ...)`), OR a resumed run carried a step's result
+#           from an earlier invocation WITHOUT proof the tree was
+#           unchanged since (issue #804 - `warn (carried, unverified:
+#           ...)`). A carry the runner verified via tree_signature is
+#           NOT a warning - see the #804 note below. Every
+#           qualification names the reason.
 #   skipped no runner AND no Makefile/pyproject gates to run     -> exit 0
 #
 # The #621/#628/#769 qualification exists because this helper is the layer the flow
@@ -61,6 +66,22 @@
 # because this helper invokes whatever CPP checkout is installed. That checkout
 # may predate #769: an unknown env var is ignored, while an unknown argparse flag
 # is a hard error that prevents the quality gate from running at all.
+#
+# #804 - a resumed run and the bare `ok` it must not print silently:
+#   The runner can auto-resume a failed run from its last completed step. That
+#   is correct for a crash (the tree is unchanged) and wrong for a repair (the
+#   fix changed the tree, so the step that would exercise it is exactly the
+#   one the resume skips). The runner now hashes the tree at persist time and
+#   again before honoring a resume: a mismatch discards the stale state and
+#   starts fresh, so a repair-resume can no longer print a bare `ok` while
+#   carrying a stale result. This helper's job is the case the runner cannot
+#   close on its own - no git, or a state file older than this field - where
+#   it still resumes (so a non-git target project does not regress) but marks
+#   the carry unverified. This helper turns that into `warn`, never a bare
+#   `ok`, and warns ONLY on "carried AND NOT verified" - a verified carry
+#   (`tree_verified: true`) is a proven-safe crash-resume, not a warning, and
+#   must stay silent: this fleet's runs get killed and resumed often, and
+#   warning on every legitimate one trains readers to stop reading the line.
 #
 # Env (test hooks - unset in normal use):
 #   FLOW_GATE_CPP_DIR   override the CPP checkout path (set empty to force
@@ -86,7 +107,7 @@ for arg in "$@"; do
         --plan=*) PLAN="${arg#--plan=}" ;;
         --check-summary) MODE="check-summary" ;;
         --help|-h)
-            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,90p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -220,6 +241,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         "$RUNNER_JSON" 2>/dev/null | head -1)
     TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
         "$RUNNER_JSON" 2>/dev/null | head -1)
+    # A resumed run may carry a step's result from an earlier invocation
+    # (issue #838 follow-up) - fine when the runner PROVED the tree hadn't
+    # changed since (issue #804, tree_verified), unverifiable otherwise. Same
+    # bracket-anchored array pull as SKIPPED_GATES above; step ids are free-
+    # form (not limited to lint/test/typecheck the way gates are), so match
+    # any quoted token instead of the fixed alternation.
+    CARRIED=$(sed -n '/"carried_from_previous_run": \[/,/\]/p' "$RUNNER_JSON" 2>/dev/null \
+        | grep -v ':' | grep -oE '"[^"]+"' | tr -d '"' | tr '\n' ' ' | sed 's/ *$//')
+    TREE_VERIFIED=0
+    if grep -q '"tree_verified": true' "$RUNNER_JSON" 2>/dev/null; then
+        TREE_VERIFIED=1
+    fi
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -231,6 +264,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         if [[ -n "$SKIPPED_GATES" ]]; then
             echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no configured tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
             verdict "warn (skipped gates: $SKIPPED_GATES)"
+            exit 0
+        fi
+        # A carried step is fine when the runner PROVED the tree hadn't
+        # changed (tree_verified) - that is a genuine crash-resume, and
+        # warning on it would fire on every ordinary killed-and-resumed run
+        # in this fleet, training readers to ignore the line (issue #804).
+        # Warn ONLY when something was carried AND that proof is missing -
+        # no git, or a state file older than the tree_signature field - which
+        # is exactly the case this helper, not the runner, has to catch.
+        if [[ -n "$CARRIED" && "$TREE_VERIFIED" -ne 1 ]]; then
+            echo "WARNING: step(s) carried a result from an earlier invocation WITHOUT proof the tree was unchanged since: $CARRIED. This gate did not verify those steps against the current tree - do not read as 'safe to merge' until you know why verification was unavailable (issue #804)." >&2
+            verdict "warn (carried, unverified: $CARRIED)"
             exit 0
         fi
         if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/codex/skills/flow-check/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-check/scripts/flow-finish-gate.sh
@@ -45,7 +45,12 @@
 #           or a test step exited 0 having executed no tests
 #           (issue #621), OR a failed test was re-run against only
 #           its failed ids and PASSED (issue #769 - `warn (rerun
-#           passed: ...)`). Every qualification names the reason.
+#           passed: ...)`), OR a resumed run carried a step's result
+#           from an earlier invocation WITHOUT proof the tree was
+#           unchanged since (issue #804 - `warn (carried, unverified:
+#           ...)`). A carry the runner verified via tree_signature is
+#           NOT a warning - see the #804 note below. Every
+#           qualification names the reason.
 #   skipped no runner AND no Makefile/pyproject gates to run     -> exit 0
 #
 # The #621/#628/#769 qualification exists because this helper is the layer the flow
@@ -61,6 +66,22 @@
 # because this helper invokes whatever CPP checkout is installed. That checkout
 # may predate #769: an unknown env var is ignored, while an unknown argparse flag
 # is a hard error that prevents the quality gate from running at all.
+#
+# #804 - a resumed run and the bare `ok` it must not print silently:
+#   The runner can auto-resume a failed run from its last completed step. That
+#   is correct for a crash (the tree is unchanged) and wrong for a repair (the
+#   fix changed the tree, so the step that would exercise it is exactly the
+#   one the resume skips). The runner now hashes the tree at persist time and
+#   again before honoring a resume: a mismatch discards the stale state and
+#   starts fresh, so a repair-resume can no longer print a bare `ok` while
+#   carrying a stale result. This helper's job is the case the runner cannot
+#   close on its own - no git, or a state file older than this field - where
+#   it still resumes (so a non-git target project does not regress) but marks
+#   the carry unverified. This helper turns that into `warn`, never a bare
+#   `ok`, and warns ONLY on "carried AND NOT verified" - a verified carry
+#   (`tree_verified: true`) is a proven-safe crash-resume, not a warning, and
+#   must stay silent: this fleet's runs get killed and resumed often, and
+#   warning on every legitimate one trains readers to stop reading the line.
 #
 # Env (test hooks - unset in normal use):
 #   FLOW_GATE_CPP_DIR   override the CPP checkout path (set empty to force
@@ -86,7 +107,7 @@ for arg in "$@"; do
         --plan=*) PLAN="${arg#--plan=}" ;;
         --check-summary) MODE="check-summary" ;;
         --help|-h)
-            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,90p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -220,6 +241,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         "$RUNNER_JSON" 2>/dev/null | head -1)
     TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
         "$RUNNER_JSON" 2>/dev/null | head -1)
+    # A resumed run may carry a step's result from an earlier invocation
+    # (issue #838 follow-up) - fine when the runner PROVED the tree hadn't
+    # changed since (issue #804, tree_verified), unverifiable otherwise. Same
+    # bracket-anchored array pull as SKIPPED_GATES above; step ids are free-
+    # form (not limited to lint/test/typecheck the way gates are), so match
+    # any quoted token instead of the fixed alternation.
+    CARRIED=$(sed -n '/"carried_from_previous_run": \[/,/\]/p' "$RUNNER_JSON" 2>/dev/null \
+        | grep -v ':' | grep -oE '"[^"]+"' | tr -d '"' | tr '\n' ' ' | sed 's/ *$//')
+    TREE_VERIFIED=0
+    if grep -q '"tree_verified": true' "$RUNNER_JSON" 2>/dev/null; then
+        TREE_VERIFIED=1
+    fi
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -231,6 +264,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         if [[ -n "$SKIPPED_GATES" ]]; then
             echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no configured tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
             verdict "warn (skipped gates: $SKIPPED_GATES)"
+            exit 0
+        fi
+        # A carried step is fine when the runner PROVED the tree hadn't
+        # changed (tree_verified) - that is a genuine crash-resume, and
+        # warning on it would fire on every ordinary killed-and-resumed run
+        # in this fleet, training readers to ignore the line (issue #804).
+        # Warn ONLY when something was carried AND that proof is missing -
+        # no git, or a state file older than the tree_signature field - which
+        # is exactly the case this helper, not the runner, has to catch.
+        if [[ -n "$CARRIED" && "$TREE_VERIFIED" -ne 1 ]]; then
+            echo "WARNING: step(s) carried a result from an earlier invocation WITHOUT proof the tree was unchanged since: $CARRIED. This gate did not verify those steps against the current tree - do not read as 'safe to merge' until you know why verification was unavailable (issue #804)." >&2
+            verdict "warn (carried, unverified: $CARRIED)"
             exit 0
         fi
         if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/codex/skills/flow-finish/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-finish/scripts/flow-finish-gate.sh
@@ -45,7 +45,12 @@
 #           or a test step exited 0 having executed no tests
 #           (issue #621), OR a failed test was re-run against only
 #           its failed ids and PASSED (issue #769 - `warn (rerun
-#           passed: ...)`). Every qualification names the reason.
+#           passed: ...)`), OR a resumed run carried a step's result
+#           from an earlier invocation WITHOUT proof the tree was
+#           unchanged since (issue #804 - `warn (carried, unverified:
+#           ...)`). A carry the runner verified via tree_signature is
+#           NOT a warning - see the #804 note below. Every
+#           qualification names the reason.
 #   skipped no runner AND no Makefile/pyproject gates to run     -> exit 0
 #
 # The #621/#628/#769 qualification exists because this helper is the layer the flow
@@ -61,6 +66,22 @@
 # because this helper invokes whatever CPP checkout is installed. That checkout
 # may predate #769: an unknown env var is ignored, while an unknown argparse flag
 # is a hard error that prevents the quality gate from running at all.
+#
+# #804 - a resumed run and the bare `ok` it must not print silently:
+#   The runner can auto-resume a failed run from its last completed step. That
+#   is correct for a crash (the tree is unchanged) and wrong for a repair (the
+#   fix changed the tree, so the step that would exercise it is exactly the
+#   one the resume skips). The runner now hashes the tree at persist time and
+#   again before honoring a resume: a mismatch discards the stale state and
+#   starts fresh, so a repair-resume can no longer print a bare `ok` while
+#   carrying a stale result. This helper's job is the case the runner cannot
+#   close on its own - no git, or a state file older than this field - where
+#   it still resumes (so a non-git target project does not regress) but marks
+#   the carry unverified. This helper turns that into `warn`, never a bare
+#   `ok`, and warns ONLY on "carried AND NOT verified" - a verified carry
+#   (`tree_verified: true`) is a proven-safe crash-resume, not a warning, and
+#   must stay silent: this fleet's runs get killed and resumed often, and
+#   warning on every legitimate one trains readers to stop reading the line.
 #
 # Env (test hooks - unset in normal use):
 #   FLOW_GATE_CPP_DIR   override the CPP checkout path (set empty to force
@@ -86,7 +107,7 @@ for arg in "$@"; do
         --plan=*) PLAN="${arg#--plan=}" ;;
         --check-summary) MODE="check-summary" ;;
         --help|-h)
-            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,90p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -220,6 +241,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         "$RUNNER_JSON" 2>/dev/null | head -1)
     TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
         "$RUNNER_JSON" 2>/dev/null | head -1)
+    # A resumed run may carry a step's result from an earlier invocation
+    # (issue #838 follow-up) - fine when the runner PROVED the tree hadn't
+    # changed since (issue #804, tree_verified), unverifiable otherwise. Same
+    # bracket-anchored array pull as SKIPPED_GATES above; step ids are free-
+    # form (not limited to lint/test/typecheck the way gates are), so match
+    # any quoted token instead of the fixed alternation.
+    CARRIED=$(sed -n '/"carried_from_previous_run": \[/,/\]/p' "$RUNNER_JSON" 2>/dev/null \
+        | grep -v ':' | grep -oE '"[^"]+"' | tr -d '"' | tr '\n' ' ' | sed 's/ *$//')
+    TREE_VERIFIED=0
+    if grep -q '"tree_verified": true' "$RUNNER_JSON" 2>/dev/null; then
+        TREE_VERIFIED=1
+    fi
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -231,6 +264,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         if [[ -n "$SKIPPED_GATES" ]]; then
             echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no configured tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
             verdict "warn (skipped gates: $SKIPPED_GATES)"
+            exit 0
+        fi
+        # A carried step is fine when the runner PROVED the tree hadn't
+        # changed (tree_verified) - that is a genuine crash-resume, and
+        # warning on it would fire on every ordinary killed-and-resumed run
+        # in this fleet, training readers to ignore the line (issue #804).
+        # Warn ONLY when something was carried AND that proof is missing -
+        # no git, or a state file older than the tree_signature field - which
+        # is exactly the case this helper, not the runner, has to catch.
+        if [[ -n "$CARRIED" && "$TREE_VERIFIED" -ne 1 ]]; then
+            echo "WARNING: step(s) carried a result from an earlier invocation WITHOUT proof the tree was unchanged since: $CARRIED. This gate did not verify those steps against the current tree - do not read as 'safe to merge' until you know why verification was unavailable (issue #804)." >&2
+            verdict "warn (carried, unverified: $CARRIED)"
             exit 0
         fi
         if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/codex/skills/flow-merge/scripts/flow-finish-gate.sh
+++ b/codex/skills/flow-merge/scripts/flow-finish-gate.sh
@@ -45,7 +45,12 @@
 #           or a test step exited 0 having executed no tests
 #           (issue #621), OR a failed test was re-run against only
 #           its failed ids and PASSED (issue #769 - `warn (rerun
-#           passed: ...)`). Every qualification names the reason.
+#           passed: ...)`), OR a resumed run carried a step's result
+#           from an earlier invocation WITHOUT proof the tree was
+#           unchanged since (issue #804 - `warn (carried, unverified:
+#           ...)`). A carry the runner verified via tree_signature is
+#           NOT a warning - see the #804 note below. Every
+#           qualification names the reason.
 #   skipped no runner AND no Makefile/pyproject gates to run     -> exit 0
 #
 # The #621/#628/#769 qualification exists because this helper is the layer the flow
@@ -61,6 +66,22 @@
 # because this helper invokes whatever CPP checkout is installed. That checkout
 # may predate #769: an unknown env var is ignored, while an unknown argparse flag
 # is a hard error that prevents the quality gate from running at all.
+#
+# #804 - a resumed run and the bare `ok` it must not print silently:
+#   The runner can auto-resume a failed run from its last completed step. That
+#   is correct for a crash (the tree is unchanged) and wrong for a repair (the
+#   fix changed the tree, so the step that would exercise it is exactly the
+#   one the resume skips). The runner now hashes the tree at persist time and
+#   again before honoring a resume: a mismatch discards the stale state and
+#   starts fresh, so a repair-resume can no longer print a bare `ok` while
+#   carrying a stale result. This helper's job is the case the runner cannot
+#   close on its own - no git, or a state file older than this field - where
+#   it still resumes (so a non-git target project does not regress) but marks
+#   the carry unverified. This helper turns that into `warn`, never a bare
+#   `ok`, and warns ONLY on "carried AND NOT verified" - a verified carry
+#   (`tree_verified: true`) is a proven-safe crash-resume, not a warning, and
+#   must stay silent: this fleet's runs get killed and resumed often, and
+#   warning on every legitimate one trains readers to stop reading the line.
 #
 # Env (test hooks - unset in normal use):
 #   FLOW_GATE_CPP_DIR   override the CPP checkout path (set empty to force
@@ -86,7 +107,7 @@ for arg in "$@"; do
         --plan=*) PLAN="${arg#--plan=}" ;;
         --check-summary) MODE="check-summary" ;;
         --help|-h)
-            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,90p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -220,6 +241,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         "$RUNNER_JSON" 2>/dev/null | head -1)
     TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
         "$RUNNER_JSON" 2>/dev/null | head -1)
+    # A resumed run may carry a step's result from an earlier invocation
+    # (issue #838 follow-up) - fine when the runner PROVED the tree hadn't
+    # changed since (issue #804, tree_verified), unverifiable otherwise. Same
+    # bracket-anchored array pull as SKIPPED_GATES above; step ids are free-
+    # form (not limited to lint/test/typecheck the way gates are), so match
+    # any quoted token instead of the fixed alternation.
+    CARRIED=$(sed -n '/"carried_from_previous_run": \[/,/\]/p' "$RUNNER_JSON" 2>/dev/null \
+        | grep -v ':' | grep -oE '"[^"]+"' | tr -d '"' | tr '\n' ' ' | sed 's/ *$//')
+    TREE_VERIFIED=0
+    if grep -q '"tree_verified": true' "$RUNNER_JSON" 2>/dev/null; then
+        TREE_VERIFIED=1
+    fi
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -231,6 +264,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         if [[ -n "$SKIPPED_GATES" ]]; then
             echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no configured tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
             verdict "warn (skipped gates: $SKIPPED_GATES)"
+            exit 0
+        fi
+        # A carried step is fine when the runner PROVED the tree hadn't
+        # changed (tree_verified) - that is a genuine crash-resume, and
+        # warning on it would fire on every ordinary killed-and-resumed run
+        # in this fleet, training readers to ignore the line (issue #804).
+        # Warn ONLY when something was carried AND that proof is missing -
+        # no git, or a state file older than the tree_signature field - which
+        # is exactly the case this helper, not the runner, has to catch.
+        if [[ -n "$CARRIED" && "$TREE_VERIFIED" -ne 1 ]]; then
+            echo "WARNING: step(s) carried a result from an earlier invocation WITHOUT proof the tree was unchanged since: $CARRIED. This gate did not verify those steps against the current tree - do not read as 'safe to merge' until you know why verification was unavailable (issue #804)." >&2
+            verdict "warn (carried, unverified: $CARRIED)"
             exit 0
         fi
         if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any, Optional, TextIO
 
 from .outcomes import parse_failed_node_ids
-from .state import RunState, StepStatus
+from .state import RunState, StepStatus, compute_tree_signature
 from .steps import (
     GATE_STEP_IDS,
     TIMEOUT_EXIT_CODE,
@@ -153,6 +153,15 @@ class RunResult:
     # success - which is exactly why the old `step_details` block could never
     # have shown this on the green path it matters most on.
     carried_from_previous_run: list[str] = field(default_factory=list)
+    # True when carried_from_previous_run is non-empty AND the carry was
+    # backed by a tree_signature match rather than assumed (issue #804): the
+    # tree was hashed at persist time and again at resume time, and the two
+    # were equal, so this is a genuine crash-resume and the carried results
+    # still describe the tree. False (the default) covers both "nothing was
+    # carried" and "something was carried but we could not verify the tree
+    # hadn't changed" - flow-finish-gate.sh tells those apart by also
+    # checking carried_from_previous_run, and warns only on the second.
+    tree_verified: bool = False
     # Full per-step detail, captured BEFORE the success cleanup removes the
     # state file so a green run can report it at all.
     step_details: list[dict[str, Any]] = field(default_factory=list)
@@ -216,14 +225,45 @@ class DeterministicRunner:
     def run(self, plan_name: str, step_defs: Optional[list[StepDef]] = None) -> RunResult:
         """Execute a named plan from scratch or resume a failed run.
 
-        If a failed run exists for this plan, it will be resumed automatically.
+        If a failed run exists for this plan, it is resumed automatically -
+        UNLESS the working tree changed since that run failed (issue #804).
+        Resume is correct for a crash (the tree the failure left behind is
+        still the tree we're about to skip re-testing); it is wrong for a
+        repair (the tree changed - usually because the failure was fixed -
+        so the results we'd carry describe a tree that no longer exists).
+        Which one this is gets decided by comparing tree_signature, not by
+        guessing: a match resumes exactly as before this fix, a mismatch
+        discards the stale state and starts fresh so every step actually
+        runs against the current tree.
         """
         # Check for existing failed run to resume
         existing = RunState.find_latest(plan_name, self.project_root)
+        current_sig: Optional[str] = None
         if existing:
-            self._log(f"Resuming failed run {existing.run_id} from step {existing.current_index + 1}")
-            self._warn_carried_over(existing)
-            return self._execute(existing, step_defs)
+            current_sig = compute_tree_signature(self.project_root)
+            if (
+                existing.tree_signature is not None
+                and current_sig is not None
+                and existing.tree_signature != current_sig
+            ):
+                self._log(
+                    f"Discarding resumable run {existing.run_id}: the tree "
+                    f"changed since step {existing.current_index + 1} failed "
+                    "(issue #804) - starting fresh so every step re-runs "
+                    "against the current tree."
+                )
+                existing.discard(self.project_root)
+                existing = None
+            else:
+                # Verified only when BOTH signatures were available and equal.
+                # Either side being None means "can't tell" - resume anyway
+                # (the pre-#804 behavior, so a non-git target project doesn't
+                # regress) but the result must say the carry is unverified so
+                # flow-finish-gate.sh's fallback check can still catch it.
+                tree_verified = existing.tree_signature is not None and current_sig is not None
+                self._log(f"Resuming failed run {existing.run_id} from step {existing.current_index + 1}")
+                self._warn_carried_over(existing, tree_verified)
+                return self._execute(existing, step_defs, tree_verified=tree_verified)
 
         # Load step definitions
         if step_defs is None:
@@ -232,6 +272,11 @@ class DeterministicRunner:
         # Create new run state
         step_ids = [s.id for s in step_defs]
         state = RunState.create(plan_name, step_ids)
+        # Reuse the signature already computed above when a stale run was
+        # just discarded, rather than shelling out to git a second time.
+        state.tree_signature = current_sig if current_sig is not None else compute_tree_signature(
+            self.project_root
+        )
 
         # Set max_attempts from step definitions
         for i, step_def in enumerate(step_defs):
@@ -270,7 +315,7 @@ class DeterministicRunner:
         state = RunState.load(run_id, self.project_root)
         return state.summary()
 
-    def _warn_carried_over(self, state: RunState) -> None:
+    def _warn_carried_over(self, state: RunState, tree_verified: bool = False) -> None:
         """Name the steps this invocation will NOT execute (issue #838 follow-up).
 
         A resumed run starts at ``current_index``, so every earlier step keeps
@@ -286,6 +331,12 @@ class DeterministicRunner:
         caught by out-of-band knowledge - grepping for "Resuming" and counting
         pytest invocations, and remembering a hand-run ``make lint`` - neither of
         which is a property of the output.
+
+        ``tree_verified`` (issue #804): true when this resume's tree_signature
+        was compared against the current tree and matched, so "the tree may
+        since have changed" is no longer a maybe - it's checked. The message
+        softens accordingly; callers that can't verify (no git, old state
+        file) get the original, more cautious wording.
         """
         carried = [
             record.step_id
@@ -294,15 +345,34 @@ class DeterministicRunner:
         ]
         if not carried:
             return
-        self._log(
-            f"  NOTE: {len(carried)} step(s) will NOT run in this invocation "
-            f"and keep their earlier result: {', '.join(carried)}. "
-            "If the tree changed since that run, those results are stale - "
-            "they are marked carried_from_previous_run in step_details."
-        )
+        if tree_verified:
+            self._log(
+                f"  NOTE: {len(carried)} step(s) will NOT run in this invocation "
+                f"and keep their earlier result: {', '.join(carried)}. "
+                "The tree is verified unchanged since then (issue #804) - "
+                "those results still describe it."
+            )
+        else:
+            self._log(
+                f"  NOTE: {len(carried)} step(s) will NOT run in this invocation "
+                f"and keep their earlier result: {', '.join(carried)}. "
+                "If the tree changed since that run, those results are stale - "
+                "they are marked carried_from_previous_run in step_details."
+            )
 
-    def _execute(self, state: RunState, step_defs: Optional[list[StepDef]] = None) -> RunResult:
-        """Execute steps from the current state index."""
+    def _execute(
+        self,
+        state: RunState,
+        step_defs: Optional[list[StepDef]] = None,
+        tree_verified: bool = False,
+    ) -> RunResult:
+        """Execute steps from the current state index.
+
+        ``tree_verified`` (issue #804): passed through from run() when this
+        is a resume whose tree_signature matched - see RunResult.tree_verified.
+        False on a fresh run (nothing carried, so it's meaningless) and on a
+        resume that couldn't be verified.
+        """
         # Where THIS invocation began, so the summary can distinguish a result
         # earned now from one carried over (issue #838 follow-up).
         executed_from = state.current_index
@@ -524,6 +594,7 @@ class DeterministicRunner:
                     warnings=warnings,
                     reruns=reruns,
                     skipped_steps=skipped,
+                    tree_verified=tree_verified,
                 )
 
         # All steps completed successfully
@@ -589,12 +660,20 @@ class DeterministicRunner:
             if entry.get("carried_from_previous_run")
         ]
         if success_carried:
-            self._log(
-                f"  NOTE: this run succeeded, but {len(success_carried)} step(s) "
-                f"kept a result from an earlier invocation: "
-                f"{', '.join(success_carried)}. If the tree changed since, those "
-                "results do not describe it."
-            )
+            if tree_verified:
+                self._log(
+                    f"  NOTE: this run succeeded, and {len(success_carried)} step(s) "
+                    f"kept a result from an earlier invocation: "
+                    f"{', '.join(success_carried)}. The tree is verified unchanged "
+                    "since then (issue #804) - those results still describe it."
+                )
+            else:
+                self._log(
+                    f"  NOTE: this run succeeded, but {len(success_carried)} step(s) "
+                    f"kept a result from an earlier invocation: "
+                    f"{', '.join(success_carried)}. If the tree changed since, those "
+                    "results do not describe it."
+                )
 
         # Clean up state file on success
         state.cleanup(self.project_root)
@@ -603,6 +682,7 @@ class DeterministicRunner:
             success=True,
             step_details=success_details,
             carried_from_previous_run=success_carried,
+            tree_verified=tree_verified,
             run_id=state.run_id,
             plan_name=state.plan_name,
             steps_completed=completed,
@@ -669,6 +749,14 @@ def run_plan(
         ]
         if carried:
             output["carried_from_previous_run"] = carried
+            # Only meaningful alongside a non-empty carry (issue #804):
+            # whether the carry was backed by a tree_signature match
+            # (RunResult.tree_verified) or merely assumed, as it was before
+            # this field existed. flow-finish-gate.sh warns on carried-but-
+            # unverified and stays quiet on carried-and-verified - the
+            # distinction between "the mechanism proved this is safe" and
+            # "we don't know, so we're telling you".
+            output["tree_verified"] = result.tree_verified
 
         print(json.dumps(output, indent=2))
 

--- a/lib/cicd/state.py
+++ b/lib/cicd/state.py
@@ -7,6 +7,10 @@ failed runs can be resumed from the last successful step.
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
+import tempfile
 import time
 import uuid
 from dataclasses import asdict, dataclass, field, fields
@@ -57,6 +61,94 @@ class StepRecord:
         return cls(**{k: v for k, v in data.items() if k in known})
 
 
+def compute_tree_signature(project_root: Path) -> Optional[str]:
+    """Content signature of the working tree, or None when it can't be trusted.
+
+    Used to tell a genuine crash-resume (the tree a failed run left behind is
+    still the tree we're about to resume against) apart from a repair-resume
+    (the tree changed - usually because the failure was fixed - so any step
+    result earned against the OLD tree no longer describes the one we're
+    about to skip re-running it against). Issue #804.
+
+    Deliberately a CONTENT hash (via a scratch git index + ``git write-tree``,
+    scoped to tracked + untracked-but-not-gitignored files), not a cheaper
+    ``git status`` (paths + M/A/D codes, no content). A status-only signature
+    was considered and rejected: it cannot distinguish a file that was
+    modified once from one modified TWICE between the two runner invocations
+    - both show the identical status line ``M path``, so the signature would
+    match and the stale result would be carried anyway. That is not a rare
+    edge case, it is this fleet's most common repair loop: a gate fails on an
+    uncommitted change, the SAME file is edited again to fix it, nothing is
+    committed until the gate goes green. A status-only signature would have
+    shipped as a fix for #804 and fixed nothing in exactly the case #804 was
+    filed for.
+
+    The scratch index is created via ``GIT_INDEX_FILE`` so this never touches
+    the caller's real index or working tree - safe to call from inside a live
+    ``run()`` without side effects on the checkout it's inspecting.
+
+    ``.claude/runs/`` - this runner's OWN state directory - is excluded
+    unconditionally, not left to the target project's ``.gitignore``. It
+    lives inside ``project_root`` and a failed run writes its state file
+    there before this function is ever asked to verify a resume, so without
+    the exclusion the file `find_latest()` is about to read back would
+    itself be new input to the hash: signature-at-persist-time computed
+    before the file existed, signature-at-resume-time computed after -
+    mismatched on every single resume regardless of whether the TREE changed
+    at all, silently deleting the crash-safety this feature exists for. CPP's
+    own ``.gitignore`` happens to cover this path, which is exactly why this
+    bug did not show up testing against a CPP checkout and only surfaced
+    against a bare scratch repo with no ``.gitignore`` - a target project
+    cannot be trusted to have made the same choice, so the exclusion does not
+    depend on it.
+
+    Returns None - "cannot verify" - rather than raising, on any of: no
+    ``git`` binary, ``project_root`` is not a git repository, or any
+    subprocess/OS failure (timeout, permissions). Callers MUST treat None as
+    unverifiable and fall back to the pre-#804 unconditional-resume behavior;
+    this function never turns "I don't know" into "nothing changed".
+    """
+    if shutil.which("git") is None:
+        return None
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {**os.environ, "GIT_INDEX_FILE": str(Path(tmp) / "index")}
+            subprocess.run(
+                ["git", "-C", str(project_root), "add", "-A"],
+                env=env,
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+            # Drop the runner's own bookkeeping from the scratch index before
+            # hashing it - see the docstring above. --ignore-unmatch so a run
+            # with no .claude/runs/ yet (nothing has failed here before) is
+            # not an error.
+            subprocess.run(
+                [
+                    "git", "-C", str(project_root),
+                    "rm", "-r", "--cached", "--ignore-unmatch", "-q",
+                    "--", ".claude/runs",
+                ],
+                env=env,
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+            result = subprocess.run(
+                ["git", "-C", str(project_root), "write-tree"],
+                env=env,
+                check=True,
+                capture_output=True,
+                timeout=30,
+                text=True,
+            )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    signature = result.stdout.strip()
+    return signature or None
+
+
 @dataclass
 class RunState:
     """Persistent state for a runner execution.
@@ -72,6 +164,17 @@ class RunState:
     started_at: Optional[str] = None
     finished_at: Optional[str] = None
     status: str = "running"  # running, success, failed
+    # Content signature of the working tree at the moment this run first
+    # became resumable (issue #804), from compute_tree_signature(). Compared
+    # against a freshly computed signature before a resume is honored: equal
+    # means a genuine crash left the tree untouched, so carried-over step
+    # results are still valid; different means the tree changed - the usual
+    # reason to resume is that something was fixed - so those results
+    # describe a tree that no longer exists. None on a state file written
+    # before this field existed, or when the signature could not be computed
+    # (no git, not a repo); either way the caller must treat it as
+    # unverifiable and fall back to the pre-#804 unconditional resume.
+    tree_signature: Optional[str] = None
 
     @classmethod
     def create(cls, plan_name: str, step_ids: list[str]) -> RunState:
@@ -108,6 +211,17 @@ class RunState:
         state_file = root / ".claude" / "runs" / f"{self.run_id}.json"
         if state_file.exists():
             state_file.unlink()
+
+    def discard(self, project_root: Optional[Path] = None) -> None:
+        """Remove state file because it was invalidated, not because it succeeded.
+
+        Same file operation as cleanup() - both just delete the state file -
+        but a different name at the call site (issue #804): the runner calls
+        this when a resumable failed run's tree_signature no longer matches
+        the current tree, so a reader of runner.py sees WHY the file is gone
+        without following cleanup()'s docstring into the wrong story.
+        """
+        self.cleanup(project_root)
 
     def mark_step_running(self, index: int) -> None:
         """Mark a step as running."""
@@ -180,6 +294,7 @@ class RunState:
             "started_at": self.started_at,
             "finished_at": self.finished_at,
             "status": self.status,
+            "tree_signature": self.tree_signature,
         }
 
     @classmethod

--- a/scripts/flow-finish-gate.sh
+++ b/scripts/flow-finish-gate.sh
@@ -45,7 +45,12 @@
 #           or a test step exited 0 having executed no tests
 #           (issue #621), OR a failed test was re-run against only
 #           its failed ids and PASSED (issue #769 - `warn (rerun
-#           passed: ...)`). Every qualification names the reason.
+#           passed: ...)`), OR a resumed run carried a step's result
+#           from an earlier invocation WITHOUT proof the tree was
+#           unchanged since (issue #804 - `warn (carried, unverified:
+#           ...)`). A carry the runner verified via tree_signature is
+#           NOT a warning - see the #804 note below. Every
+#           qualification names the reason.
 #   skipped no runner AND no Makefile/pyproject gates to run     -> exit 0
 #
 # The #621/#628/#769 qualification exists because this helper is the layer the flow
@@ -61,6 +66,22 @@
 # because this helper invokes whatever CPP checkout is installed. That checkout
 # may predate #769: an unknown env var is ignored, while an unknown argparse flag
 # is a hard error that prevents the quality gate from running at all.
+#
+# #804 - a resumed run and the bare `ok` it must not print silently:
+#   The runner can auto-resume a failed run from its last completed step. That
+#   is correct for a crash (the tree is unchanged) and wrong for a repair (the
+#   fix changed the tree, so the step that would exercise it is exactly the
+#   one the resume skips). The runner now hashes the tree at persist time and
+#   again before honoring a resume: a mismatch discards the stale state and
+#   starts fresh, so a repair-resume can no longer print a bare `ok` while
+#   carrying a stale result. This helper's job is the case the runner cannot
+#   close on its own - no git, or a state file older than this field - where
+#   it still resumes (so a non-git target project does not regress) but marks
+#   the carry unverified. This helper turns that into `warn`, never a bare
+#   `ok`, and warns ONLY on "carried AND NOT verified" - a verified carry
+#   (`tree_verified: true`) is a proven-safe crash-resume, not a warning, and
+#   must stay silent: this fleet's runs get killed and resumed often, and
+#   warning on every legitimate one trains readers to stop reading the line.
 #
 # Env (test hooks - unset in normal use):
 #   FLOW_GATE_CPP_DIR   override the CPP checkout path (set empty to force
@@ -86,7 +107,7 @@ for arg in "$@"; do
         --plan=*) PLAN="${arg#--plan=}" ;;
         --check-summary) MODE="check-summary" ;;
         --help|-h)
-            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,90p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -220,6 +241,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         "$RUNNER_JSON" 2>/dev/null | head -1)
     TIMED_OUT_AFTER=$(sed -n 's/^  "timed_out_after": \([0-9]*\),\?$/\1/p' \
         "$RUNNER_JSON" 2>/dev/null | head -1)
+    # A resumed run may carry a step's result from an earlier invocation
+    # (issue #838 follow-up) - fine when the runner PROVED the tree hadn't
+    # changed since (issue #804, tree_verified), unverifiable otherwise. Same
+    # bracket-anchored array pull as SKIPPED_GATES above; step ids are free-
+    # form (not limited to lint/test/typecheck the way gates are), so match
+    # any quoted token instead of the fixed alternation.
+    CARRIED=$(sed -n '/"carried_from_previous_run": \[/,/\]/p' "$RUNNER_JSON" 2>/dev/null \
+        | grep -v ':' | grep -oE '"[^"]+"' | tr -d '"' | tr '\n' ' ' | sed 's/ *$//')
+    TREE_VERIFIED=0
+    if grep -q '"tree_verified": true' "$RUNNER_JSON" 2>/dev/null; then
+        TREE_VERIFIED=1
+    fi
     rm -f "$RUNNER_JSON"
     # Print the #769 evidence before verdict precedence is applied: a later
     # failing step or skipped gates are more serious, but must not erase a flake
@@ -231,6 +264,18 @@ if [[ "$RUNNER_OK" -eq 1 ]]; then
         if [[ -n "$SKIPPED_GATES" ]]; then
             echo "WARNING: quality gates did NOT run: $SKIPPED_GATES (no Makefile target and no configured tool). This gate proved nothing about those checks - do not read as 'safe to merge' (issue #628)." >&2
             verdict "warn (skipped gates: $SKIPPED_GATES)"
+            exit 0
+        fi
+        # A carried step is fine when the runner PROVED the tree hadn't
+        # changed (tree_verified) - that is a genuine crash-resume, and
+        # warning on it would fire on every ordinary killed-and-resumed run
+        # in this fleet, training readers to ignore the line (issue #804).
+        # Warn ONLY when something was carried AND that proof is missing -
+        # no git, or a state file older than the tree_signature field - which
+        # is exactly the case this helper, not the runner, has to catch.
+        if [[ -n "$CARRIED" && "$TREE_VERIFIED" -ne 1 ]]; then
+            echo "WARNING: step(s) carried a result from an earlier invocation WITHOUT proof the tree was unchanged since: $CARRIED. This gate did not verify those steps against the current tree - do not read as 'safe to merge' until you know why verification was unavailable (issue #804)." >&2
+            verdict "warn (carried, unverified: $CARRIED)"
             exit 0
         fi
         if [[ -n "$RERUN_PASSED_IDS" ]]; then

--- a/tests/test_flow_finish_gate.py
+++ b/tests/test_flow_finish_gate.py
@@ -673,6 +673,83 @@ def test_runner_skipped_non_gate_still_ok(tmp_path: Path) -> None:
     assert "warn" not in proc.stdout
 
 
+# --- #804: a resumed run carrying an unverified stale result -----------------
+#
+# The runner emits a top-level "carried_from_previous_run" array whenever a
+# resumed run kept a step's result rather than re-running it (issue #838
+# follow-up), and, since #804, a "tree_verified" flag saying whether that
+# carry was backed by a tree_signature match. This helper must warn on the
+# first WITHOUT the second - and stay silent when both are present, or every
+# ordinary crash-resume in this fleet would warn and train readers to stop
+# reading the line.
+
+
+@requires_bash
+def test_carried_unverified_is_warn(tmp_path: Path) -> None:
+    """No tree_verified key at all - e.g. a runner too old to set it, or one
+    that could not compute a signature (no git). The helper cannot prove the
+    carried step still describes the tree, so it must not say `ok`."""
+    cpp = _fake_cpp(tmp_path)
+    payload = (
+        '{\n  "success": true,\n  "steps_completed": 3,\n  "steps_total": 3,\n'
+        '  "carried_from_previous_run": [\n    "lint"\n  ]\n}'
+    )
+    proc = _run_with_uv_stub(tmp_path, cpp, payload)
+    assert proc.returncode == 0
+    assert "FLOW_FINISH_GATE: warn (carried, unverified: lint)" in proc.stdout
+    assert "FLOW_FINISH_GATE: ok" not in proc.stdout
+    assert "issue #804" in proc.stdout
+
+
+@requires_bash
+def test_carried_verified_stays_ok(tmp_path: Path) -> None:
+    """tree_verified: true means the runner hashed the tree at persist time
+    and again at resume time and they matched - a proven crash-resume, not an
+    assumption. This must NOT warn: it is the case option 3 exists to make
+    silent, and warning on it anyway would fire on every ordinary
+    killed-and-resumed run."""
+    cpp = _fake_cpp(tmp_path)
+    payload = (
+        '{\n  "success": true,\n  "steps_completed": 3,\n  "steps_total": 3,\n'
+        '  "carried_from_previous_run": [\n    "lint"\n  ],\n'
+        '  "tree_verified": true\n}'
+    )
+    proc = _run_with_uv_stub(tmp_path, cpp, payload)
+    assert proc.returncode == 0
+    assert "FLOW_FINISH_GATE: ok" in proc.stdout
+    assert "warn" not in proc.stdout
+
+
+@requires_bash
+def test_multiple_carried_steps_are_all_named(tmp_path: Path) -> None:
+    cpp = _fake_cpp(tmp_path)
+    payload = (
+        '{\n  "success": true,\n  "steps_completed": 3,\n  "steps_total": 3,\n'
+        '  "carried_from_previous_run": [\n    "lint",\n    "typecheck"\n  ]\n}'
+    )
+    proc = _run_with_uv_stub(tmp_path, cpp, payload)
+    assert proc.returncode == 0
+    assert "FLOW_FINISH_GATE: warn (carried, unverified: lint typecheck)" in proc.stdout
+
+
+@requires_bash
+def test_skipped_gates_still_win_over_unverified_carry(tmp_path: Path) -> None:
+    """Same precedence question #769 answered against #628: two true things can
+    be wrong about a run at once, and the verdict has to pick the more serious
+    one rather than let either erase the other. A gate that never ran at all
+    is more serious than a step whose result merely lacks proof, so skipped
+    wins - matching test_skipped_gates_win_but_rerun_ids_are_still_printed."""
+    cpp = _fake_cpp(tmp_path)
+    payload = (
+        '{\n  "success": true,\n  "steps_completed": 3,\n  "steps_total": 4,\n'
+        '  "carried_from_previous_run": [\n    "lint"\n  ],\n'
+        '  "skipped": [\n    "typecheck"\n  ]\n}'
+    )
+    proc = _run_with_uv_stub(tmp_path, cpp, payload)
+    assert proc.returncode == 0
+    assert "FLOW_FINISH_GATE: warn (skipped gates: typecheck)" in proc.stdout
+
+
 # ── Naming what ran, and seeing a larger gate (issue #808) ──────────────────
 #
 # The fallback runs lint/test/typecheck. A repo whose real gate is a larger

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,7 @@
 import os
 import re
 import shutil
+import subprocess
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -18,7 +19,7 @@ from lib.cicd.runner import (
     _project_python_floor,
     run_plan,
 )
-from lib.cicd.state import RunState, StepRecord
+from lib.cicd.state import RunState, StepRecord, compute_tree_signature
 from lib.cicd.steps import _CPP_ROOT, BUILTIN_PLANS, GATE_STEP_IDS, ShellStep, StepDef
 
 
@@ -26,6 +27,22 @@ from lib.cicd.steps import _CPP_ROOT, BUILTIN_PLANS, GATE_STEP_IDS, ShellStep, S
 def tmp_project(tmp_path: Path) -> Path:
     """Create a temporary project directory for runner tests."""
     return tmp_path
+
+
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not available (e.g. Woodpecker validate container)"
+)
+
+
+def _git_repo(root: Path) -> Path:
+    """Init a git repo at ``root`` with one commit, so write-tree has a base."""
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "init"],
+        cwd=root,
+        check=True,
+    )
+    return root
 
 
 class TestDeterministicRunner:
@@ -1239,3 +1256,132 @@ class TestTestStepBudgetIsConfigurable:
         from lib.cicd.steps import DEFAULT_TEST_STEP_TIMEOUT
 
         assert DEFAULT_TEST_STEP_TIMEOUT > 620
+
+
+@requires_git
+class TestResumeDiscardsWhenTreeChanged:
+    """Issue #804: resume is correct for a crash (tree unchanged) and wrong
+    for a repair (tree changed - the usual reason to resume at all). The
+    runner now tells them apart by comparing compute_tree_signature() at
+    persist time and at resume time, rather than assuming a resume is always
+    a crash.
+    """
+
+    def _steps(self, test_cmd: str) -> list[StepDef]:
+        return [
+            StepDef(id="lint", command="echo 'lint ok'", timeout_seconds=30),
+            StepDef(id="test", command=test_cmd, timeout_seconds=30),
+        ]
+
+    def test_discards_and_reruns_every_step_when_the_tree_changed(
+        self, tmp_project: Path
+    ):
+        """The core #804 regression pin.
+
+        Proving invalidation alone is not enough - a test that only checks
+        the state file is gone would pass against an implementation that
+        discards the state and then somehow still skips a step. This asserts
+        three things: the signatures actually differ (negative-fixture
+        precondition), the resumable state was discarded rather than
+        resumed, and 'lint' - step 1, the one a real repair loop almost
+        always edits - actually RE-EXECUTED in the second invocation.
+        """
+        _git_repo(tmp_project)
+        (tmp_project / "src.py").write_text("x = 1\n")
+
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+        before_sig = compute_tree_signature(tmp_project)
+        first = runner.run("finish", step_defs=self._steps("exit 1"))
+        assert not first.success
+
+        # The "fix": edit the same tracked file a repair loop would touch,
+        # and make the failing step pass - the same observable facts a real
+        # source-level fix produces.
+        (tmp_project / "src.py").write_text("x = 2  # fixed\n")
+        after_sig = compute_tree_signature(tmp_project)
+        # Precondition: this fixture is only a valid negative case if the
+        # tree actually changed. Assert that BEFORE trusting anything the
+        # discard logic does with it.
+        assert before_sig is not None and after_sig is not None
+        assert before_sig != after_sig
+
+        runner2 = DeterministicRunner(project_root=tmp_project, output=log)
+        second = runner2.run("finish", step_defs=self._steps("echo 'test ok'"))
+
+        assert second.success
+        assert second.carried_from_previous_run == [], (
+            "lint must NOT be carried - the tree changed since it last ran"
+        )
+        lint_entry = next(s for s in second.step_details if s["id"] == "lint")
+        assert lint_entry.get("carried_from_previous_run") is not True
+        assert "executed_in_this_run" not in lint_entry, (
+            "a step that genuinely re-ran this invocation carries neither "
+            "marking - see TestCarriedOverStepsAreMarked in test_runner_state.py"
+        )
+        first_line = log.getvalue().splitlines()[0]
+        assert first_line.startswith("Starting plan"), (
+            f"first line must read 'Starting plan', never 'Resuming failed "
+            f"run' - a resumed-looking first line on a run that actually "
+            f"re-ran everything is the exact false signal #804 is about; "
+            f"got: {first_line!r}"
+        )
+        assert "Discarding resumable run" in log.getvalue()
+
+    def test_resumes_and_carries_lint_when_the_tree_is_unchanged(
+        self, tmp_project: Path
+    ):
+        """The crash-safety regression guard - the mirror of the test above.
+
+        If this stops passing, the #804 fix removed the feature the issue
+        explicitly says not to break: a genuine crash (nothing about the
+        tree changed) must still resume, still carry the untouched step's
+        result, and must NOT re-run it.
+        """
+        _git_repo(tmp_project)
+
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+        before_sig = compute_tree_signature(tmp_project)
+        first = runner.run("finish", step_defs=self._steps("exit 1"))
+        assert not first.success
+
+        # Simulated crash: NOTHING about the tree changes between attempts.
+        after_sig = compute_tree_signature(tmp_project)
+        # Precondition: this fixture is only a valid positive case if the
+        # tree genuinely did not change.
+        assert before_sig is not None and after_sig is not None
+        assert before_sig == after_sig
+
+        runner2 = DeterministicRunner(project_root=tmp_project, output=log)
+        second = runner2.run("finish", step_defs=self._steps("echo 'test ok'"))
+
+        assert second.success
+        assert second.carried_from_previous_run == ["lint"]
+        assert second.tree_verified is True
+        lint_entry = next(s for s in second.step_details if s["id"] == "lint")
+        assert lint_entry["carried_from_previous_run"] is True
+        assert lint_entry["executed_in_this_run"] is False
+        assert "Resuming failed run" in log.getvalue()
+        assert "Discarding resumable run" not in log.getvalue()
+
+    def test_falls_back_to_unconditional_resume_when_unverifiable(
+        self, tmp_project: Path
+    ):
+        """No git repo -> compute_tree_signature() returns None on both
+        sides -> today's pre-#804 behavior (resume unconditionally), so a
+        non-git target project does not regress. tree_verified=False is the
+        signal flow-finish-gate.sh's fallback check depends on."""
+        # Deliberately NOT a git repo.
+        log = StringIO()
+        runner = DeterministicRunner(project_root=tmp_project, output=log)
+        first = runner.run("finish", step_defs=self._steps("exit 1"))
+        assert not first.success
+
+        runner2 = DeterministicRunner(project_root=tmp_project, output=log)
+        second = runner2.run("finish", step_defs=self._steps("echo 'test ok'"))
+
+        assert second.success
+        assert second.carried_from_previous_run == ["lint"]
+        assert second.tree_verified is False
+        assert "Discarding resumable run" not in log.getvalue()

--- a/tests/test_runner_state.py
+++ b/tests/test_runner_state.py
@@ -1,16 +1,34 @@
 """Tests for CI/CD runner state persistence."""
 
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from lib.cicd.state import RunState, StepRecord, StepStatus
+from lib.cicd.state import RunState, StepRecord, StepStatus, compute_tree_signature
 
 
 @pytest.fixture
 def tmp_project(tmp_path: Path) -> Path:
     """Create a temporary project directory."""
     return tmp_path
+
+
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not available (e.g. Woodpecker validate container)"
+)
+
+
+def _git_repo(root: Path) -> Path:
+    """Init a git repo at ``root`` with one commit, so write-tree has a base."""
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "init"],
+        cwd=root,
+        check=True,
+    )
+    return root
 
 
 class TestStepRecord:
@@ -237,3 +255,74 @@ class TestCarriedOverStepsAreMarked:
         entry = state.summary(executed_from=1)["steps"][0]
         assert entry["status"] == StepStatus.SKIPPED.value
         assert "carried_from_previous_run" not in entry
+
+
+@requires_git
+class TestComputeTreeSignature:
+    """compute_tree_signature() is the crash-vs-repair discriminator for
+    issue #804: a resume is only honored when this value, taken at persist
+    time and again at resume time, matches.
+    """
+
+    def test_stable_when_nothing_changed(self, tmp_project: Path):
+        _git_repo(tmp_project)
+        (tmp_project / "a.py").write_text("x = 1\n")
+        first = compute_tree_signature(tmp_project)
+        second = compute_tree_signature(tmp_project)
+        assert first is not None
+        assert first == second
+
+    def test_changes_on_a_tracked_file_edit(self, tmp_project: Path):
+        _git_repo(tmp_project)
+        target = tmp_project / "a.py"
+        target.write_text("x = 1\n")
+        before = compute_tree_signature(tmp_project)
+        target.write_text("x = 2  # fixed\n")
+        after = compute_tree_signature(tmp_project)
+        assert before is not None and after is not None
+        assert before != after
+
+    def test_changes_on_a_new_untracked_not_gitignored_file(self, tmp_project: Path):
+        """A new file lint would pick up must count as a tree change even
+        though git has never seen it before - that's the point of scoping
+        to tracked + untracked-but-not-gitignored, not tracked alone."""
+        _git_repo(tmp_project)
+        before = compute_tree_signature(tmp_project)
+        (tmp_project / "new_module.py").write_text("y = 1\n")
+        after = compute_tree_signature(tmp_project)
+        assert before is not None and after is not None
+        assert before != after
+
+    def test_ignores_a_gitignored_file(self, tmp_project: Path):
+        _git_repo(tmp_project)
+        (tmp_project / ".gitignore").write_text("ignored.log\n")
+        before = compute_tree_signature(tmp_project)
+        (tmp_project / "ignored.log").write_text("noise\n")
+        after = compute_tree_signature(tmp_project)
+        assert before is not None and after is not None
+        assert before == after
+
+    def test_ignores_the_runners_own_state_directory(self, tmp_project: Path):
+        """.claude/runs/ is the runner's own bookkeeping, written by the
+        very run whose resume this signature is meant to gate - it must
+        never be able to invalidate itself. Regression guard: without the
+        exclusion, this signature changes on every resume regardless of
+        whether the TREE changed, because the failed run's own state file
+        did not exist yet when the first signature was taken."""
+        _git_repo(tmp_project)
+        before = compute_tree_signature(tmp_project)
+        runs_dir = tmp_project / ".claude" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "finish-deadbeef.json").write_text('{"run_id": "finish-deadbeef"}\n')
+        after = compute_tree_signature(tmp_project)
+        assert before is not None and after is not None
+        assert before == after
+
+    def test_none_outside_a_git_repository(self, tmp_project: Path):
+        # tmp_project is a bare directory - never git-init'd.
+        assert compute_tree_signature(tmp_project) is None
+
+    def test_none_when_git_is_unavailable(self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch):
+        _git_repo(tmp_project)
+        monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+        assert compute_tree_signature(tmp_project) is None


### PR DESCRIPTION
## Summary

`DeterministicRunner.run()` auto-resumed any failed run with no opt-out,
regardless of whether the tree had changed since the failure. Resume is
correct for a crash (tree unchanged); it is wrong for a repair (the usual
reason to resume at all is that the failure was fixed), and the runner
could not tell the two apart - so a repair-resume carried a stale step
result into a green run and `flow-finish-gate.sh` printed a bare
`FLOW_FINISH_GATE: ok` for a tree it never fully tested.

- `lib/cicd/state.py`: new `compute_tree_signature()` - a content hash of
  the working tree (tracked + untracked-but-not-gitignored) via a scratch
  git index + `git write-tree`, never touching the real index. Deliberately
  a content hash, not a cheaper `git status`: status alone cannot tell a
  file edited once from one edited twice between invocations - both show
  `M path` - which is this fleet's most common repair loop. `.claude/runs/`
  (the runner's own state dir) is excluded unconditionally, not left to the
  target project's `.gitignore`.
- `lib/cicd/runner.py`: `run()` compares the stored signature against a
  fresh one before honoring a resume. Mismatch -> discard the stale state,
  start fresh, every step re-runs (first line reads `Starting plan`, never
  `Resuming failed run`). Match -> resume exactly as before, crash-safety
  unchanged. Either signature unavailable (no git, old state file) -> falls
  back to the pre-#804 unconditional resume so a non-git target project
  does not regress, with the result marked `tree_verified: false`.
- `scripts/flow-finish-gate.sh`: reads `carried_from_previous_run` (already
  shipped by #807) plus the new `tree_verified` flag, and warns ONLY on
  "carried AND NOT verified" - never on a verified carry, which is a proven
  crash-resume and would otherwise fire on every ordinary killed-and-resumed
  run in this fleet.
- `make codex-skills` regenerated the four bundled copies of the script.

Full design reasoning, rejected alternatives (a `--fresh` default; warning
on every carry regardless of verification), and failure-mode/blast-radius
analysis are on issue #804.

## Test plan

- `tests/test_runner_state.py`: `compute_tree_signature()` stability,
  sensitivity to tracked/untracked changes, `.gitignore` respect, the
  `.claude/runs/` self-exclusion regression guard, and the no-git/no-repo
  fallback.
- `tests/test_runner.py`: tree-changed resume discards and re-runs every
  step (asserts the signatures actually differ, the state was discarded,
  AND `lint` genuinely re-executed - not just "not marked carried");
  tree-unchanged resume is the crash-safety regression guard (signatures
  match, `lint` carried, `tree_verified` true, no re-run); a third case
  pins the no-git fallback.
- `tests/test_flow_finish_gate.py`: unverified carry -> `warn`, verified
  carry -> `ok`, skipped-gates still wins precedence.
- `make verify` (lint, 2225 tests, mypy, binary-guards, negative-fixture,
  claude-md-budget/links/behavior, project-next-vendor) green.
- The deployed `flow-finish-gate.sh` itself, run against this worktree via
  `FLOW_GATE_CPP_DIR`, green - first line `Starting plan`, not `Resuming`.

Closes #804