### PR TITLE
test(gh-pr-merge): make the stub binary paths a guarded invariant in _run() (refs #805)

### DIFF
--- a/tests/test_gh_pr_merge.py
+++ b/tests/test_gh_pr_merge.py
@@ -453,9 +453,8 @@ def _run(
     # instead of the stub (issue #716/#717 test isolation).
     env.pop("WOODPECKER_API_TOKEN", None)
     env.pop("WOODPECKER_SERVER", None)
-    env["GH_PR_MERGE_GH"] = stubs["GH_PR_MERGE_GH"]
-    env["GH_PR_MERGE_GIT"] = stubs["GH_PR_MERGE_GIT"]
-    env["GH_PR_MERGE_CURL"] = stubs["GH_PR_MERGE_CURL"]
+    # Defaults (overridable via extra_env): timing/attempt knobs a specific
+    # test may want to tune.
     env["GH_PR_MERGE_POLL_DELAY"] = "0"  # keep the mergeability poll instant in tests
     env["GH_PR_MERGE_CONFLICT_SETTLE"] = "0"  # keep the CONFLICTING settle window instant in tests
     env["GH_PR_MERGE_POLL_ATTEMPTS"] = "5"  # pinned, same convention as *_ATTEMPTS below
@@ -465,12 +464,27 @@ def _run(
     env["GH_PR_MERGE_QUEUE_WAIT_DELAY"] = "0"  # and the #717 queue-wait budget
     env["GH_PR_MERGE_QUEUE_WAIT_ATTEMPTS"] = "3"  # bounded, so the timeout path is testable
     if extra_env:
-        # Applied LAST so a caller's override always wins over the fixed
-        # defaults above - previously this ran first and was silently
-        # clobbered for any key this function also sets a default for
-        # (issue #805 review: this is exactly what happened to the one test
-        # that overrides GH_PR_MERGE_CONFLICT_SETTLE).
+        # Applied LAST so a caller's override always wins over the defaults
+        # above - previously this ran first and was silently clobbered for
+        # any key this function also sets a default for (issue #805 review:
+        # this is exactly what happened to the one test that overrides
+        # GH_PR_MERGE_CONFLICT_SETTLE). The three stub-path keys are NOT
+        # defaults, though - see the invariants block below - so an attempt
+        # to override one of those is rejected here rather than silently
+        # allowed to win.
+        assert not (
+            set(extra_env) & {"GH_PR_MERGE_GH", "GH_PR_MERGE_GIT", "GH_PR_MERGE_CURL"}
+        ), "the stub binary paths are invariants, not overridable via extra_env"
         env.update(extra_env)
+
+    # Invariants (never overridable, not even via extra_env): the stub binary
+    # paths. Set AFTER extra_env so nothing can point a test at the real
+    # gh/git/curl on the host - this is what keeps the suite hermetic (issue
+    # #805 review: pulling extra_env earlier for the defaults above must not
+    # also loosen this).
+    env["GH_PR_MERGE_GH"] = stubs["GH_PR_MERGE_GH"]
+    env["GH_PR_MERGE_GIT"] = stubs["GH_PR_MERGE_GIT"]
+    env["GH_PR_MERGE_CURL"] = stubs["GH_PR_MERGE_CURL"]
     return subprocess.run(
         ["bash", str(SCRIPT), *args],
         check=False,
@@ -690,6 +704,19 @@ def test_conflicting_never_corroborated_fails_open(tmp_path: Path):
     assert result.returncode == 0, result.stderr
     assert "merged" in result.stdout
     assert "did not corroborate" in result.stderr
+
+
+def test_run_helper_rejects_stub_path_override_via_extra_env(tmp_path: Path):
+    # GH_PR_MERGE_GH/GIT/CURL are invariants, never overridable defaults - the
+    # #805 review flagged that moving extra_env to apply last (so a caller's
+    # timing-knob override wins over this function's own defaults) would, if
+    # left unguarded, also let a caller point a test at the REAL gh/git/curl
+    # on the host. Guard it loudly rather than rely on nobody doing it.
+    stubs = _make_stubs(tmp_path)
+    cwd = _linked_worktree(tmp_path)  # never actually exec'd - the assert raises first
+    for key in ("GH_PR_MERGE_GH", "GH_PR_MERGE_GIT", "GH_PR_MERGE_CURL"):
+        with pytest.raises(AssertionError):
+            _run(cwd, stubs, "42", "issue-805-fix", extra_env={key: "/usr/bin/env"})
 
 
 # The exact stderr GitHub returns when a sibling PR merged in the poll->merge


### PR DESCRIPTION
## Summary

Fast-follow to #805 (PR #818, merged as `0e29345`). That PR moved
`_run()`'s `extra_env` update to apply LAST so a caller's timing-knob
override always wins over the helper's own defaults - a real fix for a
latent bug (the regression test's own settle-window override was being
silently clobbered back to the test default, so the one test proving the
property was proving nothing).

That fix was right for the timing knobs and wrong for three of the nine
keys it now runs after: `GH_PR_MERGE_GH`, `GH_PR_MERGE_GIT` and
`GH_PR_MERGE_CURL` are the stub binary paths, not tunable defaults - they
are what keeps every test in `tests/test_gh_pr_merge.py` hermetic (never
touching the real `gh`, `git`, or `curl` on the host). Applying `extra_env`
last, unguarded, would let a future test pass one of those three and
silently start hitting the real `gh`/GitHub from the suite.

## Change

`_run()` env assembly is now split into two explicitly-commented groups:

- **defaults** - the eight timing/attempt knobs, overridable via
  `extra_env`, applied before it.
- **invariants** - the three stub paths, applied unconditionally *after*
  `extra_env`, never overridable.

A negative-membership assertion inside the `extra_env` branch rejects any
attempt to override a stub path with a clear message
(`the stub binary paths are invariants, not overridable via extra_env`),
backed by a new test (`test_run_helper_rejects_stub_path_override_via_extra_env`)
asserting that override raises for all three keys.

## Blast radius: zero

`extra_env` has 6 call sites on `main` today, passing exactly two keys -
`GH_PR_MERGE_STRICT_DELETIONS` and `WOODPECKER_API_TOKEN` - both already
`env.pop()`ped before the update rather than defaulted after it, so both
always worked as intended. **None of the nine keys this function defaults
is passed by any existing test.** The ordering bug #805 fixed was real and
latent but had no victims before that PR's own regression test became the
first caller to exercise it.

## Why a fast-follow, not part of #805

The gap is in test-harness hermeticity, not shipped script behavior -
nothing that landed in #818 is incorrect. It surfaced from a sequencing
race (an in-flight required-check poll had already squash-merged #818's
pushed commit by the time this requirement was raised mid-review), reported
and agreed with the cpp-issues orchestrator as a same-ticket remainder
rather than a new issue.

## Testing

- `uv run --extra dev pytest tests/test_gh_pr_merge.py -q` - 109 passed.
- Full gate (`lib.cicd run --plan finish`): lint, full suite (2445 passed -
  one unrelated `TestWatchStatus` flake on the first attempt, confirmed
  flaky by a clean re-run, tracked separately), typecheck, security scan -
  all green.

Refs #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)
