### PR TITLE
fix(scripts): a root with zero test files scanned must not exit 0 (Closes #840)

### DIFF
--- a/scripts/check-negative-fixture-preconditions.py
+++ b/scripts/check-negative-fixture-preconditions.py
@@ -77,7 +77,6 @@ from __future__ import annotations
 import argparse
 import ast
 import re
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -265,10 +264,21 @@ def check_paths(paths: list[Path]) -> list[Finding]:
     return sorted(findings, key=lambda f: (str(f.path), f.assign_lineno))
 
 
+def test_files(tests_dir: Path) -> list[Path]:
+    """The modules this gate scans - the single definition of its population.
+
+    Issue #840: main()'s empty-scan check and check_tree()'s self-check caller
+    (tests/test_negative_fixture_preconditions.py:102) both need this exact
+    set, and a second copy of the glob is a second population to keep in sync -
+    change what counts as a test file in one and the gate scans a different set
+    than the repo's own self-check asserts against, both staying green.
+    """
+    return [p for p in tests_dir.rglob("*.py") if p.name.startswith(("test_", "conftest"))]
+
+
 def check_tree(tests_dir: Path) -> list[Finding]:
     """Check every ``test_*.py`` (and ``conftest.py``) under ``tests_dir``."""
-    paths = [p for p in tests_dir.rglob("*.py") if p.name.startswith(("test_", "conftest"))]
-    return check_paths(paths)
+    return check_paths(test_files(tests_dir))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -284,10 +294,21 @@ def main(argv: list[str] | None = None) -> int:
     root: Path = args.root.resolve()
     tests_dir = root / "tests"
     if not tests_dir.is_dir():
-        print(f"negative-fixture: no tests/ directory under {root}", file=sys.stderr)
-        return 0
+        print(f"negative-fixture: no tests/ directory under {root} - nothing was scanned")
+        return 1
 
-    findings = check_tree(tests_dir)
+    # Keyed on files scanned, not directory existence (issue #840): a tests/
+    # that exists but holds no test_*.py/conftest.py is the same "examined
+    # nothing" condition as a missing directory, and un-keyed on it the "ok"
+    # message below would claim every precondition is asserted for a
+    # population of zero - a false clean bill of health, not merely a missed
+    # report.
+    paths = test_files(tests_dir)
+    if not paths:
+        print(f"negative-fixture: tests/ under {root} contains no test files - nothing was scanned")
+        return 1
+
+    findings = check_paths(paths)
     if not findings:
         print("negative-fixture: ok - every constructed absence asserts its precondition")
         return 0

--- a/scripts/check-test-binary-guards.py
+++ b/scripts/check-test-binary-guards.py
@@ -122,7 +122,6 @@ from __future__ import annotations
 import argparse
 import ast
 import re
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1115,10 +1114,21 @@ def check_paths(paths: list[Path]) -> list[Finding]:
     return sorted(findings, key=lambda f: (str(f.path), f.lineno))
 
 
+def test_files(tests_dir: Path) -> list[Path]:
+    """The modules this gate scans - the single definition of its population.
+
+    Issue #840: main()'s empty-scan check and check_tree()'s self-check caller
+    (tests/test_test_binary_guards.py:497) both need this exact set, and a
+    second copy of the glob is a second population to keep in sync - change
+    what counts as a test file in one and the gate scans a different set than
+    the repo's own self-check asserts against, both staying green.
+    """
+    return [p for p in tests_dir.rglob("*.py") if p.name.startswith(("test_", "conftest"))]
+
+
 def check_tree(tests_dir: Path) -> list[Finding]:
     """Check every ``test_*.py`` (and ``conftest.py``) under ``tests_dir``."""
-    paths = [p for p in tests_dir.rglob("*.py") if p.name.startswith(("test_", "conftest"))]
-    return check_paths(paths)
+    return check_paths(test_files(tests_dir))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1134,10 +1144,20 @@ def main(argv: list[str] | None = None) -> int:
     root: Path = args.root.resolve()
     tests_dir = root / "tests"
     if not tests_dir.is_dir():
-        print(f"binary-guards: no tests/ directory under {root}", file=sys.stderr)
-        return 0
+        print(f"binary-guards: no tests/ directory under {root} - nothing was scanned")
+        return 1
 
-    findings = check_tree(tests_dir)
+    # Keyed on files scanned, not directory existence (issue #840): a tests/
+    # that exists but holds no test_*.py/conftest.py is the same "examined
+    # nothing" condition as a missing directory, and un-keyed on it the "ok"
+    # message below would claim every test is guarded for a population of
+    # zero - a false clean bill of health, not merely a missed report.
+    paths = test_files(tests_dir)
+    if not paths:
+        print(f"binary-guards: tests/ under {root} contains no test files - nothing was scanned")
+        return 1
+
+    findings = check_paths(paths)
     if not findings:
         print("binary-guards: ok - every shelling-out test is guarded")
         return 0

--- a/tests/test_negative_fixture_preconditions.py
+++ b/tests/test_negative_fixture_preconditions.py
@@ -262,6 +262,24 @@ def test_cli_is_silent_success_on_a_clean_tree(
     assert "ok" in capsys.readouterr().out
 
 
-def test_cli_tolerates_a_missing_tests_dir(tmp_path: Path) -> None:
-    """Fail-open on a repo with no tests/ - the gate has nothing to say, not a verdict."""
-    assert checker.main(["--root", str(tmp_path)]) == 0
+def test_cli_fails_when_the_root_has_no_tests_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """#840: a missing tests/ must not read the same as a clean scan - the
+    exit code is what `make verify` reads, and the message alone (already
+    present, previously on stderr) was a silent pass through that gate."""
+    assert checker.main(["--root", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "no tests/ directory" in out
+
+
+def test_cli_fails_when_tests_directory_has_no_test_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """#840: a present-but-empty tests/ is worse than a missing one - the old
+    code printed a clean "ok" for a population of zero, a false positive
+    rather than a missed report."""
+    (tmp_path / "tests").mkdir()
+    assert checker.main(["--root", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "no test files" in out

--- a/tests/test_test_binary_guards.py
+++ b/tests/test_test_binary_guards.py
@@ -542,6 +542,29 @@ def test_cli_is_silent_success_on_a_clean_tree(
     assert "ok" in capsys.readouterr().out
 
 
+def test_cli_fails_when_the_root_has_no_tests_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """#840: a missing tests/ must not read the same as a clean scan - the
+    exit code is what `make verify` reads, and the message alone (already
+    present, previously on stderr) was a silent pass through that gate."""
+    assert checker.main(["--root", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "no tests/ directory" in out
+
+
+def test_cli_fails_when_tests_directory_has_no_test_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """#840: a present-but-empty tests/ is worse than a missing one - the old
+    code printed a clean "ok" for a population of zero, a false positive
+    rather than a missed report."""
+    (tmp_path / "tests").mkdir()
+    assert checker.main(["--root", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "no test files" in out
+
+
 # --------------------------------------------------------------------------- #
 # A `case` pattern label is read as a command invocation (issue #833)
 #


### PR DESCRIPTION
## Summary

`check-test-binary-guards.py` and `check-negative-fixture-preconditions.py` each exit 0 when there is nothing to scan - and did so on **two** separate inputs, only one of which the filed issue named:

1. A missing `tests/` directory (the filed reproduction) - printed a message to stderr and returned 0.
2. A `tests/` directory that **exists but contains no test_*.py/conftest.py files** - printed `"ok - every ... is guarded/asserted"` and returned 0.

The second case is worse than the first: a missing-directory message at least gives a reader a chance to notice something is wrong. The present-but-empty case makes a **positive false claim** - a clean bill of health for a population of zero - which is indistinguishable from a real pass to anything reading the exit code, exactly the failure mode these gates exist to catch in the tests they scan.

## Fix

Both scripts now key the check on **files scanned**, not directory existence, which subsumes both cases in one branch: `check_tree`'s own glob (`tests_dir.rglob("*.py")` filtered to `test_*`/`conftest*`) computed once in `main()`, checked for emptiness before deferring to `check_paths`. A missing directory and an empty one both produce zero paths through the same glob, so one property covers what two special cases used to.

Both cases now exit 1, with the message moved from stderr to stdout to match each script's own "N unguarded/unasserted" failure-path convention (plain `print()`, no `file=` redirect) - `sys` becomes unused in both files and its import is removed.

**No opt-out flag added.** The issue offered "nonzero exit" and "an opt-out for the rare caller that wants scan-if-present" as alternatives, not a pair; no current caller (both Makefile targets always call with no `--root`, which always finds `tests/` in a normal checkout) wants that behavior, and unused surface on a two-line-per-file fix is speculative. This fix cannot change `make verify`'s outcome on a normal checkout - it only changes the outcome for a caller whose root genuinely has nothing to scan, which is exactly the case that was silently wrong.

**Sibling gate checked by reading and running it, not inferred from resemblance to the filed issue**: `check-negative-fixture-preconditions.py` carried the byte-for-byte same defect (missing-dir) plus the same undiscovered present-but-empty gap, confirmed by reproduction before fixing either.

## One population, not two copies of it

The first pass at this fix duplicated the enumeration glob (`tests_dir.rglob("*.py")` filtered to `test_*`/`conftest*`) into two places per script: the new emptiness check in `main()`, and the pre-existing `check_tree()` - whose only remaining caller, after `main()` stopped using it, is each script's own "CPP's own suite is clean" self-check test (`test_test_binary_guards.py:497`, `test_negative_fixture_preconditions.py:102`). Two copies of what counts as a test file is a defect in its own right: change one (add `*_test.py`, exclude a fixtures subdirectory) and the gate would scan one population while the repo's self-check asserts against the other, both staying green. Extracted to a single `test_files(tests_dir)` function that both `main()` and `check_tree()` call, so there is exactly one definition of what this gate scans, in each file.

## Tests

Both test modules gain the present-but-empty case as a new test asserting the exit code (per the issue's own instruction: the message already existed for the missing-directory case, it is the exit code `make verify` actually reads). `test_negative_fixture_preconditions.py` had an existing test encoding the old, wrong behavior as intentional (`test_cli_tolerates_a_missing_tests_dir`, docstring: "Fail-open ... the gate has nothing to say, not a verdict") - replaced rather than left beside the corrected one, so a passing suite can never again mean both were true. `test_test_binary_guards.py` had no equivalent test to fix, only to add.

The existing `test_cli_is_silent_success_on_a_clean_tree` in both files already pins the true-clean-tree case at exit 0, so this change is verified not to regress the legitimate pass.

## Verified by execution, not just by test assertion

- [x] Empty root (no `tests/` at all): both scripts, exit 1, "no tests/ directory ... nothing was scanned"
- [x] Present-but-empty `tests/`: both scripts, exit 1, "contains no test files ... nothing was scanned"
- [x] Control, real checkout, no `--root` (the shape both Makefile targets actually invoke): both scripts, exit 0, unchanged "ok" message
- [x] `python -m pytest tests/test_test_binary_guards.py tests/test_negative_fixture_preconditions.py` - 85 passed
- [x] Staged-tree security gate - passes
- [x] `make verify` - 2756 passed, mypy clean (195 files), binary-guards ok, negative-fixture ok, all governance checks green

## Implementation notes

Implemented by a local model (`qwen3.8-code:latest` via Qwen Code CLI, headless, host `proxvmqwen45`; remote endpoint so the Docker sandbox was skipped per issue #749, execution fence + post-run overrun checks carrying the isolation boundary). Given the precision required, the model was given a pre-verified, exact replacement table (derived from directly reproducing both defects in both scripts before writing any fix) and wrote/ran a short match-before-write script from it - it did not compose any of the replacement text itself. Cross-model review confirmed the resulting diff line-by-line against the table; 0 unexpected commits/PRs/pushes.

## This is part of a family of fixes, each exposing the next

`#831 -> #833 -> #838 -> #840`, and now the extraction inside #840 itself (a defect the first pass at fixing #840 introduced, caught before merge) - each fix to `check-test-binary-guards.py` has exposed the next defect in the same script, including once a defect introduced by the previous fix. Noted here not as self-criticism but so the next person touching this file expects that pattern rather than being surprised by it.

Closes #840

