### PR TITLE
docs(gh-pr-merge): clarify in_linked_worktree checks the invoking worktree only

### DIFF
--- a/codex/skills/flow-auto/scripts/gh-pr-merge.sh
+++ b/codex/skills/flow-auto/scripts/gh-pr-merge.sh
@@ -376,6 +376,8 @@ LAST_MERGE_ERR=""
 
 # A linked worktree has a `.git` FILE (a gitdir pointer); the primary repo has a
 # `.git` DIRECTORY. This is the exact condition under which --delete-branch trips.
+# Checks the INVOKING worktree only - a sibling worktree elsewhere in the same
+# repo is not examined here.
 in_linked_worktree() { [[ -f .git ]]; }
 
 # A squash rejected by branch protection (issue #517) vs. any other failure.

--- a/codex/skills/flow-merge/scripts/gh-pr-merge.sh
+++ b/codex/skills/flow-merge/scripts/gh-pr-merge.sh
@@ -376,6 +376,8 @@ LAST_MERGE_ERR=""
 
 # A linked worktree has a `.git` FILE (a gitdir pointer); the primary repo has a
 # `.git` DIRECTORY. This is the exact condition under which --delete-branch trips.
+# Checks the INVOKING worktree only - a sibling worktree elsewhere in the same
+# repo is not examined here.
 in_linked_worktree() { [[ -f .git ]]; }
 
 # A squash rejected by branch protection (issue #517) vs. any other failure.

--- a/scripts/gh-pr-merge.sh
+++ b/scripts/gh-pr-merge.sh
@@ -376,6 +376,8 @@ LAST_MERGE_ERR=""
 
 # A linked worktree has a `.git` FILE (a gitdir pointer); the primary repo has a
 # `.git` DIRECTORY. This is the exact condition under which --delete-branch trips.
+# Checks the INVOKING worktree only - a sibling worktree elsewhere in the same
+# repo is not examined here.
 in_linked_worktree() { [[ -f .git ]]; }
 
 # A squash rejected by branch protection (issue #517) vs. any other failure.


### PR DESCRIPTION
Purely documentation - no behavior change. Throwaway PR created to safely reproduce and characterize the `gh-pr-merge --delete-branch` half-completion tomas hit twice today (measure-only sweep assigned by the cpp-issues orchestrator; findings will be filed separately, not fixed in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)