### PR TITLE
feat(governance): one lightweight issue contract, proportionally routed (Closes #856)

### DIFF
--- a/.claude/commands/evaluate/issue.md
+++ b/.claude/commands/evaluate/issue.md
@@ -5,7 +5,7 @@ allowed-tools: mcp__second-opinion__get_multi_model_second_opinion, mcp__second-
 
 # Evaluate Issue
 
-Orchestrate a four-phase evaluation flow using multi-model consultation and structured reasoning to produce a spec-ready artifact.
+Orchestrate a four-phase evaluation flow using multi-model consultation and structured reasoning to produce a contract-ready artifact: an issue contract for Tier 1 and Tier 2 work, a full specification for Tier 3.
 
 ARGUMENTS: $ARGUMENTS
 
@@ -22,7 +22,7 @@ Phase 2: Sequential Reasoning (12-15 steps)
   -> Human Checkpoint #2
 Phase 3: Multi-Model Validation
   -> Human Checkpoint #3
-Phase 4: Spec Output
+Phase 4: Issue Contract (Step 8a) or Spec Output (Step 8b)
 ```
 
 Each phase builds on the previous. Human checkpoints let the user steer.
@@ -65,7 +65,9 @@ Ask the user to select the domain type:
 Ask:
 > "What should the output feature be named? Use kebab-case (e.g., `user-authentication`, `caching-strategy`)"
 
-This determines the output path: `.specify/specs/{feature-name}/`
+This names the evaluation. It determines the output path
+`.specify/specs/{feature-name}/` only if Checkpoint #3 selects a spec output; an
+issue-contract output writes no files.
 
 **Question 4: Artifacts (Optional)**
 
@@ -195,7 +197,7 @@ Use AskUserQuestion:
 Options:
 - **Accept and validate** (Recommended) -- Proceed to Phase 3 multi-model validation
 - **Redirect** -- Provide new constraints or change focus, then re-run Phase 2
-- **Skip validation** -- Go directly to spec output (Phase 4)
+- **Skip validation** -- Go directly to the Phase 4 output choice
 
 If user provides additional constraints, re-run Phase 2 with the new context appended.
 
@@ -229,17 +231,32 @@ Display:
 
 Use AskUserQuestion:
 
-> "Validation complete. What type of spec output should be generated?"
+> "Validation complete. What output should be generated?"
 
 **Question 1: Output Type**
 
+Recommend proportionally, by the governance tier the evaluation actually revealed -
+not by what the pipeline can produce. Tier 3 work (new subsystem, security boundary,
+multi-issue effort) warrants the full spec; Tier 1 and Tier 2 work warrants an issue
+contract, and generating spec.md + plan.md + tasks.md for a two-file change is the
+ceremony P7 exists to prevent. Present the tier-appropriate option first and say why
+it is the recommendation.
+
 Options:
-- **Full spec** (Recommended) -- Generate spec.md + plan.md + tasks.md
+- **Issue contract** -- A short contract for one issue body: outcome, constraints
+  with rationale, acceptance examples, revisable proposed approach, assumptions.
+  No spec.md, plan.md, or tasks.md. Recommended for Tier 1 and Tier 2.
+- **Full spec** -- Generate spec.md + plan.md + tasks.md. Recommended for Tier 3.
 - **Spec only** -- Generate just spec.md (requirements and user stories)
 - **Plan only** -- Generate just plan.md (technical approach)
 - **Tasks only** -- Generate just tasks.md (actionable items)
 
-**Question 2: Confirm Feature Name**
+**If the user chose Issue contract, this checkpoint is finished.** Do not ask Question
+2, do not create any directory, and go straight to Step 8a. The lightweight path writes
+no `.specify/specs/` tree, so a question about where that tree goes is a question about
+files that will never exist.
+
+**Question 2: Confirm Feature Name** (spec outputs only)
 
 > "Output will be written to `.specify/specs/{feature-name}/`. Confirm or change?"
 
@@ -249,7 +266,55 @@ Options:
 
 ---
 
-## Step 8: Phase 4 -- Spec Output
+## Step 8a: Phase 4 -- Issue Contract Output
+
+Run this step when, and only when, the user chose **Issue contract** at Checkpoint #3.
+It creates no directories and writes no spec files. Emit one issue body, following
+[the issue contract](../../../docs/agents/issue-contract.md):
+
+- **Outcome** from the Phase 1 synthesis and the user description, stated as the
+  observable result wanted and why it matters
+- **Constraints** surfaced by the evaluation, each with the rationale that makes it
+  challengeable on the merits
+- **Acceptance** from the Phase 3 validation gaps, written as observable examples
+- **Proposed approach** from the Phase 2 recommendation, explicitly marked revisable
+- **Assumptions** from the Phase 1 divergence points and Phase 2 open questions
+
+These are distinctions, not required headings. Omit anything the evaluation did not
+actually produce rather than inventing content to fill a slot: a two-sentence contract
+that states the outcome and what counts as done is a complete result here, not a
+degraded one.
+
+### Report Output (issue contract)
+
+```
+Phase 4: Issue Contract Complete
+
+  Output:   one issue body (no spec.md, plan.md, or tasks.md written)
+  Tier:     {tier the evaluation revealed}
+  Dropped:  {evaluation findings that did not fit the contract, or "none"}
+
+Evaluation Summary:
+  Models consulted: {count} ({model names})
+  Reasoning steps: {N}
+  Total cost: ${cost}
+
+Next steps:
+  1. Review the contract above
+  2. File it with /github:issue-create
+  3. Ship it with /flow:auto <issue>
+```
+
+Report which evaluation findings did not fit the contract, so they are dropped
+knowingly rather than silently. **End the run here.** The prerequisites, spec
+generation, and spec report below apply to the spec outputs only.
+
+---
+
+## Step 8b: Phase 4 -- Spec Output
+
+Run this step for the **Full spec**, **Spec only**, **Plan only**, and **Tasks only**
+outputs.
 
 ### Check Prerequisites
 
@@ -300,7 +365,10 @@ Fill from the evaluation:
 - **Checkpoints**: At wave boundaries
 - **Status**: `Ready`
 
-### Report Output
+### Report Output (spec outputs)
+
+List only the files this run actually wrote - a **Spec only**, **Plan only**, or
+**Tasks only** run creates one of the three, not all of them.
 
 ```
 Phase 4: Spec Output Complete

--- a/.claude/commands/github/issue-create.md
+++ b/.claude/commands/github/issue-create.md
@@ -16,6 +16,25 @@ gh auth status
 
 If not authenticated, the user needs to run `gh auth login`.
 
+## What the Body Must Make Legible
+
+Whatever the type, the body an agent later implements from is a contract. Write it so
+a reader can tell these apart: the intended **outcome** and why it matters, the
+**constraints** that bound it and the rationale behind each, the **acceptance** that
+shows the outcome was reached, any **proposed approach** (a revisable hypothesis, not
+an order), and **assumptions** worth checking.
+
+These are distinctions, not required headings. A routine bug report that says what
+broke, what should happen instead, and how to reproduce it has already satisfied the
+contract; do not pad it with an invented proposed solution or assumptions nobody
+holds. Keep a suggested fix phrased as a suggestion, so an implementer who finds a
+better one is free to use it and report the substitution.
+
+The canonical definition, the outcome-versus-proposal test, and worked examples are
+in [the issue contract](../../../docs/agents/issue-contract.md). For work large
+enough to warrant a specification, reference the spec and the sections that govern
+the issue rather than copying them.
+
 ## Issue Creation Flow
 
 ### Step 1: Ask Issue Type
@@ -48,8 +67,9 @@ Based on the issue type, gather the required information:
 **For Feature Request:**
 - Feature type (command, skill, MCP, etc.)
 - Feature name
-- Problem/use case
-- Proposed solution
+- Problem/use case (the outcome wanted, and why it matters)
+- Proposed approach (optional, and recorded as revisable)
+- Constraints, each with the rationale behind it (optional)
 
 **For Bug Report:**
 - Component affected

--- a/.claude/commands/spec/help.md
+++ b/.claude/commands/spec/help.md
@@ -13,11 +13,18 @@ community-iterated and its plugin ships verification stages CPP lacked
 
 ## Overview
 
-Spec-Driven Development (SDD) ensures quality by requiring specifications before implementation:
+Spec-Driven Development (SDD) is the heavyweight end of one proportional policy:
+every change states its contract, and a full specification is how that contract is
+expressed when uncertainty or coordination warrants it.
 
 ```
 Constitution (principles) → Spec (what) → Plan (how) → Tasks (work) → Issues → Code
 ```
+
+For work that does not warrant a spec, the same contract lives in the issue body.
+The canonical definition of what it must make legible - outcome, constraints with
+their rationale, acceptance examples, revisable proposed approach, assumptions - is
+[the issue contract](../../../docs/agents/issue-contract.md).
 
 ## Available Commands
 
@@ -35,6 +42,17 @@ The full spec→plan→tasks pipeline is for **Tier 3 (Architectural)** work: ne
 subsystems, security boundaries, or multi-issue efforts. Tier 1 (Surgical) and
 Tier 2 (Considered) work should skip the spec pipeline and go directly to
 issue → `/flow:auto`.
+
+Skipping the pipeline is not skipping the contract. A Tier 1 or Tier 2 issue still
+states its outcome, its material constraints and why they hold, and what observable
+result counts as done - in a few sentences, with no spec.md, plan.md, or tasks.md.
+See [the issue contract](../../../docs/agents/issue-contract.md) for the
+distinctions and worked examples, including how a prescriptive proposed solution
+stays revisable.
+
+When work IS specified, the issue references the spec and the sections that govern
+it instead of copying them, so amending the spec cannot leave a stale duplicate in
+the tracker.
 
 ## Supported Workflow
 

--- a/.claude/skills/spec-driven-dev/SKILL.md
+++ b/.claude/skills/spec-driven-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Spec-Driven Development
-description: Specification-first development workflow and planning
-trigger: spec driven, specification, SDD, planning, requirements
+description: Contract-first development, proportional spec routing, and planning
+trigger: spec driven, specification, SDD, planning, requirements, issue contract
 metadata:
   provenance:
     class: cpp-authored
@@ -11,7 +11,10 @@ metadata:
 
 When the user asks about spec-driven development, planning, or requirements:
 
-1. Read `docs/skills/spec-driven-dev.md`
-2. Explain the SDD workflow (Spec → Sandbox → Production)
-3. Provide the spec template
-4. Reference GitHub Spec Kit for tooling
+1. Read `docs/agents/issue-contract.md` - the canonical contract every change states
+2. Route by tier: Tier 1 and Tier 2 express the contract in the issue body; Tier 3
+   escalates to a full `.specify/` spec that the issue references rather than copies
+3. Read `docs/skills/spec-driven-dev.md` for the Tier 3 workflow and templates
+4. Keep the outcome separate from a proposed approach, and treat a constraint as
+   binding even when its rationale is missing
+5. Reference GitHub Spec Kit for tooling

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -35,7 +35,7 @@ body:
     id: description
     attributes:
       label: Bug description
-      description: What happened? What did you expect to happen?
+      description: What happened? What did you expect to happen? The expected behavior is the outcome being asked for; if you also suggest a fix, it is read as a suggestion, and an implementer may fix the cause a different way.
       placeholder: |
         **What happened:**
         [describe the bug]

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -34,8 +34,8 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Problem/Use case
-      description: What problem does this solve? What's the use case?
+      label: Problem and intended outcome
+      description: What problem does this solve, and what should be true once it is solved? This is the part that is binding.
       placeholder: |
         As a [type of user], I want to [do something]
         so that [benefit/outcome].
@@ -43,17 +43,27 @@ body:
       required: true
 
   - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints (optional)
+      description: Boundaries any solution must respect, each with the reason behind it. A reason is what lets someone challenge a constraint on the merits instead of guessing.
+      placeholder: |
+        - Must not add a new runtime service - we run a single container and intend to keep it that way.
+    validations:
+      required: false
+
+  - type: textarea
     id: solution
     attributes:
-      label: Proposed solution
-      description: How should this feature work?
+      label: Proposed approach (optional)
+      description: If you have a design in mind, describe it here. This is recorded as a revisable suggestion, not a requirement - an implementer may deliver the outcome above a different way and will say why. Leave it blank if you would rather not prescribe one.
       placeholder: |
-        Describe the feature:
+        Describe the approach you have in mind:
         - What would the user do?
         - What would happen?
         - What output would they see?
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: alternatives

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -25,20 +25,26 @@ Every implementation starts with a GitHub issue and follows IDD workflow.
 - Branch naming: `issue-{N}-{description}`
 - Commits reference issues: `type(scope): Description (Closes #N)`
 
-### P3: Spec-First Implementation
+### P3: Contract-First Implementation
 
-No code without specification. Specifications become the source of truth.
+No code without an agreed contract. The contract states the intended outcome, the
+constraints that bound it and why, and what observable result counts as done.
 
-- Write spec.md before any implementation
-- Create plan.md after spec review
-- Generate tasks.md from plan
-- Sync tasks to GitHub issues before coding
+- Express the contract in the issue body for Tier 1 and Tier 2 work
+- Escalate to a full `.specify/` specification when uncertainty or coordination
+  warrants it, and for all Tier 3 work; the issue then references that spec
+  rather than copying it
+- Separate the intended outcome from a proposed approach: the outcome is
+  binding, the approach is a revisable hypothesis
+- Constraints remain binding without a stated rationale; challenge one with
+  evidence and record the decision, never silently reclassify it
+- The canonical definition is [the issue contract](../../docs/agents/issue-contract.md)
 
 ### P4: Test-Driven Quality
 
-Tests validate specifications, not just implementations.
+Tests validate the agreed outcome, not just implementations.
 
-- Write tests from acceptance criteria in spec
+- Write tests from the acceptance criteria in the issue contract or its spec
 - Tests must pass independently per feature
 - Use pytest with descriptive test names
 - No merge without passing tests
@@ -71,29 +77,34 @@ process and escalate only when analysis reveals the need.
 
 ## Development Workflow
 
-### Specification Phase
-1. Create feature spec using `/spec:create`
-2. Define user stories with acceptance criteria
-3. Review spec for completeness
-4. Clarify any ambiguities
+### Contract Phase (all tiers)
+1. State the intended outcome and why it matters
+2. Record material constraints with their rationale
+3. Give observable acceptance examples
+4. Mark any proposed approach as revisable, and name assumptions worth checking
 
-### Planning Phase
-1. Create technical plan from spec
-2. Define architecture and dependencies
-3. Identify risks and mitigations
-4. Get plan approval
+The issue body carries this for Tier 1 and Tier 2 work. See
+[the issue contract](../../docs/agents/issue-contract.md).
+
+### Specification Phase (Tier 3, or when uncertainty warrants it)
+1. Author with `/spec:adopt` and the upstream `/speckit-*` skills
+2. Define user stories with acceptance criteria
+3. De-risk ambiguity and check cross-artifact consistency
+4. Create the technical plan, architecture, dependencies, risks, and mitigations
+5. Get plan approval
 
 ### Task Breakdown
 1. Generate tasks from plan
 2. Organize by wave/phase
 3. Mark dependencies and parallel tasks
-4. Sync to GitHub issues with `/spec:sync`
+4. Create GitHub issues with `scripts/speckit-tasks-to-issues.sh`
 
 ### Implementation Phase
 1. Create worktree for issue
 2. Implement following TDD
 3. Submit PR with tests
-4. Reference spec in PR description
+4. Reference the governing contract in the PR description - the issue, or the
+   spec it points to
 
 ---
 
@@ -108,6 +119,10 @@ process and escalate only when analysis reveals the need.
   approval, implement+test, PR.
 - **Tier 3 (Architectural):** New subsystem, security boundary, multi-issue.
   Full .specify/ pipeline + ELI5 + implement + PR.
+
+Dialing spec ceremony down does not dial the contract down: work at every tier
+states its outcome, constraints, and acceptance. Only where that contract lives
+changes. See [the issue contract](../../docs/agents/issue-contract.md).
 
 ### Compliance
 - All PRs must verify alignment with constitution
@@ -129,4 +144,4 @@ Adapted for Claude Code workflows with Issue-Driven Development integration.
 
 ---
 
-*Last updated: 2025-12-24*
+*Last updated: 2026-09-12*

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -1,5 +1,10 @@
 # Feature Specification: {FEATURE_NAME}
 
+> Use this template when the work warrants a specification - Tier 3, or Tier 2 work
+> whose uncertainty or coordination needs one. Smaller work states the same contract
+> in the issue body instead; see `docs/agents/issue-contract.md`. Issues reference the
+> sections of this spec that govern them rather than copying them.
+
 > **Branch:** `issue-{N}-{feature-slug}`
 > **Created:** {DATE}
 > **Status:** Draft | In Review | Approved

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -55,7 +55,7 @@
 
 ## Issue Sync
 
-> Use `/spec:sync` to create GitHub issues from these tasks.
+> Use `scripts/speckit-tasks-to-issues.sh` to create GitHub issues from these tasks.
 
 | Task | Issue | Status |
 |------|-------|--------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ these rules remain in [commands-reference.md](docs/commands-reference.md) and
 - `docs/reference/CLAUDE_CODE_BEST_PRACTICES_FULL.md` - full best-practices guide.
 - `docs/commands-reference.md` - command decisions, histories, and workflow detail.
 - `docs/scripts.md` - script inventory and per-script behavioral history.
+- `docs/agents/issue-contract.md` - canonical issue contract and proportional spec routing.
 - `docs/agents/knowledge-lifecycle.md` - canonical completed-spec graduation policy.
 - `ISSUE_DRIVEN_DEVELOPMENT.md` - issue-driven development source.
 - `PROGRESSIVE_DISCLOSURE_GUIDE.md` - context-loading guidance.

--- a/codex/skills/evaluate-issue/reference.md
+++ b/codex/skills/evaluate-issue/reference.md
@@ -2,7 +2,7 @@
 
 # Evaluate Issue
 
-Orchestrate a four-phase evaluation flow using multi-model consultation and structured reasoning to produce a spec-ready artifact.
+Orchestrate a four-phase evaluation flow using multi-model consultation and structured reasoning to produce a contract-ready artifact: an issue contract for Tier 1 and Tier 2 work, a full specification for Tier 3.
 
 ARGUMENTS: $ARGUMENTS
 
@@ -19,7 +19,7 @@ Phase 2: Sequential Reasoning (12-15 steps)
   -> Human Checkpoint #2
 Phase 3: Multi-Model Validation
   -> Human Checkpoint #3
-Phase 4: Spec Output
+Phase 4: Issue Contract (Step 8a) or Spec Output (Step 8b)
 ```
 
 Each phase builds on the previous. Human checkpoints let the user steer.
@@ -62,7 +62,9 @@ Ask the user to select the domain type:
 Ask:
 > "What should the output feature be named? Use kebab-case (e.g., `user-authentication`, `caching-strategy`)"
 
-This determines the output path: `.specify/specs/{feature-name}/`
+This names the evaluation. It determines the output path
+`.specify/specs/{feature-name}/` only if Checkpoint #3 selects a spec output; an
+issue-contract output writes no files.
 
 **Question 4: Artifacts (Optional)**
 
@@ -192,7 +194,7 @@ Use AskUserQuestion:
 Options:
 - **Accept and validate** (Recommended) -- Proceed to Phase 3 multi-model validation
 - **Redirect** -- Provide new constraints or change focus, then re-run Phase 2
-- **Skip validation** -- Go directly to spec output (Phase 4)
+- **Skip validation** -- Go directly to the Phase 4 output choice
 
 If user provides additional constraints, re-run Phase 2 with the new context appended.
 
@@ -226,17 +228,32 @@ Display:
 
 Use AskUserQuestion:
 
-> "Validation complete. What type of spec output should be generated?"
+> "Validation complete. What output should be generated?"
 
 **Question 1: Output Type**
 
+Recommend proportionally, by the governance tier the evaluation actually revealed -
+not by what the pipeline can produce. Tier 3 work (new subsystem, security boundary,
+multi-issue effort) warrants the full spec; Tier 1 and Tier 2 work warrants an issue
+contract, and generating spec.md + plan.md + tasks.md for a two-file change is the
+ceremony P7 exists to prevent. Present the tier-appropriate option first and say why
+it is the recommendation.
+
 Options:
-- **Full spec** (Recommended) -- Generate spec.md + plan.md + tasks.md
+- **Issue contract** -- A short contract for one issue body: outcome, constraints
+  with rationale, acceptance examples, revisable proposed approach, assumptions.
+  No spec.md, plan.md, or tasks.md. Recommended for Tier 1 and Tier 2.
+- **Full spec** -- Generate spec.md + plan.md + tasks.md. Recommended for Tier 3.
 - **Spec only** -- Generate just spec.md (requirements and user stories)
 - **Plan only** -- Generate just plan.md (technical approach)
 - **Tasks only** -- Generate just tasks.md (actionable items)
 
-**Question 2: Confirm Feature Name**
+**If the user chose Issue contract, this checkpoint is finished.** Do not ask Question
+2, do not create any directory, and go straight to Step 8a. The lightweight path writes
+no `.specify/specs/` tree, so a question about where that tree goes is a question about
+files that will never exist.
+
+**Question 2: Confirm Feature Name** (spec outputs only)
 
 > "Output will be written to `.specify/specs/{feature-name}/`. Confirm or change?"
 
@@ -246,7 +263,55 @@ Options:
 
 ---
 
-## Step 8: Phase 4 -- Spec Output
+## Step 8a: Phase 4 -- Issue Contract Output
+
+Run this step when, and only when, the user chose **Issue contract** at Checkpoint #3.
+It creates no directories and writes no spec files. Emit one issue body, following
+[the issue contract](../../../docs/agents/issue-contract.md):
+
+- **Outcome** from the Phase 1 synthesis and the user description, stated as the
+  observable result wanted and why it matters
+- **Constraints** surfaced by the evaluation, each with the rationale that makes it
+  challengeable on the merits
+- **Acceptance** from the Phase 3 validation gaps, written as observable examples
+- **Proposed approach** from the Phase 2 recommendation, explicitly marked revisable
+- **Assumptions** from the Phase 1 divergence points and Phase 2 open questions
+
+These are distinctions, not required headings. Omit anything the evaluation did not
+actually produce rather than inventing content to fill a slot: a two-sentence contract
+that states the outcome and what counts as done is a complete result here, not a
+degraded one.
+
+### Report Output (issue contract)
+
+```
+Phase 4: Issue Contract Complete
+
+  Output:   one issue body (no spec.md, plan.md, or tasks.md written)
+  Tier:     {tier the evaluation revealed}
+  Dropped:  {evaluation findings that did not fit the contract, or "none"}
+
+Evaluation Summary:
+  Models consulted: {count} ({model names})
+  Reasoning steps: {N}
+  Total cost: ${cost}
+
+Next steps:
+  1. Review the contract above
+  2. File it with /github-issue-create
+  3. Ship it with /flow-auto <issue>
+```
+
+Report which evaluation findings did not fit the contract, so they are dropped
+knowingly rather than silently. **End the run here.** The prerequisites, spec
+generation, and spec report below apply to the spec outputs only.
+
+---
+
+## Step 8b: Phase 4 -- Spec Output
+
+Run this step for the **Full spec**, **Spec only**, **Plan only**, and **Tasks only**
+outputs.
 
 ### Check Prerequisites
 
@@ -297,7 +362,10 @@ Fill from the evaluation:
 - **Checkpoints**: At wave boundaries
 - **Status**: `Ready`
 
-### Report Output
+### Report Output (spec outputs)
+
+List only the files this run actually wrote - a **Spec only**, **Plan only**, or
+**Tasks only** run creates one of the three, not all of them.
 
 ```
 Phase 4: Spec Output Complete

--- a/codex/skills/github-issue-create/reference.md
+++ b/codex/skills/github-issue-create/reference.md
@@ -13,6 +13,25 @@ gh auth status
 
 If not authenticated, the user needs to run `gh auth login`.
 
+## What the Body Must Make Legible
+
+Whatever the type, the body an agent later implements from is a contract. Write it so
+a reader can tell these apart: the intended **outcome** and why it matters, the
+**constraints** that bound it and the rationale behind each, the **acceptance** that
+shows the outcome was reached, any **proposed approach** (a revisable hypothesis, not
+an order), and **assumptions** worth checking.
+
+These are distinctions, not required headings. A routine bug report that says what
+broke, what should happen instead, and how to reproduce it has already satisfied the
+contract; do not pad it with an invented proposed solution or assumptions nobody
+holds. Keep a suggested fix phrased as a suggestion, so an implementer who finds a
+better one is free to use it and report the substitution.
+
+The canonical definition, the outcome-versus-proposal test, and worked examples are
+in [the issue contract](../../../docs/agents/issue-contract.md). For work large
+enough to warrant a specification, reference the spec and the sections that govern
+the issue rather than copying them.
+
 ## Issue Creation Flow
 
 ### Step 1: Ask Issue Type
@@ -45,8 +64,9 @@ Based on the issue type, gather the required information:
 **For Feature Request:**
 - Feature type (command, skill, MCP, etc.)
 - Feature name
-- Problem/use case
-- Proposed solution
+- Problem/use case (the outcome wanted, and why it matters)
+- Proposed approach (optional, and recorded as revisable)
+- Constraints, each with the rationale behind it (optional)
 
 **For Bug Report:**
 - Component affected

--- a/docs/agents/issue-contract.md
+++ b/docs/agents/issue-contract.md
@@ -1,0 +1,153 @@
+# Issue Contract
+
+An issue is a contract between whoever wants an outcome and whoever delivers it.
+The contract fails when everything in it reads as an order. A sentence naming the
+goal, a sentence guessing at a design, and a sentence recording an assumption look
+identical on the page, so an implementer builds the guess as faithfully as the goal
+and has no way to tell which sentences are load-bearing.
+
+This document is the canonical definition of that contract for this repository.
+Other surfaces point here; they do not restate it.
+
+## The five distinctions
+
+| Distinction | What it is | How a reader treats it |
+|-------------|-----------|------------------------|
+| Outcome | The observable state to reach, and why it matters | Binding. Preserve it. |
+| Constraint | A boundary the solution must respect, with the rationale behind it | Binding. Challengeable on evidence, never silently dropped. |
+| Acceptance | Observable examples showing the outcome was reached | Binding as the evidence standard. |
+| Proposed approach | A hypothesis about how to get there | Revisable. Substitute a better one and say so. |
+| Assumption | Something believed but unverified | Not binding. An invitation to check. |
+
+**These are distinctions a reader must be able to make, not five mandatory headings
+or fields.** A two-sentence issue satisfies this contract when the distinctions are
+legible from the sentences themselves. Do not invent an assumption or a proposed
+approach to fill a slot: absence is a legitimate answer, and for a routine fix it is
+usually the honest one. A form that forces a reporter to prescribe a design
+manufactures exactly the blur this contract removes.
+
+## Telling an outcome from a proposal
+
+Substitute a different mechanism. If the sentence still says what the requester
+wants, it was an outcome; if it becomes meaningless, it was a proposal.
+
+| Written as | Reads as | Because |
+|------------|----------|---------|
+| "Remain responsive while processing continues" | Outcome | Survives swapping the queue for threads, streaming, or a smaller payload. |
+| "Use a background queue" | Proposed approach | Names a mechanism. Swap it and nothing of the request is left. |
+| "Must not add a new runtime dependency" | Constraint | A boundary on any mechanism, not a mechanism. |
+| "The cache is probably the bottleneck" | Assumption | Hedged, unverified, and the work does not depend on it being true. |
+
+**The heuristic identifies candidates; it never demotes an explicit requirement.** A
+named mechanism can itself be a constraint: "use PostgreSQL, because this has to
+integrate with the database we already run and support" names a mechanism and is
+binding all the same. Naming a mechanism is what makes a sentence a candidate for
+being a proposal, not what makes it one. When a sentence is written as a requirement,
+or carries a rationale explaining why that mechanism specifically, it is a constraint
+and the substitution test does not apply to it.
+
+An implementer who replaces a proposed approach owes the requester the reason, not
+permission - but that holds only while the substitution preserves the agreed outcome
+and every constraint, and stays inside the authority and tool permissions the
+implementer already has. A better implementation is not authorization to cross a
+security, cost, or compatibility boundary: that is a constraint change, and it needs
+evidence and agreement before it is made, not an explanation afterwards.
+
+## Constraints and bindingness
+
+A constraint is binding. Its rationale is not what makes it binding; the rationale is
+what makes it **challengeable on the merits** rather than by preference.
+
+- **A constraint with no recorded rationale is still a constraint.** Older issues are
+  full of them. Preserve it provisionally, treat it as binding, investigate what it
+  was protecting, and surface the ambiguity to whoever can answer. Do not downgrade
+  it to a proposal because its reason is missing from the page.
+- **Reclassifying a constraint requires evidence and agreement.** Evidence that the
+  rationale does not hold here, plus whatever agreement the project's authority model
+  requires for a consequential change.
+- **Record the reclassification where the decision is reviewed** - the plan presented
+  at the approval gate, the PR description, or the completion ledger's revisions line.
+  Silent reclassification is the failure this section exists to prevent: an agent may
+  argue a constraint away, but never quietly treat it as optional.
+
+## How much document
+
+| Tier | Shape of the work | What the contract lives in |
+|------|-------------------|----------------------------|
+| Tier 1 (surgical) | 1-3 files, single concern | A short issue body. No spec, plan, or tasks files. |
+| Tier 2 (considered) | 4-10 files, new model or endpoint | A short issue body. A spec only if uncertainty or coordination warrants one. |
+| Tier 3 (architectural) | New subsystem, security boundary, multi-issue effort | An authoritative spec under `.specify/specs/`; the issue links it. |
+
+Tiers are defined in `.specify/memory/constitution.md`. When work is specified,
+**the issue references the spec and the sections that govern it; it does not copy
+them.** A copied spec becomes a second, drifting description of the same
+requirement - the same failure the
+[knowledge lifecycle](knowledge-lifecycle.md) prevents after delivery.
+
+**Existing issues remain usable.** Read an older issue by inferring these
+distinctions from what it says, and surface material ambiguity instead of guessing.
+There is no migration: do not reformat issues into this shape, and do not reject work
+because its issue predates this document.
+
+## Worked examples
+
+### A routine bug, Tier 1
+
+> Login redirects in a loop after a session expires; the user cannot get back in
+> without clearing cookies. Expired sessions should land on `/login` with the
+> original destination preserved. `handle_login()` looks like the place, though the
+> redirect may be set further up.
+
+Outcome and acceptance are in the first two sentences. `handle_login()` is a proposed
+approach and the hedge marks it; an implementer who finds the bug in the router fixes
+it there and says so. Nothing is missing from this issue: it has no constraints and no
+assumptions worth recording, and inventing some would add nothing.
+
+### A feature with a prescriptive proposed solution, Tier 2
+
+> Exports of more than a few thousand rows block the UI until they finish. Use a
+> background queue so the page stays responsive, and show progress. Must not add a
+> new infrastructure service - we run one container and intend to keep it that way.
+
+"Stays responsive while the export runs, with visible progress" is the outcome. "Use a
+background queue" is a proposal, and the constraint rules out the queue services that
+would otherwise be the obvious answer. An implementer who delivers responsiveness with
+an in-process worker and a polled progress endpoint has met the contract; the report
+says the queue was not used and why. An implementer who adds a broker has violated a
+constraint whose rationale is on the page, and needs evidence and agreement first.
+
+### Architectural work, Tier 3
+
+> Implements the tenant-isolation boundary. Authoritative spec:
+> `.specify/specs/tenant-isolation/spec.md`, sections "Trust boundary" and
+> "Migration order". This issue covers the query-layer half only; the storage half
+> is #124. Acceptance is the spec's US2 criteria.
+
+The issue is a pointer with a scope. The spec stays the source of truth, so amending
+it does not leave a stale copy in the tracker.
+
+### A legacy constraint with no recorded rationale
+
+> (filed eighteen months ago) Add pagination to the admin list. Do not use the ORM's
+> `.count()` here.
+
+The prohibition has no stated reason and the author is long gone. It is still binding.
+Preserve it, implement pagination without `.count()`, and surface the ambiguity: "this
+issue forbids `.count()` and does not say why - a windowed count is slower here, so
+the reason matters. Was this about the lock it takes on the audit table?" If
+investigation shows the rationale cannot apply - the table it protected no longer
+exists - that is evidence, and the reclassification is recorded in the plan and the
+PR. What is never correct is dropping the line because it looks arbitrary.
+
+## Surfaces that route here
+
+`.specify/memory/constitution.md` (P3, P4, and the workflow phases),
+`.claude/commands/spec/help.md`, `.claude/commands/github/issue-create.md`,
+`.claude/commands/evaluate/issue.md`, `.claude/skills/spec-driven-dev/SKILL.md`,
+`docs/skills/spec-driven-dev.md`, and the issue forms under `.github/ISSUE_TEMPLATE/`.
+
+`tests/test_issue_contract_routing.py` checks that those named routes still resolve
+and that no retired command reappears as a live instruction on them. It is a fixed
+list that fails loudly when one of those surfaces drifts; it does not discover new
+surfaces, and it cannot judge whether a constraint was handled correctly. That
+judgment is what the worked examples above are for.

--- a/docs/skills/spec-driven-dev.md
+++ b/docs/skills/spec-driven-dev.md
@@ -2,6 +2,21 @@
 
 *From Claude Code Best Practices - r/ClaudeCode community wisdom*
 
+## How this repository applies it
+
+The community material below argues for writing the specification before the code.
+CPP takes the principle and sizes it: every change states its **contract** first, and
+a full specification is how that contract is expressed when the work warrants one.
+Tier 1 and Tier 2 work carries the same contract in a few sentences in the issue body,
+with no spec.md, plan.md, or tasks.md; Tier 3 work gets the full pipeline and the issue
+references the spec instead of copying it.
+
+What the contract must make legible either way - the intended outcome, constraints with
+their rationale, observable acceptance, a proposed approach marked as revisable, and
+assumptions worth checking - is defined once in
+[the issue contract](../agents/issue-contract.md). Read that before applying the
+templates below, which are the Tier 3 shape.
+
 ## Why Spec-Driven Development? (107 upvotes)
 
 **From "Why we shifted to Spec-Driven Development":**
@@ -12,10 +27,11 @@
 
 ## The SDD Approach
 
-1. **Write Detailed Specs First**
-   - Before any code
+1. **Agree the Contract First**
+   - Before any code, at a size proportional to the work
    - Include edge cases
-   - Define success criteria
+   - Define success criteria as observable outcomes
+   - Keep a proposed design labelled as a proposal, so a better one can replace it
 
 2. **Review Specs, Not Just Code**
    - Easier to fix design issues before coding
@@ -102,11 +118,23 @@ One-sentence description
 
 ## Integration with Claude Code
 
-1. Create spec in `specs/` directory
-2. Reference spec in prompts: "Implement according to specs/feature.md"
-3. Ask Claude to verify implementation against spec
-4. Update spec with learnings
+For Tier 1 and Tier 2 work:
+
+1. State the contract in the issue body per
+   [the issue contract](../agents/issue-contract.md)
+2. Ship it with `/flow:auto <issue>`
+3. Verify the implementation against the issue's acceptance examples
+
+For Tier 3 work:
+
+1. Create the spec under `.specify/specs/{feature}/` with `/spec:adopt` and the
+   upstream `/speckit-*` skills
+2. Reference the spec and its governing sections from each issue, rather than
+   copying them
+3. Ask Claude to verify implementation against the spec
+4. Update the spec with learnings, then graduate its durable facts on delivery
+   ([knowledge lifecycle](../agents/knowledge-lifecycle.md))
 
 ---
 
-*Triggers: spec driven, specification, SDD, planning, requirements*
+*Triggers: spec driven, specification, SDD, planning, requirements, issue contract*

--- a/tests/test_issue_contract_routing.py
+++ b/tests/test_issue_contract_routing.py
@@ -1,0 +1,192 @@
+"""Routing tripwire for the canonical issue contract (issue #856).
+
+What this guards, and only this: the repository used to answer "how much
+paperwork does a small change need?" three different ways on one page - the
+constitution's P3 demanded a spec before any code, P7 demanded proportional
+ceremony, and the tier table said Tier 1 needs no spec - while routing authors
+through `/spec:create` and `/spec:sync`, retired in epic #417 Phase A and absent
+from the tree. #856 replaced that with one canonical definition
+(`docs/agents/issue-contract.md`) that the authoring surfaces point at.
+
+The failure mode this catches is drift: a surface stops pointing at the canonical
+document, a pointer stops resolving, or a retired command reappears as a live
+instruction. Those are structural facts about files, so these assertions are
+structural. Nothing here inspects policy wording - a test that pins prose breaks
+on every legitimate edit and gets relaxed until it means nothing, and the presence
+of a word is not evidence that the policy it names is coherent.
+
+What this test CANNOT do, stated so nobody reads a green run as more than it is:
+
+  * It does NOT discover new surfaces. ``ROUTED_SURFACES`` is a fixed list. A new
+    authoring surface added tomorrow is invisible here until someone adds it, and
+    the test passing says nothing about it. The list is a tripwire that fails
+    loudly when a listed surface drifts, not a coverage map.
+  * It does NOT verify any semantic acceptance criterion of #856 - not that the
+    parts stay optional, not that tiers route proportionally, and above all not
+    criterion 6, that a constrained implementation choice stays binding and cannot
+    be silently reclassified as optional. Those are properties of judgment, and no
+    string check reaches them. They are carried by the reviewed worked examples in
+    the canonical document, including the legacy constraint with no recorded
+    rationale, and by human review of that document.
+  * It does NOT prove an author or agent actually used the contract.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+CANONICAL = Path("docs/agents/issue-contract.md")
+
+# Fixed tripwire list: every surface #856 routed to the canonical contract. Adding
+# a surface here is a deliberate act; the list never grows by itself.
+ROUTED_SURFACES = (
+    Path(".specify/memory/constitution.md"),
+    Path(".claude/commands/spec/help.md"),
+    Path(".claude/commands/github/issue-create.md"),
+    Path(".claude/commands/evaluate/issue.md"),
+    Path(".claude/skills/spec-driven-dev/SKILL.md"),
+    Path("docs/skills/spec-driven-dev.md"),
+    Path(".specify/templates/spec-template.md"),
+    Path("CLAUDE.md"),
+)
+
+# Commands retired in epic #417 Phase A. `lib/spec_bridge` went with them.
+RETIRED_COMMANDS = ("/spec:create", "/spec:sync", "/spec:status", "/spec:init")
+
+# The two documents whose JOB is to record that retirement. A mention here is
+# history, not an instruction - but only when the surrounding lines say so, which
+# is asserted below rather than assumed.
+RETIREMENT_HISTORY = frozenset(
+    {
+        Path(".claude/commands/spec/help.md"),
+        Path(".claude/commands/spec/adopt.md"),
+    }
+)
+
+RETIREMENT_WORDS = ("retire", "removed", "legacy", "no longer")
+
+# Paths that must not instruct anyone to run a retired command. Supported surfaces
+# only: historical review notes and completed specs under .specify/specs/ record
+# what the repository used to do and are not instructions.
+LIVE_INSTRUCTION_PATHS = ROUTED_SURFACES + (
+    Path(".claude/commands/spec/adopt.md"),
+    Path(".specify/templates/tasks-template.md"),
+    Path(".github/ISSUE_TEMPLATE/feature-request.yml"),
+    Path(".github/ISSUE_TEMPLATE/bug-report.yml"),
+)
+
+FEATURE_FORM = Path(".github/ISSUE_TEMPLATE/feature-request.yml")
+
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)#]+)")
+
+# A repo-root mention: the canonical path NOT preceded by path characters, so the
+# tail of `../agents/issue-contract.md` or a wrongly rooted
+# `../../docs/agents/issue-contract.md` does not count as one. Those spellings are
+# relative links and are recognized only by resolving them.
+REPO_ROOT_MENTION_RE = re.compile(r"(?<![\w./-])" + re.escape(CANONICAL.as_posix()))
+
+
+def _read(rel: Path) -> str:
+    path = REPO / rel
+    assert path.is_file(), f"{rel} is missing; the tripwire list is stale"
+    return path.read_text(encoding="utf-8")
+
+
+def _resolved_link_targets(surface: Path, text: str) -> list[Path]:
+    """Local markdown link targets, resolved against the file that contains them."""
+    parent = (REPO / surface).parent
+    targets = []
+    for target in MARKDOWN_LINK_RE.findall(text):
+        target = target.strip()
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        targets.append((parent / target).resolve())
+    return targets
+
+
+def _routes_to_canonical(surface: Path, text: str) -> bool:
+    """True when this surface points at the canonical contract.
+
+    Exactly two spellings are recognized, because exactly two are used here: a
+    repo-root path (the SKILL.md and CLAUDE.md house style) or a relative markdown
+    link that RESOLVES to the file. A relative link is resolved rather than
+    string-matched, so one that spells the path correctly but is rooted wrong
+    fails. Any other way of gesturing at the document is not recognized, which is
+    a limit of this check and not a claim about the document.
+    """
+    if REPO_ROOT_MENTION_RE.search(text):
+        return True
+    return (REPO / CANONICAL).resolve() in _resolved_link_targets(surface, text)
+
+
+def test_canonical_contract_exists() -> None:
+    """Every surface below points here, so its absence breaks all of them at once."""
+    assert (REPO / CANONICAL).is_file(), f"{CANONICAL} is missing"
+
+
+@pytest.mark.parametrize("surface", ROUTED_SURFACES, ids=lambda p: str(p))
+def test_routed_surface_points_at_the_canonical_contract(surface: Path) -> None:
+    """A named route still resolves. This is the drift this test exists to catch."""
+    assert _routes_to_canonical(surface, _read(surface)), (
+        f"{surface} no longer references {CANONICAL} as a repo-root path or a "
+        f"resolving relative link - either the route was dropped or the canonical "
+        f"document moved and this list was not updated"
+    )
+
+
+@pytest.mark.parametrize("surface", ROUTED_SURFACES, ids=lambda p: str(p))
+def test_routed_surface_relative_links_resolve(surface: Path) -> None:
+    """A pointer to a file that does not exist is worse than no pointer."""
+    for target in _resolved_link_targets(surface, _read(surface)):
+        assert target.exists(), f"{surface} links to missing {target}"
+
+
+@pytest.mark.parametrize("surface", LIVE_INSTRUCTION_PATHS, ids=lambda p: str(p))
+def test_no_retired_command_reads_as_a_live_instruction(surface: Path) -> None:
+    """Criterion 5's second half: obsolete command references on touched paths.
+
+    A mention is tolerated only in the documents that record the retirement, and
+    only when the lines around it say it was retired. Without that second half the
+    allowlist would be a hole a live instruction could slip back through.
+    """
+    lines = _read(surface).splitlines()
+
+    for number, line in enumerate(lines):
+        hits = [command for command in RETIRED_COMMANDS if command in line]
+        if not hits:
+            continue
+        assert surface in RETIREMENT_HISTORY, (
+            f"{surface}:{number + 1} references retired {hits} as a live instruction"
+        )
+        window = " ".join(lines[max(0, number - 2) : number + 3]).lower()
+        assert any(word in window for word in RETIREMENT_WORDS), (
+            f"{surface}:{number + 1} mentions retired {hits} without marking it retired"
+        )
+
+
+def test_feature_form_does_not_require_a_prescribed_design() -> None:
+    """Criterion 4, as form behavior rather than as wording.
+
+    A form that makes a proposed design mandatory manufactures the blur this issue
+    removes: the reporter must invent a mechanism, and it then reads as binding.
+    The intended outcome stays required; the design does not.
+    """
+    form = yaml.safe_load(_read(FEATURE_FORM))
+    fields = {
+        field["id"]: field
+        for field in form["body"]
+        if isinstance(field, dict) and "id" in field
+    }
+
+    assert fields["problem"]["validations"]["required"] is True, (
+        "the intended outcome is the binding part of a feature request"
+    )
+    assert fields["solution"].get("validations", {}).get("required", False) is False, (
+        "the proposed approach must be optional - requiring it asks the reporter to "
+        "prescribe a design, which is what #856 removes"
+    )

--- a/tests/test_skills_check.py
+++ b/tests/test_skills_check.py
@@ -151,8 +151,14 @@ EXPECTED_LOADING_METADATA = {
     },
     "spec-driven-dev": {
         "name": "Spec-Driven Development",
-        "description": "Specification-first development workflow and planning",
-        "trigger": "spec driven, specification, SDD, planning, requirements",
+        # Revised by #856: the description and trigger are the skill's ACTIVE
+        # guidance (the line every session's skill listing shows), and
+        # "Specification-first" contradicted the proportional contract-first
+        # policy the constitution now states. The fixture still pins the
+        # post-conversion shape against silent loss; this is a reviewed edit to
+        # one entry, not a relaxation of the check.
+        "description": "Contract-first development, proportional spec routing, and planning",
+        "trigger": "spec driven, specification, SDD, planning, requirements, issue contract",
     },
 }
 


### PR DESCRIPTION
## What this changes

Requirements, implementation suggestions, and assumptions blurred together in issue bodies, so agents treated every sentence as binding. The repository said so in three voices at once: constitution **P3** demanded a spec before any code, **P7** demanded proportional ceremony, and the tier table said Tier 1 needs no spec - while the workflow phases still routed authors through `/spec:create` and `/spec:sync`, retired in epic #417 Phase A and absent from the tree.

This establishes `docs/agents/issue-contract.md` as the canonical definition and routes the authoring surfaces updated in this PR to it - the constitution, `spec/help.md`, `github/issue-create.md`, `evaluate/issue.md`, the spec-driven-dev skill and doc, `spec-template.md`, `CLAUDE.md`, and the issue forms - following the existing knowledge-lifecycle pattern: one normative document, pointers everywhere else. That fixed list is what the routing test covers; it is not a claim about every surface that exists.

## Acceptance criteria

| # | Criterion | Where it is met |
|---|-----------|-----------------|
| 1 | Small fix expresses its contract in a short issue body, no mandatory spec.md/plan.md/tasks.md | Canonical doc "How much document" table; constitution P3; `spec/help.md` routing; `evaluate/issue.md` Step 8a writes no files |
| 2 | Larger work references an authoritative spec without duplicating it | Canonical doc Tier 3 row and the Tier 3 worked example; `spec-template.md` header note |
| 3 | Existing issues stay usable; infer missing structure, surface ambiguity, no blanket migration | Canonical doc "Existing issues remain usable" plus the legacy-constraint example |
| 4 | Examples distinguish "use a background queue" (proposal) from "remain responsive while processing continues" (outcome) | Canonical doc classification table and the Tier 2 worked example; feature-request form makes the proposed approach optional and revisable |
| 5 | Constitution, active authoring guidance, and lightweight/full-spec routing express one proportional policy; obsolete command references removed on touched paths | P3, P4, workflow phases, tier note; `spec/help.md`, `github/issue-create.md`, `evaluate/issue.md`, spec-driven-dev skill + doc; `/spec:create` and `/spec:sync` removed from `constitution.md` and `tasks-template.md` |
| 6 | A constrained choice stays binding when its rationale requires it; challengeable but not silently reclassified | Canonical doc "Constraints and bindingness" plus the legacy example. Reviewed prose, deliberately not asserted by a test |

## The bindingness rule, stated precisely

A constraint is binding. Its rationale does not create that bindingness - it makes the constraint challengeable on the merits. So a constraint with no recorded rationale (common in older issues) is preserved provisionally and investigated, never demoted to a proposal. Reclassification needs evidence plus the agreement the authority model requires, and is recorded where the decision is reviewed.

The substitution heuristic ("swap the mechanism and see if the sentence survives") identifies *candidates* for being a proposal. It never overrides an explicit requirement: `use PostgreSQL, because this has to integrate with the database we already run` names a mechanism and is binding all the same. And substituting an approach is owed a reason rather than permission only while the substitution preserves the outcome and every constraint and stays inside existing authority and tool permissions - a better implementation does not authorize crossing a security, cost, or compatibility boundary.

## Test, and what it does not do

`tests/test_issue_contract_routing.py` is a narrow structural tripwire: named routes resolve (repo-root literal or a *resolving* relative link - a wrongly rooted one fails), local links point at files that exist, no retired command reads as a live instruction on a supported path, and the feature form keeps the outcome required while the proposed design is optional.

Its docstring states the limits rather than leaving them implied: the surface list is fixed and discovers nothing, and no assertion here reaches criterion 6's semantics or any other policy meaning. Earlier drafts contained word-presence checks whose docstrings overclaimed; those were removed rather than reworded.

## Verification

- `make verify`: **exit 0** - 2816 passed, 0 failed; mypy clean on 196 source files; binary-guards, negative-fixture, claude-md-budget (1197/2000), claude-md-links, claude-md-behavior, project-next-vendor all ok
- `flow-finish-gate.sh`: `FLOW_FINISH_GATE: ok` - lint, test, typecheck, security_scan all success
- Mutation controls: breaking a route and injecting `/spec:create` into `CLAUDE.md` each fail the tripwire; both pass again on restore
- `make codex-skills` regenerated the two affected mirrors; the `spec` family is unpackaged by design (`UNPACKAGED_FAMILIES`) so it has no mirror

One earlier run of `make verify` was red: `test_skills_check.py::test_conversion_preserves_enumerated_loading_metadata` pins each skill's frontmatter from the flat-to-package conversion, and this change edits the spec-driven-dev description and trigger - the line every session's skill listing shows, which still read "Specification-first". That fixture entry was updated under an explicit lane extension; its other assertions are untouched.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQUjuiK5LmADM7ejk1FJ5