### PR TITLE
fix(speckit): scope task identity to its feature and stop parsing silently (Closes #857)

### DIFF
--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -65,8 +65,11 @@ identity marker in its body:
 <!-- speckit-task:v1:<feature>:T001 -->
 ```
 
-`<feature>` defaults to this file's repository-relative path; pass `--feature SLUG`
-to pin an identity that survives the file being moved. Re-runs match on that marker,
+`<feature>` defaults to this file's repository-relative path. Moving this file
+therefore changes the identity: to keep the issues already filed, pass
+`--feature <the original path>` from then on. Any other slug declares a NEW
+identity and files every task again, so the pin only helps when it carries the
+value the existing issues were created under. Re-runs match on that marker,
 so two features' T001 stay distinct and a re-run files nothing twice. Issues created
 before the marker existed are matched by the `Auto-created from <path>` line in their
 body; one with neither is reported for resolution rather than guessed at.

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -57,6 +57,20 @@
 
 > Use `scripts/speckit-tasks-to-issues.sh` to create GitHub issues from these tasks.
 
+Task IDs restart at T001 in every feature, so they identify a task only WITHIN one
+tasks file. Each issue the converter creates therefore carries a feature-scoped
+identity marker in its body:
+
+```
+<!-- speckit-task:v1:<feature>:T001 -->
+```
+
+`<feature>` defaults to this file's repository-relative path; pass `--feature SLUG`
+to pin an identity that survives the file being moved. Re-runs match on that marker,
+so two features' T001 stay distinct and a re-run files nothing twice. Issues created
+before the marker existed are matched by the `Auto-created from <path>` line in their
+body; one with neither is reported for resolution rather than guessed at.
+
 | Task | Issue | Status |
 |------|-------|--------|
 | T001-T003 (Wave 1) | #{N} | pending |

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -132,6 +132,42 @@ echo "Remote:     $REMOTE_URL"
 marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
 provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
 
+# Two spellings of the SAME file must compare equal, or a legacy issue recorded
+# as `./a/tasks.md` reads as another feature's and its task is filed a second
+# time - the duplicate this whole change exists to prevent, caused by the
+# comparison rather than by the identity.
+#
+# Deliberately conservative: leading `./`, repeated slashes, and a trailing
+# slash are noise and are removed, and an ABSOLUTE path is made
+# repository-relative only when it is genuinely inside THIS repository. Nothing
+# else is inferred - `..` segments are left alone and an absolute path from
+# another checkout or machine stays absolute, so it correctly fails to match
+# rather than being guessed equal.
+normalize_source_path() {
+    local path="$1"
+    if [ -n "${_repo_root:-}" ]; then
+        case "$path" in
+            "$_repo_root"/*) path="${path#"$_repo_root"/}" ;;
+        esac
+    fi
+    while :; do
+        case "$path" in
+            ./*) path="${path#./}" ;;
+            *) break ;;
+        esac
+    done
+    while [[ "$path" == *//* ]]; do
+        path="${path//\/\//\/}"
+    done
+    case "$path" in
+        */) path="${path%/}" ;;
+    esac
+    printf '%s' "$path"
+}
+
+TASKS_NORM="$(normalize_source_path "$TASKS")"
+TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
+
 # --- Pass 1: parse tasks.md ------------------------------------------------------
 # Parsing runs to completion BEFORE any issue is created: a file this script cannot
 # read is a failure to report, not a zero-task success to celebrate (issue #857).
@@ -178,8 +214,17 @@ while IFS= read -r line || [ -n "$line" ]; do
             # `and` tolerated as a connector (the same separator the planner's
             # own edge grammar accepts). Anything else is reported with its line
             # rather than quietly dropped.
+            # Split WITHOUT pathname expansion. An unquoted `$(...)` in a `for`
+            # list is glob-expanded as well as word-split, so `(depends on T00?)`
+            # became a valid token in any directory that happened to contain a
+            # file called T002 - the validation passed because the filesystem
+            # supplied the answer. `IFS= read` takes each token literally.
+            dep_tokens=()
+            while IFS= read -r dep_token; do
+                [ -n "$dep_token" ] && dep_tokens+=("$dep_token")
+            done < <(printf '%s\n' "$dep_clause" | tr ', \t' '\n\n\n')
             dep_bad=""
-            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+            for dep_token in ${dep_tokens+"${dep_tokens[@]}"}; do
                 case "$dep_token" in
                     and|AND|And) continue ;;
                 esac
@@ -334,7 +379,8 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     fi
     [ -n "$ltid" ] || continue
     if [ -n "$prov" ]; then
-        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+        prov_norm="$(normalize_source_path "$prov")"
+        if [ "$prov_norm" = "$TASKS_NORM" ] || [ "$prov_norm" = "$TASKS_REL_NORM" ]; then
             # A pre-#857 issue this script created from THIS tasks file. The
             # recorded source path is real feature provenance, so adopting it is
             # evidence, not a guess.

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -162,7 +162,15 @@ while IFS= read -r line || [ -n "$line" ]; do
         SEEN_TID["$tid"]=1
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+            dep_clause="${BASH_REMATCH[1]}"
+            # `|| true`: grep exits 1 when a clause names no valid task id, and
+            # under `set -e` that killed the whole run with no diagnostic at all -
+            # the same silence this change exists to remove, in the error path.
+            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            if [ -z "$dep_list" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                continue
+            fi
         fi
         TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
     elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
@@ -274,16 +282,24 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     inventory_count=$((inventory_count + 1))
     if [ -n "$marker" ]; then
         # Exact identity. A marker naming a DIFFERENT feature is a known other
-        # task, not a claim on this one, so it is simply not this feature's.
-        case "$marker" in
-            "speckit-task:v1:${FEATURE}:"*)
-                tid="${marker##*:}"
+        # task, not a claim on this one.
+        #
+        # The comparison is EXACT, never a prefix: a feature may legitimately
+        # contain a colon (`--feature f:other`), so testing `speckit-task:v1:f:*`
+        # accepts `speckit-task:v1:f:other:T001` and hands one feature's task to
+        # another. Split the last field off as the task id and compare what
+        # remains to this feature in full.
+        marker_rest="${marker#speckit-task:v1:}"
+        if [ "$marker_rest" != "$marker" ]; then
+            tid="${marker_rest##*:}"
+            marker_feature="${marker_rest%:*}"
+            if [[ "$tid" =~ ^T[0-9]{3}$ ]] && [ "$marker_feature" = "$FEATURE" ]; then
                 MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
                 FILED_NUM["$tid"]="$number"
                 FILED_VIA["$tid"]="marker"
                 EXISTING_REFS["$tid"]="$refs"
-                ;;
-        esac
+            fi
+        fi
         continue
     fi
     [ -n "$ltid" ] || continue
@@ -324,14 +340,16 @@ echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 declare -a AMBIGUOUS=()
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
-    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
-    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
-    if [ "$claims" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
-        continue
-    fi
-    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+    # Count DISTINCT issues claiming this feature's task, whatever kind of claim
+    # they carry. Counting each bucket separately misses the mixed case - one
+    # issue with the marker and a different issue whose recorded source is this
+    # tasks file - which is two issues claiming one task and is exactly as
+    # ambiguous as two of either kind. The same issue appearing in both buckets
+    # cannot happen (a marker short-circuits the provenance read), so a repeat
+    # number here is always two different records.
+    claimants="$(printf '%s %s' "${MARKER_CLAIMS[$tid]:-}" "${PROV_CLAIMS[$tid]:-}" | tr ' ' '\n' | grep -c '^#[0-9]' || true)"
+    if [ "$claimants" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: ${claimants} issues claim this feature's task: marker ${MARKER_CLAIMS[$tid]:-none} / recorded source ${PROV_CLAIMS[$tid]:-none}")
         continue
     fi
     # An identified task is not made ambiguous by somebody else's untraceable

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -21,8 +21,10 @@
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
 #   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
-#                    repository-relative path. Pass it explicitly to keep identity
-#                    stable if the file moves.
+#                    repository-relative path. If the file MOVES, pass the value
+#                    the existing issues were filed under - the ORIGINAL path -
+#                    or they are no longer recognised and get filed again. A new
+#                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
 #
@@ -101,7 +103,9 @@ fi
 # across re-runs, and derivable without asking. A human heading is deliberately NOT
 # used - two specs may both be titled "# Tasks: Reporting", and the collision would
 # be silent. `--feature` overrides it, which is also how identity survives the file
-# being moved or renamed later.
+# being moved or renamed later - but only when it carries the value those issues
+# were filed under. Passing some other slug after a move does not preserve
+# anything: it declares a new identity, and every task is filed a second time.
 TASKS_REL="$TASKS"
 if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
     _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
@@ -163,12 +167,38 @@ while IFS= read -r line || [ -n "$line" ]; do
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
             dep_clause="${BASH_REMATCH[1]}"
-            # `|| true`: grep exits 1 when a clause names no valid task id, and
-            # under `set -e` that killed the whole run with no diagnostic at all -
-            # the same silence this change exists to remove, in the error path.
-            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            # Validate WHOLE tokens, never substrings. Extracting `T[0-9]{3}` out
+            # of the clause silently accepted two corruptions: `T002, T1` dropped
+            # the invalid half and wrote a partial edge, and `T0020` matched its
+            # own first four characters and wrote an edge to T002 - a dependency
+            # that was never declared. A fabricated edge is worse than a missing
+            # one, because the planner treats it as a real constraint.
+            #
+            # Supported syntax is comma- and/or space-separated task ids, with
+            # `and` tolerated as a connector (the same separator the planner's
+            # own edge grammar accepts). Anything else is reported with its line
+            # rather than quietly dropped.
+            dep_bad=""
+            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+                case "$dep_token" in
+                    and|AND|And) continue ;;
+                esac
+                if [[ "$dep_token" =~ ^T[0-9]{3}$ ]]; then
+                    case " $dep_list" in
+                        *" $dep_token "*) continue ;;
+                    esac
+                    dep_list+="$dep_token "
+                else
+                    dep_bad+="'${dep_token}' "
+                fi
+            done
+            dep_list="${dep_list%"${dep_list##*[![:space:]]}"}"
+            if [ -n "$dep_bad" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' has unreadable token(s) ${dep_bad}(expected T001..T999): ${line}")
+                continue
+            fi
             if [ -z "$dep_list" ]; then
-                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no task id (expected T001..T999): ${line}")
                 continue
             fi
         fi

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -6,38 +6,63 @@
 # Part of Claude Power Pack (CPP). Replaces upstream /speckit-taskstoissues, which
 # hard-requires the github-mcp-server. CPP is gh-CLI based, so this reproduces the
 # same behaviour with `gh`:
-#   - one label-free issue per task, titled "T001: <description>"
-#   - dedup against existing issues by \bT\d{3}\b title match (re-run safe)
+#   - one issue per task, titled "T001 (<feature>): <description>"
+#   - every issue carries a FEATURE-SCOPED identity marker, so re-runs are safe
+#     and two features' T001 are different tasks (issue #857)
 #   - refuses to run unless the git remote is a GitHub URL
 #
 # Usage:
 #   scripts/speckit-tasks-to-issues.sh [--dry-run] [--tasks PATH] [--repo OWNER/NAME]
+#                                      [--feature SLUG] [--limit N]
 #
 # Options:
 #   --dry-run        Print what would be created; create nothing.
 #   --tasks PATH     Path to tasks.md. Default: auto-detect the single
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
+#   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
+#                    repository-relative path. Pass it explicitly to keep identity
+#                    stable if the file moves.
+#   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
+#
+# Exit codes:
+#   0  success
+#   1  environment refusal (no gh, no GitHub remote, no tasks file)
+#   2  usage error
+#   3  tasks.md could not be parsed (malformed task lines, or no tasks at all)
+#   4  the existing-issue inventory could not be established (lookup failed, or
+#      the result may be truncated)
+#   5  one or more tasks have an ambiguous legacy identity awaiting resolution
+#   6  issues were created but a dependency edge could not be written; re-run to
+#      reconcile
 set -euo pipefail
 
 DRY_RUN=0
 TASKS=""
 REPO=""
+FEATURE=""
+LIMIT=1000
 
-usage() { sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
         --tasks) TASKS="${2:?--tasks needs a path}"; shift 2 ;;
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
+        --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
+        --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
+[[ "$LIMIT" =~ ^[0-9]+$ ]] && [ "$LIMIT" -gt 0 ] || {
+    echo "ERROR: --limit must be a positive integer (got '$LIMIT')." >&2; exit 2; }
+
 command -v gh > /dev/null 2>&1 || { echo "ERROR: gh CLI not found." >&2; exit 1; }
+command -v jq > /dev/null 2>&1 || { echo "ERROR: jq not found." >&2; exit 1; }
 
 # --- Safety: only operate against a GitHub remote --------------------------------
 REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
@@ -65,18 +90,114 @@ if [ -z "$TASKS" ]; then
 fi
 [ -f "$TASKS" ] || { echo "ERROR: tasks file not found: $TASKS" >&2; exit 1; }
 
+# --- Feature identity (issue #857) -----------------------------------------------
+# A task ID is only unique WITHIN a feature: every feature starts again at T001, so
+# "T001" alone identified nothing and one feature's T001 issue made every other
+# feature's T001 look already-filed.
+#
+# Identity is therefore the pair (feature, task id), and the feature half has to be
+# something that cannot collapse two different tasks files into one identity. The
+# tasks file's REPOSITORY-RELATIVE PATH is that: unique by construction, stable
+# across re-runs, and derivable without asking. A human heading is deliberately NOT
+# used - two specs may both be titled "# Tasks: Reporting", and the collision would
+# be silent. `--feature` overrides it, which is also how identity survives the file
+# being moved or renamed later.
+TASKS_REL="$TASKS"
+if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
+    _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
+    case "$_tasks_abs" in
+        "$_repo_root"/*) TASKS_REL="${_tasks_abs#"$_repo_root"/}" ;;
+        *) TASKS_REL="$_tasks_abs" ;;
+    esac
+fi
+if [ -z "$FEATURE" ]; then
+    FEATURE="$TASKS_REL"
+fi
+case "$FEATURE" in
+    *$'\n'*|"") echo "ERROR: feature identity is empty or multi-line; pass --feature SLUG." >&2; exit 2 ;;
+esac
+
 GH_REPO_ARGS=()
 [ -n "$REPO" ] && GH_REPO_ARGS=(--repo "$REPO")
 
 echo "Tasks file: $TASKS"
+echo "Feature:    $FEATURE"
 echo "Remote:     $REMOTE_URL"
 [ "$DRY_RUN" -eq 1 ] && echo "Mode:       DRY RUN (no issues will be created)"
 
-# --- Existing issue IDs (dedup + task -> issue-number map) -----------------------
-# Match \bT\d{3}\b in existing titles (open + closed) so re-runs skip done tasks.
-# The number map (issue #607) lets a later task's dependency clause resolve to
-# `- Blocked by #N` lines in its body - the planner's native edge form.
+marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
+provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
+
+# --- Pass 1: parse tasks.md ------------------------------------------------------
+# Parsing runs to completion BEFORE any issue is created: a file this script cannot
+# read is a failure to report, not a zero-task success to celebrate (issue #857).
 #
+# Both ID spellings the shipped templates use are accepted. `.specify/templates/
+# tasks-template.md` writes the BOLD form (`- [ ] **T001** [US1] ...`), which the
+# original strict-plain parser skipped silently - so the converter could not read
+# the template this repository ships. Story tags are stripped in both the single
+# (`[US1]`) and comma (`[US1,US2]`, `[US1, US2]`) spellings; the comma form is on
+# the template's own T007 line and used to leak into the issue title.
+declare -a TIDS=() DESCS=() DEPS=()
+declare -A SEEN_TID=()
+declare -a MALFORMED=() UNRECOGNISED=()
+lineno=0
+while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[[[:space:]xX]\] ]] || continue
+    body="${line#*] }"
+    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+([[:space:]]*,[[:space:]]*US?[0-9]+)*\]//gI; s/^[[:space:]]+//')"
+    body="$(printf '%s' "$body" | sed -E 's/^(\*\*|__)[[:space:]]*(T[0-9]{3})[[:space:]]*(\*\*|__)/\2/')"
+    if [[ "$body" =~ ^(T[0-9]{3})([:[:space:]]+(.*))?$ ]]; then
+        tid="${BASH_REMATCH[1]}"
+        desc="$(printf '%s' "${BASH_REMATCH[3]:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        if [ -z "$desc" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: ${tid} has no description: ${line}")
+            continue
+        fi
+        if [ -n "${SEEN_TID[$tid]:-}" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: duplicate task id ${tid} in this feature: ${line}")
+            continue
+        fi
+        SEEN_TID["$tid"]=1
+        dep_list=""
+        if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
+            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        fi
+        TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
+    elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
+        # Carries a T-number that is not a valid task id (T1, T12, T0001 ...).
+        # Silently skipping these is how a file of malformed tasks reported
+        # "0 to create" and exited 0.
+        MALFORMED+=("${TASKS}:${lineno}: task-like line with a malformed T-number (expected T001..T999): ${line}")
+    else
+        # A checkbox line with no T-number at all. It may be a legitimate non-task
+        # checkbox, so it does not fail the run on its own - but it is never
+        # swallowed either, and a file where EVERY line lands here still fails
+        # below on the zero-task check rather than reporting a successful nothing.
+        UNRECOGNISED+=("${TASKS}:${lineno}: checkbox line is not a task and was ignored: ${line}")
+    fi
+done < "$TASKS"
+
+if [ "${#UNRECOGNISED[@]}" -gt 0 ]; then
+    echo "NOTE: ${#UNRECOGNISED[@]} checkbox line(s) were not read as tasks:" >&2
+    printf '  %s\n' "${UNRECOGNISED[@]}" >&2
+fi
+
+if [ "${#MALFORMED[@]}" -gt 0 ]; then
+    echo "ERROR: ${#MALFORMED[@]} task-like line(s) could not be parsed:" >&2
+    printf '  %s\n' "${MALFORMED[@]}" >&2
+    echo "Fix the lines above (or pass a different --tasks) and re-run. No issues were created." >&2
+    exit 3
+fi
+if [ "${#TIDS[@]}" -eq 0 ]; then
+    echo "ERROR: no tasks found in ${TASKS}." >&2
+    echo "Expected checkbox lines such as '- [ ] **T001** [US1] Description'." >&2
+    exit 3
+fi
+echo "Parsed:     ${#TIDS[@]} task(s)"
+
+# --- Inventory of existing issues ------------------------------------------------
 # ISSUE_FS - the ONE field separator for the `gh issue list` records parsed below
 # (issue #700), ASCII unit separator (0x1F) and deliberately NOT tab.
 #
@@ -91,9 +212,12 @@ echo "Remote:     $REMOTE_URL"
 # SHIFTED FIELDS (issue bodies built from the wrong values), not an error.
 # `\037` is not IFS whitespace, so empty fields survive in every position.
 #
+# That is exactly what happened here: #857 added three more fields, and two of them
+# (marker, provenance path) are EMPTY for every issue this script did not create.
+#
 # Same defect class as #698, which fixed the live instance in
 # scripts/flow-wave-registry.sh (a branchless worktree produced an empty middle
-# field on the ordinary path); this was the last whitespace-IFS read in scripts/.
+# field on the ordinary path).
 #
 # ONE definition, two spellings: the producer is a jq filter needing the `\uHHHH`
 # escape text, the reader is a shell `read` needing the byte, so the escape is
@@ -108,66 +232,232 @@ if [ "${#ISSUE_FS}" -ne 1 ] || [ "${#ISSUE_FS_JQ}" -ne 6 ]; then
     exit 1
 fi
 
-declare -A EXISTING
-declare -A TASK_ISSUE
-while IFS="$ISSUE_FS" read -r number title; do
-    if [[ "$title" =~ (^|[^A-Za-z0-9])(T[0-9]{3})([^0-9]|$) ]]; then
-        EXISTING["${BASH_REMATCH[2]}"]=1
-        TASK_ISSUE["${BASH_REMATCH[2]}"]="$number"
+# Record: number FS marker FS provenance-path FS legacy-tid FS blocked-refs
+# marker         - the speckit-task identity comment, when the body carries one
+# provenance     - the tasks path recorded in the "Auto-created from ..." line, which
+#                  is the only feature evidence a pre-#857 issue carries
+# legacy-tid     - a bare T-number in the TITLE, the pre-#857 identity
+# blocked-refs   - "#N" refs already present on this body's `Blocked by` lines, so a
+#                  re-run can tell a missing edge from one already written
+INVENTORY_JQ='
+.[] |
+  (.body // "") as $b |
+  ($b | capture("<!--\\s*(?<m>speckit-task:v1:[^>]*?)\\s*-->") // {m:""} | .m) as $marker |
+  ($b | capture("Auto-created from (?<p>.+?) \\(T[0-9]{3}\\) by CPP speckit-tasks-to-issues") // {p:""} | .p) as $prov |
+  ((.title // "") | capture("(^|[^A-Za-z0-9])(?<t>T[0-9]{3})([^0-9]|$)") // {t:""} | .t) as $ltid |
+  ([$b | scan("(?im)^\\s*[-*]?\\s*blocked by[^#\\n]*(#[0-9]+)") | .[0]] | join(",")) as $refs |
+  "\(.number)FS\($marker)FS\($prov)FS\($ltid)FS\($refs)"
+'
+INVENTORY_JQ="${INVENTORY_JQ//FS/$ISSUE_FS_JQ}"
+
+inventory_raw=""
+inventory_status=0
+inventory_raw="$(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit "$LIMIT" \
+    --json number,title,body --jq "$INVENTORY_JQ" 2>&1)" || inventory_status=$?
+if [ "$inventory_status" -ne 0 ]; then
+    echo "ERROR: could not list existing issues (gh exited ${inventory_status})." >&2
+    printf '  %s\n' "$inventory_raw" >&2
+    echo "Refusing to continue: an unreadable inventory is not an empty one, and treating" >&2
+    echo "it as empty re-files every task that already has an issue." >&2
+    exit 4
+fi
+
+declare -A FILED_NUM=()       # tid -> issue number claimed for THIS feature
+declare -A FILED_VIA=()       # tid -> marker | provenance
+declare -A EXISTING_REFS=()   # tid -> "#12,#13" already on the issue body
+declare -A MARKER_CLAIMS=()   # tid -> "#N #M" issues whose marker names this feature
+declare -A PROV_CLAIMS=()     # tid -> "#N #M" issues whose recorded source is this file
+declare -A UNRESOLVED_HITS=() # tid -> "#N" bare-title issues carrying no feature evidence
+inventory_count=0
+while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
+    [ -n "$number" ] || continue
+    inventory_count=$((inventory_count + 1))
+    if [ -n "$marker" ]; then
+        # Exact identity. A marker naming a DIFFERENT feature is a known other
+        # task, not a claim on this one, so it is simply not this feature's.
+        case "$marker" in
+            "speckit-task:v1:${FEATURE}:"*)
+                tid="${marker##*:}"
+                MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
+                FILED_NUM["$tid"]="$number"
+                FILED_VIA["$tid"]="marker"
+                EXISTING_REFS["$tid"]="$refs"
+                ;;
+        esac
+        continue
     fi
-done < <(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit 1000 --json number,title --jq ".[] | \"\(.number)${ISSUE_FS_JQ}\(.title)\"" 2>/dev/null || true)
+    [ -n "$ltid" ] || continue
+    if [ -n "$prov" ]; then
+        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+            # A pre-#857 issue this script created from THIS tasks file. The
+            # recorded source path is real feature provenance, so adopting it is
+            # evidence, not a guess.
+            PROV_CLAIMS["$ltid"]="${PROV_CLAIMS[$ltid]:-}#${number} "
+            if [ -z "${FILED_NUM[$ltid]:-}" ]; then
+                FILED_NUM["$ltid"]="$number"
+                FILED_VIA["$ltid"]="provenance"
+                EXISTING_REFS["$ltid"]="$refs"
+            fi
+        fi
+        # A provenance line naming a DIFFERENT tasks file is a known different
+        # feature. It says nothing about this feature's task of the same number,
+        # so it must not block this one from being filed.
+        continue
+    fi
+    # A bare T-number in a title, with no marker and no recorded source at all.
+    # Whose task it is cannot be established: two features routinely share both a
+    # task id AND its description ("T001 Add tests"), so a description match is not
+    # provenance. Recorded as unresolved and settled by a human, never guessed.
+    UNRESOLVED_HITS["$ltid"]="${UNRESOLVED_HITS[$ltid]:-}#${number} "
+done <<< "$inventory_raw"
 
-# --- Parse tasks.md and create issues -------------------------------------------
-created=0; skipped=0
-while IFS= read -r line; do
-    # Only checkbox task lines.
-    [[ "$line" =~ ^-\ \[[\ xX]\] ]] || continue
-    # Strip the checkbox (up to the first "] ") and any [P] / [US#] markers.
-    body="${line#*] }"
-    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+\]//g; s/^[[:space:]]+//')"
-    # Recover the task ID (T + 3 digits) and description.
-    [[ "$body" =~ ^(T[0-9]{3})[:[:space:]]+(.*)$ ]] || continue
-    tid="${BASH_REMATCH[1]}"
-    desc="$(printf '%s' "${BASH_REMATCH[2]}" | sed -E 's/[[:space:]]+$//')"
-    title="${tid}: ${desc}"
+if [ "$inventory_count" -ge "$LIMIT" ]; then
+    echo "ERROR: the issue inventory returned ${inventory_count} record(s), the same as" >&2
+    echo "--limit ${LIMIT}. The list may be truncated, and a truncated inventory cannot" >&2
+    echo "support the re-run guarantee: a task whose issue fell past the cutoff would be" >&2
+    echo "filed a second time. Re-run with a larger --limit." >&2
+    exit 4
+fi
+echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 
-    if [ -n "${EXISTING[$tid]:-}" ]; then
-        echo "skip  ${tid} (issue already exists)"
+# --- Ambiguity scan: everything that must stop the run happens BEFORE any write ---
+declare -a AMBIGUOUS=()
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
+    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
+    if [ "$claims" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
+        continue
+    fi
+    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+        continue
+    fi
+    # An identified task is not made ambiguous by somebody else's untraceable
+    # issue: this feature's task already has evidence naming it.
+    [ -n "${FILED_NUM[$tid]:-}" ] && continue
+    [ -n "${UNRESOLVED_HITS[$tid]:-}" ] || continue
+    AMBIGUOUS+=("${tid}: ${UNRESOLVED_HITS[$tid]}(title carries ${tid}, records no source feature)")
+done
+if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
+    echo "ERROR: ${#AMBIGUOUS[@]} task(s) have an unresolved identity:" >&2
+    printf '  %s\n' "${AMBIGUOUS[@]}" >&2
+    echo "Each names an existing issue that carries this task number but no evidence of which" >&2
+    echo "feature it belongs to, or more than one issue claiming this feature's task. This" >&2
+    echo "script will not decide. Resolve by adding the identity marker to the correct issue's" >&2
+    echo "body (or removing the duplicate claim), then re-run:" >&2
+    echo "  $(marker_for T001)" >&2
+    echo "(substituting the task id). An issue whose body records a DIFFERENT tasks file needs" >&2
+    echo "no change - it is already recognised as another feature's task." >&2
+    exit 5
+fi
+
+# --- Create pass -----------------------------------------------------------------
+created=0; skipped=0; adopted=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    title="${tid} (${FEATURE}): ${DESCS[$i]}"
+    if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
+                 "add '$(marker_for "$tid")' to its body to make the identity explicit)"
+            adopted=$((adopted + 1))
+        else
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]} already carries this feature's marker)"
+        fi
         skipped=$((skipped + 1))
         continue
     fi
-    # Dependency clause -> machine-readable body lines (issue #607). The clause
-    # used to survive only as title prose, which drifted from tasks.md with
-    # nothing to detect it. The body now carries BOTH forms: a `Depends on:`
-    # task-id line (joinable via the spec's Issue Sync table even when numbers
-    # are unknown), and `- Blocked by #N` bullets - flow-wave-plan.py's native
-    # edge grammar - for every dep already resolvable to an issue number
-    # (created earlier this run, or found by the dedup scan above).
-    issue_body="Auto-created from ${TASKS} (${tid}) by CPP speckit-tasks-to-issues."
-    if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-        dep_clause="${BASH_REMATCH[1]}"
-        dep_tids="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ')"
-        if [ -n "$dep_tids" ]; then
-            issue_body+=$'\n\n'"Depends on: $(printf '%s' "$dep_tids" | sed 's/ $//; s/ /, /g')"
-            for dep in $dep_tids; do
-                if [ -n "${TASK_ISSUE[$dep]:-}" ]; then
-                    issue_body+=$'\n'"- Blocked by #${TASK_ISSUE[$dep]}"
-                fi
-            done
-        fi
+
+    issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
+    if [ -n "${DEPS[$i]}" ]; then
+        issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "would create: ${title}"
+        FILED_NUM["$tid"]=""
     else
         url="$(gh issue create "${GH_REPO_ARGS[@]}" --title "$title" --body "$issue_body" 2>&1)"
         echo "create ${tid} -> ${url}"
-        EXISTING["$tid"]=1
         num="${url##*/}"
-        [[ "$num" =~ ^[0-9]+$ ]] && TASK_ISSUE["$tid"]="$num"
+        if [[ "$num" =~ ^[0-9]+$ ]]; then
+            FILED_NUM["$tid"]="$num"
+            FILED_VIA["$tid"]="marker"
+            EXISTING_REFS["$tid"]=""
+        fi
     fi
     created=$((created + 1))
-done < "$TASKS"
+done
+
+# --- Dependency reconciliation ---------------------------------------------------
+# Deliberately NOT "annotate what this run created". A dependency may point FORWARD
+# to a task declared later in the file, and a run that dies between creating issues
+# and writing their edges must be repairable - otherwise those edges are missing
+# forever, because the next run sees the issues as already filed and skips them
+# (issue #857). So every filed task in this feature is reconciled on every run:
+# expected refs minus refs already in the body, appended, existing content kept.
+#
+# Edges resolve ONLY within this feature. A T-number that belongs to another
+# feature's tasks file cannot contribute an edge here - that cross-feature guess is
+# the same defect as the identity one, one level down.
+edges_written=0; edges_failed=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    [ -n "${DEPS[$i]}" ] || continue
+    number="${FILED_NUM[$tid]:-}"
+
+    missing=""
+    for dep in ${DEPS[$i]}; do
+        dep_num="${FILED_NUM[$dep]:-}"
+        if [ -z "$dep_num" ]; then
+            if [ -z "${SEEN_TID[$dep]:-}" ]; then
+                echo "note  ${tid} depends on ${dep}, which is not a task in this feature - no edge written." >&2
+            fi
+            continue
+        fi
+        case ",${EXISTING_REFS[$tid]:-}," in
+            *",#${dep_num},"*) continue ;;
+        esac
+        case "$missing" in
+            *"#${dep_num} "*) continue ;;
+        esac
+        missing+="#${dep_num} "
+    done
+    [ -n "$missing" ] || continue
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "would link:   ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//')"
+        continue
+    fi
+    [ -n "$number" ] || continue
+
+    current_body="$(gh issue view "$number" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || {
+        echo "WARN: could not read issue #${number} to add its dependency edges; re-run to reconcile." >&2
+        printf '  %s\n' "$current_body" >&2
+        edges_failed=$((edges_failed + 1))
+        continue
+    }
+    new_body="$current_body"
+    for ref in $missing; do
+        new_body+=$'\n'"- Blocked by ${ref}"
+    done
+    if printf '%s' "$new_body" | gh issue edit "$number" "${GH_REPO_ARGS[@]}" --body-file - > /dev/null 2>&1; then
+        echo "link  ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//') (issue #${number})"
+        edges_written=$((edges_written + 1))
+    else
+        echo "WARN: could not write dependency edges for ${tid} (issue #${number}); re-run to reconcile." >&2
+        edges_failed=$((edges_failed + 1))
+    fi
+done
 
 echo "---"
-echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist)."
+echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
+[ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$edges_failed" -gt 0 ]; then
+    echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
+    echo "command to reconcile the missing edges - it will not create duplicates." >&2
+    exit 6
+fi
+exit 0

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -132,6 +132,42 @@ echo "Remote:     $REMOTE_URL"
 marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
 provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
 
+# Two spellings of the SAME file must compare equal, or a legacy issue recorded
+# as `./a/tasks.md` reads as another feature's and its task is filed a second
+# time - the duplicate this whole change exists to prevent, caused by the
+# comparison rather than by the identity.
+#
+# Deliberately conservative: leading `./`, repeated slashes, and a trailing
+# slash are noise and are removed, and an ABSOLUTE path is made
+# repository-relative only when it is genuinely inside THIS repository. Nothing
+# else is inferred - `..` segments are left alone and an absolute path from
+# another checkout or machine stays absolute, so it correctly fails to match
+# rather than being guessed equal.
+normalize_source_path() {
+    local path="$1"
+    if [ -n "${_repo_root:-}" ]; then
+        case "$path" in
+            "$_repo_root"/*) path="${path#"$_repo_root"/}" ;;
+        esac
+    fi
+    while :; do
+        case "$path" in
+            ./*) path="${path#./}" ;;
+            *) break ;;
+        esac
+    done
+    while [[ "$path" == *//* ]]; do
+        path="${path//\/\//\/}"
+    done
+    case "$path" in
+        */) path="${path%/}" ;;
+    esac
+    printf '%s' "$path"
+}
+
+TASKS_NORM="$(normalize_source_path "$TASKS")"
+TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
+
 # --- Pass 1: parse tasks.md ------------------------------------------------------
 # Parsing runs to completion BEFORE any issue is created: a file this script cannot
 # read is a failure to report, not a zero-task success to celebrate (issue #857).
@@ -178,8 +214,17 @@ while IFS= read -r line || [ -n "$line" ]; do
             # `and` tolerated as a connector (the same separator the planner's
             # own edge grammar accepts). Anything else is reported with its line
             # rather than quietly dropped.
+            # Split WITHOUT pathname expansion. An unquoted `$(...)` in a `for`
+            # list is glob-expanded as well as word-split, so `(depends on T00?)`
+            # became a valid token in any directory that happened to contain a
+            # file called T002 - the validation passed because the filesystem
+            # supplied the answer. `IFS= read` takes each token literally.
+            dep_tokens=()
+            while IFS= read -r dep_token; do
+                [ -n "$dep_token" ] && dep_tokens+=("$dep_token")
+            done < <(printf '%s\n' "$dep_clause" | tr ', \t' '\n\n\n')
             dep_bad=""
-            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+            for dep_token in ${dep_tokens+"${dep_tokens[@]}"}; do
                 case "$dep_token" in
                     and|AND|And) continue ;;
                 esac
@@ -334,7 +379,8 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     fi
     [ -n "$ltid" ] || continue
     if [ -n "$prov" ]; then
-        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+        prov_norm="$(normalize_source_path "$prov")"
+        if [ "$prov_norm" = "$TASKS_NORM" ] || [ "$prov_norm" = "$TASKS_REL_NORM" ]; then
             # A pre-#857 issue this script created from THIS tasks file. The
             # recorded source path is real feature provenance, so adopting it is
             # evidence, not a guess.

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -162,7 +162,15 @@ while IFS= read -r line || [ -n "$line" ]; do
         SEEN_TID["$tid"]=1
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+            dep_clause="${BASH_REMATCH[1]}"
+            # `|| true`: grep exits 1 when a clause names no valid task id, and
+            # under `set -e` that killed the whole run with no diagnostic at all -
+            # the same silence this change exists to remove, in the error path.
+            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            if [ -z "$dep_list" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                continue
+            fi
         fi
         TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
     elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
@@ -274,16 +282,24 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     inventory_count=$((inventory_count + 1))
     if [ -n "$marker" ]; then
         # Exact identity. A marker naming a DIFFERENT feature is a known other
-        # task, not a claim on this one, so it is simply not this feature's.
-        case "$marker" in
-            "speckit-task:v1:${FEATURE}:"*)
-                tid="${marker##*:}"
+        # task, not a claim on this one.
+        #
+        # The comparison is EXACT, never a prefix: a feature may legitimately
+        # contain a colon (`--feature f:other`), so testing `speckit-task:v1:f:*`
+        # accepts `speckit-task:v1:f:other:T001` and hands one feature's task to
+        # another. Split the last field off as the task id and compare what
+        # remains to this feature in full.
+        marker_rest="${marker#speckit-task:v1:}"
+        if [ "$marker_rest" != "$marker" ]; then
+            tid="${marker_rest##*:}"
+            marker_feature="${marker_rest%:*}"
+            if [[ "$tid" =~ ^T[0-9]{3}$ ]] && [ "$marker_feature" = "$FEATURE" ]; then
                 MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
                 FILED_NUM["$tid"]="$number"
                 FILED_VIA["$tid"]="marker"
                 EXISTING_REFS["$tid"]="$refs"
-                ;;
-        esac
+            fi
+        fi
         continue
     fi
     [ -n "$ltid" ] || continue
@@ -324,14 +340,16 @@ echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 declare -a AMBIGUOUS=()
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
-    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
-    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
-    if [ "$claims" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
-        continue
-    fi
-    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+    # Count DISTINCT issues claiming this feature's task, whatever kind of claim
+    # they carry. Counting each bucket separately misses the mixed case - one
+    # issue with the marker and a different issue whose recorded source is this
+    # tasks file - which is two issues claiming one task and is exactly as
+    # ambiguous as two of either kind. The same issue appearing in both buckets
+    # cannot happen (a marker short-circuits the provenance read), so a repeat
+    # number here is always two different records.
+    claimants="$(printf '%s %s' "${MARKER_CLAIMS[$tid]:-}" "${PROV_CLAIMS[$tid]:-}" | tr ' ' '\n' | grep -c '^#[0-9]' || true)"
+    if [ "$claimants" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: ${claimants} issues claim this feature's task: marker ${MARKER_CLAIMS[$tid]:-none} / recorded source ${PROV_CLAIMS[$tid]:-none}")
         continue
     fi
     # An identified task is not made ambiguous by somebody else's untraceable

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -21,8 +21,10 @@
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
 #   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
-#                    repository-relative path. Pass it explicitly to keep identity
-#                    stable if the file moves.
+#                    repository-relative path. If the file MOVES, pass the value
+#                    the existing issues were filed under - the ORIGINAL path -
+#                    or they are no longer recognised and get filed again. A new
+#                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
 #
@@ -101,7 +103,9 @@ fi
 # across re-runs, and derivable without asking. A human heading is deliberately NOT
 # used - two specs may both be titled "# Tasks: Reporting", and the collision would
 # be silent. `--feature` overrides it, which is also how identity survives the file
-# being moved or renamed later.
+# being moved or renamed later - but only when it carries the value those issues
+# were filed under. Passing some other slug after a move does not preserve
+# anything: it declares a new identity, and every task is filed a second time.
 TASKS_REL="$TASKS"
 if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
     _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
@@ -163,12 +167,38 @@ while IFS= read -r line || [ -n "$line" ]; do
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
             dep_clause="${BASH_REMATCH[1]}"
-            # `|| true`: grep exits 1 when a clause names no valid task id, and
-            # under `set -e` that killed the whole run with no diagnostic at all -
-            # the same silence this change exists to remove, in the error path.
-            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            # Validate WHOLE tokens, never substrings. Extracting `T[0-9]{3}` out
+            # of the clause silently accepted two corruptions: `T002, T1` dropped
+            # the invalid half and wrote a partial edge, and `T0020` matched its
+            # own first four characters and wrote an edge to T002 - a dependency
+            # that was never declared. A fabricated edge is worse than a missing
+            # one, because the planner treats it as a real constraint.
+            #
+            # Supported syntax is comma- and/or space-separated task ids, with
+            # `and` tolerated as a connector (the same separator the planner's
+            # own edge grammar accepts). Anything else is reported with its line
+            # rather than quietly dropped.
+            dep_bad=""
+            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+                case "$dep_token" in
+                    and|AND|And) continue ;;
+                esac
+                if [[ "$dep_token" =~ ^T[0-9]{3}$ ]]; then
+                    case " $dep_list" in
+                        *" $dep_token "*) continue ;;
+                    esac
+                    dep_list+="$dep_token "
+                else
+                    dep_bad+="'${dep_token}' "
+                fi
+            done
+            dep_list="${dep_list%"${dep_list##*[![:space:]]}"}"
+            if [ -n "$dep_bad" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' has unreadable token(s) ${dep_bad}(expected T001..T999): ${line}")
+                continue
+            fi
             if [ -z "$dep_list" ]; then
-                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no task id (expected T001..T999): ${line}")
                 continue
             fi
         fi

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -6,38 +6,63 @@
 # Part of Claude Power Pack (CPP). Replaces upstream /speckit-taskstoissues, which
 # hard-requires the github-mcp-server. CPP is gh-CLI based, so this reproduces the
 # same behaviour with `gh`:
-#   - one label-free issue per task, titled "T001: <description>"
-#   - dedup against existing issues by \bT\d{3}\b title match (re-run safe)
+#   - one issue per task, titled "T001 (<feature>): <description>"
+#   - every issue carries a FEATURE-SCOPED identity marker, so re-runs are safe
+#     and two features' T001 are different tasks (issue #857)
 #   - refuses to run unless the git remote is a GitHub URL
 #
 # Usage:
 #   scripts/speckit-tasks-to-issues.sh [--dry-run] [--tasks PATH] [--repo OWNER/NAME]
+#                                      [--feature SLUG] [--limit N]
 #
 # Options:
 #   --dry-run        Print what would be created; create nothing.
 #   --tasks PATH     Path to tasks.md. Default: auto-detect the single
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
+#   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
+#                    repository-relative path. Pass it explicitly to keep identity
+#                    stable if the file moves.
+#   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
+#
+# Exit codes:
+#   0  success
+#   1  environment refusal (no gh, no GitHub remote, no tasks file)
+#   2  usage error
+#   3  tasks.md could not be parsed (malformed task lines, or no tasks at all)
+#   4  the existing-issue inventory could not be established (lookup failed, or
+#      the result may be truncated)
+#   5  one or more tasks have an ambiguous legacy identity awaiting resolution
+#   6  issues were created but a dependency edge could not be written; re-run to
+#      reconcile
 set -euo pipefail
 
 DRY_RUN=0
 TASKS=""
 REPO=""
+FEATURE=""
+LIMIT=1000
 
-usage() { sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
         --tasks) TASKS="${2:?--tasks needs a path}"; shift 2 ;;
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
+        --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
+        --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
+[[ "$LIMIT" =~ ^[0-9]+$ ]] && [ "$LIMIT" -gt 0 ] || {
+    echo "ERROR: --limit must be a positive integer (got '$LIMIT')." >&2; exit 2; }
+
 command -v gh > /dev/null 2>&1 || { echo "ERROR: gh CLI not found." >&2; exit 1; }
+command -v jq > /dev/null 2>&1 || { echo "ERROR: jq not found." >&2; exit 1; }
 
 # --- Safety: only operate against a GitHub remote --------------------------------
 REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
@@ -65,18 +90,114 @@ if [ -z "$TASKS" ]; then
 fi
 [ -f "$TASKS" ] || { echo "ERROR: tasks file not found: $TASKS" >&2; exit 1; }
 
+# --- Feature identity (issue #857) -----------------------------------------------
+# A task ID is only unique WITHIN a feature: every feature starts again at T001, so
+# "T001" alone identified nothing and one feature's T001 issue made every other
+# feature's T001 look already-filed.
+#
+# Identity is therefore the pair (feature, task id), and the feature half has to be
+# something that cannot collapse two different tasks files into one identity. The
+# tasks file's REPOSITORY-RELATIVE PATH is that: unique by construction, stable
+# across re-runs, and derivable without asking. A human heading is deliberately NOT
+# used - two specs may both be titled "# Tasks: Reporting", and the collision would
+# be silent. `--feature` overrides it, which is also how identity survives the file
+# being moved or renamed later.
+TASKS_REL="$TASKS"
+if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
+    _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
+    case "$_tasks_abs" in
+        "$_repo_root"/*) TASKS_REL="${_tasks_abs#"$_repo_root"/}" ;;
+        *) TASKS_REL="$_tasks_abs" ;;
+    esac
+fi
+if [ -z "$FEATURE" ]; then
+    FEATURE="$TASKS_REL"
+fi
+case "$FEATURE" in
+    *$'\n'*|"") echo "ERROR: feature identity is empty or multi-line; pass --feature SLUG." >&2; exit 2 ;;
+esac
+
 GH_REPO_ARGS=()
 [ -n "$REPO" ] && GH_REPO_ARGS=(--repo "$REPO")
 
 echo "Tasks file: $TASKS"
+echo "Feature:    $FEATURE"
 echo "Remote:     $REMOTE_URL"
 [ "$DRY_RUN" -eq 1 ] && echo "Mode:       DRY RUN (no issues will be created)"
 
-# --- Existing issue IDs (dedup + task -> issue-number map) -----------------------
-# Match \bT\d{3}\b in existing titles (open + closed) so re-runs skip done tasks.
-# The number map (issue #607) lets a later task's dependency clause resolve to
-# `- Blocked by #N` lines in its body - the planner's native edge form.
+marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
+provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
+
+# --- Pass 1: parse tasks.md ------------------------------------------------------
+# Parsing runs to completion BEFORE any issue is created: a file this script cannot
+# read is a failure to report, not a zero-task success to celebrate (issue #857).
 #
+# Both ID spellings the shipped templates use are accepted. `.specify/templates/
+# tasks-template.md` writes the BOLD form (`- [ ] **T001** [US1] ...`), which the
+# original strict-plain parser skipped silently - so the converter could not read
+# the template this repository ships. Story tags are stripped in both the single
+# (`[US1]`) and comma (`[US1,US2]`, `[US1, US2]`) spellings; the comma form is on
+# the template's own T007 line and used to leak into the issue title.
+declare -a TIDS=() DESCS=() DEPS=()
+declare -A SEEN_TID=()
+declare -a MALFORMED=() UNRECOGNISED=()
+lineno=0
+while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[[[:space:]xX]\] ]] || continue
+    body="${line#*] }"
+    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+([[:space:]]*,[[:space:]]*US?[0-9]+)*\]//gI; s/^[[:space:]]+//')"
+    body="$(printf '%s' "$body" | sed -E 's/^(\*\*|__)[[:space:]]*(T[0-9]{3})[[:space:]]*(\*\*|__)/\2/')"
+    if [[ "$body" =~ ^(T[0-9]{3})([:[:space:]]+(.*))?$ ]]; then
+        tid="${BASH_REMATCH[1]}"
+        desc="$(printf '%s' "${BASH_REMATCH[3]:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        if [ -z "$desc" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: ${tid} has no description: ${line}")
+            continue
+        fi
+        if [ -n "${SEEN_TID[$tid]:-}" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: duplicate task id ${tid} in this feature: ${line}")
+            continue
+        fi
+        SEEN_TID["$tid"]=1
+        dep_list=""
+        if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
+            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        fi
+        TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
+    elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
+        # Carries a T-number that is not a valid task id (T1, T12, T0001 ...).
+        # Silently skipping these is how a file of malformed tasks reported
+        # "0 to create" and exited 0.
+        MALFORMED+=("${TASKS}:${lineno}: task-like line with a malformed T-number (expected T001..T999): ${line}")
+    else
+        # A checkbox line with no T-number at all. It may be a legitimate non-task
+        # checkbox, so it does not fail the run on its own - but it is never
+        # swallowed either, and a file where EVERY line lands here still fails
+        # below on the zero-task check rather than reporting a successful nothing.
+        UNRECOGNISED+=("${TASKS}:${lineno}: checkbox line is not a task and was ignored: ${line}")
+    fi
+done < "$TASKS"
+
+if [ "${#UNRECOGNISED[@]}" -gt 0 ]; then
+    echo "NOTE: ${#UNRECOGNISED[@]} checkbox line(s) were not read as tasks:" >&2
+    printf '  %s\n' "${UNRECOGNISED[@]}" >&2
+fi
+
+if [ "${#MALFORMED[@]}" -gt 0 ]; then
+    echo "ERROR: ${#MALFORMED[@]} task-like line(s) could not be parsed:" >&2
+    printf '  %s\n' "${MALFORMED[@]}" >&2
+    echo "Fix the lines above (or pass a different --tasks) and re-run. No issues were created." >&2
+    exit 3
+fi
+if [ "${#TIDS[@]}" -eq 0 ]; then
+    echo "ERROR: no tasks found in ${TASKS}." >&2
+    echo "Expected checkbox lines such as '- [ ] **T001** [US1] Description'." >&2
+    exit 3
+fi
+echo "Parsed:     ${#TIDS[@]} task(s)"
+
+# --- Inventory of existing issues ------------------------------------------------
 # ISSUE_FS - the ONE field separator for the `gh issue list` records parsed below
 # (issue #700), ASCII unit separator (0x1F) and deliberately NOT tab.
 #
@@ -91,9 +212,12 @@ echo "Remote:     $REMOTE_URL"
 # SHIFTED FIELDS (issue bodies built from the wrong values), not an error.
 # `\037` is not IFS whitespace, so empty fields survive in every position.
 #
+# That is exactly what happened here: #857 added three more fields, and two of them
+# (marker, provenance path) are EMPTY for every issue this script did not create.
+#
 # Same defect class as #698, which fixed the live instance in
 # scripts/flow-wave-registry.sh (a branchless worktree produced an empty middle
-# field on the ordinary path); this was the last whitespace-IFS read in scripts/.
+# field on the ordinary path).
 #
 # ONE definition, two spellings: the producer is a jq filter needing the `\uHHHH`
 # escape text, the reader is a shell `read` needing the byte, so the escape is
@@ -108,66 +232,232 @@ if [ "${#ISSUE_FS}" -ne 1 ] || [ "${#ISSUE_FS_JQ}" -ne 6 ]; then
     exit 1
 fi
 
-declare -A EXISTING
-declare -A TASK_ISSUE
-while IFS="$ISSUE_FS" read -r number title; do
-    if [[ "$title" =~ (^|[^A-Za-z0-9])(T[0-9]{3})([^0-9]|$) ]]; then
-        EXISTING["${BASH_REMATCH[2]}"]=1
-        TASK_ISSUE["${BASH_REMATCH[2]}"]="$number"
+# Record: number FS marker FS provenance-path FS legacy-tid FS blocked-refs
+# marker         - the speckit-task identity comment, when the body carries one
+# provenance     - the tasks path recorded in the "Auto-created from ..." line, which
+#                  is the only feature evidence a pre-#857 issue carries
+# legacy-tid     - a bare T-number in the TITLE, the pre-#857 identity
+# blocked-refs   - "#N" refs already present on this body's `Blocked by` lines, so a
+#                  re-run can tell a missing edge from one already written
+INVENTORY_JQ='
+.[] |
+  (.body // "") as $b |
+  ($b | capture("<!--\\s*(?<m>speckit-task:v1:[^>]*?)\\s*-->") // {m:""} | .m) as $marker |
+  ($b | capture("Auto-created from (?<p>.+?) \\(T[0-9]{3}\\) by CPP speckit-tasks-to-issues") // {p:""} | .p) as $prov |
+  ((.title // "") | capture("(^|[^A-Za-z0-9])(?<t>T[0-9]{3})([^0-9]|$)") // {t:""} | .t) as $ltid |
+  ([$b | scan("(?im)^\\s*[-*]?\\s*blocked by[^#\\n]*(#[0-9]+)") | .[0]] | join(",")) as $refs |
+  "\(.number)FS\($marker)FS\($prov)FS\($ltid)FS\($refs)"
+'
+INVENTORY_JQ="${INVENTORY_JQ//FS/$ISSUE_FS_JQ}"
+
+inventory_raw=""
+inventory_status=0
+inventory_raw="$(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit "$LIMIT" \
+    --json number,title,body --jq "$INVENTORY_JQ" 2>&1)" || inventory_status=$?
+if [ "$inventory_status" -ne 0 ]; then
+    echo "ERROR: could not list existing issues (gh exited ${inventory_status})." >&2
+    printf '  %s\n' "$inventory_raw" >&2
+    echo "Refusing to continue: an unreadable inventory is not an empty one, and treating" >&2
+    echo "it as empty re-files every task that already has an issue." >&2
+    exit 4
+fi
+
+declare -A FILED_NUM=()       # tid -> issue number claimed for THIS feature
+declare -A FILED_VIA=()       # tid -> marker | provenance
+declare -A EXISTING_REFS=()   # tid -> "#12,#13" already on the issue body
+declare -A MARKER_CLAIMS=()   # tid -> "#N #M" issues whose marker names this feature
+declare -A PROV_CLAIMS=()     # tid -> "#N #M" issues whose recorded source is this file
+declare -A UNRESOLVED_HITS=() # tid -> "#N" bare-title issues carrying no feature evidence
+inventory_count=0
+while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
+    [ -n "$number" ] || continue
+    inventory_count=$((inventory_count + 1))
+    if [ -n "$marker" ]; then
+        # Exact identity. A marker naming a DIFFERENT feature is a known other
+        # task, not a claim on this one, so it is simply not this feature's.
+        case "$marker" in
+            "speckit-task:v1:${FEATURE}:"*)
+                tid="${marker##*:}"
+                MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
+                FILED_NUM["$tid"]="$number"
+                FILED_VIA["$tid"]="marker"
+                EXISTING_REFS["$tid"]="$refs"
+                ;;
+        esac
+        continue
     fi
-done < <(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit 1000 --json number,title --jq ".[] | \"\(.number)${ISSUE_FS_JQ}\(.title)\"" 2>/dev/null || true)
+    [ -n "$ltid" ] || continue
+    if [ -n "$prov" ]; then
+        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+            # A pre-#857 issue this script created from THIS tasks file. The
+            # recorded source path is real feature provenance, so adopting it is
+            # evidence, not a guess.
+            PROV_CLAIMS["$ltid"]="${PROV_CLAIMS[$ltid]:-}#${number} "
+            if [ -z "${FILED_NUM[$ltid]:-}" ]; then
+                FILED_NUM["$ltid"]="$number"
+                FILED_VIA["$ltid"]="provenance"
+                EXISTING_REFS["$ltid"]="$refs"
+            fi
+        fi
+        # A provenance line naming a DIFFERENT tasks file is a known different
+        # feature. It says nothing about this feature's task of the same number,
+        # so it must not block this one from being filed.
+        continue
+    fi
+    # A bare T-number in a title, with no marker and no recorded source at all.
+    # Whose task it is cannot be established: two features routinely share both a
+    # task id AND its description ("T001 Add tests"), so a description match is not
+    # provenance. Recorded as unresolved and settled by a human, never guessed.
+    UNRESOLVED_HITS["$ltid"]="${UNRESOLVED_HITS[$ltid]:-}#${number} "
+done <<< "$inventory_raw"
 
-# --- Parse tasks.md and create issues -------------------------------------------
-created=0; skipped=0
-while IFS= read -r line; do
-    # Only checkbox task lines.
-    [[ "$line" =~ ^-\ \[[\ xX]\] ]] || continue
-    # Strip the checkbox (up to the first "] ") and any [P] / [US#] markers.
-    body="${line#*] }"
-    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+\]//g; s/^[[:space:]]+//')"
-    # Recover the task ID (T + 3 digits) and description.
-    [[ "$body" =~ ^(T[0-9]{3})[:[:space:]]+(.*)$ ]] || continue
-    tid="${BASH_REMATCH[1]}"
-    desc="$(printf '%s' "${BASH_REMATCH[2]}" | sed -E 's/[[:space:]]+$//')"
-    title="${tid}: ${desc}"
+if [ "$inventory_count" -ge "$LIMIT" ]; then
+    echo "ERROR: the issue inventory returned ${inventory_count} record(s), the same as" >&2
+    echo "--limit ${LIMIT}. The list may be truncated, and a truncated inventory cannot" >&2
+    echo "support the re-run guarantee: a task whose issue fell past the cutoff would be" >&2
+    echo "filed a second time. Re-run with a larger --limit." >&2
+    exit 4
+fi
+echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 
-    if [ -n "${EXISTING[$tid]:-}" ]; then
-        echo "skip  ${tid} (issue already exists)"
+# --- Ambiguity scan: everything that must stop the run happens BEFORE any write ---
+declare -a AMBIGUOUS=()
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
+    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
+    if [ "$claims" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
+        continue
+    fi
+    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+        continue
+    fi
+    # An identified task is not made ambiguous by somebody else's untraceable
+    # issue: this feature's task already has evidence naming it.
+    [ -n "${FILED_NUM[$tid]:-}" ] && continue
+    [ -n "${UNRESOLVED_HITS[$tid]:-}" ] || continue
+    AMBIGUOUS+=("${tid}: ${UNRESOLVED_HITS[$tid]}(title carries ${tid}, records no source feature)")
+done
+if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
+    echo "ERROR: ${#AMBIGUOUS[@]} task(s) have an unresolved identity:" >&2
+    printf '  %s\n' "${AMBIGUOUS[@]}" >&2
+    echo "Each names an existing issue that carries this task number but no evidence of which" >&2
+    echo "feature it belongs to, or more than one issue claiming this feature's task. This" >&2
+    echo "script will not decide. Resolve by adding the identity marker to the correct issue's" >&2
+    echo "body (or removing the duplicate claim), then re-run:" >&2
+    echo "  $(marker_for T001)" >&2
+    echo "(substituting the task id). An issue whose body records a DIFFERENT tasks file needs" >&2
+    echo "no change - it is already recognised as another feature's task." >&2
+    exit 5
+fi
+
+# --- Create pass -----------------------------------------------------------------
+created=0; skipped=0; adopted=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    title="${tid} (${FEATURE}): ${DESCS[$i]}"
+    if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
+                 "add '$(marker_for "$tid")' to its body to make the identity explicit)"
+            adopted=$((adopted + 1))
+        else
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]} already carries this feature's marker)"
+        fi
         skipped=$((skipped + 1))
         continue
     fi
-    # Dependency clause -> machine-readable body lines (issue #607). The clause
-    # used to survive only as title prose, which drifted from tasks.md with
-    # nothing to detect it. The body now carries BOTH forms: a `Depends on:`
-    # task-id line (joinable via the spec's Issue Sync table even when numbers
-    # are unknown), and `- Blocked by #N` bullets - flow-wave-plan.py's native
-    # edge grammar - for every dep already resolvable to an issue number
-    # (created earlier this run, or found by the dedup scan above).
-    issue_body="Auto-created from ${TASKS} (${tid}) by CPP speckit-tasks-to-issues."
-    if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-        dep_clause="${BASH_REMATCH[1]}"
-        dep_tids="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ')"
-        if [ -n "$dep_tids" ]; then
-            issue_body+=$'\n\n'"Depends on: $(printf '%s' "$dep_tids" | sed 's/ $//; s/ /, /g')"
-            for dep in $dep_tids; do
-                if [ -n "${TASK_ISSUE[$dep]:-}" ]; then
-                    issue_body+=$'\n'"- Blocked by #${TASK_ISSUE[$dep]}"
-                fi
-            done
-        fi
+
+    issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
+    if [ -n "${DEPS[$i]}" ]; then
+        issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "would create: ${title}"
+        FILED_NUM["$tid"]=""
     else
         url="$(gh issue create "${GH_REPO_ARGS[@]}" --title "$title" --body "$issue_body" 2>&1)"
         echo "create ${tid} -> ${url}"
-        EXISTING["$tid"]=1
         num="${url##*/}"
-        [[ "$num" =~ ^[0-9]+$ ]] && TASK_ISSUE["$tid"]="$num"
+        if [[ "$num" =~ ^[0-9]+$ ]]; then
+            FILED_NUM["$tid"]="$num"
+            FILED_VIA["$tid"]="marker"
+            EXISTING_REFS["$tid"]=""
+        fi
     fi
     created=$((created + 1))
-done < "$TASKS"
+done
+
+# --- Dependency reconciliation ---------------------------------------------------
+# Deliberately NOT "annotate what this run created". A dependency may point FORWARD
+# to a task declared later in the file, and a run that dies between creating issues
+# and writing their edges must be repairable - otherwise those edges are missing
+# forever, because the next run sees the issues as already filed and skips them
+# (issue #857). So every filed task in this feature is reconciled on every run:
+# expected refs minus refs already in the body, appended, existing content kept.
+#
+# Edges resolve ONLY within this feature. A T-number that belongs to another
+# feature's tasks file cannot contribute an edge here - that cross-feature guess is
+# the same defect as the identity one, one level down.
+edges_written=0; edges_failed=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    [ -n "${DEPS[$i]}" ] || continue
+    number="${FILED_NUM[$tid]:-}"
+
+    missing=""
+    for dep in ${DEPS[$i]}; do
+        dep_num="${FILED_NUM[$dep]:-}"
+        if [ -z "$dep_num" ]; then
+            if [ -z "${SEEN_TID[$dep]:-}" ]; then
+                echo "note  ${tid} depends on ${dep}, which is not a task in this feature - no edge written." >&2
+            fi
+            continue
+        fi
+        case ",${EXISTING_REFS[$tid]:-}," in
+            *",#${dep_num},"*) continue ;;
+        esac
+        case "$missing" in
+            *"#${dep_num} "*) continue ;;
+        esac
+        missing+="#${dep_num} "
+    done
+    [ -n "$missing" ] || continue
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "would link:   ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//')"
+        continue
+    fi
+    [ -n "$number" ] || continue
+
+    current_body="$(gh issue view "$number" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || {
+        echo "WARN: could not read issue #${number} to add its dependency edges; re-run to reconcile." >&2
+        printf '  %s\n' "$current_body" >&2
+        edges_failed=$((edges_failed + 1))
+        continue
+    }
+    new_body="$current_body"
+    for ref in $missing; do
+        new_body+=$'\n'"- Blocked by ${ref}"
+    done
+    if printf '%s' "$new_body" | gh issue edit "$number" "${GH_REPO_ARGS[@]}" --body-file - > /dev/null 2>&1; then
+        echo "link  ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//') (issue #${number})"
+        edges_written=$((edges_written + 1))
+    else
+        echo "WARN: could not write dependency edges for ${tid} (issue #${number}); re-run to reconcile." >&2
+        edges_failed=$((edges_failed + 1))
+    fi
+done
 
 echo "---"
-echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist)."
+echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
+[ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$edges_failed" -gt 0 ]; then
+    echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
+    echo "command to reconcile the missing edges - it will not create duplicates." >&2
+    exit 6
+fi
+exit 0

--- a/codex/skills/flow-wave/scripts/flow-wave-plan.py
+++ b/codex/skills/flow-wave/scripts/flow-wave-plan.py
@@ -173,7 +173,15 @@ def _strip_code_for_edges(body: str) -> str:
 REF_RE = re.compile(r"#(\d+)")
 # tasks.md shapes (#607): a checkbox task line with an optional depends clause,
 # and the Issue Sync join of task IDs to issue numbers.
-TASK_LINE_RE = re.compile(r"^\s*-\s*\[[ xX]\]\s*(?:\[[^\]]+\]\s*)*(T\d{3})\b(.*)$")
+# The task id may be emphasised: `.specify/templates/tasks-template.md` writes
+# `- [ ] **T001** [US1] ...`, and the specs in this repo use that form. Reading
+# only the bare spelling made every such file parse as zero tasks, so the spec
+# `(depends on ...)` edges below were silently absent rather than reported
+# missing - the same representation defect #857 fixed in the issue converter.
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\[[^\]]+\]\s*)*"
+    r"(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
 DEPENDS_CLAUSE_RE = re.compile(r"\(depends on\s+([^)]*)\)", re.IGNORECASE)
 TASK_ID_RE = re.compile(r"T\d{3}")
 ISSUE_SYNC_HEADING_RE = re.compile(r"^#{2,}\s*Issue Sync\b", re.IGNORECASE)

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -132,6 +132,42 @@ echo "Remote:     $REMOTE_URL"
 marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
 provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
 
+# Two spellings of the SAME file must compare equal, or a legacy issue recorded
+# as `./a/tasks.md` reads as another feature's and its task is filed a second
+# time - the duplicate this whole change exists to prevent, caused by the
+# comparison rather than by the identity.
+#
+# Deliberately conservative: leading `./`, repeated slashes, and a trailing
+# slash are noise and are removed, and an ABSOLUTE path is made
+# repository-relative only when it is genuinely inside THIS repository. Nothing
+# else is inferred - `..` segments are left alone and an absolute path from
+# another checkout or machine stays absolute, so it correctly fails to match
+# rather than being guessed equal.
+normalize_source_path() {
+    local path="$1"
+    if [ -n "${_repo_root:-}" ]; then
+        case "$path" in
+            "$_repo_root"/*) path="${path#"$_repo_root"/}" ;;
+        esac
+    fi
+    while :; do
+        case "$path" in
+            ./*) path="${path#./}" ;;
+            *) break ;;
+        esac
+    done
+    while [[ "$path" == *//* ]]; do
+        path="${path//\/\//\/}"
+    done
+    case "$path" in
+        */) path="${path%/}" ;;
+    esac
+    printf '%s' "$path"
+}
+
+TASKS_NORM="$(normalize_source_path "$TASKS")"
+TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
+
 # --- Pass 1: parse tasks.md ------------------------------------------------------
 # Parsing runs to completion BEFORE any issue is created: a file this script cannot
 # read is a failure to report, not a zero-task success to celebrate (issue #857).
@@ -178,8 +214,17 @@ while IFS= read -r line || [ -n "$line" ]; do
             # `and` tolerated as a connector (the same separator the planner's
             # own edge grammar accepts). Anything else is reported with its line
             # rather than quietly dropped.
+            # Split WITHOUT pathname expansion. An unquoted `$(...)` in a `for`
+            # list is glob-expanded as well as word-split, so `(depends on T00?)`
+            # became a valid token in any directory that happened to contain a
+            # file called T002 - the validation passed because the filesystem
+            # supplied the answer. `IFS= read` takes each token literally.
+            dep_tokens=()
+            while IFS= read -r dep_token; do
+                [ -n "$dep_token" ] && dep_tokens+=("$dep_token")
+            done < <(printf '%s\n' "$dep_clause" | tr ', \t' '\n\n\n')
             dep_bad=""
-            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+            for dep_token in ${dep_tokens+"${dep_tokens[@]}"}; do
                 case "$dep_token" in
                     and|AND|And) continue ;;
                 esac
@@ -334,7 +379,8 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     fi
     [ -n "$ltid" ] || continue
     if [ -n "$prov" ]; then
-        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+        prov_norm="$(normalize_source_path "$prov")"
+        if [ "$prov_norm" = "$TASKS_NORM" ] || [ "$prov_norm" = "$TASKS_REL_NORM" ]; then
             # A pre-#857 issue this script created from THIS tasks file. The
             # recorded source path is real feature provenance, so adopting it is
             # evidence, not a guess.

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -162,7 +162,15 @@ while IFS= read -r line || [ -n "$line" ]; do
         SEEN_TID["$tid"]=1
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+            dep_clause="${BASH_REMATCH[1]}"
+            # `|| true`: grep exits 1 when a clause names no valid task id, and
+            # under `set -e` that killed the whole run with no diagnostic at all -
+            # the same silence this change exists to remove, in the error path.
+            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            if [ -z "$dep_list" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                continue
+            fi
         fi
         TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
     elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
@@ -274,16 +282,24 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     inventory_count=$((inventory_count + 1))
     if [ -n "$marker" ]; then
         # Exact identity. A marker naming a DIFFERENT feature is a known other
-        # task, not a claim on this one, so it is simply not this feature's.
-        case "$marker" in
-            "speckit-task:v1:${FEATURE}:"*)
-                tid="${marker##*:}"
+        # task, not a claim on this one.
+        #
+        # The comparison is EXACT, never a prefix: a feature may legitimately
+        # contain a colon (`--feature f:other`), so testing `speckit-task:v1:f:*`
+        # accepts `speckit-task:v1:f:other:T001` and hands one feature's task to
+        # another. Split the last field off as the task id and compare what
+        # remains to this feature in full.
+        marker_rest="${marker#speckit-task:v1:}"
+        if [ "$marker_rest" != "$marker" ]; then
+            tid="${marker_rest##*:}"
+            marker_feature="${marker_rest%:*}"
+            if [[ "$tid" =~ ^T[0-9]{3}$ ]] && [ "$marker_feature" = "$FEATURE" ]; then
                 MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
                 FILED_NUM["$tid"]="$number"
                 FILED_VIA["$tid"]="marker"
                 EXISTING_REFS["$tid"]="$refs"
-                ;;
-        esac
+            fi
+        fi
         continue
     fi
     [ -n "$ltid" ] || continue
@@ -324,14 +340,16 @@ echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 declare -a AMBIGUOUS=()
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
-    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
-    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
-    if [ "$claims" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
-        continue
-    fi
-    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+    # Count DISTINCT issues claiming this feature's task, whatever kind of claim
+    # they carry. Counting each bucket separately misses the mixed case - one
+    # issue with the marker and a different issue whose recorded source is this
+    # tasks file - which is two issues claiming one task and is exactly as
+    # ambiguous as two of either kind. The same issue appearing in both buckets
+    # cannot happen (a marker short-circuits the provenance read), so a repeat
+    # number here is always two different records.
+    claimants="$(printf '%s %s' "${MARKER_CLAIMS[$tid]:-}" "${PROV_CLAIMS[$tid]:-}" | tr ' ' '\n' | grep -c '^#[0-9]' || true)"
+    if [ "$claimants" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: ${claimants} issues claim this feature's task: marker ${MARKER_CLAIMS[$tid]:-none} / recorded source ${PROV_CLAIMS[$tid]:-none}")
         continue
     fi
     # An identified task is not made ambiguous by somebody else's untraceable

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -21,8 +21,10 @@
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
 #   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
-#                    repository-relative path. Pass it explicitly to keep identity
-#                    stable if the file moves.
+#                    repository-relative path. If the file MOVES, pass the value
+#                    the existing issues were filed under - the ORIGINAL path -
+#                    or they are no longer recognised and get filed again. A new
+#                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
 #
@@ -101,7 +103,9 @@ fi
 # across re-runs, and derivable without asking. A human heading is deliberately NOT
 # used - two specs may both be titled "# Tasks: Reporting", and the collision would
 # be silent. `--feature` overrides it, which is also how identity survives the file
-# being moved or renamed later.
+# being moved or renamed later - but only when it carries the value those issues
+# were filed under. Passing some other slug after a move does not preserve
+# anything: it declares a new identity, and every task is filed a second time.
 TASKS_REL="$TASKS"
 if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
     _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
@@ -163,12 +167,38 @@ while IFS= read -r line || [ -n "$line" ]; do
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
             dep_clause="${BASH_REMATCH[1]}"
-            # `|| true`: grep exits 1 when a clause names no valid task id, and
-            # under `set -e` that killed the whole run with no diagnostic at all -
-            # the same silence this change exists to remove, in the error path.
-            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            # Validate WHOLE tokens, never substrings. Extracting `T[0-9]{3}` out
+            # of the clause silently accepted two corruptions: `T002, T1` dropped
+            # the invalid half and wrote a partial edge, and `T0020` matched its
+            # own first four characters and wrote an edge to T002 - a dependency
+            # that was never declared. A fabricated edge is worse than a missing
+            # one, because the planner treats it as a real constraint.
+            #
+            # Supported syntax is comma- and/or space-separated task ids, with
+            # `and` tolerated as a connector (the same separator the planner's
+            # own edge grammar accepts). Anything else is reported with its line
+            # rather than quietly dropped.
+            dep_bad=""
+            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+                case "$dep_token" in
+                    and|AND|And) continue ;;
+                esac
+                if [[ "$dep_token" =~ ^T[0-9]{3}$ ]]; then
+                    case " $dep_list" in
+                        *" $dep_token "*) continue ;;
+                    esac
+                    dep_list+="$dep_token "
+                else
+                    dep_bad+="'${dep_token}' "
+                fi
+            done
+            dep_list="${dep_list%"${dep_list##*[![:space:]]}"}"
+            if [ -n "$dep_bad" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' has unreadable token(s) ${dep_bad}(expected T001..T999): ${line}")
+                continue
+            fi
             if [ -z "$dep_list" ]; then
-                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no task id (expected T001..T999): ${line}")
                 continue
             fi
         fi

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -6,38 +6,63 @@
 # Part of Claude Power Pack (CPP). Replaces upstream /speckit-taskstoissues, which
 # hard-requires the github-mcp-server. CPP is gh-CLI based, so this reproduces the
 # same behaviour with `gh`:
-#   - one label-free issue per task, titled "T001: <description>"
-#   - dedup against existing issues by \bT\d{3}\b title match (re-run safe)
+#   - one issue per task, titled "T001 (<feature>): <description>"
+#   - every issue carries a FEATURE-SCOPED identity marker, so re-runs are safe
+#     and two features' T001 are different tasks (issue #857)
 #   - refuses to run unless the git remote is a GitHub URL
 #
 # Usage:
 #   scripts/speckit-tasks-to-issues.sh [--dry-run] [--tasks PATH] [--repo OWNER/NAME]
+#                                      [--feature SLUG] [--limit N]
 #
 # Options:
 #   --dry-run        Print what would be created; create nothing.
 #   --tasks PATH     Path to tasks.md. Default: auto-detect the single
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
+#   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
+#                    repository-relative path. Pass it explicitly to keep identity
+#                    stable if the file moves.
+#   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
+#
+# Exit codes:
+#   0  success
+#   1  environment refusal (no gh, no GitHub remote, no tasks file)
+#   2  usage error
+#   3  tasks.md could not be parsed (malformed task lines, or no tasks at all)
+#   4  the existing-issue inventory could not be established (lookup failed, or
+#      the result may be truncated)
+#   5  one or more tasks have an ambiguous legacy identity awaiting resolution
+#   6  issues were created but a dependency edge could not be written; re-run to
+#      reconcile
 set -euo pipefail
 
 DRY_RUN=0
 TASKS=""
 REPO=""
+FEATURE=""
+LIMIT=1000
 
-usage() { sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
         --tasks) TASKS="${2:?--tasks needs a path}"; shift 2 ;;
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
+        --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
+        --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
+[[ "$LIMIT" =~ ^[0-9]+$ ]] && [ "$LIMIT" -gt 0 ] || {
+    echo "ERROR: --limit must be a positive integer (got '$LIMIT')." >&2; exit 2; }
+
 command -v gh > /dev/null 2>&1 || { echo "ERROR: gh CLI not found." >&2; exit 1; }
+command -v jq > /dev/null 2>&1 || { echo "ERROR: jq not found." >&2; exit 1; }
 
 # --- Safety: only operate against a GitHub remote --------------------------------
 REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
@@ -65,18 +90,114 @@ if [ -z "$TASKS" ]; then
 fi
 [ -f "$TASKS" ] || { echo "ERROR: tasks file not found: $TASKS" >&2; exit 1; }
 
+# --- Feature identity (issue #857) -----------------------------------------------
+# A task ID is only unique WITHIN a feature: every feature starts again at T001, so
+# "T001" alone identified nothing and one feature's T001 issue made every other
+# feature's T001 look already-filed.
+#
+# Identity is therefore the pair (feature, task id), and the feature half has to be
+# something that cannot collapse two different tasks files into one identity. The
+# tasks file's REPOSITORY-RELATIVE PATH is that: unique by construction, stable
+# across re-runs, and derivable without asking. A human heading is deliberately NOT
+# used - two specs may both be titled "# Tasks: Reporting", and the collision would
+# be silent. `--feature` overrides it, which is also how identity survives the file
+# being moved or renamed later.
+TASKS_REL="$TASKS"
+if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
+    _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
+    case "$_tasks_abs" in
+        "$_repo_root"/*) TASKS_REL="${_tasks_abs#"$_repo_root"/}" ;;
+        *) TASKS_REL="$_tasks_abs" ;;
+    esac
+fi
+if [ -z "$FEATURE" ]; then
+    FEATURE="$TASKS_REL"
+fi
+case "$FEATURE" in
+    *$'\n'*|"") echo "ERROR: feature identity is empty or multi-line; pass --feature SLUG." >&2; exit 2 ;;
+esac
+
 GH_REPO_ARGS=()
 [ -n "$REPO" ] && GH_REPO_ARGS=(--repo "$REPO")
 
 echo "Tasks file: $TASKS"
+echo "Feature:    $FEATURE"
 echo "Remote:     $REMOTE_URL"
 [ "$DRY_RUN" -eq 1 ] && echo "Mode:       DRY RUN (no issues will be created)"
 
-# --- Existing issue IDs (dedup + task -> issue-number map) -----------------------
-# Match \bT\d{3}\b in existing titles (open + closed) so re-runs skip done tasks.
-# The number map (issue #607) lets a later task's dependency clause resolve to
-# `- Blocked by #N` lines in its body - the planner's native edge form.
+marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
+provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
+
+# --- Pass 1: parse tasks.md ------------------------------------------------------
+# Parsing runs to completion BEFORE any issue is created: a file this script cannot
+# read is a failure to report, not a zero-task success to celebrate (issue #857).
 #
+# Both ID spellings the shipped templates use are accepted. `.specify/templates/
+# tasks-template.md` writes the BOLD form (`- [ ] **T001** [US1] ...`), which the
+# original strict-plain parser skipped silently - so the converter could not read
+# the template this repository ships. Story tags are stripped in both the single
+# (`[US1]`) and comma (`[US1,US2]`, `[US1, US2]`) spellings; the comma form is on
+# the template's own T007 line and used to leak into the issue title.
+declare -a TIDS=() DESCS=() DEPS=()
+declare -A SEEN_TID=()
+declare -a MALFORMED=() UNRECOGNISED=()
+lineno=0
+while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[[[:space:]xX]\] ]] || continue
+    body="${line#*] }"
+    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+([[:space:]]*,[[:space:]]*US?[0-9]+)*\]//gI; s/^[[:space:]]+//')"
+    body="$(printf '%s' "$body" | sed -E 's/^(\*\*|__)[[:space:]]*(T[0-9]{3})[[:space:]]*(\*\*|__)/\2/')"
+    if [[ "$body" =~ ^(T[0-9]{3})([:[:space:]]+(.*))?$ ]]; then
+        tid="${BASH_REMATCH[1]}"
+        desc="$(printf '%s' "${BASH_REMATCH[3]:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        if [ -z "$desc" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: ${tid} has no description: ${line}")
+            continue
+        fi
+        if [ -n "${SEEN_TID[$tid]:-}" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: duplicate task id ${tid} in this feature: ${line}")
+            continue
+        fi
+        SEEN_TID["$tid"]=1
+        dep_list=""
+        if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
+            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        fi
+        TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
+    elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
+        # Carries a T-number that is not a valid task id (T1, T12, T0001 ...).
+        # Silently skipping these is how a file of malformed tasks reported
+        # "0 to create" and exited 0.
+        MALFORMED+=("${TASKS}:${lineno}: task-like line with a malformed T-number (expected T001..T999): ${line}")
+    else
+        # A checkbox line with no T-number at all. It may be a legitimate non-task
+        # checkbox, so it does not fail the run on its own - but it is never
+        # swallowed either, and a file where EVERY line lands here still fails
+        # below on the zero-task check rather than reporting a successful nothing.
+        UNRECOGNISED+=("${TASKS}:${lineno}: checkbox line is not a task and was ignored: ${line}")
+    fi
+done < "$TASKS"
+
+if [ "${#UNRECOGNISED[@]}" -gt 0 ]; then
+    echo "NOTE: ${#UNRECOGNISED[@]} checkbox line(s) were not read as tasks:" >&2
+    printf '  %s\n' "${UNRECOGNISED[@]}" >&2
+fi
+
+if [ "${#MALFORMED[@]}" -gt 0 ]; then
+    echo "ERROR: ${#MALFORMED[@]} task-like line(s) could not be parsed:" >&2
+    printf '  %s\n' "${MALFORMED[@]}" >&2
+    echo "Fix the lines above (or pass a different --tasks) and re-run. No issues were created." >&2
+    exit 3
+fi
+if [ "${#TIDS[@]}" -eq 0 ]; then
+    echo "ERROR: no tasks found in ${TASKS}." >&2
+    echo "Expected checkbox lines such as '- [ ] **T001** [US1] Description'." >&2
+    exit 3
+fi
+echo "Parsed:     ${#TIDS[@]} task(s)"
+
+# --- Inventory of existing issues ------------------------------------------------
 # ISSUE_FS - the ONE field separator for the `gh issue list` records parsed below
 # (issue #700), ASCII unit separator (0x1F) and deliberately NOT tab.
 #
@@ -91,9 +212,12 @@ echo "Remote:     $REMOTE_URL"
 # SHIFTED FIELDS (issue bodies built from the wrong values), not an error.
 # `\037` is not IFS whitespace, so empty fields survive in every position.
 #
+# That is exactly what happened here: #857 added three more fields, and two of them
+# (marker, provenance path) are EMPTY for every issue this script did not create.
+#
 # Same defect class as #698, which fixed the live instance in
 # scripts/flow-wave-registry.sh (a branchless worktree produced an empty middle
-# field on the ordinary path); this was the last whitespace-IFS read in scripts/.
+# field on the ordinary path).
 #
 # ONE definition, two spellings: the producer is a jq filter needing the `\uHHHH`
 # escape text, the reader is a shell `read` needing the byte, so the escape is
@@ -108,66 +232,232 @@ if [ "${#ISSUE_FS}" -ne 1 ] || [ "${#ISSUE_FS_JQ}" -ne 6 ]; then
     exit 1
 fi
 
-declare -A EXISTING
-declare -A TASK_ISSUE
-while IFS="$ISSUE_FS" read -r number title; do
-    if [[ "$title" =~ (^|[^A-Za-z0-9])(T[0-9]{3})([^0-9]|$) ]]; then
-        EXISTING["${BASH_REMATCH[2]}"]=1
-        TASK_ISSUE["${BASH_REMATCH[2]}"]="$number"
+# Record: number FS marker FS provenance-path FS legacy-tid FS blocked-refs
+# marker         - the speckit-task identity comment, when the body carries one
+# provenance     - the tasks path recorded in the "Auto-created from ..." line, which
+#                  is the only feature evidence a pre-#857 issue carries
+# legacy-tid     - a bare T-number in the TITLE, the pre-#857 identity
+# blocked-refs   - "#N" refs already present on this body's `Blocked by` lines, so a
+#                  re-run can tell a missing edge from one already written
+INVENTORY_JQ='
+.[] |
+  (.body // "") as $b |
+  ($b | capture("<!--\\s*(?<m>speckit-task:v1:[^>]*?)\\s*-->") // {m:""} | .m) as $marker |
+  ($b | capture("Auto-created from (?<p>.+?) \\(T[0-9]{3}\\) by CPP speckit-tasks-to-issues") // {p:""} | .p) as $prov |
+  ((.title // "") | capture("(^|[^A-Za-z0-9])(?<t>T[0-9]{3})([^0-9]|$)") // {t:""} | .t) as $ltid |
+  ([$b | scan("(?im)^\\s*[-*]?\\s*blocked by[^#\\n]*(#[0-9]+)") | .[0]] | join(",")) as $refs |
+  "\(.number)FS\($marker)FS\($prov)FS\($ltid)FS\($refs)"
+'
+INVENTORY_JQ="${INVENTORY_JQ//FS/$ISSUE_FS_JQ}"
+
+inventory_raw=""
+inventory_status=0
+inventory_raw="$(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit "$LIMIT" \
+    --json number,title,body --jq "$INVENTORY_JQ" 2>&1)" || inventory_status=$?
+if [ "$inventory_status" -ne 0 ]; then
+    echo "ERROR: could not list existing issues (gh exited ${inventory_status})." >&2
+    printf '  %s\n' "$inventory_raw" >&2
+    echo "Refusing to continue: an unreadable inventory is not an empty one, and treating" >&2
+    echo "it as empty re-files every task that already has an issue." >&2
+    exit 4
+fi
+
+declare -A FILED_NUM=()       # tid -> issue number claimed for THIS feature
+declare -A FILED_VIA=()       # tid -> marker | provenance
+declare -A EXISTING_REFS=()   # tid -> "#12,#13" already on the issue body
+declare -A MARKER_CLAIMS=()   # tid -> "#N #M" issues whose marker names this feature
+declare -A PROV_CLAIMS=()     # tid -> "#N #M" issues whose recorded source is this file
+declare -A UNRESOLVED_HITS=() # tid -> "#N" bare-title issues carrying no feature evidence
+inventory_count=0
+while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
+    [ -n "$number" ] || continue
+    inventory_count=$((inventory_count + 1))
+    if [ -n "$marker" ]; then
+        # Exact identity. A marker naming a DIFFERENT feature is a known other
+        # task, not a claim on this one, so it is simply not this feature's.
+        case "$marker" in
+            "speckit-task:v1:${FEATURE}:"*)
+                tid="${marker##*:}"
+                MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
+                FILED_NUM["$tid"]="$number"
+                FILED_VIA["$tid"]="marker"
+                EXISTING_REFS["$tid"]="$refs"
+                ;;
+        esac
+        continue
     fi
-done < <(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit 1000 --json number,title --jq ".[] | \"\(.number)${ISSUE_FS_JQ}\(.title)\"" 2>/dev/null || true)
+    [ -n "$ltid" ] || continue
+    if [ -n "$prov" ]; then
+        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+            # A pre-#857 issue this script created from THIS tasks file. The
+            # recorded source path is real feature provenance, so adopting it is
+            # evidence, not a guess.
+            PROV_CLAIMS["$ltid"]="${PROV_CLAIMS[$ltid]:-}#${number} "
+            if [ -z "${FILED_NUM[$ltid]:-}" ]; then
+                FILED_NUM["$ltid"]="$number"
+                FILED_VIA["$ltid"]="provenance"
+                EXISTING_REFS["$ltid"]="$refs"
+            fi
+        fi
+        # A provenance line naming a DIFFERENT tasks file is a known different
+        # feature. It says nothing about this feature's task of the same number,
+        # so it must not block this one from being filed.
+        continue
+    fi
+    # A bare T-number in a title, with no marker and no recorded source at all.
+    # Whose task it is cannot be established: two features routinely share both a
+    # task id AND its description ("T001 Add tests"), so a description match is not
+    # provenance. Recorded as unresolved and settled by a human, never guessed.
+    UNRESOLVED_HITS["$ltid"]="${UNRESOLVED_HITS[$ltid]:-}#${number} "
+done <<< "$inventory_raw"
 
-# --- Parse tasks.md and create issues -------------------------------------------
-created=0; skipped=0
-while IFS= read -r line; do
-    # Only checkbox task lines.
-    [[ "$line" =~ ^-\ \[[\ xX]\] ]] || continue
-    # Strip the checkbox (up to the first "] ") and any [P] / [US#] markers.
-    body="${line#*] }"
-    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+\]//g; s/^[[:space:]]+//')"
-    # Recover the task ID (T + 3 digits) and description.
-    [[ "$body" =~ ^(T[0-9]{3})[:[:space:]]+(.*)$ ]] || continue
-    tid="${BASH_REMATCH[1]}"
-    desc="$(printf '%s' "${BASH_REMATCH[2]}" | sed -E 's/[[:space:]]+$//')"
-    title="${tid}: ${desc}"
+if [ "$inventory_count" -ge "$LIMIT" ]; then
+    echo "ERROR: the issue inventory returned ${inventory_count} record(s), the same as" >&2
+    echo "--limit ${LIMIT}. The list may be truncated, and a truncated inventory cannot" >&2
+    echo "support the re-run guarantee: a task whose issue fell past the cutoff would be" >&2
+    echo "filed a second time. Re-run with a larger --limit." >&2
+    exit 4
+fi
+echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 
-    if [ -n "${EXISTING[$tid]:-}" ]; then
-        echo "skip  ${tid} (issue already exists)"
+# --- Ambiguity scan: everything that must stop the run happens BEFORE any write ---
+declare -a AMBIGUOUS=()
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
+    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
+    if [ "$claims" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
+        continue
+    fi
+    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+        continue
+    fi
+    # An identified task is not made ambiguous by somebody else's untraceable
+    # issue: this feature's task already has evidence naming it.
+    [ -n "${FILED_NUM[$tid]:-}" ] && continue
+    [ -n "${UNRESOLVED_HITS[$tid]:-}" ] || continue
+    AMBIGUOUS+=("${tid}: ${UNRESOLVED_HITS[$tid]}(title carries ${tid}, records no source feature)")
+done
+if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
+    echo "ERROR: ${#AMBIGUOUS[@]} task(s) have an unresolved identity:" >&2
+    printf '  %s\n' "${AMBIGUOUS[@]}" >&2
+    echo "Each names an existing issue that carries this task number but no evidence of which" >&2
+    echo "feature it belongs to, or more than one issue claiming this feature's task. This" >&2
+    echo "script will not decide. Resolve by adding the identity marker to the correct issue's" >&2
+    echo "body (or removing the duplicate claim), then re-run:" >&2
+    echo "  $(marker_for T001)" >&2
+    echo "(substituting the task id). An issue whose body records a DIFFERENT tasks file needs" >&2
+    echo "no change - it is already recognised as another feature's task." >&2
+    exit 5
+fi
+
+# --- Create pass -----------------------------------------------------------------
+created=0; skipped=0; adopted=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    title="${tid} (${FEATURE}): ${DESCS[$i]}"
+    if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
+                 "add '$(marker_for "$tid")' to its body to make the identity explicit)"
+            adopted=$((adopted + 1))
+        else
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]} already carries this feature's marker)"
+        fi
         skipped=$((skipped + 1))
         continue
     fi
-    # Dependency clause -> machine-readable body lines (issue #607). The clause
-    # used to survive only as title prose, which drifted from tasks.md with
-    # nothing to detect it. The body now carries BOTH forms: a `Depends on:`
-    # task-id line (joinable via the spec's Issue Sync table even when numbers
-    # are unknown), and `- Blocked by #N` bullets - flow-wave-plan.py's native
-    # edge grammar - for every dep already resolvable to an issue number
-    # (created earlier this run, or found by the dedup scan above).
-    issue_body="Auto-created from ${TASKS} (${tid}) by CPP speckit-tasks-to-issues."
-    if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-        dep_clause="${BASH_REMATCH[1]}"
-        dep_tids="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ')"
-        if [ -n "$dep_tids" ]; then
-            issue_body+=$'\n\n'"Depends on: $(printf '%s' "$dep_tids" | sed 's/ $//; s/ /, /g')"
-            for dep in $dep_tids; do
-                if [ -n "${TASK_ISSUE[$dep]:-}" ]; then
-                    issue_body+=$'\n'"- Blocked by #${TASK_ISSUE[$dep]}"
-                fi
-            done
-        fi
+
+    issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
+    if [ -n "${DEPS[$i]}" ]; then
+        issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "would create: ${title}"
+        FILED_NUM["$tid"]=""
     else
         url="$(gh issue create "${GH_REPO_ARGS[@]}" --title "$title" --body "$issue_body" 2>&1)"
         echo "create ${tid} -> ${url}"
-        EXISTING["$tid"]=1
         num="${url##*/}"
-        [[ "$num" =~ ^[0-9]+$ ]] && TASK_ISSUE["$tid"]="$num"
+        if [[ "$num" =~ ^[0-9]+$ ]]; then
+            FILED_NUM["$tid"]="$num"
+            FILED_VIA["$tid"]="marker"
+            EXISTING_REFS["$tid"]=""
+        fi
     fi
     created=$((created + 1))
-done < "$TASKS"
+done
+
+# --- Dependency reconciliation ---------------------------------------------------
+# Deliberately NOT "annotate what this run created". A dependency may point FORWARD
+# to a task declared later in the file, and a run that dies between creating issues
+# and writing their edges must be repairable - otherwise those edges are missing
+# forever, because the next run sees the issues as already filed and skips them
+# (issue #857). So every filed task in this feature is reconciled on every run:
+# expected refs minus refs already in the body, appended, existing content kept.
+#
+# Edges resolve ONLY within this feature. A T-number that belongs to another
+# feature's tasks file cannot contribute an edge here - that cross-feature guess is
+# the same defect as the identity one, one level down.
+edges_written=0; edges_failed=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    [ -n "${DEPS[$i]}" ] || continue
+    number="${FILED_NUM[$tid]:-}"
+
+    missing=""
+    for dep in ${DEPS[$i]}; do
+        dep_num="${FILED_NUM[$dep]:-}"
+        if [ -z "$dep_num" ]; then
+            if [ -z "${SEEN_TID[$dep]:-}" ]; then
+                echo "note  ${tid} depends on ${dep}, which is not a task in this feature - no edge written." >&2
+            fi
+            continue
+        fi
+        case ",${EXISTING_REFS[$tid]:-}," in
+            *",#${dep_num},"*) continue ;;
+        esac
+        case "$missing" in
+            *"#${dep_num} "*) continue ;;
+        esac
+        missing+="#${dep_num} "
+    done
+    [ -n "$missing" ] || continue
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "would link:   ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//')"
+        continue
+    fi
+    [ -n "$number" ] || continue
+
+    current_body="$(gh issue view "$number" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || {
+        echo "WARN: could not read issue #${number} to add its dependency edges; re-run to reconcile." >&2
+        printf '  %s\n' "$current_body" >&2
+        edges_failed=$((edges_failed + 1))
+        continue
+    }
+    new_body="$current_body"
+    for ref in $missing; do
+        new_body+=$'\n'"- Blocked by ${ref}"
+    done
+    if printf '%s' "$new_body" | gh issue edit "$number" "${GH_REPO_ARGS[@]}" --body-file - > /dev/null 2>&1; then
+        echo "link  ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//') (issue #${number})"
+        edges_written=$((edges_written + 1))
+    else
+        echo "WARN: could not write dependency edges for ${tid} (issue #${number}); re-run to reconcile." >&2
+        edges_failed=$((edges_failed + 1))
+    fi
+done
 
 echo "---"
-echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist)."
+echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
+[ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$edges_failed" -gt 0 ]; then
+    echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
+    echo "command to reconcile the missing edges - it will not create duplicates." >&2
+    exit 6
+fi
+exit 0

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -132,6 +132,42 @@ echo "Remote:     $REMOTE_URL"
 marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
 provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
 
+# Two spellings of the SAME file must compare equal, or a legacy issue recorded
+# as `./a/tasks.md` reads as another feature's and its task is filed a second
+# time - the duplicate this whole change exists to prevent, caused by the
+# comparison rather than by the identity.
+#
+# Deliberately conservative: leading `./`, repeated slashes, and a trailing
+# slash are noise and are removed, and an ABSOLUTE path is made
+# repository-relative only when it is genuinely inside THIS repository. Nothing
+# else is inferred - `..` segments are left alone and an absolute path from
+# another checkout or machine stays absolute, so it correctly fails to match
+# rather than being guessed equal.
+normalize_source_path() {
+    local path="$1"
+    if [ -n "${_repo_root:-}" ]; then
+        case "$path" in
+            "$_repo_root"/*) path="${path#"$_repo_root"/}" ;;
+        esac
+    fi
+    while :; do
+        case "$path" in
+            ./*) path="${path#./}" ;;
+            *) break ;;
+        esac
+    done
+    while [[ "$path" == *//* ]]; do
+        path="${path//\/\//\/}"
+    done
+    case "$path" in
+        */) path="${path%/}" ;;
+    esac
+    printf '%s' "$path"
+}
+
+TASKS_NORM="$(normalize_source_path "$TASKS")"
+TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
+
 # --- Pass 1: parse tasks.md ------------------------------------------------------
 # Parsing runs to completion BEFORE any issue is created: a file this script cannot
 # read is a failure to report, not a zero-task success to celebrate (issue #857).
@@ -178,8 +214,17 @@ while IFS= read -r line || [ -n "$line" ]; do
             # `and` tolerated as a connector (the same separator the planner's
             # own edge grammar accepts). Anything else is reported with its line
             # rather than quietly dropped.
+            # Split WITHOUT pathname expansion. An unquoted `$(...)` in a `for`
+            # list is glob-expanded as well as word-split, so `(depends on T00?)`
+            # became a valid token in any directory that happened to contain a
+            # file called T002 - the validation passed because the filesystem
+            # supplied the answer. `IFS= read` takes each token literally.
+            dep_tokens=()
+            while IFS= read -r dep_token; do
+                [ -n "$dep_token" ] && dep_tokens+=("$dep_token")
+            done < <(printf '%s\n' "$dep_clause" | tr ', \t' '\n\n\n')
             dep_bad=""
-            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+            for dep_token in ${dep_tokens+"${dep_tokens[@]}"}; do
                 case "$dep_token" in
                     and|AND|And) continue ;;
                 esac
@@ -334,7 +379,8 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     fi
     [ -n "$ltid" ] || continue
     if [ -n "$prov" ]; then
-        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+        prov_norm="$(normalize_source_path "$prov")"
+        if [ "$prov_norm" = "$TASKS_NORM" ] || [ "$prov_norm" = "$TASKS_REL_NORM" ]; then
             # A pre-#857 issue this script created from THIS tasks file. The
             # recorded source path is real feature provenance, so adopting it is
             # evidence, not a guess.

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -162,7 +162,15 @@ while IFS= read -r line || [ -n "$line" ]; do
         SEEN_TID["$tid"]=1
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+            dep_clause="${BASH_REMATCH[1]}"
+            # `|| true`: grep exits 1 when a clause names no valid task id, and
+            # under `set -e` that killed the whole run with no diagnostic at all -
+            # the same silence this change exists to remove, in the error path.
+            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            if [ -z "$dep_list" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                continue
+            fi
         fi
         TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
     elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
@@ -274,16 +282,24 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     inventory_count=$((inventory_count + 1))
     if [ -n "$marker" ]; then
         # Exact identity. A marker naming a DIFFERENT feature is a known other
-        # task, not a claim on this one, so it is simply not this feature's.
-        case "$marker" in
-            "speckit-task:v1:${FEATURE}:"*)
-                tid="${marker##*:}"
+        # task, not a claim on this one.
+        #
+        # The comparison is EXACT, never a prefix: a feature may legitimately
+        # contain a colon (`--feature f:other`), so testing `speckit-task:v1:f:*`
+        # accepts `speckit-task:v1:f:other:T001` and hands one feature's task to
+        # another. Split the last field off as the task id and compare what
+        # remains to this feature in full.
+        marker_rest="${marker#speckit-task:v1:}"
+        if [ "$marker_rest" != "$marker" ]; then
+            tid="${marker_rest##*:}"
+            marker_feature="${marker_rest%:*}"
+            if [[ "$tid" =~ ^T[0-9]{3}$ ]] && [ "$marker_feature" = "$FEATURE" ]; then
                 MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
                 FILED_NUM["$tid"]="$number"
                 FILED_VIA["$tid"]="marker"
                 EXISTING_REFS["$tid"]="$refs"
-                ;;
-        esac
+            fi
+        fi
         continue
     fi
     [ -n "$ltid" ] || continue
@@ -324,14 +340,16 @@ echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 declare -a AMBIGUOUS=()
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
-    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
-    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
-    if [ "$claims" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
-        continue
-    fi
-    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+    # Count DISTINCT issues claiming this feature's task, whatever kind of claim
+    # they carry. Counting each bucket separately misses the mixed case - one
+    # issue with the marker and a different issue whose recorded source is this
+    # tasks file - which is two issues claiming one task and is exactly as
+    # ambiguous as two of either kind. The same issue appearing in both buckets
+    # cannot happen (a marker short-circuits the provenance read), so a repeat
+    # number here is always two different records.
+    claimants="$(printf '%s %s' "${MARKER_CLAIMS[$tid]:-}" "${PROV_CLAIMS[$tid]:-}" | tr ' ' '\n' | grep -c '^#[0-9]' || true)"
+    if [ "$claimants" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: ${claimants} issues claim this feature's task: marker ${MARKER_CLAIMS[$tid]:-none} / recorded source ${PROV_CLAIMS[$tid]:-none}")
         continue
     fi
     # An identified task is not made ambiguous by somebody else's untraceable

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -21,8 +21,10 @@
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
 #   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
-#                    repository-relative path. Pass it explicitly to keep identity
-#                    stable if the file moves.
+#                    repository-relative path. If the file MOVES, pass the value
+#                    the existing issues were filed under - the ORIGINAL path -
+#                    or they are no longer recognised and get filed again. A new
+#                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
 #
@@ -101,7 +103,9 @@ fi
 # across re-runs, and derivable without asking. A human heading is deliberately NOT
 # used - two specs may both be titled "# Tasks: Reporting", and the collision would
 # be silent. `--feature` overrides it, which is also how identity survives the file
-# being moved or renamed later.
+# being moved or renamed later - but only when it carries the value those issues
+# were filed under. Passing some other slug after a move does not preserve
+# anything: it declares a new identity, and every task is filed a second time.
 TASKS_REL="$TASKS"
 if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
     _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
@@ -163,12 +167,38 @@ while IFS= read -r line || [ -n "$line" ]; do
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
             dep_clause="${BASH_REMATCH[1]}"
-            # `|| true`: grep exits 1 when a clause names no valid task id, and
-            # under `set -e` that killed the whole run with no diagnostic at all -
-            # the same silence this change exists to remove, in the error path.
-            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            # Validate WHOLE tokens, never substrings. Extracting `T[0-9]{3}` out
+            # of the clause silently accepted two corruptions: `T002, T1` dropped
+            # the invalid half and wrote a partial edge, and `T0020` matched its
+            # own first four characters and wrote an edge to T002 - a dependency
+            # that was never declared. A fabricated edge is worse than a missing
+            # one, because the planner treats it as a real constraint.
+            #
+            # Supported syntax is comma- and/or space-separated task ids, with
+            # `and` tolerated as a connector (the same separator the planner's
+            # own edge grammar accepts). Anything else is reported with its line
+            # rather than quietly dropped.
+            dep_bad=""
+            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+                case "$dep_token" in
+                    and|AND|And) continue ;;
+                esac
+                if [[ "$dep_token" =~ ^T[0-9]{3}$ ]]; then
+                    case " $dep_list" in
+                        *" $dep_token "*) continue ;;
+                    esac
+                    dep_list+="$dep_token "
+                else
+                    dep_bad+="'${dep_token}' "
+                fi
+            done
+            dep_list="${dep_list%"${dep_list##*[![:space:]]}"}"
+            if [ -n "$dep_bad" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' has unreadable token(s) ${dep_bad}(expected T001..T999): ${line}")
+                continue
+            fi
             if [ -z "$dep_list" ]; then
-                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no task id (expected T001..T999): ${line}")
                 continue
             fi
         fi

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -6,38 +6,63 @@
 # Part of Claude Power Pack (CPP). Replaces upstream /speckit-taskstoissues, which
 # hard-requires the github-mcp-server. CPP is gh-CLI based, so this reproduces the
 # same behaviour with `gh`:
-#   - one label-free issue per task, titled "T001: <description>"
-#   - dedup against existing issues by \bT\d{3}\b title match (re-run safe)
+#   - one issue per task, titled "T001 (<feature>): <description>"
+#   - every issue carries a FEATURE-SCOPED identity marker, so re-runs are safe
+#     and two features' T001 are different tasks (issue #857)
 #   - refuses to run unless the git remote is a GitHub URL
 #
 # Usage:
 #   scripts/speckit-tasks-to-issues.sh [--dry-run] [--tasks PATH] [--repo OWNER/NAME]
+#                                      [--feature SLUG] [--limit N]
 #
 # Options:
 #   --dry-run        Print what would be created; create nothing.
 #   --tasks PATH     Path to tasks.md. Default: auto-detect the single
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
+#   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
+#                    repository-relative path. Pass it explicitly to keep identity
+#                    stable if the file moves.
+#   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
+#
+# Exit codes:
+#   0  success
+#   1  environment refusal (no gh, no GitHub remote, no tasks file)
+#   2  usage error
+#   3  tasks.md could not be parsed (malformed task lines, or no tasks at all)
+#   4  the existing-issue inventory could not be established (lookup failed, or
+#      the result may be truncated)
+#   5  one or more tasks have an ambiguous legacy identity awaiting resolution
+#   6  issues were created but a dependency edge could not be written; re-run to
+#      reconcile
 set -euo pipefail
 
 DRY_RUN=0
 TASKS=""
 REPO=""
+FEATURE=""
+LIMIT=1000
 
-usage() { sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
         --tasks) TASKS="${2:?--tasks needs a path}"; shift 2 ;;
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
+        --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
+        --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
+[[ "$LIMIT" =~ ^[0-9]+$ ]] && [ "$LIMIT" -gt 0 ] || {
+    echo "ERROR: --limit must be a positive integer (got '$LIMIT')." >&2; exit 2; }
+
 command -v gh > /dev/null 2>&1 || { echo "ERROR: gh CLI not found." >&2; exit 1; }
+command -v jq > /dev/null 2>&1 || { echo "ERROR: jq not found." >&2; exit 1; }
 
 # --- Safety: only operate against a GitHub remote --------------------------------
 REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
@@ -65,18 +90,114 @@ if [ -z "$TASKS" ]; then
 fi
 [ -f "$TASKS" ] || { echo "ERROR: tasks file not found: $TASKS" >&2; exit 1; }
 
+# --- Feature identity (issue #857) -----------------------------------------------
+# A task ID is only unique WITHIN a feature: every feature starts again at T001, so
+# "T001" alone identified nothing and one feature's T001 issue made every other
+# feature's T001 look already-filed.
+#
+# Identity is therefore the pair (feature, task id), and the feature half has to be
+# something that cannot collapse two different tasks files into one identity. The
+# tasks file's REPOSITORY-RELATIVE PATH is that: unique by construction, stable
+# across re-runs, and derivable without asking. A human heading is deliberately NOT
+# used - two specs may both be titled "# Tasks: Reporting", and the collision would
+# be silent. `--feature` overrides it, which is also how identity survives the file
+# being moved or renamed later.
+TASKS_REL="$TASKS"
+if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
+    _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
+    case "$_tasks_abs" in
+        "$_repo_root"/*) TASKS_REL="${_tasks_abs#"$_repo_root"/}" ;;
+        *) TASKS_REL="$_tasks_abs" ;;
+    esac
+fi
+if [ -z "$FEATURE" ]; then
+    FEATURE="$TASKS_REL"
+fi
+case "$FEATURE" in
+    *$'\n'*|"") echo "ERROR: feature identity is empty or multi-line; pass --feature SLUG." >&2; exit 2 ;;
+esac
+
 GH_REPO_ARGS=()
 [ -n "$REPO" ] && GH_REPO_ARGS=(--repo "$REPO")
 
 echo "Tasks file: $TASKS"
+echo "Feature:    $FEATURE"
 echo "Remote:     $REMOTE_URL"
 [ "$DRY_RUN" -eq 1 ] && echo "Mode:       DRY RUN (no issues will be created)"
 
-# --- Existing issue IDs (dedup + task -> issue-number map) -----------------------
-# Match \bT\d{3}\b in existing titles (open + closed) so re-runs skip done tasks.
-# The number map (issue #607) lets a later task's dependency clause resolve to
-# `- Blocked by #N` lines in its body - the planner's native edge form.
+marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
+provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
+
+# --- Pass 1: parse tasks.md ------------------------------------------------------
+# Parsing runs to completion BEFORE any issue is created: a file this script cannot
+# read is a failure to report, not a zero-task success to celebrate (issue #857).
 #
+# Both ID spellings the shipped templates use are accepted. `.specify/templates/
+# tasks-template.md` writes the BOLD form (`- [ ] **T001** [US1] ...`), which the
+# original strict-plain parser skipped silently - so the converter could not read
+# the template this repository ships. Story tags are stripped in both the single
+# (`[US1]`) and comma (`[US1,US2]`, `[US1, US2]`) spellings; the comma form is on
+# the template's own T007 line and used to leak into the issue title.
+declare -a TIDS=() DESCS=() DEPS=()
+declare -A SEEN_TID=()
+declare -a MALFORMED=() UNRECOGNISED=()
+lineno=0
+while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[[[:space:]xX]\] ]] || continue
+    body="${line#*] }"
+    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+([[:space:]]*,[[:space:]]*US?[0-9]+)*\]//gI; s/^[[:space:]]+//')"
+    body="$(printf '%s' "$body" | sed -E 's/^(\*\*|__)[[:space:]]*(T[0-9]{3})[[:space:]]*(\*\*|__)/\2/')"
+    if [[ "$body" =~ ^(T[0-9]{3})([:[:space:]]+(.*))?$ ]]; then
+        tid="${BASH_REMATCH[1]}"
+        desc="$(printf '%s' "${BASH_REMATCH[3]:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        if [ -z "$desc" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: ${tid} has no description: ${line}")
+            continue
+        fi
+        if [ -n "${SEEN_TID[$tid]:-}" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: duplicate task id ${tid} in this feature: ${line}")
+            continue
+        fi
+        SEEN_TID["$tid"]=1
+        dep_list=""
+        if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
+            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        fi
+        TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
+    elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
+        # Carries a T-number that is not a valid task id (T1, T12, T0001 ...).
+        # Silently skipping these is how a file of malformed tasks reported
+        # "0 to create" and exited 0.
+        MALFORMED+=("${TASKS}:${lineno}: task-like line with a malformed T-number (expected T001..T999): ${line}")
+    else
+        # A checkbox line with no T-number at all. It may be a legitimate non-task
+        # checkbox, so it does not fail the run on its own - but it is never
+        # swallowed either, and a file where EVERY line lands here still fails
+        # below on the zero-task check rather than reporting a successful nothing.
+        UNRECOGNISED+=("${TASKS}:${lineno}: checkbox line is not a task and was ignored: ${line}")
+    fi
+done < "$TASKS"
+
+if [ "${#UNRECOGNISED[@]}" -gt 0 ]; then
+    echo "NOTE: ${#UNRECOGNISED[@]} checkbox line(s) were not read as tasks:" >&2
+    printf '  %s\n' "${UNRECOGNISED[@]}" >&2
+fi
+
+if [ "${#MALFORMED[@]}" -gt 0 ]; then
+    echo "ERROR: ${#MALFORMED[@]} task-like line(s) could not be parsed:" >&2
+    printf '  %s\n' "${MALFORMED[@]}" >&2
+    echo "Fix the lines above (or pass a different --tasks) and re-run. No issues were created." >&2
+    exit 3
+fi
+if [ "${#TIDS[@]}" -eq 0 ]; then
+    echo "ERROR: no tasks found in ${TASKS}." >&2
+    echo "Expected checkbox lines such as '- [ ] **T001** [US1] Description'." >&2
+    exit 3
+fi
+echo "Parsed:     ${#TIDS[@]} task(s)"
+
+# --- Inventory of existing issues ------------------------------------------------
 # ISSUE_FS - the ONE field separator for the `gh issue list` records parsed below
 # (issue #700), ASCII unit separator (0x1F) and deliberately NOT tab.
 #
@@ -91,9 +212,12 @@ echo "Remote:     $REMOTE_URL"
 # SHIFTED FIELDS (issue bodies built from the wrong values), not an error.
 # `\037` is not IFS whitespace, so empty fields survive in every position.
 #
+# That is exactly what happened here: #857 added three more fields, and two of them
+# (marker, provenance path) are EMPTY for every issue this script did not create.
+#
 # Same defect class as #698, which fixed the live instance in
 # scripts/flow-wave-registry.sh (a branchless worktree produced an empty middle
-# field on the ordinary path); this was the last whitespace-IFS read in scripts/.
+# field on the ordinary path).
 #
 # ONE definition, two spellings: the producer is a jq filter needing the `\uHHHH`
 # escape text, the reader is a shell `read` needing the byte, so the escape is
@@ -108,66 +232,232 @@ if [ "${#ISSUE_FS}" -ne 1 ] || [ "${#ISSUE_FS_JQ}" -ne 6 ]; then
     exit 1
 fi
 
-declare -A EXISTING
-declare -A TASK_ISSUE
-while IFS="$ISSUE_FS" read -r number title; do
-    if [[ "$title" =~ (^|[^A-Za-z0-9])(T[0-9]{3})([^0-9]|$) ]]; then
-        EXISTING["${BASH_REMATCH[2]}"]=1
-        TASK_ISSUE["${BASH_REMATCH[2]}"]="$number"
+# Record: number FS marker FS provenance-path FS legacy-tid FS blocked-refs
+# marker         - the speckit-task identity comment, when the body carries one
+# provenance     - the tasks path recorded in the "Auto-created from ..." line, which
+#                  is the only feature evidence a pre-#857 issue carries
+# legacy-tid     - a bare T-number in the TITLE, the pre-#857 identity
+# blocked-refs   - "#N" refs already present on this body's `Blocked by` lines, so a
+#                  re-run can tell a missing edge from one already written
+INVENTORY_JQ='
+.[] |
+  (.body // "") as $b |
+  ($b | capture("<!--\\s*(?<m>speckit-task:v1:[^>]*?)\\s*-->") // {m:""} | .m) as $marker |
+  ($b | capture("Auto-created from (?<p>.+?) \\(T[0-9]{3}\\) by CPP speckit-tasks-to-issues") // {p:""} | .p) as $prov |
+  ((.title // "") | capture("(^|[^A-Za-z0-9])(?<t>T[0-9]{3})([^0-9]|$)") // {t:""} | .t) as $ltid |
+  ([$b | scan("(?im)^\\s*[-*]?\\s*blocked by[^#\\n]*(#[0-9]+)") | .[0]] | join(",")) as $refs |
+  "\(.number)FS\($marker)FS\($prov)FS\($ltid)FS\($refs)"
+'
+INVENTORY_JQ="${INVENTORY_JQ//FS/$ISSUE_FS_JQ}"
+
+inventory_raw=""
+inventory_status=0
+inventory_raw="$(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit "$LIMIT" \
+    --json number,title,body --jq "$INVENTORY_JQ" 2>&1)" || inventory_status=$?
+if [ "$inventory_status" -ne 0 ]; then
+    echo "ERROR: could not list existing issues (gh exited ${inventory_status})." >&2
+    printf '  %s\n' "$inventory_raw" >&2
+    echo "Refusing to continue: an unreadable inventory is not an empty one, and treating" >&2
+    echo "it as empty re-files every task that already has an issue." >&2
+    exit 4
+fi
+
+declare -A FILED_NUM=()       # tid -> issue number claimed for THIS feature
+declare -A FILED_VIA=()       # tid -> marker | provenance
+declare -A EXISTING_REFS=()   # tid -> "#12,#13" already on the issue body
+declare -A MARKER_CLAIMS=()   # tid -> "#N #M" issues whose marker names this feature
+declare -A PROV_CLAIMS=()     # tid -> "#N #M" issues whose recorded source is this file
+declare -A UNRESOLVED_HITS=() # tid -> "#N" bare-title issues carrying no feature evidence
+inventory_count=0
+while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
+    [ -n "$number" ] || continue
+    inventory_count=$((inventory_count + 1))
+    if [ -n "$marker" ]; then
+        # Exact identity. A marker naming a DIFFERENT feature is a known other
+        # task, not a claim on this one, so it is simply not this feature's.
+        case "$marker" in
+            "speckit-task:v1:${FEATURE}:"*)
+                tid="${marker##*:}"
+                MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
+                FILED_NUM["$tid"]="$number"
+                FILED_VIA["$tid"]="marker"
+                EXISTING_REFS["$tid"]="$refs"
+                ;;
+        esac
+        continue
     fi
-done < <(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit 1000 --json number,title --jq ".[] | \"\(.number)${ISSUE_FS_JQ}\(.title)\"" 2>/dev/null || true)
+    [ -n "$ltid" ] || continue
+    if [ -n "$prov" ]; then
+        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+            # A pre-#857 issue this script created from THIS tasks file. The
+            # recorded source path is real feature provenance, so adopting it is
+            # evidence, not a guess.
+            PROV_CLAIMS["$ltid"]="${PROV_CLAIMS[$ltid]:-}#${number} "
+            if [ -z "${FILED_NUM[$ltid]:-}" ]; then
+                FILED_NUM["$ltid"]="$number"
+                FILED_VIA["$ltid"]="provenance"
+                EXISTING_REFS["$ltid"]="$refs"
+            fi
+        fi
+        # A provenance line naming a DIFFERENT tasks file is a known different
+        # feature. It says nothing about this feature's task of the same number,
+        # so it must not block this one from being filed.
+        continue
+    fi
+    # A bare T-number in a title, with no marker and no recorded source at all.
+    # Whose task it is cannot be established: two features routinely share both a
+    # task id AND its description ("T001 Add tests"), so a description match is not
+    # provenance. Recorded as unresolved and settled by a human, never guessed.
+    UNRESOLVED_HITS["$ltid"]="${UNRESOLVED_HITS[$ltid]:-}#${number} "
+done <<< "$inventory_raw"
 
-# --- Parse tasks.md and create issues -------------------------------------------
-created=0; skipped=0
-while IFS= read -r line; do
-    # Only checkbox task lines.
-    [[ "$line" =~ ^-\ \[[\ xX]\] ]] || continue
-    # Strip the checkbox (up to the first "] ") and any [P] / [US#] markers.
-    body="${line#*] }"
-    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+\]//g; s/^[[:space:]]+//')"
-    # Recover the task ID (T + 3 digits) and description.
-    [[ "$body" =~ ^(T[0-9]{3})[:[:space:]]+(.*)$ ]] || continue
-    tid="${BASH_REMATCH[1]}"
-    desc="$(printf '%s' "${BASH_REMATCH[2]}" | sed -E 's/[[:space:]]+$//')"
-    title="${tid}: ${desc}"
+if [ "$inventory_count" -ge "$LIMIT" ]; then
+    echo "ERROR: the issue inventory returned ${inventory_count} record(s), the same as" >&2
+    echo "--limit ${LIMIT}. The list may be truncated, and a truncated inventory cannot" >&2
+    echo "support the re-run guarantee: a task whose issue fell past the cutoff would be" >&2
+    echo "filed a second time. Re-run with a larger --limit." >&2
+    exit 4
+fi
+echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 
-    if [ -n "${EXISTING[$tid]:-}" ]; then
-        echo "skip  ${tid} (issue already exists)"
+# --- Ambiguity scan: everything that must stop the run happens BEFORE any write ---
+declare -a AMBIGUOUS=()
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
+    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
+    if [ "$claims" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
+        continue
+    fi
+    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+        continue
+    fi
+    # An identified task is not made ambiguous by somebody else's untraceable
+    # issue: this feature's task already has evidence naming it.
+    [ -n "${FILED_NUM[$tid]:-}" ] && continue
+    [ -n "${UNRESOLVED_HITS[$tid]:-}" ] || continue
+    AMBIGUOUS+=("${tid}: ${UNRESOLVED_HITS[$tid]}(title carries ${tid}, records no source feature)")
+done
+if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
+    echo "ERROR: ${#AMBIGUOUS[@]} task(s) have an unresolved identity:" >&2
+    printf '  %s\n' "${AMBIGUOUS[@]}" >&2
+    echo "Each names an existing issue that carries this task number but no evidence of which" >&2
+    echo "feature it belongs to, or more than one issue claiming this feature's task. This" >&2
+    echo "script will not decide. Resolve by adding the identity marker to the correct issue's" >&2
+    echo "body (or removing the duplicate claim), then re-run:" >&2
+    echo "  $(marker_for T001)" >&2
+    echo "(substituting the task id). An issue whose body records a DIFFERENT tasks file needs" >&2
+    echo "no change - it is already recognised as another feature's task." >&2
+    exit 5
+fi
+
+# --- Create pass -----------------------------------------------------------------
+created=0; skipped=0; adopted=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    title="${tid} (${FEATURE}): ${DESCS[$i]}"
+    if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
+                 "add '$(marker_for "$tid")' to its body to make the identity explicit)"
+            adopted=$((adopted + 1))
+        else
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]} already carries this feature's marker)"
+        fi
         skipped=$((skipped + 1))
         continue
     fi
-    # Dependency clause -> machine-readable body lines (issue #607). The clause
-    # used to survive only as title prose, which drifted from tasks.md with
-    # nothing to detect it. The body now carries BOTH forms: a `Depends on:`
-    # task-id line (joinable via the spec's Issue Sync table even when numbers
-    # are unknown), and `- Blocked by #N` bullets - flow-wave-plan.py's native
-    # edge grammar - for every dep already resolvable to an issue number
-    # (created earlier this run, or found by the dedup scan above).
-    issue_body="Auto-created from ${TASKS} (${tid}) by CPP speckit-tasks-to-issues."
-    if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-        dep_clause="${BASH_REMATCH[1]}"
-        dep_tids="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ')"
-        if [ -n "$dep_tids" ]; then
-            issue_body+=$'\n\n'"Depends on: $(printf '%s' "$dep_tids" | sed 's/ $//; s/ /, /g')"
-            for dep in $dep_tids; do
-                if [ -n "${TASK_ISSUE[$dep]:-}" ]; then
-                    issue_body+=$'\n'"- Blocked by #${TASK_ISSUE[$dep]}"
-                fi
-            done
-        fi
+
+    issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
+    if [ -n "${DEPS[$i]}" ]; then
+        issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "would create: ${title}"
+        FILED_NUM["$tid"]=""
     else
         url="$(gh issue create "${GH_REPO_ARGS[@]}" --title "$title" --body "$issue_body" 2>&1)"
         echo "create ${tid} -> ${url}"
-        EXISTING["$tid"]=1
         num="${url##*/}"
-        [[ "$num" =~ ^[0-9]+$ ]] && TASK_ISSUE["$tid"]="$num"
+        if [[ "$num" =~ ^[0-9]+$ ]]; then
+            FILED_NUM["$tid"]="$num"
+            FILED_VIA["$tid"]="marker"
+            EXISTING_REFS["$tid"]=""
+        fi
     fi
     created=$((created + 1))
-done < "$TASKS"
+done
+
+# --- Dependency reconciliation ---------------------------------------------------
+# Deliberately NOT "annotate what this run created". A dependency may point FORWARD
+# to a task declared later in the file, and a run that dies between creating issues
+# and writing their edges must be repairable - otherwise those edges are missing
+# forever, because the next run sees the issues as already filed and skips them
+# (issue #857). So every filed task in this feature is reconciled on every run:
+# expected refs minus refs already in the body, appended, existing content kept.
+#
+# Edges resolve ONLY within this feature. A T-number that belongs to another
+# feature's tasks file cannot contribute an edge here - that cross-feature guess is
+# the same defect as the identity one, one level down.
+edges_written=0; edges_failed=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    [ -n "${DEPS[$i]}" ] || continue
+    number="${FILED_NUM[$tid]:-}"
+
+    missing=""
+    for dep in ${DEPS[$i]}; do
+        dep_num="${FILED_NUM[$dep]:-}"
+        if [ -z "$dep_num" ]; then
+            if [ -z "${SEEN_TID[$dep]:-}" ]; then
+                echo "note  ${tid} depends on ${dep}, which is not a task in this feature - no edge written." >&2
+            fi
+            continue
+        fi
+        case ",${EXISTING_REFS[$tid]:-}," in
+            *",#${dep_num},"*) continue ;;
+        esac
+        case "$missing" in
+            *"#${dep_num} "*) continue ;;
+        esac
+        missing+="#${dep_num} "
+    done
+    [ -n "$missing" ] || continue
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "would link:   ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//')"
+        continue
+    fi
+    [ -n "$number" ] || continue
+
+    current_body="$(gh issue view "$number" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || {
+        echo "WARN: could not read issue #${number} to add its dependency edges; re-run to reconcile." >&2
+        printf '  %s\n' "$current_body" >&2
+        edges_failed=$((edges_failed + 1))
+        continue
+    }
+    new_body="$current_body"
+    for ref in $missing; do
+        new_body+=$'\n'"- Blocked by ${ref}"
+    done
+    if printf '%s' "$new_body" | gh issue edit "$number" "${GH_REPO_ARGS[@]}" --body-file - > /dev/null 2>&1; then
+        echo "link  ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//') (issue #${number})"
+        edges_written=$((edges_written + 1))
+    else
+        echo "WARN: could not write dependency edges for ${tid} (issue #${number}); re-run to reconcile." >&2
+        edges_failed=$((edges_failed + 1))
+    fi
+done
 
 echo "---"
-echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist)."
+echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
+[ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$edges_failed" -gt 0 ]; then
+    echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
+    echo "command to reconcile the missing edges - it will not create duplicates." >&2
+    exit 6
+fi
+exit 0

--- a/scripts/flow-wave-plan.py
+++ b/scripts/flow-wave-plan.py
@@ -173,7 +173,15 @@ def _strip_code_for_edges(body: str) -> str:
 REF_RE = re.compile(r"#(\d+)")
 # tasks.md shapes (#607): a checkbox task line with an optional depends clause,
 # and the Issue Sync join of task IDs to issue numbers.
-TASK_LINE_RE = re.compile(r"^\s*-\s*\[[ xX]\]\s*(?:\[[^\]]+\]\s*)*(T\d{3})\b(.*)$")
+# The task id may be emphasised: `.specify/templates/tasks-template.md` writes
+# `- [ ] **T001** [US1] ...`, and the specs in this repo use that form. Reading
+# only the bare spelling made every such file parse as zero tasks, so the spec
+# `(depends on ...)` edges below were silently absent rather than reported
+# missing - the same representation defect #857 fixed in the issue converter.
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\[[^\]]+\]\s*)*"
+    r"(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
 DEPENDS_CLAUSE_RE = re.compile(r"\(depends on\s+([^)]*)\)", re.IGNORECASE)
 TASK_ID_RE = re.compile(r"T\d{3}")
 ISSUE_SYNC_HEADING_RE = re.compile(r"^#{2,}\s*Issue Sync\b", re.IGNORECASE)

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -132,6 +132,42 @@ echo "Remote:     $REMOTE_URL"
 marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
 provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
 
+# Two spellings of the SAME file must compare equal, or a legacy issue recorded
+# as `./a/tasks.md` reads as another feature's and its task is filed a second
+# time - the duplicate this whole change exists to prevent, caused by the
+# comparison rather than by the identity.
+#
+# Deliberately conservative: leading `./`, repeated slashes, and a trailing
+# slash are noise and are removed, and an ABSOLUTE path is made
+# repository-relative only when it is genuinely inside THIS repository. Nothing
+# else is inferred - `..` segments are left alone and an absolute path from
+# another checkout or machine stays absolute, so it correctly fails to match
+# rather than being guessed equal.
+normalize_source_path() {
+    local path="$1"
+    if [ -n "${_repo_root:-}" ]; then
+        case "$path" in
+            "$_repo_root"/*) path="${path#"$_repo_root"/}" ;;
+        esac
+    fi
+    while :; do
+        case "$path" in
+            ./*) path="${path#./}" ;;
+            *) break ;;
+        esac
+    done
+    while [[ "$path" == *//* ]]; do
+        path="${path//\/\//\/}"
+    done
+    case "$path" in
+        */) path="${path%/}" ;;
+    esac
+    printf '%s' "$path"
+}
+
+TASKS_NORM="$(normalize_source_path "$TASKS")"
+TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
+
 # --- Pass 1: parse tasks.md ------------------------------------------------------
 # Parsing runs to completion BEFORE any issue is created: a file this script cannot
 # read is a failure to report, not a zero-task success to celebrate (issue #857).
@@ -178,8 +214,17 @@ while IFS= read -r line || [ -n "$line" ]; do
             # `and` tolerated as a connector (the same separator the planner's
             # own edge grammar accepts). Anything else is reported with its line
             # rather than quietly dropped.
+            # Split WITHOUT pathname expansion. An unquoted `$(...)` in a `for`
+            # list is glob-expanded as well as word-split, so `(depends on T00?)`
+            # became a valid token in any directory that happened to contain a
+            # file called T002 - the validation passed because the filesystem
+            # supplied the answer. `IFS= read` takes each token literally.
+            dep_tokens=()
+            while IFS= read -r dep_token; do
+                [ -n "$dep_token" ] && dep_tokens+=("$dep_token")
+            done < <(printf '%s\n' "$dep_clause" | tr ', \t' '\n\n\n')
             dep_bad=""
-            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+            for dep_token in ${dep_tokens+"${dep_tokens[@]}"}; do
                 case "$dep_token" in
                     and|AND|And) continue ;;
                 esac
@@ -334,7 +379,8 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     fi
     [ -n "$ltid" ] || continue
     if [ -n "$prov" ]; then
-        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+        prov_norm="$(normalize_source_path "$prov")"
+        if [ "$prov_norm" = "$TASKS_NORM" ] || [ "$prov_norm" = "$TASKS_REL_NORM" ]; then
             # A pre-#857 issue this script created from THIS tasks file. The
             # recorded source path is real feature provenance, so adopting it is
             # evidence, not a guess.

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -162,7 +162,15 @@ while IFS= read -r line || [ -n "$line" ]; do
         SEEN_TID["$tid"]=1
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+            dep_clause="${BASH_REMATCH[1]}"
+            # `|| true`: grep exits 1 when a clause names no valid task id, and
+            # under `set -e` that killed the whole run with no diagnostic at all -
+            # the same silence this change exists to remove, in the error path.
+            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            if [ -z "$dep_list" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                continue
+            fi
         fi
         TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
     elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
@@ -274,16 +282,24 @@ while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
     inventory_count=$((inventory_count + 1))
     if [ -n "$marker" ]; then
         # Exact identity. A marker naming a DIFFERENT feature is a known other
-        # task, not a claim on this one, so it is simply not this feature's.
-        case "$marker" in
-            "speckit-task:v1:${FEATURE}:"*)
-                tid="${marker##*:}"
+        # task, not a claim on this one.
+        #
+        # The comparison is EXACT, never a prefix: a feature may legitimately
+        # contain a colon (`--feature f:other`), so testing `speckit-task:v1:f:*`
+        # accepts `speckit-task:v1:f:other:T001` and hands one feature's task to
+        # another. Split the last field off as the task id and compare what
+        # remains to this feature in full.
+        marker_rest="${marker#speckit-task:v1:}"
+        if [ "$marker_rest" != "$marker" ]; then
+            tid="${marker_rest##*:}"
+            marker_feature="${marker_rest%:*}"
+            if [[ "$tid" =~ ^T[0-9]{3}$ ]] && [ "$marker_feature" = "$FEATURE" ]; then
                 MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
                 FILED_NUM["$tid"]="$number"
                 FILED_VIA["$tid"]="marker"
                 EXISTING_REFS["$tid"]="$refs"
-                ;;
-        esac
+            fi
+        fi
         continue
     fi
     [ -n "$ltid" ] || continue
@@ -324,14 +340,16 @@ echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 declare -a AMBIGUOUS=()
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
-    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
-    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
-    if [ "$claims" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
-        continue
-    fi
-    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
-        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+    # Count DISTINCT issues claiming this feature's task, whatever kind of claim
+    # they carry. Counting each bucket separately misses the mixed case - one
+    # issue with the marker and a different issue whose recorded source is this
+    # tasks file - which is two issues claiming one task and is exactly as
+    # ambiguous as two of either kind. The same issue appearing in both buckets
+    # cannot happen (a marker short-circuits the provenance read), so a repeat
+    # number here is always two different records.
+    claimants="$(printf '%s %s' "${MARKER_CLAIMS[$tid]:-}" "${PROV_CLAIMS[$tid]:-}" | tr ' ' '\n' | grep -c '^#[0-9]' || true)"
+    if [ "$claimants" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: ${claimants} issues claim this feature's task: marker ${MARKER_CLAIMS[$tid]:-none} / recorded source ${PROV_CLAIMS[$tid]:-none}")
         continue
     fi
     # An identified task is not made ambiguous by somebody else's untraceable

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -21,8 +21,10 @@
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
 #   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
-#                    repository-relative path. Pass it explicitly to keep identity
-#                    stable if the file moves.
+#                    repository-relative path. If the file MOVES, pass the value
+#                    the existing issues were filed under - the ORIGINAL path -
+#                    or they are no longer recognised and get filed again. A new
+#                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
 #
@@ -101,7 +103,9 @@ fi
 # across re-runs, and derivable without asking. A human heading is deliberately NOT
 # used - two specs may both be titled "# Tasks: Reporting", and the collision would
 # be silent. `--feature` overrides it, which is also how identity survives the file
-# being moved or renamed later.
+# being moved or renamed later - but only when it carries the value those issues
+# were filed under. Passing some other slug after a move does not preserve
+# anything: it declares a new identity, and every task is filed a second time.
 TASKS_REL="$TASKS"
 if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
     _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
@@ -163,12 +167,38 @@ while IFS= read -r line || [ -n "$line" ]; do
         dep_list=""
         if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
             dep_clause="${BASH_REMATCH[1]}"
-            # `|| true`: grep exits 1 when a clause names no valid task id, and
-            # under `set -e` that killed the whole run with no diagnostic at all -
-            # the same silence this change exists to remove, in the error path.
-            dep_list="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+            # Validate WHOLE tokens, never substrings. Extracting `T[0-9]{3}` out
+            # of the clause silently accepted two corruptions: `T002, T1` dropped
+            # the invalid half and wrote a partial edge, and `T0020` matched its
+            # own first four characters and wrote an edge to T002 - a dependency
+            # that was never declared. A fabricated edge is worse than a missing
+            # one, because the planner treats it as a real constraint.
+            #
+            # Supported syntax is comma- and/or space-separated task ids, with
+            # `and` tolerated as a connector (the same separator the planner's
+            # own edge grammar accepts). Anything else is reported with its line
+            # rather than quietly dropped.
+            dep_bad=""
+            for dep_token in $(printf '%s' "$dep_clause" | tr ',' ' '); do
+                case "$dep_token" in
+                    and|AND|And) continue ;;
+                esac
+                if [[ "$dep_token" =~ ^T[0-9]{3}$ ]]; then
+                    case " $dep_list" in
+                        *" $dep_token "*) continue ;;
+                    esac
+                    dep_list+="$dep_token "
+                else
+                    dep_bad+="'${dep_token}' "
+                fi
+            done
+            dep_list="${dep_list%"${dep_list##*[![:space:]]}"}"
+            if [ -n "$dep_bad" ]; then
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' has unreadable token(s) ${dep_bad}(expected T001..T999): ${line}")
+                continue
+            fi
             if [ -z "$dep_list" ]; then
-                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no valid task id (expected T001..T999): ${line}")
+                MALFORMED+=("${TASKS}:${lineno}: dependency clause '(depends on ${dep_clause})' names no task id (expected T001..T999): ${line}")
                 continue
             fi
         fi

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -6,38 +6,63 @@
 # Part of Claude Power Pack (CPP). Replaces upstream /speckit-taskstoissues, which
 # hard-requires the github-mcp-server. CPP is gh-CLI based, so this reproduces the
 # same behaviour with `gh`:
-#   - one label-free issue per task, titled "T001: <description>"
-#   - dedup against existing issues by \bT\d{3}\b title match (re-run safe)
+#   - one issue per task, titled "T001 (<feature>): <description>"
+#   - every issue carries a FEATURE-SCOPED identity marker, so re-runs are safe
+#     and two features' T001 are different tasks (issue #857)
 #   - refuses to run unless the git remote is a GitHub URL
 #
 # Usage:
 #   scripts/speckit-tasks-to-issues.sh [--dry-run] [--tasks PATH] [--repo OWNER/NAME]
+#                                      [--feature SLUG] [--limit N]
 #
 # Options:
 #   --dry-run        Print what would be created; create nothing.
 #   --tasks PATH     Path to tasks.md. Default: auto-detect the single
 #                    .specify/specs/*/tasks.md, else error.
 #   --repo OWNER/NM  Target repo for gh (default: the origin remote's repo).
+#   --feature SLUG   Feature identity for these tasks. Default: the tasks file's
+#                    repository-relative path. Pass it explicitly to keep identity
+#                    stable if the file moves.
+#   --limit N        Issues to scan for the existing-work inventory (default 1000).
 #   -h, --help       Show this help.
+#
+# Exit codes:
+#   0  success
+#   1  environment refusal (no gh, no GitHub remote, no tasks file)
+#   2  usage error
+#   3  tasks.md could not be parsed (malformed task lines, or no tasks at all)
+#   4  the existing-issue inventory could not be established (lookup failed, or
+#      the result may be truncated)
+#   5  one or more tasks have an ambiguous legacy identity awaiting resolution
+#   6  issues were created but a dependency edge could not be written; re-run to
+#      reconcile
 set -euo pipefail
 
 DRY_RUN=0
 TASKS=""
 REPO=""
+FEATURE=""
+LIMIT=1000
 
-usage() { sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
         --tasks) TASKS="${2:?--tasks needs a path}"; shift 2 ;;
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
+        --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
+        --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
+[[ "$LIMIT" =~ ^[0-9]+$ ]] && [ "$LIMIT" -gt 0 ] || {
+    echo "ERROR: --limit must be a positive integer (got '$LIMIT')." >&2; exit 2; }
+
 command -v gh > /dev/null 2>&1 || { echo "ERROR: gh CLI not found." >&2; exit 1; }
+command -v jq > /dev/null 2>&1 || { echo "ERROR: jq not found." >&2; exit 1; }
 
 # --- Safety: only operate against a GitHub remote --------------------------------
 REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
@@ -65,18 +90,114 @@ if [ -z "$TASKS" ]; then
 fi
 [ -f "$TASKS" ] || { echo "ERROR: tasks file not found: $TASKS" >&2; exit 1; }
 
+# --- Feature identity (issue #857) -----------------------------------------------
+# A task ID is only unique WITHIN a feature: every feature starts again at T001, so
+# "T001" alone identified nothing and one feature's T001 issue made every other
+# feature's T001 look already-filed.
+#
+# Identity is therefore the pair (feature, task id), and the feature half has to be
+# something that cannot collapse two different tasks files into one identity. The
+# tasks file's REPOSITORY-RELATIVE PATH is that: unique by construction, stable
+# across re-runs, and derivable without asking. A human heading is deliberately NOT
+# used - two specs may both be titled "# Tasks: Reporting", and the collision would
+# be silent. `--feature` overrides it, which is also how identity survives the file
+# being moved or renamed later.
+TASKS_REL="$TASKS"
+if _repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$_repo_root" ]; then
+    _tasks_abs="$(cd "$(dirname "$TASKS")" && pwd)/$(basename "$TASKS")"
+    case "$_tasks_abs" in
+        "$_repo_root"/*) TASKS_REL="${_tasks_abs#"$_repo_root"/}" ;;
+        *) TASKS_REL="$_tasks_abs" ;;
+    esac
+fi
+if [ -z "$FEATURE" ]; then
+    FEATURE="$TASKS_REL"
+fi
+case "$FEATURE" in
+    *$'\n'*|"") echo "ERROR: feature identity is empty or multi-line; pass --feature SLUG." >&2; exit 2 ;;
+esac
+
 GH_REPO_ARGS=()
 [ -n "$REPO" ] && GH_REPO_ARGS=(--repo "$REPO")
 
 echo "Tasks file: $TASKS"
+echo "Feature:    $FEATURE"
 echo "Remote:     $REMOTE_URL"
 [ "$DRY_RUN" -eq 1 ] && echo "Mode:       DRY RUN (no issues will be created)"
 
-# --- Existing issue IDs (dedup + task -> issue-number map) -----------------------
-# Match \bT\d{3}\b in existing titles (open + closed) so re-runs skip done tasks.
-# The number map (issue #607) lets a later task's dependency clause resolve to
-# `- Blocked by #N` lines in its body - the planner's native edge form.
+marker_for() { printf '<!-- speckit-task:v1:%s:%s -->' "$FEATURE" "$1"; }
+provenance_for() { printf 'Auto-created from %s (%s) by CPP speckit-tasks-to-issues.' "$TASKS" "$1"; }
+
+# --- Pass 1: parse tasks.md ------------------------------------------------------
+# Parsing runs to completion BEFORE any issue is created: a file this script cannot
+# read is a failure to report, not a zero-task success to celebrate (issue #857).
 #
+# Both ID spellings the shipped templates use are accepted. `.specify/templates/
+# tasks-template.md` writes the BOLD form (`- [ ] **T001** [US1] ...`), which the
+# original strict-plain parser skipped silently - so the converter could not read
+# the template this repository ships. Story tags are stripped in both the single
+# (`[US1]`) and comma (`[US1,US2]`, `[US1, US2]`) spellings; the comma form is on
+# the template's own T007 line and used to leak into the issue title.
+declare -a TIDS=() DESCS=() DEPS=()
+declare -A SEEN_TID=()
+declare -a MALFORMED=() UNRECOGNISED=()
+lineno=0
+while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[[[:space:]xX]\] ]] || continue
+    body="${line#*] }"
+    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+([[:space:]]*,[[:space:]]*US?[0-9]+)*\]//gI; s/^[[:space:]]+//')"
+    body="$(printf '%s' "$body" | sed -E 's/^(\*\*|__)[[:space:]]*(T[0-9]{3})[[:space:]]*(\*\*|__)/\2/')"
+    if [[ "$body" =~ ^(T[0-9]{3})([:[:space:]]+(.*))?$ ]]; then
+        tid="${BASH_REMATCH[1]}"
+        desc="$(printf '%s' "${BASH_REMATCH[3]:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        if [ -z "$desc" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: ${tid} has no description: ${line}")
+            continue
+        fi
+        if [ -n "${SEEN_TID[$tid]:-}" ]; then
+            MALFORMED+=("${TASKS}:${lineno}: duplicate task id ${tid} in this feature: ${line}")
+            continue
+        fi
+        SEEN_TID["$tid"]=1
+        dep_list=""
+        if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
+            dep_list="$(printf '%s' "${BASH_REMATCH[1]}" | grep -oE 'T[0-9]{3}' | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        fi
+        TIDS+=("$tid"); DESCS+=("$desc"); DEPS+=("$dep_list")
+    elif [[ "$body" =~ (^|[^A-Za-z0-9])T[0-9]+([^A-Za-z0-9]|$) ]]; then
+        # Carries a T-number that is not a valid task id (T1, T12, T0001 ...).
+        # Silently skipping these is how a file of malformed tasks reported
+        # "0 to create" and exited 0.
+        MALFORMED+=("${TASKS}:${lineno}: task-like line with a malformed T-number (expected T001..T999): ${line}")
+    else
+        # A checkbox line with no T-number at all. It may be a legitimate non-task
+        # checkbox, so it does not fail the run on its own - but it is never
+        # swallowed either, and a file where EVERY line lands here still fails
+        # below on the zero-task check rather than reporting a successful nothing.
+        UNRECOGNISED+=("${TASKS}:${lineno}: checkbox line is not a task and was ignored: ${line}")
+    fi
+done < "$TASKS"
+
+if [ "${#UNRECOGNISED[@]}" -gt 0 ]; then
+    echo "NOTE: ${#UNRECOGNISED[@]} checkbox line(s) were not read as tasks:" >&2
+    printf '  %s\n' "${UNRECOGNISED[@]}" >&2
+fi
+
+if [ "${#MALFORMED[@]}" -gt 0 ]; then
+    echo "ERROR: ${#MALFORMED[@]} task-like line(s) could not be parsed:" >&2
+    printf '  %s\n' "${MALFORMED[@]}" >&2
+    echo "Fix the lines above (or pass a different --tasks) and re-run. No issues were created." >&2
+    exit 3
+fi
+if [ "${#TIDS[@]}" -eq 0 ]; then
+    echo "ERROR: no tasks found in ${TASKS}." >&2
+    echo "Expected checkbox lines such as '- [ ] **T001** [US1] Description'." >&2
+    exit 3
+fi
+echo "Parsed:     ${#TIDS[@]} task(s)"
+
+# --- Inventory of existing issues ------------------------------------------------
 # ISSUE_FS - the ONE field separator for the `gh issue list` records parsed below
 # (issue #700), ASCII unit separator (0x1F) and deliberately NOT tab.
 #
@@ -91,9 +212,12 @@ echo "Remote:     $REMOTE_URL"
 # SHIFTED FIELDS (issue bodies built from the wrong values), not an error.
 # `\037` is not IFS whitespace, so empty fields survive in every position.
 #
+# That is exactly what happened here: #857 added three more fields, and two of them
+# (marker, provenance path) are EMPTY for every issue this script did not create.
+#
 # Same defect class as #698, which fixed the live instance in
 # scripts/flow-wave-registry.sh (a branchless worktree produced an empty middle
-# field on the ordinary path); this was the last whitespace-IFS read in scripts/.
+# field on the ordinary path).
 #
 # ONE definition, two spellings: the producer is a jq filter needing the `\uHHHH`
 # escape text, the reader is a shell `read` needing the byte, so the escape is
@@ -108,66 +232,232 @@ if [ "${#ISSUE_FS}" -ne 1 ] || [ "${#ISSUE_FS_JQ}" -ne 6 ]; then
     exit 1
 fi
 
-declare -A EXISTING
-declare -A TASK_ISSUE
-while IFS="$ISSUE_FS" read -r number title; do
-    if [[ "$title" =~ (^|[^A-Za-z0-9])(T[0-9]{3})([^0-9]|$) ]]; then
-        EXISTING["${BASH_REMATCH[2]}"]=1
-        TASK_ISSUE["${BASH_REMATCH[2]}"]="$number"
+# Record: number FS marker FS provenance-path FS legacy-tid FS blocked-refs
+# marker         - the speckit-task identity comment, when the body carries one
+# provenance     - the tasks path recorded in the "Auto-created from ..." line, which
+#                  is the only feature evidence a pre-#857 issue carries
+# legacy-tid     - a bare T-number in the TITLE, the pre-#857 identity
+# blocked-refs   - "#N" refs already present on this body's `Blocked by` lines, so a
+#                  re-run can tell a missing edge from one already written
+INVENTORY_JQ='
+.[] |
+  (.body // "") as $b |
+  ($b | capture("<!--\\s*(?<m>speckit-task:v1:[^>]*?)\\s*-->") // {m:""} | .m) as $marker |
+  ($b | capture("Auto-created from (?<p>.+?) \\(T[0-9]{3}\\) by CPP speckit-tasks-to-issues") // {p:""} | .p) as $prov |
+  ((.title // "") | capture("(^|[^A-Za-z0-9])(?<t>T[0-9]{3})([^0-9]|$)") // {t:""} | .t) as $ltid |
+  ([$b | scan("(?im)^\\s*[-*]?\\s*blocked by[^#\\n]*(#[0-9]+)") | .[0]] | join(",")) as $refs |
+  "\(.number)FS\($marker)FS\($prov)FS\($ltid)FS\($refs)"
+'
+INVENTORY_JQ="${INVENTORY_JQ//FS/$ISSUE_FS_JQ}"
+
+inventory_raw=""
+inventory_status=0
+inventory_raw="$(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit "$LIMIT" \
+    --json number,title,body --jq "$INVENTORY_JQ" 2>&1)" || inventory_status=$?
+if [ "$inventory_status" -ne 0 ]; then
+    echo "ERROR: could not list existing issues (gh exited ${inventory_status})." >&2
+    printf '  %s\n' "$inventory_raw" >&2
+    echo "Refusing to continue: an unreadable inventory is not an empty one, and treating" >&2
+    echo "it as empty re-files every task that already has an issue." >&2
+    exit 4
+fi
+
+declare -A FILED_NUM=()       # tid -> issue number claimed for THIS feature
+declare -A FILED_VIA=()       # tid -> marker | provenance
+declare -A EXISTING_REFS=()   # tid -> "#12,#13" already on the issue body
+declare -A MARKER_CLAIMS=()   # tid -> "#N #M" issues whose marker names this feature
+declare -A PROV_CLAIMS=()     # tid -> "#N #M" issues whose recorded source is this file
+declare -A UNRESOLVED_HITS=() # tid -> "#N" bare-title issues carrying no feature evidence
+inventory_count=0
+while IFS="$ISSUE_FS" read -r number marker prov ltid refs; do
+    [ -n "$number" ] || continue
+    inventory_count=$((inventory_count + 1))
+    if [ -n "$marker" ]; then
+        # Exact identity. A marker naming a DIFFERENT feature is a known other
+        # task, not a claim on this one, so it is simply not this feature's.
+        case "$marker" in
+            "speckit-task:v1:${FEATURE}:"*)
+                tid="${marker##*:}"
+                MARKER_CLAIMS["$tid"]="${MARKER_CLAIMS[$tid]:-}#${number} "
+                FILED_NUM["$tid"]="$number"
+                FILED_VIA["$tid"]="marker"
+                EXISTING_REFS["$tid"]="$refs"
+                ;;
+        esac
+        continue
     fi
-done < <(gh issue list "${GH_REPO_ARGS[@]}" --state all --limit 1000 --json number,title --jq ".[] | \"\(.number)${ISSUE_FS_JQ}\(.title)\"" 2>/dev/null || true)
+    [ -n "$ltid" ] || continue
+    if [ -n "$prov" ]; then
+        if [ "$prov" = "$TASKS" ] || [ "$prov" = "$TASKS_REL" ]; then
+            # A pre-#857 issue this script created from THIS tasks file. The
+            # recorded source path is real feature provenance, so adopting it is
+            # evidence, not a guess.
+            PROV_CLAIMS["$ltid"]="${PROV_CLAIMS[$ltid]:-}#${number} "
+            if [ -z "${FILED_NUM[$ltid]:-}" ]; then
+                FILED_NUM["$ltid"]="$number"
+                FILED_VIA["$ltid"]="provenance"
+                EXISTING_REFS["$ltid"]="$refs"
+            fi
+        fi
+        # A provenance line naming a DIFFERENT tasks file is a known different
+        # feature. It says nothing about this feature's task of the same number,
+        # so it must not block this one from being filed.
+        continue
+    fi
+    # A bare T-number in a title, with no marker and no recorded source at all.
+    # Whose task it is cannot be established: two features routinely share both a
+    # task id AND its description ("T001 Add tests"), so a description match is not
+    # provenance. Recorded as unresolved and settled by a human, never guessed.
+    UNRESOLVED_HITS["$ltid"]="${UNRESOLVED_HITS[$ltid]:-}#${number} "
+done <<< "$inventory_raw"
 
-# --- Parse tasks.md and create issues -------------------------------------------
-created=0; skipped=0
-while IFS= read -r line; do
-    # Only checkbox task lines.
-    [[ "$line" =~ ^-\ \[[\ xX]\] ]] || continue
-    # Strip the checkbox (up to the first "] ") and any [P] / [US#] markers.
-    body="${line#*] }"
-    body="$(printf '%s' "$body" | sed -E 's/\[P\]//g; s/\[US[0-9]+\]//g; s/^[[:space:]]+//')"
-    # Recover the task ID (T + 3 digits) and description.
-    [[ "$body" =~ ^(T[0-9]{3})[:[:space:]]+(.*)$ ]] || continue
-    tid="${BASH_REMATCH[1]}"
-    desc="$(printf '%s' "${BASH_REMATCH[2]}" | sed -E 's/[[:space:]]+$//')"
-    title="${tid}: ${desc}"
+if [ "$inventory_count" -ge "$LIMIT" ]; then
+    echo "ERROR: the issue inventory returned ${inventory_count} record(s), the same as" >&2
+    echo "--limit ${LIMIT}. The list may be truncated, and a truncated inventory cannot" >&2
+    echo "support the re-run guarantee: a task whose issue fell past the cutoff would be" >&2
+    echo "filed a second time. Re-run with a larger --limit." >&2
+    exit 4
+fi
+echo "Inventory:  ${inventory_count} issue(s) scanned (limit ${LIMIT})"
 
-    if [ -n "${EXISTING[$tid]:-}" ]; then
-        echo "skip  ${tid} (issue already exists)"
+# --- Ambiguity scan: everything that must stop the run happens BEFORE any write ---
+declare -a AMBIGUOUS=()
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    claims="$(printf '%s' "${MARKER_CLAIMS[$tid]:-}" | wc -w)"
+    provs="$(printf '%s' "${PROV_CLAIMS[$tid]:-}" | wc -w)"
+    if [ "$claims" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing markers for this feature: ${MARKER_CLAIMS[$tid]}")
+        continue
+    fi
+    if [ "$claims" -eq 0 ] && [ "$provs" -gt 1 ]; then
+        AMBIGUOUS+=("${tid}: competing issues record this tasks file as their source: ${PROV_CLAIMS[$tid]}")
+        continue
+    fi
+    # An identified task is not made ambiguous by somebody else's untraceable
+    # issue: this feature's task already has evidence naming it.
+    [ -n "${FILED_NUM[$tid]:-}" ] && continue
+    [ -n "${UNRESOLVED_HITS[$tid]:-}" ] || continue
+    AMBIGUOUS+=("${tid}: ${UNRESOLVED_HITS[$tid]}(title carries ${tid}, records no source feature)")
+done
+if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
+    echo "ERROR: ${#AMBIGUOUS[@]} task(s) have an unresolved identity:" >&2
+    printf '  %s\n' "${AMBIGUOUS[@]}" >&2
+    echo "Each names an existing issue that carries this task number but no evidence of which" >&2
+    echo "feature it belongs to, or more than one issue claiming this feature's task. This" >&2
+    echo "script will not decide. Resolve by adding the identity marker to the correct issue's" >&2
+    echo "body (or removing the duplicate claim), then re-run:" >&2
+    echo "  $(marker_for T001)" >&2
+    echo "(substituting the task id). An issue whose body records a DIFFERENT tasks file needs" >&2
+    echo "no change - it is already recognised as another feature's task." >&2
+    exit 5
+fi
+
+# --- Create pass -----------------------------------------------------------------
+created=0; skipped=0; adopted=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    title="${tid} (${FEATURE}): ${DESCS[$i]}"
+    if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
+                 "add '$(marker_for "$tid")' to its body to make the identity explicit)"
+            adopted=$((adopted + 1))
+        else
+            echo "skip  ${tid} (issue #${FILED_NUM[$tid]} already carries this feature's marker)"
+        fi
         skipped=$((skipped + 1))
         continue
     fi
-    # Dependency clause -> machine-readable body lines (issue #607). The clause
-    # used to survive only as title prose, which drifted from tasks.md with
-    # nothing to detect it. The body now carries BOTH forms: a `Depends on:`
-    # task-id line (joinable via the spec's Issue Sync table even when numbers
-    # are unknown), and `- Blocked by #N` bullets - flow-wave-plan.py's native
-    # edge grammar - for every dep already resolvable to an issue number
-    # (created earlier this run, or found by the dedup scan above).
-    issue_body="Auto-created from ${TASKS} (${tid}) by CPP speckit-tasks-to-issues."
-    if [[ "$desc" =~ \(depends\ on\ ([^\)]*)\) ]]; then
-        dep_clause="${BASH_REMATCH[1]}"
-        dep_tids="$(printf '%s' "$dep_clause" | grep -oE 'T[0-9]{3}' | tr '\n' ' ')"
-        if [ -n "$dep_tids" ]; then
-            issue_body+=$'\n\n'"Depends on: $(printf '%s' "$dep_tids" | sed 's/ $//; s/ /, /g')"
-            for dep in $dep_tids; do
-                if [ -n "${TASK_ISSUE[$dep]:-}" ]; then
-                    issue_body+=$'\n'"- Blocked by #${TASK_ISSUE[$dep]}"
-                fi
-            done
-        fi
+
+    issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
+    if [ -n "${DEPS[$i]}" ]; then
+        issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "would create: ${title}"
+        FILED_NUM["$tid"]=""
     else
         url="$(gh issue create "${GH_REPO_ARGS[@]}" --title "$title" --body "$issue_body" 2>&1)"
         echo "create ${tid} -> ${url}"
-        EXISTING["$tid"]=1
         num="${url##*/}"
-        [[ "$num" =~ ^[0-9]+$ ]] && TASK_ISSUE["$tid"]="$num"
+        if [[ "$num" =~ ^[0-9]+$ ]]; then
+            FILED_NUM["$tid"]="$num"
+            FILED_VIA["$tid"]="marker"
+            EXISTING_REFS["$tid"]=""
+        fi
     fi
     created=$((created + 1))
-done < "$TASKS"
+done
+
+# --- Dependency reconciliation ---------------------------------------------------
+# Deliberately NOT "annotate what this run created". A dependency may point FORWARD
+# to a task declared later in the file, and a run that dies between creating issues
+# and writing their edges must be repairable - otherwise those edges are missing
+# forever, because the next run sees the issues as already filed and skips them
+# (issue #857). So every filed task in this feature is reconciled on every run:
+# expected refs minus refs already in the body, appended, existing content kept.
+#
+# Edges resolve ONLY within this feature. A T-number that belongs to another
+# feature's tasks file cannot contribute an edge here - that cross-feature guess is
+# the same defect as the identity one, one level down.
+edges_written=0; edges_failed=0
+for i in "${!TIDS[@]}"; do
+    tid="${TIDS[$i]}"
+    [ -n "${DEPS[$i]}" ] || continue
+    number="${FILED_NUM[$tid]:-}"
+
+    missing=""
+    for dep in ${DEPS[$i]}; do
+        dep_num="${FILED_NUM[$dep]:-}"
+        if [ -z "$dep_num" ]; then
+            if [ -z "${SEEN_TID[$dep]:-}" ]; then
+                echo "note  ${tid} depends on ${dep}, which is not a task in this feature - no edge written." >&2
+            fi
+            continue
+        fi
+        case ",${EXISTING_REFS[$tid]:-}," in
+            *",#${dep_num},"*) continue ;;
+        esac
+        case "$missing" in
+            *"#${dep_num} "*) continue ;;
+        esac
+        missing+="#${dep_num} "
+    done
+    [ -n "$missing" ] || continue
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "would link:   ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//')"
+        continue
+    fi
+    [ -n "$number" ] || continue
+
+    current_body="$(gh issue view "$number" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || {
+        echo "WARN: could not read issue #${number} to add its dependency edges; re-run to reconcile." >&2
+        printf '  %s\n' "$current_body" >&2
+        edges_failed=$((edges_failed + 1))
+        continue
+    }
+    new_body="$current_body"
+    for ref in $missing; do
+        new_body+=$'\n'"- Blocked by ${ref}"
+    done
+    if printf '%s' "$new_body" | gh issue edit "$number" "${GH_REPO_ARGS[@]}" --body-file - > /dev/null 2>&1; then
+        echo "link  ${tid} -> $(printf '%s' "$missing" | sed 's/[[:space:]]*$//') (issue #${number})"
+        edges_written=$((edges_written + 1))
+    else
+        echo "WARN: could not write dependency edges for ${tid} (issue #${number}); re-run to reconcile." >&2
+        edges_failed=$((edges_failed + 1))
+    fi
+done
 
 echo "---"
-echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist)."
+echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
+[ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$edges_failed" -gt 0 ]; then
+    echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
+    echo "command to reconcile the missing edges - it will not create duplicates." >&2
+    exit 6
+fi
+exit 0

--- a/tests/test_flow_wave_plan.py
+++ b/tests/test_flow_wave_plan.py
@@ -376,6 +376,7 @@ class TestSpecDeclaredDeps:
         # The unresolvable dep creates no edge - #60 stays startable.
         assert 60 in plan["startable"]
 
+
     def test_speckit_emitted_body_parses_end_to_end(self, tmp_path) -> None:
         # The exact body shape scripts/speckit-tasks-to-issues.sh now writes
         # (#607): the T-id line alone creates no edge; the Blocked-by bullets
@@ -410,3 +411,70 @@ class TestSpecDeclaredDeps:
         assert proc.returncode == 0, proc.stderr
         plan = json.loads(proc.stdout)
         assert plan["spec_drift"] == {"52": [56]}
+
+
+# The spelling `.specify/templates/tasks-template.md` actually writes, and that
+# every tasks.md in this repo's own .specify/specs/ uses. Identical in content to
+# TASKS_MD above; only the task-id emphasis differs.
+TASKS_MD_BOLD = """# Tasks
+
+- [ ] **T031** [US1] Add visual regression tests (depends on T027, T033)
+- [x] **T027** [US1] Base harness
+- [ ] **T033** Watchdog groundwork
+
+## Issue Sync
+
+| Task | Issue |
+|------|-------|
+| T031 | #52 |
+| T027 | #40 |
+| T033 | #56 |
+"""
+
+
+class TestBoldTaskIdsDeclareTheSameEdges:
+    """Issue #857: an emphasised task id must not silently erase its edges.
+
+    The planner read only the bare `T031` spelling, so a tasks.md written in the
+    shipped template's BOLD form parsed as zero tasks. That is worse than a parse
+    error: `parse_specs` reports what it cannot resolve, but a line it never
+    recognised as a task has nothing to report - the dependency simply was not
+    there, and the plan looked healthy.
+
+    The assertion is therefore about EDGES, not about the regex: the bold file
+    must produce the same graph as the plain one.
+    """
+
+    def _specs(self, tmp_path, text):
+        d = tmp_path / "specs" / "feature-x"
+        d.mkdir(parents=True)
+        (d / "tasks.md").write_text(text)
+        return tmp_path / "specs"
+
+    def test_bold_ids_produce_the_same_edges_as_plain_ids(self, tmp_path) -> None:
+        bold_edges, _ = MOD.parse_specs(self._specs(tmp_path / "bold", TASKS_MD_BOLD))
+        plain_edges, _ = MOD.parse_specs(
+            self._specs(
+                tmp_path / "plain",
+                TASKS_MD_BOLD.replace("**", ""),
+            )
+        )
+
+        assert bold_edges == {52: {40, 56}}, (
+            "bold task ids produced no spec edges - the #857 representation defect"
+        )
+        assert bold_edges == plain_edges
+
+    def test_bold_dependency_reaches_the_plan_and_blocks_startability(self, tmp_path) -> None:
+        """End to end: the edge changes the answer `/flow:wave` acts on."""
+        spec_edges, unresolved = MOD.parse_specs(self._specs(tmp_path, TASKS_MD_BOLD))
+        plan = MOD.build_plan(
+            MOD.parse_issues([_issue(52), _issue(40, state="CLOSED"), _issue(56)]),
+            spec_edges,
+            unresolved,
+        )
+
+        assert plan["issues"]["52"]["blocked_by"] == [40, 56]
+        # #56 is OPEN, so #52 is blocked. Before the fix it read as startable,
+        # and a wave would have handed out an issue whose dependency was open.
+        assert 52 not in plan["startable"]

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -320,6 +320,32 @@ class TestParsing:
         ]
         assert edges == expected
 
+    def test_a_matching_filename_cannot_validate_a_dependency_token(
+        self, project
+    ) -> None:
+        """Validation must read the clause, not the working directory.
+
+        An unquoted `$(...)` in a `for` list is glob-expanded as well as
+        word-split, so `(depends on T00?)` became a VALID token in any directory
+        that happened to contain a file called T002 - the filesystem supplied the
+        answer and an undeclared edge was written. The same input must be
+        rejected identically whether or not that file exists.
+        """
+        tasks = (
+            "- [ ] **T001** Build A (depends on T00?)\n"
+            "- [ ] **T002** Build B\n"
+        )
+        repo, bindir, state = project({"a/tasks.md": tasks})
+        decoy = repo / "T002"
+        decoy.write_text("", encoding="utf-8")
+        assert decoy.exists(), "fixture must provide the filename the glob would match"
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 3, result.stdout + result.stderr
+        assert "T00?" in result.stderr
+        assert _issues(state) == [], "no issue may be created from a rejected clause"
+
     def test_file_with_no_tasks_is_an_error_not_a_success(self, project) -> None:
         repo, bindir, state = project({"a/tasks.md": "# Tasks\n\nNothing here yet.\n"})
 
@@ -428,6 +454,35 @@ class TestLegacyIdentity:
         assert "skip  T001 (issue #50" in result.stdout
         assert "recorded source path" in result.stdout
         assert len(_issues(state)) == 1
+
+    def test_legacy_provenance_written_as_dot_slash_is_the_same_file(
+        self, project
+    ) -> None:
+        """`./a/tasks.md` and `a/tasks.md` are one file, so one identity.
+
+        A raw string comparison read the dot-slash spelling as another feature's
+        source and filed the task a second time - the duplicate this change
+        exists to prevent, produced by the comparison rather than by the identity.
+        """
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {
+                    "number": 7,
+                    "title": "T001: Build the widget",
+                    "body": _provenance("./a/tasks.md", "T001"),
+                }
+            ],
+        )
+        assert "./a/tasks.md" in _issues(state)[0]["body"], (
+            "fixture must record the dot-slash spelling under test"
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "skip  T001 (issue #7" in result.stdout
+        assert len(_issues(state)) == 1, "the dot-slash spelling must not create a duplicate"
 
     def test_legacy_issue_from_another_tasks_file_does_not_block_this_one(
         self, project

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -1,22 +1,27 @@
-"""Regression tests for the speckit issue-sync record parse (issue #700).
+"""Behavioural tests for the speckit task-to-issue converter (issues #700, #857).
 
-`scripts/speckit-tasks-to-issues.sh` reads `gh issue list` records as
-`<number><SEP><title>` to dedup tasks that already have issues. It shipped with
-SEP=tab, and tab is IFS *whitespace*: shell field splitting collapses a run of it
-and an EMPTY field vanishes instead of arriving empty, shifting every later field
-up one slot. The same defect class was live in `scripts/flow-wave-registry.sh`
-(#698); this site was latent, guarded only by the accident that `.number` is
-never empty.
+`scripts/speckit-tasks-to-issues.sh` turns a spec-kit tasks.md into one GitHub
+issue per task. #857 fixed what it could not see and what it silently guessed:
 
-The test that matters therefore uses an EMPTY FIRST FIELD - #698's lesson was
-that a fixture with all fields populated passes against the broken code and
-proves nothing. `test_populated_record_still_parses` is the control that pins
-that the ordinary path is unchanged.
+  * the BOLD task id `.specify/templates/tasks-template.md` actually writes was
+    unreadable, so the converter finished successfully having created nothing
+  * a task was identified by a bare `T001` found in any issue title, so one
+    feature's T001 made every other feature's T001 look already-filed
+  * a failed `gh issue list` was swallowed and read as an empty inventory
+  * task-like lines that did not parse were skipped without a word
 
-The `gh` stub deliberately derives its output separator from the `--jq` filter
-the script asks for, rather than hard-coding one. That makes these tests
-sensitive to producer/reader AGREEMENT: reverting either side alone to tab
-reproduces the bug and fails the empty-field test.
+Identity is now the pair (feature, task id), recorded as an HTML comment in the
+issue body, with the feature half taken from the tasks file's repository-relative
+path. Pre-#857 issues carry no marker, so the only feature evidence they have is
+the `Auto-created from <path>` line this script has always written - which is
+used where it exists and reported as unresolved where it does not. A description
+match is NEVER treated as provenance: two features routinely share both a task
+number and its wording.
+
+The `gh` stub models list/create/view/edit against a JSON state file and pipes
+`issue list` through the REAL `jq` with the filter the script supplies, so these
+tests exercise the script's own jq program and the producer/reader separator
+agreement rather than a re-implementation of either.
 """
 
 from __future__ import annotations
@@ -33,69 +38,150 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "speckit-tasks-to-issues.sh"
 
-# These tests drive real `git` and `bash` subprocesses. The Woodpecker `validate`
-# step runs in `uv:python3.11-bookworm-slim`, which ships bash but NOT git, so
-# without this guard the module errors and turns CI red (core directive; #602).
+# These tests drive real `git`, `bash` and `jq` subprocesses. The Woodpecker
+# `validate` step runs in `uv:python3.11-bookworm-slim`, which ships bash but NOT
+# git, so without this guard the module errors and turns CI red (core directive;
+# #602).
 pytestmark = pytest.mark.skipif(
-    shutil.which("git") is None or shutil.which("bash") is None,
-    reason="requires git and bash on PATH",
+    shutil.which("git") is None
+    or shutil.which("bash") is None
+    or shutil.which("jq") is None,
+    reason="requires git, bash and jq on PATH",
 )
 
-# A stub `gh` that models the one behaviour under test: whatever separator the
-# script's --jq filter asks for between .number and .title is the separator the
-# records come back with. `unicode_escape` decodes the unit-separator escape
-# and \t exactly as jq does, so the stub cannot silently agree with a drifted reader.
 GH_STUB = r'''#!/usr/bin/env python3
-import json, os, re, sys
+"""Stub gh: issue list/create/view/edit over a JSON state file."""
+import json, os, subprocess, sys
+from pathlib import Path
 
+STATE = Path(os.environ["GH_STUB_STATE"])
 argv = sys.argv[1:]
-if argv[:2] != ["issue", "list"]:
+
+def load():
+    return json.loads(STATE.read_text())
+
+def save(state):
+    STATE.write_text(json.dumps(state))
+
+if argv[:2] == ["issue", "list"]:
+    if os.environ.get("GH_STUB_LIST_FAIL") == "1":
+        sys.stderr.write("gh: API rate limit exceeded for this host\n")
+        sys.exit(1)
+    state = load()
+    limit = int(argv[argv.index("--limit") + 1]) if "--limit" in argv else 30
+    rows = [{k: i[k] for k in ("number", "title", "body")} for i in state["issues"][:limit]]
+    jq_filter = argv[argv.index("--jq") + 1] if "--jq" in argv else "."
+    done = subprocess.run(
+        ["jq", "-r", jq_filter], input=json.dumps(rows), capture_output=True, text=True
+    )
+    sys.stdout.write(done.stdout)
+    sys.stderr.write(done.stderr)
+    sys.exit(done.returncode)
+
+if argv[:2] == ["issue", "create"]:
+    state = load()
+    number = state["next"]
+    state["next"] = number + 1
+    state["issues"].append(
+        {
+            "number": number,
+            "title": argv[argv.index("--title") + 1],
+            "body": argv[argv.index("--body") + 1],
+        }
+    )
+    save(state)
+    print("https://github.com/acme/widget/issues/%d" % number)
     sys.exit(0)
 
-jq_filter = argv[argv.index("--jq") + 1]
-match = re.search(r"\\\(\.number\)(.*?)\\\(\.title\)", jq_filter)
-if not match:
-    sys.stderr.write("stub gh: unrecognised --jq filter: %s\n" % jq_filter)
+if argv[:2] == ["issue", "view"]:
+    for issue in load()["issues"]:
+        if str(issue["number"]) == argv[2]:
+            print(issue["body"])
+            sys.exit(0)
+    sys.stderr.write("gh: not found\n")
     sys.exit(1)
-sep = match.group(1).encode("utf-8").decode("unicode_escape")
 
-for number, title in json.loads(os.environ["GH_STUB_RECORDS"]):
-    sys.stdout.write("%s%s%s\n" % (number, sep, title))
+if argv[:2] == ["issue", "edit"]:
+    if os.environ.get("GH_STUB_EDIT_FAIL") == "1":
+        sys.stderr.write("gh: could not update issue\n")
+        sys.exit(1)
+    state = load()
+    source = argv[argv.index("--body-file") + 1]
+    body = sys.stdin.read() if source == "-" else Path(source).read_text()
+    for issue in state["issues"]:
+        if str(issue["number"]) == argv[2]:
+            issue["body"] = body
+            save(state)
+            sys.exit(0)
+    sys.stderr.write("gh: not found\n")
+    sys.exit(1)
+
+sys.exit(0)
 '''
+
+# What the shipped template writes: bold id, story tag, and the comma story form
+# from its own T007 line.
+BOLD_TASKS = "- [ ] **T001** [US1] Build the widget\n"
+
+
+def _marker(feature: str, tid: str) -> str:
+    return f"<!-- speckit-task:v1:{feature}:{tid} -->"
+
+
+def _provenance(tasks_path: str, tid: str) -> str:
+    return f"Auto-created from {tasks_path} ({tid}) by CPP speckit-tasks-to-issues."
 
 
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
 
 
-def _project(tmp_path: Path, tasks: str) -> tuple[Path, Path]:
-    """A git repo with a GitHub origin, a tasks.md, and a stub `gh` on PATH."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init", "-q")
-    _git(repo, "remote", "add", "origin", "https://github.com/acme/widget.git")
+@pytest.fixture
+def project(tmp_path: Path):
+    """A git repo with a GitHub origin, a stub `gh` on PATH, and issue state."""
 
-    tasks_file = repo / "tasks.md"
-    tasks_file.write_text(tasks, encoding="utf-8")
+    def _make(tasks: dict[str, str], issues: list[dict] | None = None, next_number: int = 100):
+        repo = tmp_path / "repo"
+        repo.mkdir(exist_ok=True)
+        _git(repo, "init", "-q")
+        _git(repo, "remote", "add", "origin", "https://github.com/acme/widget.git")
+        for rel, text in tasks.items():
+            path = repo / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
 
-    bindir = tmp_path / "bin"
-    bindir.mkdir()
-    gh = bindir / "gh"
-    gh.write_text(GH_STUB, encoding="utf-8")
-    gh.chmod(0o755)
-    return repo, bindir
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        gh = bindir / "gh"
+        gh.write_text(GH_STUB, encoding="utf-8")
+        gh.chmod(0o755)
+
+        state = tmp_path / "state.json"
+        state.write_text(json.dumps({"next": next_number, "issues": issues or []}))
+        return repo, bindir, state
+
+    return _make
 
 
 def _run(
-    repo: Path, bindir: Path, tasks_file: Path, records: list[list[str]]
+    repo: Path,
+    bindir: Path,
+    state: Path,
+    *args: str,
+    list_fails: bool = False,
+    edit_fails: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     env = {
         "PATH": f"{bindir}:{os.environ['PATH']}",
         "HOME": str(repo.parent),
-        "GH_STUB_RECORDS": json.dumps(records),
+        "GH_STUB_STATE": str(state),
     }
+    if list_fails:
+        env["GH_STUB_LIST_FAIL"] = "1"
+    if edit_fails:
+        env["GH_STUB_EDIT_FAIL"] = "1"
     return subprocess.run(
-        ["bash", str(SCRIPT), "--dry-run", "--tasks", str(tasks_file)],
+        ["bash", str(SCRIPT), *args],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -103,64 +189,357 @@ def _run(
     )
 
 
-def test_empty_first_field_does_not_shift_the_title(tmp_path: Path) -> None:
-    """An empty `.number` must leave the title in field 2, not shift it into field 1.
+def _issues(state: Path) -> list[dict]:
+    return json.loads(state.read_text())["issues"]
 
-    This is the #700 fixture. Under the tab spelling the record collapses to a
-    single field, the title lands in `number`, the T-ID regex never matches, and
-    the already-filed task is offered for creation a second time.
-    """
-    repo, bindir = _project(tmp_path, "- [ ] T001: Wire the frobnicator\n")
-    result = _run(repo, bindir, repo / "tasks.md", [["", "T001: Wire the frobnicator"]])
 
-    assert result.returncode == 0, result.stderr
-    assert "skip  T001" in result.stdout, (
-        "an empty first field shifted the title out of field 2 - the #700 "
-        f"collapse. stdout:\n{result.stdout}"
+class TestParsing:
+    """Acceptance 1 and 6: read what the templates write; never a silent zero."""
+
+    def test_bold_task_id_from_the_shipped_template_is_read(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
+        assert "**T001**" in BOLD_TASKS, "fixture must use the bold form under test"
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "would create: T001 (a/tasks.md): Build the widget" in result.stdout
+
+    def test_plain_and_bold_ids_produce_the_same_task(self, project) -> None:
+        repo, bindir, state = project(
+            {"bold/tasks.md": BOLD_TASKS, "plain/tasks.md": "- [ ] T001: [US1] Build the widget\n"}
+        )
+
+        bold = _run(repo, bindir, state, "--dry-run", "--tasks", "bold/tasks.md", "--feature", "f")
+        plain = _run(repo, bindir, state, "--dry-run", "--tasks", "plain/tasks.md", "--feature", "f")
+
+        assert bold.returncode == plain.returncode == 0
+        assert "would create: T001 (f): Build the widget" in bold.stdout
+        assert "would create: T001 (f): Build the widget" in plain.stdout
+
+    def test_comma_story_tag_does_not_leak_into_the_title(self, project) -> None:
+        """The template's own T007 line carries `[US1,US2]`."""
+        repo, bindir, state = project(
+            {"a/tasks.md": "- [ ] **T007** [US1,US2] Integration testing\n"}
+        )
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+
+        assert "would create: T007 (a/tasks.md): Integration testing" in result.stdout
+        assert "US1,US2" not in result.stdout
+
+    def test_malformed_t_number_fails_with_a_line_number(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": "- [ ] T1: too few digits\n"})
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+
+        assert result.returncode == 3
+        assert "a/tasks.md:1" in result.stderr
+        assert "malformed T-number" in result.stderr
+        assert "0 to create" not in result.stdout
+
+    def test_file_with_no_tasks_is_an_error_not_a_success(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": "# Tasks\n\nNothing here yet.\n"})
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+
+        assert result.returncode == 3
+        assert "no tasks found" in result.stderr
+
+    def test_non_task_checkbox_is_reported_but_does_not_fail_the_run(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS + "- [ ] Checkpoint verified\n"})
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "Checkpoint verified" in result.stderr
+        assert "would create: T001 (a/tasks.md): Build the widget" in result.stdout
+
+
+class TestFeatureScopedIdentity:
+    """Acceptance 2 and 3: T001 belongs to a feature, and re-runs are stable."""
+
+    def test_two_features_with_identical_t001_get_distinct_issues(self, project) -> None:
+        """The wording is identical on purpose: description is not provenance."""
+        tasks = "- [ ] **T001** [US1] Add tests\n"
+        repo, bindir, state = project({"a/tasks.md": tasks, "b/tasks.md": tasks})
+
+        first = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+        second = _run(repo, bindir, state, "--tasks", "b/tasks.md")
+
+        assert first.returncode == 0, first.stderr
+        assert second.returncode == 0, second.stderr
+        assert "create T001" in second.stdout, (
+            "feature b's T001 was swallowed by feature a's - the #857 collision"
+        )
+        numbers = [i["number"] for i in _issues(state)]
+        assert len(numbers) == len(set(numbers)) == 2
+
+    def test_rerun_creates_nothing_and_is_stable(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
+        _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        again = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert again.returncode == 0, again.stderr
+        assert "skip  T001" in again.stdout
+        assert len(_issues(state)) == 1
+
+    def test_closed_issues_still_count_as_filed(self, project) -> None:
+        """`--state all` has always been the query; the marker must work there too."""
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {
+                    "number": 7,
+                    "title": "T001 (a/tasks.md): Build the widget",
+                    "body": _marker("a/tasks.md", "T001"),
+                }
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "skip  T001 (issue #7" in result.stdout
+        assert len(_issues(state)) == 1
+
+    def test_explicit_feature_flag_overrides_the_path(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
+
+        _run(repo, bindir, state, "--tasks", "a/tasks.md", "--feature", "widget-v2")
+
+        assert _marker("widget-v2", "T001") in _issues(state)[0]["body"]
+
+
+class TestLegacyIdentity:
+    """Acceptance 4: adopt on evidence, diagnose ambiguity, never guess."""
+
+    def test_legacy_issue_from_this_tasks_file_is_adopted(self, project) -> None:
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {
+                    "number": 50,
+                    "title": "T001: Build the widget",
+                    "body": _provenance("a/tasks.md", "T001"),
+                }
+            ],
+        )
+        assert "speckit-task:v1" not in _issues(state)[0]["body"], (
+            "fixture must be a PRE-marker issue, or it tests the marker path instead"
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "skip  T001 (issue #50" in result.stdout
+        assert "recorded source path" in result.stdout
+        assert len(_issues(state)) == 1
+
+    def test_legacy_issue_from_another_tasks_file_does_not_block_this_one(
+        self, project
+    ) -> None:
+        """A body naming a different source is a known other feature, not a claim."""
+        repo, bindir, state = project(
+            {"b/tasks.md": "- [ ] **T001** [US1] Add tests\n"},
+            issues=[
+                {
+                    "number": 50,
+                    "title": "T001: Add tests",
+                    "body": _provenance("a/tasks.md", "T001"),
+                }
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "b/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "create T001" in result.stdout
+        assert len(_issues(state)) == 2
+
+    def test_legacy_issue_with_no_provenance_is_reported_not_guessed(self, project) -> None:
+        repo, bindir, state = project(
+            {"b/tasks.md": "- [ ] **T001** [US1] Add tests\n"},
+            issues=[{"number": 50, "title": "T001: Add tests", "body": "Filed by hand.\n"}],
+        )
+        body = _issues(state)[0]["body"]
+        assert "speckit-task:v1" not in body and "Auto-created from" not in body, (
+            "fixture must carry NO feature evidence, or the ambiguity under test cannot arise"
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "b/tasks.md")
+
+        assert result.returncode == 5
+        assert "unresolved identity" in result.stderr
+        assert "#50" in result.stderr
+        assert len(_issues(state)) == 1, "an unresolved identity must create nothing"
+
+    def test_competing_claims_for_the_same_feature_are_ambiguous(self, project) -> None:
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {"number": 50, "title": "T001 (a/tasks.md): x", "body": _marker("a/tasks.md", "T001")},
+                {"number": 51, "title": "T001 (a/tasks.md): y", "body": _marker("a/tasks.md", "T001")},
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 5
+        assert "competing markers" in result.stderr
+
+
+class TestInventoryHonesty:
+    """Acceptance 5: an inventory you cannot establish is not an empty one."""
+
+    def test_failed_lookup_refuses_instead_of_refiling(self, project) -> None:
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {
+                    "number": 7,
+                    "title": "T001 (a/tasks.md): Build the widget",
+                    "body": _marker("a/tasks.md", "T001"),
+                }
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md", list_fails=True)
+
+        assert result.returncode == 4
+        assert "not an empty one" in result.stderr
+        assert len(_issues(state)) == 1, "the already-filed task must not be filed again"
+
+    def test_possibly_truncated_inventory_refuses(self, project) -> None:
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[{"number": n, "title": f"unrelated {n}", "body": ""} for n in (1, 2, 3)],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md", "--limit", "3")
+
+        assert result.returncode == 4
+        assert "may be truncated" in result.stderr
+        assert len(_issues(state)) == 3
+
+    def test_empty_field_in_a_record_does_not_shift_the_next_one(self, project) -> None:
+        """The #700 property, on the field that is now EMPTY on the ordinary path.
+
+        Every pre-marker issue produces an empty marker field, so the separator's
+        empty-field behaviour is no longer a latent concern: under an IFS-whitespace
+        separator the empty marker collapses, the provenance path shifts into the
+        marker slot, and this legacy issue stops being recognised as this feature's
+        - which re-files a task that already has an issue. `\\037` is not IFS
+        whitespace, so the empty field survives and the provenance still matches.
+        """
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {
+                    "number": 50,
+                    "title": "T001: Build the widget",
+                    "body": _provenance("a/tasks.md", "T001"),
+                }
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert "skip  T001 (issue #50" in result.stdout, (
+            "the empty marker field shifted the provenance path out of position - "
+            f"the #700 collapse. stdout:\n{result.stdout}"
+        )
+        assert len(_issues(state)) == 1
+
+    def test_title_containing_whitespace_survives(self, project) -> None:
+        """Control: a title carrying embedded tabs still round-trips."""
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {
+                    "number": 50,
+                    "title": "T001:\tBuild\tthe\twidget",
+                    "body": _marker("a/tasks.md", "T001"),
+                }
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "skip  T001" in result.stdout
+
+
+class TestDependencies:
+    """Acceptance 7: correct edges, forward references included, and resumable."""
+
+    FORWARD = (
+        "- [ ] **T001** [US1] Build A (depends on T002)\n"
+        "- [ ] **T002** [US1] Build B\n"
     )
-    assert "would create" not in result.stdout
 
+    def test_forward_reference_resolves_to_an_edge(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": self.FORWARD})
 
-def test_populated_record_still_parses(tmp_path: Path) -> None:
-    """Control: the ordinary all-fields-populated path is unchanged."""
-    repo, bindir = _project(tmp_path, "- [ ] T001: Wire the frobnicator\n")
-    result = _run(
-        repo, bindir, repo / "tasks.md", [["42", "T001: Wire the frobnicator"]]
-    )
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
 
-    assert result.returncode == 0, result.stderr
-    assert "skip  T001" in result.stdout
-    assert "would create" not in result.stdout
+        assert result.returncode == 0, result.stderr
+        bodies = {i["number"]: i["body"] for i in _issues(state)}
+        assert "- Blocked by #101" in bodies[100]
+        assert "Depends on: T002" in bodies[100]
 
+    def test_failed_edit_is_reconciled_by_the_next_run(self, project) -> None:
+        """The resumability property: created-but-unlinked must not be permanent."""
+        repo, bindir, state = project({"a/tasks.md": self.FORWARD})
 
-def test_unmatched_task_is_still_created(tmp_path: Path) -> None:
-    """A task with no existing issue is still offered for creation."""
-    repo, bindir = _project(tmp_path, "- [ ] T007: Not filed anywhere\n")
-    result = _run(repo, bindir, repo / "tasks.md", [["42", "T001: Something else"]])
+        broken = _run(repo, bindir, state, "--tasks", "a/tasks.md", edit_fails=True)
+        assert broken.returncode == 6, broken.stderr
+        bodies = {i["number"]: i["body"] for i in _issues(state)}
+        assert "- Blocked by" not in bodies[100], "fixture must leave the edge unwritten"
 
-    assert result.returncode == 0, result.stderr
-    assert "would create: T007: Not filed anywhere" in result.stdout
-    assert "skip  T007" not in result.stdout
+        repaired = _run(repo, bindir, state, "--tasks", "a/tasks.md")
 
+        assert repaired.returncode == 0, repaired.stderr
+        assert len(_issues(state)) == 2, "reconciliation must not create duplicates"
+        bodies = {i["number"]: i["body"] for i in _issues(state)}
+        assert "- Blocked by #101" in bodies[100]
 
-def test_title_containing_whitespace_survives(tmp_path: Path) -> None:
-    """Control: a title carrying embedded tabs still round-trips.
+    def test_reconciliation_preserves_existing_body_content(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": self.FORWARD})
+        _run(repo, bindir, state, "--tasks", "a/tasks.md", edit_fails=True)
+        issues = json.loads(state.read_text())
+        for issue in issues["issues"]:
+            if issue["number"] == 100:
+                issue["body"] += "\n\nA human wrote this paragraph.\n"
+        state.write_text(json.dumps(issues))
 
-    Deliberately NOT a discriminator - `read -r number title` assigns the whole
-    remainder to the last variable, so embedded tabs survive under either
-    separator (verified: this passes against the pre-#700 tab code too). It pins
-    that moving to `\\037` did not regress titles that contain whitespace.
-    """
-    repo, bindir = _project(tmp_path, "- [ ] T001: Wire the frobnicator\n")
-    result = _run(
-        repo,
-        bindir,
-        repo / "tasks.md",
-        [["42", "T001: Wire\tthe\tfrobnicator"]],
-    )
+        _run(repo, bindir, state, "--tasks", "a/tasks.md")
 
-    assert result.returncode == 0, result.stderr
-    assert "skip  T001" in result.stdout
+        body = {i["number"]: i["body"] for i in _issues(state)}[100]
+        assert "A human wrote this paragraph." in body
+        assert "- Blocked by #101" in body
+
+    def test_edges_are_not_rewritten_on_a_clean_rerun(self, project) -> None:
+        repo, bindir, state = project({"a/tasks.md": self.FORWARD})
+        _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        again = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert "link  T001" not in again.stdout
+        body = {i["number"]: i["body"] for i in _issues(state)}[100]
+        assert body.count("- Blocked by #101") == 1
+
+    def test_dependency_outside_this_feature_writes_no_edge(self, project) -> None:
+        repo, bindir, state = project(
+            {"a/tasks.md": "- [ ] **T001** [US1] Build A (depends on T009)\n"}
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        assert "not a task in this feature" in result.stderr
+        assert "- Blocked by" not in _issues(state)[0]["body"]
 
 
 def test_no_whitespace_ifs_read_remains_in_scripts() -> None:

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -246,24 +246,79 @@ class TestParsing:
         assert "malformed T-number" in result.stderr
         assert "0 to create" not in result.stdout
 
-    def test_malformed_dependency_clause_is_diagnosed_not_a_bare_failure(
-        self, project
+    @pytest.mark.parametrize(
+        "clause, offending",
+        [
+            ("T002, T1", "T1"),        # partly invalid: the bad half used to vanish
+            ("T0020", "T0020"),        # over-long: used to match its own first four chars
+            ("T1", "T1"),              # nothing valid at all
+            ("nothing", "nothing"),    # not a task id in any spelling
+        ],
+    )
+    def test_unreadable_dependency_tokens_are_diagnosed(
+        self, project, clause: str, offending: str
     ) -> None:
-        """`(depends on T1)` used to abort the run with exit 1 and no message.
+        """Whole tokens are validated, never substrings.
 
-        `grep` exits 1 when a clause names no valid id, and under `set -e` that
-        killed the script mid-parse - a silent failure in the code path added to
-        remove silent failures.
+        Extracting `T[0-9]{3}` out of the clause accepted two corruptions in
+        silence: `T002, T1` wrote a partial edge and dropped the invalid half,
+        and `T0020` matched its own first four characters and wrote an edge to
+        T002 - a dependency nobody declared. A fabricated edge is worse than a
+        missing one, because the planner treats it as a real constraint.
+
+        These inputs also cover the earlier failure this replaced: `grep` exits 1
+        when a clause names nothing valid, and under `set -e` that took the run
+        down with exit 1 and no message at all. Every case here must exit 3 WITH
+        a source line.
         """
         repo, bindir, state = project(
-            {"a/tasks.md": "- [ ] **T001** [US1] Build A (depends on T1)\n"}
+            {
+                "a/tasks.md": (
+                    f"- [ ] **T001** Build A (depends on {clause})\n"
+                    "- [ ] **T002** Build B\n"
+                )
+            }
         )
 
-        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
 
         assert result.returncode == 3, result.stdout + result.stderr
         assert "a/tasks.md:1" in result.stderr
-        assert "names no valid task id" in result.stderr
+        assert offending in result.stderr
+        assert _issues(state) == [], "a parse failure must happen before any write"
+
+    @pytest.mark.parametrize(
+        "clause, expected",
+        [
+            ("T002", ["#101"]),
+            ("T002, T003", ["#101", "#102"]),
+            ("T002 T003", ["#101", "#102"]),
+            ("T002 and T003", ["#101", "#102"]),
+            ("T002, T002", ["#101"]),
+        ],
+    )
+    def test_supported_dependency_spellings_still_write_their_edges(
+        self, project, clause: str, expected: list[str]
+    ) -> None:
+        """Control: tightening the parse must not narrow what already worked."""
+        repo, bindir, state = project(
+            {
+                "a/tasks.md": (
+                    f"- [ ] **T001** Build A (depends on {clause})\n"
+                    "- [ ] **T002** Build B\n"
+                    "- [ ] **T003** Build C\n"
+                )
+            }
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        body = {i["number"]: i["body"] for i in _issues(state)}[100]
+        edges = [
+            line.split()[-1] for line in body.splitlines() if line.startswith("- Blocked by")
+        ]
+        assert edges == expected
 
     def test_file_with_no_tasks_is_an_error_not_a_success(self, project) -> None:
         repo, bindir, state = project({"a/tasks.md": "# Tasks\n\nNothing here yet.\n"})

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -69,7 +69,15 @@ if argv[:2] == ["issue", "list"]:
         sys.exit(1)
     state = load()
     limit = int(argv[argv.index("--limit") + 1]) if "--limit" in argv else 30
-    rows = [{k: i[k] for k in ("number", "title", "body")} for i in state["issues"][:limit]]
+    # Model --state the way gh does: without it, only OPEN issues come back. A
+    # dedup scan that forgot `--state all` would therefore stop seeing closed
+    # tasks here, exactly as it would against real gh.
+    wanted = argv[argv.index("--state") + 1].upper() if "--state" in argv else "OPEN"
+    issues = [
+        i for i in state["issues"]
+        if wanted == "ALL" or i.get("state", "OPEN").upper() == wanted
+    ]
+    rows = [{k: i[k] for k in ("number", "title", "body")} for i in issues[:limit]]
     jq_filter = argv[argv.index("--jq") + 1] if "--jq" in argv else "."
     done = subprocess.run(
         ["jq", "-r", jq_filter], input=json.dumps(rows), capture_output=True, text=True
@@ -238,6 +246,25 @@ class TestParsing:
         assert "malformed T-number" in result.stderr
         assert "0 to create" not in result.stdout
 
+    def test_malformed_dependency_clause_is_diagnosed_not_a_bare_failure(
+        self, project
+    ) -> None:
+        """`(depends on T1)` used to abort the run with exit 1 and no message.
+
+        `grep` exits 1 when a clause names no valid id, and under `set -e` that
+        killed the script mid-parse - a silent failure in the code path added to
+        remove silent failures.
+        """
+        repo, bindir, state = project(
+            {"a/tasks.md": "- [ ] **T001** [US1] Build A (depends on T1)\n"}
+        )
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md")
+
+        assert result.returncode == 3, result.stdout + result.stderr
+        assert "a/tasks.md:1" in result.stderr
+        assert "names no valid task id" in result.stderr
+
     def test_file_with_no_tasks_is_an_error_not_a_success(self, project) -> None:
         repo, bindir, state = project({"a/tasks.md": "# Tasks\n\nNothing here yet.\n"})
 
@@ -286,7 +313,13 @@ class TestFeatureScopedIdentity:
         assert len(_issues(state)) == 1
 
     def test_closed_issues_still_count_as_filed(self, project) -> None:
-        """`--state all` has always been the query; the marker must work there too."""
+        """A finished task stays filed: the scan must ask for closed issues too.
+
+        The stub returns only OPEN issues unless the caller passes `--state all`,
+        so this fixture fails if that flag is ever dropped - which is the whole
+        claim the test makes. A fixture with no state would pass either way and
+        prove nothing.
+        """
         repo, bindir, state = project(
             {"a/tasks.md": BOLD_TASKS},
             issues=[
@@ -294,15 +327,19 @@ class TestFeatureScopedIdentity:
                     "number": 7,
                     "title": "T001 (a/tasks.md): Build the widget",
                     "body": _marker("a/tasks.md", "T001"),
+                    "state": "CLOSED",
                 }
             ],
+        )
+        assert _issues(state)[0]["state"] == "CLOSED", (
+            "fixture must be CLOSED, or it does not exercise the --state all query"
         )
 
         result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
 
         assert result.returncode == 0, result.stderr
         assert "skip  T001 (issue #7" in result.stdout
-        assert len(_issues(state)) == 1
+        assert len(_issues(state)) == 1, "a closed task must not be filed again"
 
     def test_explicit_feature_flag_overrides_the_path(self, project) -> None:
         repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
@@ -375,7 +412,7 @@ class TestLegacyIdentity:
         assert "#50" in result.stderr
         assert len(_issues(state)) == 1, "an unresolved identity must create nothing"
 
-    def test_competing_claims_for_the_same_feature_are_ambiguous(self, project) -> None:
+    def test_two_markers_for_the_same_task_are_ambiguous(self, project) -> None:
         repo, bindir, state = project(
             {"a/tasks.md": BOLD_TASKS},
             issues=[
@@ -387,7 +424,78 @@ class TestLegacyIdentity:
         result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
 
         assert result.returncode == 5
-        assert "competing markers" in result.stderr
+        assert "claim this feature's task" in result.stderr
+        assert "#50" in result.stderr and "#51" in result.stderr
+
+    def test_a_marker_and_a_provenance_claim_on_different_issues_are_ambiguous(
+        self, project
+    ) -> None:
+        """Two claims of DIFFERENT kinds are still two claims.
+
+        Counting each kind separately reads one marker and one recorded-source
+        issue as "one of each, no conflict" and silently picks the marker, which
+        is the guess this criterion forbids. The claimants are counted across
+        both kinds instead.
+        """
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {"number": 7, "title": "T001 (f): x", "body": _marker("f", "T001")},
+                {
+                    "number": 8,
+                    "title": "T001: legacy",
+                    "body": _provenance("a/tasks.md", "T001"),
+                },
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md", "--feature", "f")
+
+        assert result.returncode == 5, result.stdout + result.stderr
+        assert "#7" in result.stderr and "#8" in result.stderr
+        assert len(_issues(state)) == 2, "an unresolved identity must create nothing"
+
+    def test_a_feature_name_that_is_a_prefix_of_another_does_not_match(
+        self, project
+    ) -> None:
+        """`--feature f` must not adopt `f:other`'s task.
+
+        A prefix test on `speckit-task:v1:<feature>:` accepts any feature whose
+        name starts with this one and contains a colon, handing one feature's
+        issue to another - the identity collision this change exists to remove,
+        reintroduced by the matching rule itself.
+        """
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {"number": 7, "title": "T001 (f:other): x", "body": _marker("f:other", "T001")}
+            ],
+        )
+        assert "f:other" in _issues(state)[0]["body"], (
+            "fixture marker must name a DIFFERENT feature that extends this one"
+        )
+
+        result = _run(repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md", "--feature", "f")
+
+        assert result.returncode == 0, result.stderr
+        assert "would create: T001 (f): Build the widget" in result.stdout
+        assert "skip  T001" not in result.stdout
+
+    def test_exact_feature_with_a_colon_still_matches_its_own_task(self, project) -> None:
+        """Control: the colon-bearing feature name is not simply rejected."""
+        repo, bindir, state = project(
+            {"a/tasks.md": BOLD_TASKS},
+            issues=[
+                {"number": 7, "title": "T001 (f:other): x", "body": _marker("f:other", "T001")}
+            ],
+        )
+
+        result = _run(
+            repo, bindir, state, "--dry-run", "--tasks", "a/tasks.md", "--feature", "f:other"
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "skip  T001 (issue #7" in result.stdout
 
 
 class TestInventoryHonesty:


### PR DESCRIPTION
## What was wrong

Two silent failures, both reproduced against the merged tree before any code was written:

| | Before |
|---|---|
| `- [ ] **T001** [US1] Build B` (this repo's own template line) | exit 0, "0 to create, 0 skipped" |
| Feature B's T001, with an unrelated issue titled "T001: Build feature A" | "skip T001 (issue already exists)" |
| `gh issue list` fails | swallowed by `2>/dev/null \|\| true`, inventory read as empty, task re-filed |
| `- [ ] T1: too few digits` | exit 0, nothing on stderr |
| `[US1,US2]` (the template's own T007 line) | leaked into the issue title |
| A dependency declared later in the file | no `Blocked by #N` edge at all |

Neither of the first two is distinguishable from a correct run, which is what made them expensive.

## Identity

A task ID restarts at T001 in every feature, so it identifies a task only within one tasks file. Identity is now the pair **(feature, task id)**, recorded as `<!-- speckit-task:v1:<feature>:T001 -->` in the issue body and matched **exactly** - a prefix test would hand `f`'s task to `f:other`.

The feature half is the tasks file's **repository-relative path**. Moving that file therefore changes the identity: to keep the issues already filed, pass `--feature <the original path>` from then on. Any other slug declares a *new* identity and files every task again, so the pin helps only when it carries the value the existing issues were created under. A human heading is deliberately not used - two specs may both be titled `# Tasks: Reporting`, and that collision would be silent.

## Legacy issues and ambiguity

A pre-marker issue is adopted only on provenance this script itself wrote - the `Auto-created from <path>` line - and equivalent spellings of one path are one source: leading `./`, repeated slashes, a trailing slash, and absolute paths genuinely inside this repository are normalised before comparison. Nothing further is inferred: `..` segments are left alone and a path from another checkout stays absolute, so genuinely different sources still do not match.

A body naming a **different** tasks file is a known other feature and never blocks this one. A body naming **none** is reported for resolution and creates nothing. Two issues claiming the same task are ambiguous whatever evidence each carries - a marker on one and a recorded source on another is still two claims. A matching description is never treated as provenance: two features routinely share both a task number and its wording.

## Honesty about what the run knows

- a failed `gh issue list` exits 4 rather than proceeding on an empty inventory
- a result whose size equals `--limit` exits 4: a possibly-truncated inventory cannot support the re-run guarantee
- malformed task lines and unreadable dependency tokens exit 3 with file and line. Dependency clauses are validated as **whole tokens** parsed literally - substring extraction silently truncated `T0020` into an edge to T002, and glob expansion let a file named `T002` validate `T00?`, both writing dependencies nobody declared
- a checkbox line with no T-number at all is reported but does not fail the run; a file that yields no tasks is an error rather than a successful nothing

## Dependencies

Reconciliation runs over every filed task on every run, not just what this run created. A forward reference resolves, and a run that dies between creating issues and writing their edges is repaired by the next run instead of being skipped forever. Existing body content is preserved, and edges resolve only inside the feature. Comma, space and `and` separate task ids - the same connector the planner's edge grammar already accepts.

## flow-wave-plan

`TASK_LINE_RE` had the same bold blindness, so spec-declared dependency edges vanished for every tasks.md in the template's shape - including `.specify/specs/wave-6-polish-quality-dx/tasks.md` in this tree. The tests assert the resulting **edges** and startability through the `--specs` / Issue Sync mapping, not that a regex matches.

## Verification

- `make verify`: **exit 0** - 2851 passed, mypy clean on 196 source files, all repo checks ok
- `flow-finish-gate.sh`: `FLOW_FINISH_GATE: ok` (lint, test, typecheck, security_scan)
- 38 converter tests and 2 planner tests, several parameterized over the malformed and the supported dependency spellings
- **Positive controls**, because a suite that passes both ways proves nothing: against the pre-change script 23 of the 24 original tests fail (the one that passes is the whitespace-IFS class guard, which is version-independent); the identity, whole-token, glob and path-equivalence regressions each fail against the intermediate commit they were written for; and removing `--state all` fails the closed-mapping test
- `make codex-skills` regenerates bundled payloads across four skills even when no command document changes - the generator bundles referenced `scripts/` files byte-identically. Parity verified with `cmp` and `make codex-skills-check`

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQUjuiK5LmADM7ejk1FJ5
