### PR TITLE
feat(speckit): carry a task's declared governing context into its generated issue (Closes #858)

### DIFF
--- a/.claude/commands/evaluate/help.md
+++ b/.claude/commands/evaluate/help.md
@@ -78,6 +78,9 @@ Generates spec artifacts in `.specify/specs/{feature-name}/`:
 
 Use `./scripts/speckit-tasks-to-issues.sh` to create GitHub issues from the generated tasks.
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 ## Cost
 
 Typical evaluation costs $0.10-0.30 depending on model selection and depth. Phase 1 and 3 use multi-model calls; Phase 2 uses sequential reasoning (no external LLM cost if using Sequential Thinking MCP).

--- a/.claude/commands/evaluate/help.md
+++ b/.claude/commands/evaluate/help.md
@@ -78,7 +78,7 @@ Generates spec artifacts in `.specify/specs/{feature-name}/`:
 
 Use `./scripts/speckit-tasks-to-issues.sh` to create GitHub issues from the generated tasks.
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 ## Cost

--- a/.claude/commands/evaluate/issue.md
+++ b/.claude/commands/evaluate/issue.md
@@ -390,7 +390,7 @@ Next steps:
   3. Use /flow:start <issue> to begin implementation
 ```
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 ---

--- a/.claude/commands/evaluate/issue.md
+++ b/.claude/commands/evaluate/issue.md
@@ -390,6 +390,9 @@ Next steps:
   3. Use /flow:start <issue> to begin implementation
 ```
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 ---
 
 ## Domain-Specific Guidance

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -291,9 +291,21 @@ Working from the worktree, analyze the issue and codebase to form an implementat
    issue and the block is a bounded CACHE of the task's declared context - not the
    authority. Before forming a plan:
 
+   Fetch the body to a FILE first and check that the fetch succeeded. A process
+   substitution hides a failed `gh` behind an empty body, and an empty body reads
+   as `absent` - a successful-looking "this issue has no context block" produced by
+   a network error. Resolve the helper from CPP's own tooling, not from a
+   `scripts/` directory in the target project, which may not have one:
+
    ```bash
-   scripts/speckit-context.py check --body-file <(gh issue view "$ISSUE_NUM" --json body --jq .body)
+   gh issue view "$ISSUE_NUM" --json body --jq .body > /tmp/issue-body.md
+   ~/.claude/scripts/speckit-context.py check --body-file /tmp/issue-body.md --root .
    ```
+
+   (Exit 127 - helper not installed at the stable path: fall back to
+   `${CLAUDE_PLUGIN_ROOT}/scripts/speckit-context.py`, else the CPP-checkout copy;
+   tell the user to run **`/flow:repair`**. If the `gh` fetch fails, STOP and report
+   it - do not run the check against an empty file.)
 
    Act on `SPECKIT_CONTEXT_STATE`:
    - `current` - the cache matches its source; read the **Authoritative source** named

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -287,6 +287,37 @@ Working from the worktree, analyze the issue and codebase to form an implementat
    - Identify referenced files, components, or areas
    - Note any dependencies or constraints mentioned
 
+   **If the body carries a `speckit-context` block** (issue #858), it is a generated
+   issue and the block is a bounded CACHE of the task's declared context - not the
+   authority. Before forming a plan:
+
+   ```bash
+   scripts/speckit-context.py check --body-file <(gh issue view "$ISSUE_NUM" --json body --jq .body)
+   ```
+
+   Act on `SPECKIT_CONTEXT_STATE`:
+   - `current` - the cache matches its source; read the **Authoritative source** named
+     in the block, including the cross-cutting sections it lists, then plan.
+   - `changed-in-scope` / `changed-outside-scope` - bytes changed in the source since
+     the issue was written. That is a byte difference, NOT a ruling that acceptance
+     changed. Read the source, decide whether it matters under the existing authority
+     model, and say so in the Step 3 report. It is not a new approval gate, and it is
+     not permission to overwrite an accepted decision.
+   - `block-edited` / `block-damaged` - someone edited inside the block or its
+     boundaries are broken. Treat the block as unreliable, read the source directly,
+     and do not refresh it as a side effect of this run.
+   - `source-missing` / `source-unresolved` - plan from the issue body and say plainly
+     that the governing source could not be read.
+   - `absent` - an ordinary issue. Its body IS the contract (see
+     [the issue contract](../../../docs/agents/issue-contract.md)); no spec, story tag
+     or digest is required and none is owed.
+
+   The block's **Task wording** line is the task's own sentence, not a ruling: resolve
+   whether it proposes an approach you may replace or restates a binding constraint
+   against the sections the block names. An **Unresolved** or **Capped** note means the
+   context is incomplete and must be resolved before planning - never that the task has
+   no constraints.
+
 2. **Explore the codebase:**
    - Read files referenced in the issue
    - Understand existing patterns and conventions

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -341,8 +341,10 @@ Working from the worktree, analyze the issue and codebase to form an implementat
    The block's **Task wording** line is the task's own sentence, not a ruling: resolve
    whether it proposes an approach you may replace or restates a binding constraint
    against the sections the block names. An **Unresolved** or **Capped** note means the
-   context is incomplete and must be resolved before planning - never that the task has
-   no constraints.
+   context is incomplete - never that the task has no constraints. Apply the same
+   material-ambiguity standard as everywhere else: resolve what would change the work,
+   surface the rest in the Step 3 report, and plan from what you have. Missing optional
+   structure is not a gate.
 
 2. **Explore the codebase:**
    - Read files referenced in the issue

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -289,37 +289,51 @@ Working from the worktree, analyze the issue and codebase to form an implementat
 
    **If the body carries a `speckit-context` block** (issue #858), it is a generated
    issue and the block is a bounded CACHE of the task's declared context - not the
-   authority. Before forming a plan:
-
-   Fetch the body to a FILE first and check that the fetch succeeded. A process
-   substitution hides a failed `gh` behind an empty body, and an empty body reads
-   as `absent` - a successful-looking "this issue has no context block" produced by
-   a network error. Resolve the helper from CPP's own tooling, not from a
-   `scripts/` directory in the target project, which may not have one:
+   authority. Fetch the body to a UNIQUE file, check that the fetch succeeded, and
+   only then run the checker: a failed `gh` leaves an empty body, and an empty body
+   reports `absent`, which reads exactly like a healthy issue that simply has no
+   block. A fixed `/tmp` name also collides between concurrent wave workers.
 
    ```bash
-   gh issue view "$ISSUE_NUM" --json body --jq .body > /tmp/issue-body.md
-   ~/.claude/scripts/speckit-context.py check --body-file /tmp/issue-body.md --root .
+   BODY_FILE="$(mktemp -t flow-auto-body-XXXXXX.md)"
+   if ! gh issue view "$ISSUE_NUM" --json body --jq .body > "$BODY_FILE"; then
+       echo "STOP: could not fetch issue #$ISSUE_NUM; not checking context against an empty body."
+       exit 1
+   fi
+   ~/.claude/scripts/speckit-context.py check --body-file "$BODY_FILE" --root .
    ```
 
-   (Exit 127 - helper not installed at the stable path: fall back to
-   `${CLAUDE_PLUGIN_ROOT}/scripts/speckit-context.py`, else the CPP-checkout copy;
-   tell the user to run **`/flow:repair`**. If the `gh` fetch fails, STOP and report
-   it - do not run the check against an empty file.)
+   Helper resolution: `~/.claude/scripts/speckit-context.py` is the stable path
+   (`/flow:repair` installs it). On exit 127 fall back to
+   `${CLAUDE_PLUGIN_ROOT}/scripts/speckit-context.py`, else the CPP-checkout copy.
+   Running inside a generated Codex skill, use the copy bundled in that skill's own
+   `scripts/` directory - never a `scripts/` directory in the target project, which
+   has no reason to contain CPP tooling.
 
    Act on `SPECKIT_CONTEXT_STATE`:
-   - `current` - the cache matches its source; read the **Authoritative source** named
-     in the block, including the cross-cutting sections it lists, then plan.
-   - `changed-in-scope` / `changed-outside-scope` - bytes changed in the source since
-     the issue was written. That is a byte difference, NOT a ruling that acceptance
+   - `current` - the cache matches its source. Read the **Reference source** named in
+     the block, including the cross-cutting sections it lists, then plan.
+   - `changed-in-scope` / `changed-outside-scope` - source bytes changed since the
+     issue was written. That is a byte difference, NOT a ruling that acceptance
      changed. Read the source, decide whether it matters under the existing authority
-     model, and say so in the Step 3 report. It is not a new approval gate, and it is
-     not permission to overwrite an accepted decision.
-   - `block-edited` / `block-damaged` - someone edited inside the block or its
+     model, and say so in the Step 3 report. Newer bytes do not by themselves override
+     a constraint or plan already accepted on the issue; a recorded
+     `Acceptance-revision:` line is reported with the version it names, and whether it
+     predates the change is part of what you must resolve.
+   - `changed-task` - the task line itself changed: its wording, or the `[USn]` tag
+     that decides which requirements apply. The cached mapping no longer matches the
+     plan, so re-read the task line and its story before planning, and treat the
+     block's requirement list as provisional.
+   - `tasks-missing` - the tasks file the block was built from is not present under
+     this root. Plan from the issue body and the source if one resolves, and report
+     that the task-side mapping could not be re-checked.
+   - `block-edited` / `block-damaged` - someone edited inside the block, or its
      boundaries are broken. Treat the block as unreliable, read the source directly,
      and do not refresh it as a side effect of this run.
-   - `source-missing` / `source-unresolved` - plan from the issue body and say plainly
-     that the governing source could not be read.
+   - `source-missing` / `source-unresolved` - no governing source could be read. Plan
+     from the issue body, which is the contract in that case, and surface any
+     ambiguity that is material to the work rather than trying to resolve everything
+     first.
    - `absent` - an ordinary issue. Its body IS the contract (see
      [the issue contract](../../../docs/agents/issue-contract.md)); no spec, story tag
      or digest is required and none is owed.

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -334,13 +334,26 @@ the escape when a prose line happens to open with a reserved word.
   issue untouched:
 
   ```bash
-  gh issue view "$N" --json body --jq .body > /tmp/body.md || exit 1   # never skip this check
-  ~/.claude/scripts/speckit-context.py refresh --body-file /tmp/body.md \
-      --tasks .specify/specs/<feature>/tasks.md --task T001 \
-      --feature .specify/specs/<feature>/tasks.md --root . > /tmp/new-body.md
-  # exit 0: write it back.   exit 4: REFUSED - read the message, change nothing.
-  gh issue edit "$N" --body-file /tmp/new-body.md
+  CUR="$(mktemp -t wave-body-XXXXXX.md)"; NEW="$(mktemp -t wave-new-XXXXXX.md)"
+  status=0
+  if ! gh issue view "$N" --json body --jq .body > "$CUR"; then
+      echo "STOP: could not fetch issue #$N; nothing was changed."
+      status=1
+  elif ~/.claude/scripts/speckit-context.py refresh --body-file "$CUR" \
+           --tasks .specify/specs/<feature>/tasks.md --task T001 \
+           --feature .specify/specs/<feature>/tasks.md --root . > "$NEW"; then
+      gh issue edit "$N" --body-file "$NEW" || status=$?
+  else
+      echo "REFUSED: $N was not changed. Read the reason above and resolve it by hand."
+      status=4
+  fi
+  rm -f "$CUR" "$NEW"
+  exit "$status"   # cleanup succeeds; it must not report a failed write as success
   ```
+
+  Every retry starts from a freshly fetched body in its own scratch files: reusing a
+  stale copy would write back a body that has moved on, and a shared path collides
+  between concurrent workers.
 
   It refuses when the block's text or metadata was edited after generation, when the
   boundaries are damaged or duplicated, and when the replacement names a different
@@ -359,7 +372,7 @@ the escape when a prose line happens to open with a reserved word.
 - **No spec:** take the `--issues` label/milestone/list as the set; edges are
   whatever `- Blocked by #N` lines the bodies already carry.
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 ## Phase 2: The orchestration loop

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -321,10 +321,13 @@ the escape when a prose line happens to open with a reserved word.
 
 ## Phase 1: Scaffold the issue set
 
-- **Spec-kit repo:** run `scripts/speckit-tasks-to-issues.sh` (dedup-safe) to
-  emit one issue per task, then add the dependency edges - that script emits no
-  `- Blocked by #N` lines itself. Derive edges from `tasks.md` ordering/notes
-  and write them with `gh issue edit`.
+- **Spec-kit repo:** run `scripts/speckit-tasks-to-issues.sh` (dedup-safe) to emit
+  one issue per task. It ALSO writes the dependency edges itself: a task's
+  `(depends on T00N)` clause becomes a `Depends on:` line plus `- Blocked by #N`
+  bullets, and every filed task is reconciled on each run, so a forward reference
+  or an edge whose write failed earlier is completed rather than lost (#607, #857).
+  It also attaches a `speckit-context` block carrying the task's declared context
+  (#858). Add edges by hand only for relationships `tasks.md` does not declare.
 - **Edge edits are ADDITIVE and IDEMPOTENT** (#637 gate condition): read the
   current body, append a `- Blocked by #N` line ONLY when no equivalent edge
   line is already present, and never rewrite or reflow the surrounding body
@@ -334,6 +337,9 @@ the escape when a prose line happens to open with a reserved word.
   body plus the appended line - no other diff.)
 - **No spec:** take the `--issues` label/milestone/list as the set; edges are
   whatever `- Blocked by #N` lines the bodies already carry.
+
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
 
 ## Phase 2: The orchestration loop
 

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -328,6 +328,27 @@ the escape when a prose line happens to open with a reserved word.
   or an edge whose write failed earlier is completed rather than lost (#607, #857).
   It also attaches a `speckit-context` block carrying the task's declared context
   (#858). Add edges by hand only for relationships `tasks.md` does not declare.
+- **Refreshing an EXISTING issue's context block** (#858), including attaching one
+  to an issue filed before the block existed. Fetch, refresh, and write back only
+  on success - the helper refuses rather than guessing, and a refusal must leave the
+  issue untouched:
+
+  ```bash
+  gh issue view "$N" --json body --jq .body > /tmp/body.md || exit 1   # never skip this check
+  ~/.claude/scripts/speckit-context.py refresh --body-file /tmp/body.md \
+      --tasks .specify/specs/<feature>/tasks.md --task T001 \
+      --feature .specify/specs/<feature>/tasks.md --root . > /tmp/new-body.md
+  # exit 0: write it back.   exit 4: REFUSED - read the message, change nothing.
+  gh issue edit "$N" --body-file /tmp/new-body.md
+  ```
+
+  It refuses when the block's text or metadata was edited after generation, when the
+  boundaries are damaged or duplicated, and when the replacement names a different
+  feature or task. An issue with NO block gains one additively with its existing body
+  preserved; that legitimate first attachment is not permission to repair a truncated
+  block by rewriting it. A refresh updates the cached extract - it is NOT a record
+  that a requirements change was acknowledged by anyone.
+
 - **Edge edits are ADDITIVE and IDEMPOTENT** (#637 gate condition): read the
   current body, append a `- Blocked by #N` line ONLY when no equivalent edge
   line is already present, and never rewrite or reflow the surrounding body

--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -582,6 +582,9 @@ Then ask: "Sync tasks to GitHub issues now?"
 - **Yes** → run `./scripts/speckit-tasks-to-issues.sh`
 - **Skip** → sync later
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 Report: `Step 5/6: Initial spec created` or `Step 5/6: Skipped`
 
 ---

--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -582,7 +582,7 @@ Then ask: "Sync tasks to GitHub issues now?"
 - **Yes** → run `./scripts/speckit-tasks-to-issues.sh`
 - **Skip** → sync later
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 Report: `Step 5/6: Initial spec created` or `Step 5/6: Skipped`

--- a/.claude/commands/spec/adopt.md
+++ b/.claude/commands/spec/adopt.md
@@ -81,7 +81,7 @@ Spec-kit installed. Supported CPP workflow:
   --> then create issues:  scripts/speckit-tasks-to-issues.sh
   7. /flow:auto <issue>      - ship each issue through CPP's gate policy
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 Note: upstream /speckit-taskstoissues requires github-mcp-server (which CPP does

--- a/.claude/commands/spec/adopt.md
+++ b/.claude/commands/spec/adopt.md
@@ -81,6 +81,9 @@ Spec-kit installed. Supported CPP workflow:
   --> then create issues:  scripts/speckit-tasks-to-issues.sh
   7. /flow:auto <issue>      - ship each issue through CPP's gate policy
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 Note: upstream /speckit-taskstoissues requires github-mcp-server (which CPP does
 not run). Use the bundled gh-CLI sync instead:
 

--- a/.claude/commands/spec/help.md
+++ b/.claude/commands/spec/help.md
@@ -81,7 +81,7 @@ the tracker.
    > Upstream `/speckit-taskstoissues` requires github-mcp-server (which CPP does not
    > run); the bundled gh-CLI script is the CPP-supported substitute.
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 4. **Ship each issue** through CPP's gate policy:

--- a/.claude/commands/spec/help.md
+++ b/.claude/commands/spec/help.md
@@ -81,6 +81,9 @@ the tracker.
    > Upstream `/speckit-taskstoissues` requires github-mcp-server (which CPP does not
    > run); the bundled gh-CLI script is the CPP-supported substitute.
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 4. **Ship each issue** through CPP's gate policy:
    ```
    /flow:auto <issue>

--- a/codex/skills/evaluate-help/SKILL.md
+++ b/codex/skills/evaluate-help/SKILL.md
@@ -87,6 +87,9 @@ Generates spec artifacts in `.specify/specs/{feature-name}/`:
 
 Use `./scripts/speckit-tasks-to-issues.sh` to create GitHub issues from the generated tasks.
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 ## Cost
 
 Typical evaluation costs $0.10-0.30 depending on model selection and depth. Phase 1 and 3 use multi-model calls; Phase 2 uses sequential reasoning (no external LLM cost if using Sequential Thinking MCP).

--- a/codex/skills/evaluate-help/SKILL.md
+++ b/codex/skills/evaluate-help/SKILL.md
@@ -87,7 +87,7 @@ Generates spec artifacts in `.specify/specs/{feature-name}/`:
 
 Use `./scripts/speckit-tasks-to-issues.sh` to create GitHub issues from the generated tasks.
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 ## Cost

--- a/codex/skills/evaluate-help/scripts/speckit-context.py
+++ b/codex/skills/evaluate-help/scripts/speckit-context.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Resolve, render and refresh the task-context cache in a generated issue (#858).
+
+A generated issue used to carry its provenance, its identity marker and its
+dependencies - and nothing about the behaviour it was meant to produce. The task
+title was the whole description, so a receiving agent could not tell which words
+were the goal and which were somebody's suggested mechanism, and had nothing
+pointing at the document that actually governs the work.
+
+This helper resolves a task's DECLARED context and renders it into a bounded,
+fingerprinted block. The block is a CACHE, not a second authority: the spec named
+inside it stays authoritative, everything in it is traceable to a source section,
+and every part carries a digest so drift is visible instead of silent.
+
+What is declared, and therefore used:
+
+  * the story tag on the task line (`- [ ] **T001** [US1] ...`), which names a
+    `### US1:` section in the sibling spec.md
+  * the Functional Requirements table's `User Story` column, which maps
+    individual requirements to that story
+
+What is NOT inferred: nothing is derived from task NUMBERS, and requirements with
+no declared story mapping are never claimed as this task's. Non-Functional
+Requirements and Out of Scope carry no story mapping at all, so they are indexed
+as cross-cutting sections the consumer must read in the source - and they are
+covered by the whole-file digest, so a changed global security or compatibility
+constraint is visible even though it is not attributed to this task.
+
+What a digest establishes, and what it does not: a differing digest means those
+BYTES changed since the block was written. It is not a ruling that acceptance
+changed, that the change is material to this task, or that anything was approved.
+A reflow or a typo fix reads as a change. The states this helper reports are
+deliberately named for what they observe.
+
+Usage:
+    speckit-context.py render  --tasks PATH --task T001 [--feature SLUG]
+    speckit-context.py check   --body-file PATH [--root DIR]
+    speckit-context.py refresh --body-file PATH --tasks PATH --task T001 [--feature SLUG]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BLOCK_BEGIN = "<!-- speckit-context:v1"
+BLOCK_END = "<!-- speckit-context:end -->"
+DIGEST_LEN = 12
+
+# Declared task -> story mapping, written by .specify/templates/tasks-template.md.
+STORY_TAG_RE = re.compile(r"\[(US\d+(?:\s*,\s*US?\d+)*)\]", re.IGNORECASE)
+STORY_ID_RE = re.compile(r"US\d+", re.IGNORECASE)
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
+STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
+ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
+BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# A structured, reviewable record that a requirements revision was accepted. The
+# helper REPORTS it; it never decides that it is authorised, and a free-text
+# "acknowledged" somewhere in the body is not this.
+REVISION_RE = re.compile(
+    r"^\s*Acceptance-revision:\s*source-digest=([0-9a-f]{6,64})\s*(?:ref=(\S.*))?$",
+    re.MULTILINE,
+)
+
+CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
+# A cap keeps the cache bounded; beyond it the block points at the source instead
+# of copying, and says that it did (an incomplete extract is never silence).
+MAX_ITEMS = 12
+MAX_ITEM_CHARS = 300
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:DIGEST_LEN]
+
+
+@dataclass
+class Resolution:
+    """What the declared mappings produced for one task."""
+
+    task_id: str
+    task_wording: str
+    source: Path | None = None
+    story_ids: list[str] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+    acceptance: list[tuple[str, str]] = field(default_factory=list)
+    requirements: list[tuple[str, str]] = field(default_factory=list)
+    cross_cutting: list[str] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    truncated: list[str] = field(default_factory=list)
+    scope_text: str = ""
+    source_text: str = ""
+
+
+def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Heading text -> (start, end) line span, for top-level `##`/`###` headings."""
+    spans: dict[str, tuple[int, int]] = {}
+    current: str | None = None
+    start = 0
+    for index, line in enumerate(lines):
+        if ANY_HEADING_RE.match(line):
+            if current is not None:
+                spans[current] = (start, index)
+            current = line.lstrip("#").strip()
+            start = index
+    if current is not None:
+        spans[current] = (start, len(lines))
+    return spans
+
+
+def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = STORY_HEADING_RE.match(line)
+        if match and match.group(1).upper() == story_id.upper():
+            for end in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[end]):
+                    return (index, end)
+            return (index, len(lines))
+    return None
+
+
+def _story_outcome(block: list[str]) -> str:
+    """The story's own sentence: the heading text plus its As/I want/So that lines."""
+    parts: list[str] = []
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if parts:
+                break
+            continue
+        if stripped.startswith("**Acceptance") or ANY_HEADING_RE.match(line):
+            break
+        parts.append(stripped)
+    return " ".join(parts).strip()
+
+
+def _story_acceptance(block: list[str]) -> list[str]:
+    items: list[str] = []
+    collecting = False
+    for line in block:
+        if ACCEPTANCE_HEADING_RE.match(line.strip()):
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
+                break
+            bullet = BULLET_RE.match(line)
+            if bullet:
+                items.append(bullet.group(1))
+            elif line.strip() and items:
+                items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
+def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str, str]]:
+    """FR rows whose declared `User Story` column names one of these stories.
+
+    The mapping is read from the table the spec template ships; a row with no
+    story column, or one naming another story, is never attributed to this task.
+    """
+    wanted = {s.upper() for s in story_ids}
+    spans = _sections(lines)
+    span = spans.get("Functional Requirements")
+    if span is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    header: list[str] | None = None
+    for line in lines[span[0] : span[1]]:
+        match = TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in match.group(1).split("|")]
+        if header is None:
+            header = [c.lower() for c in cells]
+            continue
+        if all(set(c) <= {"-", ":"} for c in cells if c):
+            continue
+        if "user story" not in header:
+            continue
+        story_index = header.index("user story")
+        if story_index >= len(cells):
+            continue
+        declared = {s.upper() for s in STORY_ID_RE.findall(cells[story_index])}
+        if not declared & wanted:
+            continue
+        ident = cells[0] if cells else ""
+        text_index = header.index("requirement") if "requirement" in header else 1
+        text = cells[text_index] if text_index < len(cells) else ""
+        priority_index = header.index("priority") if "priority" in header else None
+        if priority_index is not None and priority_index < len(cells):
+            text = f"{text} ({cells[priority_index]})"
+        rows.append((ident, text))
+    return rows
+
+
+def resolve(tasks_path: Path, task_id: str) -> Resolution:
+    """Resolve one task's declared context, disclosing whatever does not resolve."""
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    wording = ""
+    story_ids: list[str] = []
+    found = False
+    for line in tasks_text.splitlines():
+        match = TASK_LINE_RE.match(line)
+        if not match or match.group(1).upper() != task_id.upper():
+            continue
+        found = True
+        rest = match.group(2)
+        for tag in STORY_TAG_RE.findall(rest):
+            story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
+        wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
+        break
+
+    resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if not found:
+        resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
+        return resolution
+
+    source = tasks_path.parent / "spec.md"
+    if not source.is_file():
+        resolution.unresolved.append(
+            f"no spec.md beside {tasks_path} - no declared source to resolve against"
+        )
+        return resolution
+    resolution.source = source
+    resolution.source_text = source.read_text(encoding="utf-8")
+    lines = resolution.source_text.splitlines()
+
+    if not story_ids:
+        resolution.unresolved.append(
+            f"{resolution.task_id} declares no [USn] story tag, so its governing "
+            "requirement is not resolvable from the task line"
+        )
+
+    scope_parts: list[str] = []
+    for story_id in dict.fromkeys(story_ids):
+        span = _story_span(lines, story_id)
+        if span is None:
+            resolution.unresolved.append(
+                f"{story_id} is tagged on the task but has no '### {story_id}:' "
+                f"section in {source.name}"
+            )
+            continue
+        block = lines[span[0] : span[1]]
+        scope_parts.append("\n".join(block))
+        heading = STORY_HEADING_RE.match(block[0])
+        title = heading.group(2) if heading else story_id
+        outcome = _story_outcome(block)
+        resolution.outcomes.append((story_id, f"{title}. {outcome}".strip()))
+        for item in _story_acceptance(block):
+            resolution.acceptance.append((story_id, item))
+
+    for ident, text in _requirements_for(lines, story_ids):
+        resolution.requirements.append((ident, text))
+        scope_parts.append(f"{ident}|{text}")
+
+    spans = _sections(lines)
+    for heading in CROSS_CUTTING_HEADINGS:
+        if heading in spans:
+            resolution.cross_cutting.append(heading)
+
+    resolution.scope_text = "\n".join(scope_parts)
+    return resolution
+
+
+def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list[tuple[str, str]]:
+    if len(items) > MAX_ITEMS:
+        truncated.append(f"{label}: showing {MAX_ITEMS} of {len(items)}")
+        items = items[:MAX_ITEMS]
+    capped: list[tuple[str, str]] = []
+    for ident, text in items:
+        if len(text) > MAX_ITEM_CHARS:
+            text = text[:MAX_ITEM_CHARS].rstrip() + " [...]"
+            truncated.append(f"{label} {ident}: shortened")
+        capped.append((ident, text))
+    return capped
+
+
+def render(resolution: Resolution, feature: str) -> str:
+    """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
+    truncated: list[str] = list(resolution.truncated)
+    acceptance = _cap(resolution.acceptance, "acceptance", truncated)
+    requirements = _cap(resolution.requirements, "requirements", truncated)
+
+    body: list[str] = ["### Governing context (generated cache)", ""]
+    if resolution.source is not None:
+        body.append(
+            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            "below there before planning. This block is a task-scoped extract kept for "
+            "convenience; where the two differ, the source governs."
+        )
+    else:
+        body.append(
+            "**Authoritative source:** none resolved. See the unresolved notes below."
+        )
+    body.append("")
+
+    for story_id, outcome in resolution.outcomes:
+        body.append(f"**Outcome ({story_id}):** {outcome}")
+    if resolution.outcomes:
+        body.append("")
+
+    if acceptance:
+        body.append("**Acceptance, as declared by the story:**")
+        body.extend(f"- ({story_id}) {item}" for story_id, item in acceptance)
+        body.append("")
+
+    if requirements:
+        body.append("**Requirements declared against this story:**")
+        body.extend(f"- {ident}: {text}" for ident, text in requirements)
+        body.append("")
+
+    if resolution.cross_cutting:
+        body.append(
+            "**Cross-cutting sections to read in the source before planning** - these "
+            "carry no story mapping, so they are named rather than attributed to this "
+            "task: " + ", ".join(f"`{h}`" for h in resolution.cross_cutting)
+        )
+        body.append("")
+
+    if resolution.task_wording:
+        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        body.append(
+            "  Resolve its authority against the sections above before acting on it. It "
+            "may propose an approach you are free to replace, or it may restate a binding "
+            "constraint; the line alone does not say which."
+        )
+        body.append("")
+
+    if resolution.outcomes:
+        body.append(
+            "**Granularity:** acceptance is declared at user-story level, so the items "
+            "above may also cover sibling tasks of the same story. Narrow them to this "
+            "task yourself; this block does not decide that for you."
+        )
+        body.append("")
+
+    if resolution.unresolved:
+        body.append("**Unresolved - incomplete context, not an absence of constraints:**")
+        body.extend(f"- {note}" for note in resolution.unresolved)
+        body.append("")
+
+    if truncated:
+        body.append("**Capped for size - read the source for the rest:**")
+        body.extend(f"- {note}" for note in truncated)
+        body.append("")
+
+    content = "\n".join(body).rstrip() + "\n"
+    header = [
+        BLOCK_BEGIN,
+        f"feature: {feature}",
+        f"task: {resolution.task_id}",
+        f"source: {resolution.source if resolution.source else '-'}",
+        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
+        f"scope-digest: {digest(resolution.scope_text)}",
+        f"source-digest: {digest(resolution.source_text)}",
+        f"block-digest: {digest(content)}",
+        "-->",
+    ]
+    return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
+
+
+@dataclass
+class ParsedBlock:
+    start: int
+    end: int
+    meta: dict[str, str]
+    content: str
+
+
+def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
+    """Locate the managed block. Returns (block, fault); a fault forbids rewriting."""
+    starts = [m.start() for m in re.finditer(re.escape(BLOCK_BEGIN), body)]
+    ends = [m.start() for m in re.finditer(re.escape(BLOCK_END), body)]
+    if not starts and not ends:
+        return None, None
+    if len(starts) > 1 or len(ends) > 1:
+        return None, "duplicate context block boundaries"
+    if not starts or not ends:
+        return None, "damaged context block: one boundary is missing"
+    start, end = starts[0], ends[0]
+    if end < start:
+        return None, "damaged context block: boundaries are out of order"
+    header_end = body.find("-->", start)
+    if header_end == -1 or header_end > end:
+        return None, "damaged context block: header is unterminated"
+    meta: dict[str, str] = {}
+    for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    content = body[header_end + len("-->") : end].lstrip("\n")
+    return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
+
+
+def recorded_revisions(body: str, block: ParsedBlock | None) -> list[tuple[str, str]]:
+    """Structured revision records OUTSIDE the managed block.
+
+    Reported, never judged: this helper cannot tell whether a record was written
+    by someone with the authority to accept a requirements change, and a
+    free-text "acknowledged" is deliberately not matched.
+    """
+    outside = body if block is None else body[: block.start] + body[block.end :]
+    return [(m.group(1), (m.group(2) or "").strip()) for m in REVISION_RE.finditer(outside)]
+
+
+def check(body: str, root: Path) -> tuple[str, list[str]]:
+    """Freshness of the cache against its source. Returns (state, detail lines)."""
+    block, fault = find_block(body)
+    detail: list[str] = []
+    if fault:
+        return "block-damaged", [fault]
+    if block is None:
+        return "absent", ["this issue carries no generated context block"]
+
+    detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        detail.append(
+            "the block's own text has been edited since it was generated; a refresh "
+            "would overwrite that edit and is refused"
+        )
+        return "block-edited", detail
+
+    source_name = block.meta.get("source", "-")
+    if source_name in ("-", ""):
+        return "source-unresolved", detail + [
+            "no source was resolved when this block was written; its notes say why"
+        ]
+    source = root / source_name
+    if not source.is_file():
+        return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    source_text = source.read_text(encoding="utf-8")
+    source_now = digest(source_text)
+    source_then = block.meta.get("source-digest", "")
+    for recorded, ref in recorded_revisions(body, block):
+        detail.append(
+            f"recorded revision: source-digest={recorded} ref={ref or '-'} "
+            "(a record found in the issue body; this helper does not judge whether it "
+            "was authorised - resolve it under the existing authority model)"
+        )
+        if recorded == source_now:
+            detail.append("that record names the CURRENT source version")
+
+    if source_now == source_then:
+        return "current", detail + ["source bytes are unchanged since generation"]
+
+    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
+    task_id = block.meta.get("task", "")
+    scope_now = ""
+    if task_id and stories:
+        tasks_path = source.parent / "tasks.md"
+        if tasks_path.is_file():
+            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if scope_now and scope_now != block.meta.get("scope-digest", ""):
+        return "changed-in-scope", detail + [
+            "bytes changed inside the sections this task maps to. That is a byte "
+            "difference, not a ruling that acceptance changed - assess it against the "
+            "source before continuing."
+        ]
+    return "changed-outside-scope", detail + [
+        "the source file changed, but not inside the sections this task maps to. The "
+        "change may still matter (cross-cutting requirements carry no story mapping), "
+        "so read it; nothing here claims it is relevant to this task."
+    ]
+
+
+def refresh(body: str, block_text: str) -> tuple[str | None, str]:
+    """Replace ONLY the managed block. Any doubt leaves the body byte-identical."""
+    block, fault = find_block(body)
+    if fault:
+        return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
+    if block is None:
+        return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        return None, (
+            "refused: the block's text was edited after it was generated. The body is "
+            "unchanged. Move the edit outside the block, or delete the block to have it "
+            "regenerated, if you want the cache refreshed."
+        )
+    updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
+    if updated == body:
+        return updated, "unchanged: the regenerated block is identical"
+    return updated, "refreshed: the block was replaced; text outside it is untouched"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_render = sub.add_parser("render", help="print the managed block for one task")
+    p_render.add_argument("--tasks", type=Path, required=True)
+    p_render.add_argument("--task", required=True)
+    p_render.add_argument("--feature", default="")
+
+    p_check = sub.add_parser("check", help="report cache freshness for an issue body")
+    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--root", type=Path, default=Path("."))
+
+    p_refresh = sub.add_parser("refresh", help="replace only the managed block")
+    p_refresh.add_argument("--body-file", type=Path, required=True)
+    p_refresh.add_argument("--tasks", type=Path, required=True)
+    p_refresh.add_argument("--task", required=True)
+    p_refresh.add_argument("--feature", default="")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        resolution = resolve(args.tasks, args.task)
+        sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
+        return 0
+
+    if args.command == "check":
+        body = args.body_file.read_text(encoding="utf-8")
+        state, detail = check(body, args.root)
+        for line in detail:
+            print(f"  {line}")
+        print(f"SPECKIT_CONTEXT_STATE: {state}")
+        return 0 if state in ("current", "absent") else 3
+
+    body = args.body_file.read_text(encoding="utf-8")
+    resolution = resolve(args.tasks, args.task)
+    block_text = render(resolution, args.feature or str(args.tasks))
+    updated, message = refresh(body, block_text)
+    print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)
+    if updated is None:
+        return 4
+    sys.stdout.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/evaluate-help/scripts/speckit-context.py
+++ b/codex/skills/evaluate-help/scripts/speckit-context.py
@@ -61,6 +61,11 @@ STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
 ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
 BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+# `---` under an acceptance list is a horizontal rule, and `- -` is how a naive
+# bullet regex reads it: the real shipped template produced a phantom acceptance
+# item of "--". Rules end a list, they are never items in it.
+HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
+FENCE_RE = re.compile(r"^(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -75,6 +80,9 @@ CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
 # of copying, and says that it did (an incomplete extract is never silence).
 MAX_ITEMS = 12
 MAX_ITEM_CHARS = 300
+MAX_PROSE_CHARS = 600
+MAX_BLOCK_CHARS = 8000
+REQUIRED_META = ("feature", "task", "tasks", "source", "integrity")
 
 
 def digest(text: str) -> str:
@@ -97,6 +105,9 @@ class Resolution:
     truncated: list[str] = field(default_factory=list)
     scope_text: str = ""
     source_text: str = ""
+    task_text: str = ""
+    tasks_rel: str | None = None
+    source_rel: str | None = None
 
 
 def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
@@ -115,15 +126,19 @@ def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
     return spans
 
 
-def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+def _story_spans(lines: list[str], story_id: str) -> list[tuple[int, int]]:
+    """Every span declaring this story. More than one is ambiguity, not a choice."""
+    spans: list[tuple[int, int]] = []
     for index, line in enumerate(lines):
         match = STORY_HEADING_RE.match(line)
         if match and match.group(1).upper() == story_id.upper():
-            for end in range(index + 1, len(lines)):
-                if ANY_HEADING_RE.match(lines[end]):
-                    return (index, end)
-            return (index, len(lines))
-    return None
+            end = len(lines)
+            for candidate in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[candidate]):
+                    end = candidate
+                    break
+            spans.append((index, end))
+    return spans
 
 
 def _story_outcome(block: list[str]) -> str:
@@ -141,6 +156,19 @@ def _story_outcome(block: list[str]) -> str:
     return " ".join(parts).strip()
 
 
+def _strip_fences(lines: list[str]) -> list[str]:
+    """Blank out fenced blocks: a sample inside a fence is an example, not a declaration."""
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside = not inside
+            out.append("")
+            continue
+        out.append("" if inside else line)
+    return out
+
+
 def _story_acceptance(block: list[str]) -> list[str]:
     items: list[str] = []
     collecting = False
@@ -149,6 +177,8 @@ def _story_acceptance(block: list[str]) -> list[str]:
             collecting = True
             continue
         if collecting:
+            if HRULE_RE.match(line):
+                break
             if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
                 break
             bullet = BULLET_RE.match(line)
@@ -200,8 +230,36 @@ def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str,
     return rows
 
 
-def resolve(tasks_path: Path, task_id: str) -> Resolution:
+def project_root(start: Path, explicit: Path | None = None) -> Path:
+    """The root every persisted path is relative to.
+
+    Persisting the path as GIVEN was a defect: an absolute source recorded by the
+    producer's checkout kept resolving back to that checkout, so a consumer in a
+    different clone checked the wrong tree and was told `current` while its own
+    spec had changed. Paths are stored relative to this root and re-resolved
+    against the consumer's `--root`.
+    """
+    if explicit is not None:
+        return explicit.resolve()
+    here = start.resolve()
+    here = here if here.is_dir() else here.parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return here
+
+
+def relative_to_root(path: Path, root: Path) -> str | None:
+    """Project-relative spelling, or None when the path escapes the root."""
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolution:
     """Resolve one task's declared context, disclosing whatever does not resolve."""
+    base = project_root(tasks_path, root)
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
@@ -218,6 +276,16 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    resolution.tasks_rel = relative_to_root(tasks_path, base)
+    if resolution.tasks_rel is None:
+        resolution.unresolved.append(
+            f"{tasks_path} lies outside the project root {base}; its location cannot be "
+            "recorded portably, so a consumer in another checkout cannot re-resolve it"
+        )
+    # The task line is a governing input in its own right: its wording can carry a
+    # constraint, and its [USn] tag decides which requirements apply. A digest over
+    # the spec alone left a re-tagged or re-worded task reading as unchanged.
+    resolution.task_text = f"{task_id.upper()}|{','.join(sorted(set(story_ids)))}|{wording}"
     if not found:
         resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
         return resolution
@@ -229,8 +297,9 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         )
         return resolution
     resolution.source = source
+    resolution.source_rel = relative_to_root(source, base)
     resolution.source_text = source.read_text(encoding="utf-8")
-    lines = resolution.source_text.splitlines()
+    lines = _strip_fences(resolution.source_text.splitlines())
 
     if not story_ids:
         resolution.unresolved.append(
@@ -240,13 +309,20 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
 
     scope_parts: list[str] = []
     for story_id in dict.fromkeys(story_ids):
-        span = _story_span(lines, story_id)
-        if span is None:
+        spans = _story_spans(lines, story_id)
+        if not spans:
             resolution.unresolved.append(
                 f"{story_id} is tagged on the task but has no '### {story_id}:' "
                 f"section in {source.name}"
             )
             continue
+        if len(spans) > 1:
+            resolution.unresolved.append(
+                f"{story_id} is declared {len(spans)} times in {source.name}; the "
+                "ambiguity is reported rather than resolved here - read the source"
+            )
+            continue
+        span = spans[0]
         block = lines[span[0] : span[1]]
         scope_parts.append("\n".join(block))
         heading = STORY_HEADING_RE.match(block[0])
@@ -282,6 +358,24 @@ def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list
     return capped
 
 
+def _clip(text: str, limit: int, label: str, truncated: list[str]) -> str:
+    if len(text) <= limit:
+        return text
+    truncated.append(f"{label}: shortened to {limit} characters - read the source")
+    return text[:limit].rstrip() + " [...]"
+
+
+def _meta_digest(meta: dict[str, str], content: str) -> str:
+    """Integrity over the MANAGED METADATA and the content, minus the field itself.
+
+    Covering only the visible text left `task:`, `source:` and the other digests
+    editable in place: the block could be re-pointed at another task's source and
+    a refresh would accept it as its own.
+    """
+    payload = "\n".join(f"{k}={meta[k]}" for k in sorted(meta) if k != "integrity")
+    return digest(payload + "\n--\n" + content)
+
+
 def render(resolution: Resolution, feature: str) -> str:
     """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
     truncated: list[str] = list(resolution.truncated)
@@ -291,7 +385,7 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
             "below there before planning. This block is a task-scoped extract kept for "
             "convenience; where the two differ, the source governs."
         )
@@ -302,7 +396,10 @@ def render(resolution: Resolution, feature: str) -> str:
     body.append("")
 
     for story_id, outcome in resolution.outcomes:
-        body.append(f"**Outcome ({story_id}):** {outcome}")
+        body.append(
+            f"**Outcome ({story_id}):** "
+            + _clip(outcome, MAX_PROSE_CHARS, f"outcome {story_id}", truncated)
+        )
     if resolution.outcomes:
         body.append("")
 
@@ -325,7 +422,8 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     if resolution.task_wording:
-        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        wording = _clip(resolution.task_wording, MAX_PROSE_CHARS, "task wording", truncated)
+        body.append(f'**Task wording (from tasks.md):** "{wording}"')
         body.append(
             "  Resolve its authority against the sections above before acting on it. It "
             "may propose an approach you are free to replace, or it may restate a binding "
@@ -352,17 +450,26 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     content = "\n".join(body).rstrip() + "\n"
-    header = [
-        BLOCK_BEGIN,
-        f"feature: {feature}",
-        f"task: {resolution.task_id}",
-        f"source: {resolution.source if resolution.source else '-'}",
-        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
-        f"scope-digest: {digest(resolution.scope_text)}",
-        f"source-digest: {digest(resolution.source_text)}",
-        f"block-digest: {digest(content)}",
-        "-->",
-    ]
+    if len(content) > MAX_BLOCK_CHARS:
+        keep = content[:MAX_BLOCK_CHARS].rstrip()
+        content = (
+            keep
+            + "\n\n**Capped for size - this extract is INCOMPLETE.** Read the "
+            "authoritative source named above before planning; the constraints that "
+            "make the decision are not guaranteed to be among the lines kept here.\n"
+        )
+    meta = {
+        "feature": feature,
+        "task": resolution.task_id,
+        "tasks": resolution.tasks_rel or "-",
+        "source": resolution.source_rel or "-",
+        "stories": ",".join(story for story, _ in resolution.outcomes) or "-",
+        "task-digest": digest(resolution.task_text),
+        "scope-digest": digest(resolution.scope_text),
+        "source-digest": digest(resolution.source_text),
+    }
+    meta["integrity"] = _meta_digest(meta, content)
+    header = [BLOCK_BEGIN] + [f"{k}: {meta[k]}" for k in meta] + ["-->"]
     return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
 
 
@@ -392,9 +499,16 @@ def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
         return None, "damaged context block: header is unterminated"
     meta: dict[str, str] = {}
     for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
-        if ":" in line:
-            key, _, value = line.partition(":")
-            meta[key.strip()] = value.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in meta:
+            return None, f"damaged context block: duplicate metadata field '{key}'"
+        meta[key] = value.strip()
+    missing = [name for name in REQUIRED_META if name not in meta]
+    if missing:
+        return None, "damaged context block: missing metadata " + ", ".join(missing)
     content = body[header_end + len("-->") : end].lstrip("\n")
     return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
 
@@ -420,10 +534,11 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         return "absent", ["this issue carries no generated context block"]
 
     detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         detail.append(
-            "the block's own text has been edited since it was generated; a refresh "
-            "would overwrite that edit and is refused"
+            "the block has been edited since it was generated - its text, or the "
+            "metadata naming its task and source. A refresh would overwrite that edit "
+            "and is refused"
         )
         return "block-edited", detail
 
@@ -435,6 +550,28 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
     source = root / source_name
     if not source.is_file():
         return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    # The task line is a governing input too: a re-tagged or re-worded task changes
+    # which requirements apply, without touching the spec at all.
+    tasks_name = block.meta.get("tasks", "-")
+    task_id = block.meta.get("task", "")
+    tasks_path = root / tasks_name if tasks_name not in ("-", "") else None
+    task_state: str | None = None
+    if tasks_path is None or not tasks_path.is_file():
+        detail.append(
+            f"the tasks file recorded for this block ({tasks_name}) is not present under "
+            "this root, so the task side of the mapping cannot be re-checked"
+        )
+        task_state = "tasks-missing"
+    else:
+        current = resolve(tasks_path, task_id, root)
+        if digest(current.task_text) != block.meta.get("task-digest", ""):
+            detail.append(
+                "the task line itself changed - its wording, or the [USn] tag that "
+                "decides which requirements apply. The mapping this block was built "
+                "from no longer matches the plan."
+            )
+            task_state = "changed-task"
 
     source_text = source.read_text(encoding="utf-8")
     source_now = digest(source_text)
@@ -448,16 +585,15 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
 
-    if source_now == source_then:
-        return "current", detail + ["source bytes are unchanged since generation"]
+    if task_state is not None:
+        return task_state, detail
 
-    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
-    task_id = block.meta.get("task", "")
+    if source_now == source_then:
+        return "current", detail + ["source and task bytes are unchanged since generation"]
+
     scope_now = ""
-    if task_id and stories:
-        tasks_path = source.parent / "tasks.md"
-        if tasks_path.is_file():
-            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if tasks_path is not None and tasks_path.is_file():
+        scope_now = digest(resolve(tasks_path, task_id, root).scope_text)
     if scope_now and scope_now != block.meta.get("scope-digest", ""):
         return "changed-in-scope", detail + [
             "bytes changed inside the sections this task maps to. That is a byte "
@@ -478,12 +614,23 @@ def refresh(body: str, block_text: str) -> tuple[str | None, str]:
         return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
     if block is None:
         return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         return None, (
             "refused: the block's text was edited after it was generated. The body is "
             "unchanged. Move the edit outside the block, or delete the block to have it "
             "regenerated, if you want the cache refreshed."
         )
+    incoming, fault = find_block(block_text)
+    if incoming is None:
+        return None, f"refused: the replacement block is unusable ({fault})"
+    for key in ("feature", "task"):
+        if block.meta.get(key) != incoming.meta.get(key):
+            return None, (
+                f"refused: identity mismatch - this block is {key}="
+                f"{block.meta.get(key)} and the replacement is {key}="
+                f"{incoming.meta.get(key)}. The body is unchanged; refreshing one "
+                "task's context with another's is never a refresh."
+            )
     updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
     if updated == body:
         return updated, "unchanged: the regenerated block is identical"
@@ -498,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--tasks", type=Path, required=True)
     p_render.add_argument("--task", required=True)
     p_render.add_argument("--feature", default="")
+    p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
     p_check.add_argument("--body-file", type=Path, required=True)
@@ -508,11 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     p_refresh.add_argument("--tasks", type=Path, required=True)
     p_refresh.add_argument("--task", required=True)
     p_refresh.add_argument("--feature", default="")
+    p_refresh.add_argument("--root", type=Path, default=None)
 
     args = parser.parse_args(argv)
 
     if args.command == "render":
-        resolution = resolve(args.tasks, args.task)
+        resolution = resolve(args.tasks, args.task, args.root)
         sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
         return 0
 
@@ -525,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if state in ("current", "absent") else 3
 
     body = args.body_file.read_text(encoding="utf-8")
-    resolution = resolve(args.tasks, args.task)
+    resolution = resolve(args.tasks, args.task, args.root)
     block_text = render(resolution, args.feature or str(args.tasks))
     updated, message = refresh(body, block_text)
     print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)

--- a/codex/skills/evaluate-help/scripts/speckit-context.py
+++ b/codex/skills/evaluate-help/scripts/speckit-context.py
@@ -65,7 +65,7 @@ BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
 # bullet regex reads it: the real shipped template produced a phantom acceptance
 # item of "--". Rules end a list, they are never items in it.
 HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
-FENCE_RE = re.compile(r"^(?:```|~~~)")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -263,19 +263,30 @@ def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolut
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
+    duplicates = 0
     found = False
-    for line in tasks_text.splitlines():
+    # A task line inside a fence is an EXAMPLE. Reading declarations out of fenced
+    # samples let a documentation snippet outrank the real task and supply the wrong
+    # story mapping, so tasks.md gets the same fence handling as the spec.
+    for line in _strip_fences(tasks_text.splitlines()):
         match = TASK_LINE_RE.match(line)
         if not match or match.group(1).upper() != task_id.upper():
+            continue
+        if found:
+            duplicates += 1
             continue
         found = True
         rest = match.group(2)
         for tag in STORY_TAG_RE.findall(rest):
             story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
         wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
-        break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if duplicates:
+        resolution.unresolved.append(
+            f"{task_id.upper()} is declared {duplicates + 1} times in {tasks_path.name}; "
+            "the first was used and the ambiguity is reported rather than resolved here"
+        )
     resolution.tasks_rel = relative_to_root(tasks_path, base)
     if resolution.tasks_rel is None:
         resolution.unresolved.append(
@@ -385,13 +396,15 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
-            "below there before planning. This block is a task-scoped extract kept for "
-            "convenience; where the two differ, the source governs."
+            f"**Reference source:** `{resolution.source_rel or resolution.source}` - read "
+            "the sections named below there before planning. This block is a task-scoped "
+            "extract taken at the version recorded above. A difference between the two is "
+            "a CHANGED VERSION to resolve under the existing authority model - it does not "
+            "by itself override a constraint or plan already accepted on this issue."
         )
     else:
         body.append(
-            "**Authoritative source:** none resolved. See the unresolved notes below."
+            "**Reference source:** none resolved. See the unresolved notes below."
         )
     body.append("")
 
@@ -584,6 +597,17 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         )
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
+        elif recorded == source_then:
+            detail.append(
+                "that record names the version THIS BLOCK CACHED, not the current source - "
+                "so the decision it records predates the change below and must be resolved, "
+                "not assumed to cover it"
+            )
+        else:
+            detail.append(
+                "that record names neither the current source nor the cached version; it "
+                "refers to some third version and cannot be matched automatically"
+            )
 
     if task_state is not None:
         return task_state, detail
@@ -648,7 +672,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
-    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--body-file", type=Path, required=True, help="'-' reads stdin")
     p_check.add_argument("--root", type=Path, default=Path("."))
 
     p_refresh = sub.add_parser("refresh", help="replace only the managed block")
@@ -666,7 +690,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        body = args.body_file.read_text(encoding="utf-8")
+        body = (
+            sys.stdin.read()
+            if str(args.body_file) == "-"
+            else args.body_file.read_text(encoding="utf-8")
+        )
         state, detail = check(body, args.root)
         for line in detail:
             print(f"  {line}")

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -165,6 +165,16 @@ normalize_source_path() {
     printf '%s' "$path"
 }
 
+# scripts/speckit-context.py renders the task-context cache (#858). It ships in the
+# same directory as this script, including inside a generated Codex skill bundle, so
+# it is resolved relative to THIS file rather than to the caller's cwd. Absent or
+# unusable, the converter keeps working and simply writes no context block.
+CONTEXT_HELPER=""
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+    CONTEXT_HELPER="$_self_dir/speckit-context.py"
+fi
+
 TASKS_NORM="$(normalize_source_path "$TASKS")"
 TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
 
@@ -467,6 +477,19 @@ for i in "${!TIDS[@]}"; do
     issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
     if [ -n "${DEPS[$i]}" ]; then
         issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
+    fi
+    # Task context (issue #857 -> #858). A generated issue used to carry its
+    # provenance, its marker and its dependencies, and nothing about the behaviour
+    # it was meant to produce - so the receiving agent had only the title, and no
+    # pointer to the document that governs the work. The helper renders a bounded,
+    # fingerprinted cache of the task's DECLARED context; the spec stays
+    # authoritative. Conditional by design: with no helper and no resolvable spec
+    # the issue body is the whole contract, exactly as before.
+    if [ -n "$CONTEXT_HELPER" ]; then
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
+        if [ -n "$context_block" ]; then
+            issue_body+=$'\n\n'"$context_block"
+        fi
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -26,6 +26,8 @@
 #                    or they are no longer recognised and get filed again. A new
 #                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
+#   --no-context     Do not render task-context blocks. The deliberate opt-out; a
+#                    helper that is missing or fails is an ERROR, not a silent skip.
 #   -h, --help       Show this help.
 #
 # Exit codes:
@@ -38,6 +40,7 @@
 #   5  one or more tasks have an ambiguous legacy identity awaiting resolution
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
+#   7  the task-context helper is missing or failed (use --no-context to opt out)
 set -euo pipefail
 
 DRY_RUN=0
@@ -45,6 +48,7 @@ TASKS=""
 REPO=""
 FEATURE=""
 LIMIT=1000
+NO_CONTEXT=0
 
 usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
@@ -55,6 +59,7 @@ while [ $# -gt 0 ]; do
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
         --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
         --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
+        --no-context) NO_CONTEXT=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -171,7 +176,19 @@ normalize_source_path() {
 # unusable, the converter keeps working and simply writes no context block.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+if [ "$NO_CONTEXT" -eq 0 ]; then
+    if ! command -v python3 > /dev/null 2>&1; then
+        echo "ERROR: python3 is required to render task context and was not found." >&2
+        echo "Install python3, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
+    if [ ! -f "$_self_dir/speckit-context.py" ]; then
+        echo "ERROR: speckit-context.py is missing from $_self_dir." >&2
+        echo "It ships beside this script, including inside a generated skill bundle; a" >&2
+        echo "packaging that separates them is broken, not a context-free installation." >&2
+        echo "Reinstall, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
     CONTEXT_HELPER="$_self_dir/speckit-context.py"
 fi
 
@@ -485,11 +502,20 @@ for i in "${!TIDS[@]}"; do
     # fingerprinted cache of the task's DECLARED context; the spec stays
     # authoritative. Conditional by design: with no helper and no resolvable spec
     # the issue body is the whole contract, exactly as before.
-    if [ -n "$CONTEXT_HELPER" ]; then
-        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
-        if [ -n "$context_block" ]; then
-            issue_body+=$'\n\n'"$context_block"
+    if [ "$NO_CONTEXT" -eq 0 ]; then
+        context_status=0
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
+        if [ "$context_status" -ne 0 ] || [ -z "$context_block" ]; then
+            # A broken helper is not a lightweight issue. Swallowing this produced a
+            # context-free issue that looked like a successful conversion, which is
+            # the failure this whole change exists to remove - so it stops here,
+            # before any further write. `--no-context` is the deliberate opt-out.
+            echo "ERROR: could not render the task context for ${tid} (helper exited ${context_status})." >&2
+            printf '  %s\n' "$context_block" >&2
+            echo "Fix the helper or pass --no-context to convert without context blocks." >&2
+            exit 7
         fi
+        issue_body+=$'\n\n'"$context_block"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -41,6 +41,7 @@
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
 #   7  the task-context helper is missing or failed (use --no-context to opt out)
+#   8  an existing issue's context could not be read or checked on a re-run
 set -euo pipefail
 
 DRY_RUN=0
@@ -173,7 +174,8 @@ normalize_source_path() {
 # scripts/speckit-context.py renders the task-context cache (#858). It ships in the
 # same directory as this script, including inside a generated Codex skill bundle, so
 # it is resolved relative to THIS file rather than to the caller's cwd. Absent or
-# unusable, the converter keeps working and simply writes no context block.
+# unusable, the run STOPS: a packaging fault that silently produced context-free
+# issues would look exactly like a successful conversion. `--no-context` opts out.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$NO_CONTEXT" -eq 0 ]; then
@@ -475,7 +477,7 @@ if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
 fi
 
 # --- Create pass -----------------------------------------------------------------
-created=0; skipped=0; adopted=0
+created=0; skipped=0; adopted=0; context_checks_failed=0
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
@@ -485,13 +487,29 @@ for i in "${!TIDS[@]}"; do
         # invisible until somebody happened to re-read it. Reporting only: this
         # never edits an issue, and a refresh is the explicit documented workflow.
         if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
-            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
-                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
-                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
-            case "$ctx_state" in
-                ""|current|absent) : ;;
-                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
-            esac
+            ctx_read_status=0
+            ctx_body="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || ctx_read_status=$?
+            if [ "$ctx_read_status" -ne 0 ]; then
+                echo "WARN: could not read issue #${FILED_NUM[$tid]} to check ${tid}'s context (gh exited ${ctx_read_status})." >&2
+                printf '  %s\n' "$ctx_body" >&2
+                context_checks_failed=$((context_checks_failed + 1))
+            else
+                ctx_check_status=0
+                ctx_report="$(printf '%s' "$ctx_body" | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>&1)" || ctx_check_status=$?
+                ctx_state="$(printf '%s' "$ctx_report" | sed -n 's/^SPECKIT_CONTEXT_STATE: //p')"
+                # `check` exits 3 for any state other than current/absent; anything
+                # else is a broken checker, not a verdict.
+                if { [ "$ctx_check_status" -ne 0 ] && [ "$ctx_check_status" -ne 3 ]; } || [ -z "$ctx_state" ]; then
+                    echo "WARN: the context check for ${tid} (issue #${FILED_NUM[$tid]}) failed (exit ${ctx_check_status})." >&2
+                    printf '  %s\n' "$ctx_report" >&2
+                    context_checks_failed=$((context_checks_failed + 1))
+                else
+                    case "$ctx_state" in
+                        current|absent) : ;;
+                        *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+                    esac
+                fi
+            fi
         fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
@@ -513,8 +531,9 @@ for i in "${!TIDS[@]}"; do
     # it was meant to produce - so the receiving agent had only the title, and no
     # pointer to the document that governs the work. The helper renders a bounded,
     # fingerprinted cache of the task's DECLARED context; the spec stays
-    # authoritative. Conditional by design: with no helper and no resolvable spec
-    # the issue body is the whole contract, exactly as before.
+    # authoritative. Conditional on the INPUT, not on the installation: a tasks file
+    # with no resolvable spec still gets a block disclosing what did not resolve,
+    # while a missing or failing helper is an error rather than a quiet omission.
     if [ "$NO_CONTEXT" -eq 0 ]; then
         context_status=0
         context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
@@ -611,6 +630,12 @@ done
 echo "---"
 echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
 [ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$context_checks_failed" -gt 0 ]; then
+    echo "ERROR: ${context_checks_failed} context check(s) could not be completed; their" >&2
+    echo "diagnostics are above. An unreadable issue or a broken checker is not the same" >&2
+    echo "as an issue with no context block, and is not reported as one." >&2
+    exit 8
+fi
 if [ "$edges_failed" -gt 0 ]; then
     echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
     echo "command to reconcile the missing edges - it will not create duplicates." >&2

--- a/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh
@@ -480,6 +480,19 @@ for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
     if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        # Drift visibility on a re-run (#858). An already-filed task used to skip
+        # straight past its context, so a spec that moved under a filed issue was
+        # invisible until somebody happened to re-read it. Reporting only: this
+        # never edits an issue, and a refresh is the explicit documented workflow.
+        if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
+            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
+                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
+                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
+            case "$ctx_state" in
+                ""|current|absent) : ;;
+                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+            esac
+        fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
                  "add '$(marker_for "$tid")' to its body to make the identity explicit)"

--- a/codex/skills/evaluate-issue/reference.md
+++ b/codex/skills/evaluate-issue/reference.md
@@ -387,6 +387,9 @@ Next steps:
   3. Use /flow-start <issue> to begin implementation
 ```
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 ---
 
 ## Domain-Specific Guidance

--- a/codex/skills/evaluate-issue/reference.md
+++ b/codex/skills/evaluate-issue/reference.md
@@ -387,7 +387,7 @@ Next steps:
   3. Use /flow-start <issue> to begin implementation
 ```
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 ---

--- a/codex/skills/evaluate-issue/scripts/speckit-context.py
+++ b/codex/skills/evaluate-issue/scripts/speckit-context.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Resolve, render and refresh the task-context cache in a generated issue (#858).
+
+A generated issue used to carry its provenance, its identity marker and its
+dependencies - and nothing about the behaviour it was meant to produce. The task
+title was the whole description, so a receiving agent could not tell which words
+were the goal and which were somebody's suggested mechanism, and had nothing
+pointing at the document that actually governs the work.
+
+This helper resolves a task's DECLARED context and renders it into a bounded,
+fingerprinted block. The block is a CACHE, not a second authority: the spec named
+inside it stays authoritative, everything in it is traceable to a source section,
+and every part carries a digest so drift is visible instead of silent.
+
+What is declared, and therefore used:
+
+  * the story tag on the task line (`- [ ] **T001** [US1] ...`), which names a
+    `### US1:` section in the sibling spec.md
+  * the Functional Requirements table's `User Story` column, which maps
+    individual requirements to that story
+
+What is NOT inferred: nothing is derived from task NUMBERS, and requirements with
+no declared story mapping are never claimed as this task's. Non-Functional
+Requirements and Out of Scope carry no story mapping at all, so they are indexed
+as cross-cutting sections the consumer must read in the source - and they are
+covered by the whole-file digest, so a changed global security or compatibility
+constraint is visible even though it is not attributed to this task.
+
+What a digest establishes, and what it does not: a differing digest means those
+BYTES changed since the block was written. It is not a ruling that acceptance
+changed, that the change is material to this task, or that anything was approved.
+A reflow or a typo fix reads as a change. The states this helper reports are
+deliberately named for what they observe.
+
+Usage:
+    speckit-context.py render  --tasks PATH --task T001 [--feature SLUG]
+    speckit-context.py check   --body-file PATH [--root DIR]
+    speckit-context.py refresh --body-file PATH --tasks PATH --task T001 [--feature SLUG]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BLOCK_BEGIN = "<!-- speckit-context:v1"
+BLOCK_END = "<!-- speckit-context:end -->"
+DIGEST_LEN = 12
+
+# Declared task -> story mapping, written by .specify/templates/tasks-template.md.
+STORY_TAG_RE = re.compile(r"\[(US\d+(?:\s*,\s*US?\d+)*)\]", re.IGNORECASE)
+STORY_ID_RE = re.compile(r"US\d+", re.IGNORECASE)
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
+STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
+ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
+BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# A structured, reviewable record that a requirements revision was accepted. The
+# helper REPORTS it; it never decides that it is authorised, and a free-text
+# "acknowledged" somewhere in the body is not this.
+REVISION_RE = re.compile(
+    r"^\s*Acceptance-revision:\s*source-digest=([0-9a-f]{6,64})\s*(?:ref=(\S.*))?$",
+    re.MULTILINE,
+)
+
+CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
+# A cap keeps the cache bounded; beyond it the block points at the source instead
+# of copying, and says that it did (an incomplete extract is never silence).
+MAX_ITEMS = 12
+MAX_ITEM_CHARS = 300
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:DIGEST_LEN]
+
+
+@dataclass
+class Resolution:
+    """What the declared mappings produced for one task."""
+
+    task_id: str
+    task_wording: str
+    source: Path | None = None
+    story_ids: list[str] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+    acceptance: list[tuple[str, str]] = field(default_factory=list)
+    requirements: list[tuple[str, str]] = field(default_factory=list)
+    cross_cutting: list[str] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    truncated: list[str] = field(default_factory=list)
+    scope_text: str = ""
+    source_text: str = ""
+
+
+def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Heading text -> (start, end) line span, for top-level `##`/`###` headings."""
+    spans: dict[str, tuple[int, int]] = {}
+    current: str | None = None
+    start = 0
+    for index, line in enumerate(lines):
+        if ANY_HEADING_RE.match(line):
+            if current is not None:
+                spans[current] = (start, index)
+            current = line.lstrip("#").strip()
+            start = index
+    if current is not None:
+        spans[current] = (start, len(lines))
+    return spans
+
+
+def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = STORY_HEADING_RE.match(line)
+        if match and match.group(1).upper() == story_id.upper():
+            for end in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[end]):
+                    return (index, end)
+            return (index, len(lines))
+    return None
+
+
+def _story_outcome(block: list[str]) -> str:
+    """The story's own sentence: the heading text plus its As/I want/So that lines."""
+    parts: list[str] = []
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if parts:
+                break
+            continue
+        if stripped.startswith("**Acceptance") or ANY_HEADING_RE.match(line):
+            break
+        parts.append(stripped)
+    return " ".join(parts).strip()
+
+
+def _story_acceptance(block: list[str]) -> list[str]:
+    items: list[str] = []
+    collecting = False
+    for line in block:
+        if ACCEPTANCE_HEADING_RE.match(line.strip()):
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
+                break
+            bullet = BULLET_RE.match(line)
+            if bullet:
+                items.append(bullet.group(1))
+            elif line.strip() and items:
+                items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
+def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str, str]]:
+    """FR rows whose declared `User Story` column names one of these stories.
+
+    The mapping is read from the table the spec template ships; a row with no
+    story column, or one naming another story, is never attributed to this task.
+    """
+    wanted = {s.upper() for s in story_ids}
+    spans = _sections(lines)
+    span = spans.get("Functional Requirements")
+    if span is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    header: list[str] | None = None
+    for line in lines[span[0] : span[1]]:
+        match = TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in match.group(1).split("|")]
+        if header is None:
+            header = [c.lower() for c in cells]
+            continue
+        if all(set(c) <= {"-", ":"} for c in cells if c):
+            continue
+        if "user story" not in header:
+            continue
+        story_index = header.index("user story")
+        if story_index >= len(cells):
+            continue
+        declared = {s.upper() for s in STORY_ID_RE.findall(cells[story_index])}
+        if not declared & wanted:
+            continue
+        ident = cells[0] if cells else ""
+        text_index = header.index("requirement") if "requirement" in header else 1
+        text = cells[text_index] if text_index < len(cells) else ""
+        priority_index = header.index("priority") if "priority" in header else None
+        if priority_index is not None and priority_index < len(cells):
+            text = f"{text} ({cells[priority_index]})"
+        rows.append((ident, text))
+    return rows
+
+
+def resolve(tasks_path: Path, task_id: str) -> Resolution:
+    """Resolve one task's declared context, disclosing whatever does not resolve."""
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    wording = ""
+    story_ids: list[str] = []
+    found = False
+    for line in tasks_text.splitlines():
+        match = TASK_LINE_RE.match(line)
+        if not match or match.group(1).upper() != task_id.upper():
+            continue
+        found = True
+        rest = match.group(2)
+        for tag in STORY_TAG_RE.findall(rest):
+            story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
+        wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
+        break
+
+    resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if not found:
+        resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
+        return resolution
+
+    source = tasks_path.parent / "spec.md"
+    if not source.is_file():
+        resolution.unresolved.append(
+            f"no spec.md beside {tasks_path} - no declared source to resolve against"
+        )
+        return resolution
+    resolution.source = source
+    resolution.source_text = source.read_text(encoding="utf-8")
+    lines = resolution.source_text.splitlines()
+
+    if not story_ids:
+        resolution.unresolved.append(
+            f"{resolution.task_id} declares no [USn] story tag, so its governing "
+            "requirement is not resolvable from the task line"
+        )
+
+    scope_parts: list[str] = []
+    for story_id in dict.fromkeys(story_ids):
+        span = _story_span(lines, story_id)
+        if span is None:
+            resolution.unresolved.append(
+                f"{story_id} is tagged on the task but has no '### {story_id}:' "
+                f"section in {source.name}"
+            )
+            continue
+        block = lines[span[0] : span[1]]
+        scope_parts.append("\n".join(block))
+        heading = STORY_HEADING_RE.match(block[0])
+        title = heading.group(2) if heading else story_id
+        outcome = _story_outcome(block)
+        resolution.outcomes.append((story_id, f"{title}. {outcome}".strip()))
+        for item in _story_acceptance(block):
+            resolution.acceptance.append((story_id, item))
+
+    for ident, text in _requirements_for(lines, story_ids):
+        resolution.requirements.append((ident, text))
+        scope_parts.append(f"{ident}|{text}")
+
+    spans = _sections(lines)
+    for heading in CROSS_CUTTING_HEADINGS:
+        if heading in spans:
+            resolution.cross_cutting.append(heading)
+
+    resolution.scope_text = "\n".join(scope_parts)
+    return resolution
+
+
+def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list[tuple[str, str]]:
+    if len(items) > MAX_ITEMS:
+        truncated.append(f"{label}: showing {MAX_ITEMS} of {len(items)}")
+        items = items[:MAX_ITEMS]
+    capped: list[tuple[str, str]] = []
+    for ident, text in items:
+        if len(text) > MAX_ITEM_CHARS:
+            text = text[:MAX_ITEM_CHARS].rstrip() + " [...]"
+            truncated.append(f"{label} {ident}: shortened")
+        capped.append((ident, text))
+    return capped
+
+
+def render(resolution: Resolution, feature: str) -> str:
+    """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
+    truncated: list[str] = list(resolution.truncated)
+    acceptance = _cap(resolution.acceptance, "acceptance", truncated)
+    requirements = _cap(resolution.requirements, "requirements", truncated)
+
+    body: list[str] = ["### Governing context (generated cache)", ""]
+    if resolution.source is not None:
+        body.append(
+            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            "below there before planning. This block is a task-scoped extract kept for "
+            "convenience; where the two differ, the source governs."
+        )
+    else:
+        body.append(
+            "**Authoritative source:** none resolved. See the unresolved notes below."
+        )
+    body.append("")
+
+    for story_id, outcome in resolution.outcomes:
+        body.append(f"**Outcome ({story_id}):** {outcome}")
+    if resolution.outcomes:
+        body.append("")
+
+    if acceptance:
+        body.append("**Acceptance, as declared by the story:**")
+        body.extend(f"- ({story_id}) {item}" for story_id, item in acceptance)
+        body.append("")
+
+    if requirements:
+        body.append("**Requirements declared against this story:**")
+        body.extend(f"- {ident}: {text}" for ident, text in requirements)
+        body.append("")
+
+    if resolution.cross_cutting:
+        body.append(
+            "**Cross-cutting sections to read in the source before planning** - these "
+            "carry no story mapping, so they are named rather than attributed to this "
+            "task: " + ", ".join(f"`{h}`" for h in resolution.cross_cutting)
+        )
+        body.append("")
+
+    if resolution.task_wording:
+        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        body.append(
+            "  Resolve its authority against the sections above before acting on it. It "
+            "may propose an approach you are free to replace, or it may restate a binding "
+            "constraint; the line alone does not say which."
+        )
+        body.append("")
+
+    if resolution.outcomes:
+        body.append(
+            "**Granularity:** acceptance is declared at user-story level, so the items "
+            "above may also cover sibling tasks of the same story. Narrow them to this "
+            "task yourself; this block does not decide that for you."
+        )
+        body.append("")
+
+    if resolution.unresolved:
+        body.append("**Unresolved - incomplete context, not an absence of constraints:**")
+        body.extend(f"- {note}" for note in resolution.unresolved)
+        body.append("")
+
+    if truncated:
+        body.append("**Capped for size - read the source for the rest:**")
+        body.extend(f"- {note}" for note in truncated)
+        body.append("")
+
+    content = "\n".join(body).rstrip() + "\n"
+    header = [
+        BLOCK_BEGIN,
+        f"feature: {feature}",
+        f"task: {resolution.task_id}",
+        f"source: {resolution.source if resolution.source else '-'}",
+        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
+        f"scope-digest: {digest(resolution.scope_text)}",
+        f"source-digest: {digest(resolution.source_text)}",
+        f"block-digest: {digest(content)}",
+        "-->",
+    ]
+    return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
+
+
+@dataclass
+class ParsedBlock:
+    start: int
+    end: int
+    meta: dict[str, str]
+    content: str
+
+
+def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
+    """Locate the managed block. Returns (block, fault); a fault forbids rewriting."""
+    starts = [m.start() for m in re.finditer(re.escape(BLOCK_BEGIN), body)]
+    ends = [m.start() for m in re.finditer(re.escape(BLOCK_END), body)]
+    if not starts and not ends:
+        return None, None
+    if len(starts) > 1 or len(ends) > 1:
+        return None, "duplicate context block boundaries"
+    if not starts or not ends:
+        return None, "damaged context block: one boundary is missing"
+    start, end = starts[0], ends[0]
+    if end < start:
+        return None, "damaged context block: boundaries are out of order"
+    header_end = body.find("-->", start)
+    if header_end == -1 or header_end > end:
+        return None, "damaged context block: header is unterminated"
+    meta: dict[str, str] = {}
+    for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    content = body[header_end + len("-->") : end].lstrip("\n")
+    return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
+
+
+def recorded_revisions(body: str, block: ParsedBlock | None) -> list[tuple[str, str]]:
+    """Structured revision records OUTSIDE the managed block.
+
+    Reported, never judged: this helper cannot tell whether a record was written
+    by someone with the authority to accept a requirements change, and a
+    free-text "acknowledged" is deliberately not matched.
+    """
+    outside = body if block is None else body[: block.start] + body[block.end :]
+    return [(m.group(1), (m.group(2) or "").strip()) for m in REVISION_RE.finditer(outside)]
+
+
+def check(body: str, root: Path) -> tuple[str, list[str]]:
+    """Freshness of the cache against its source. Returns (state, detail lines)."""
+    block, fault = find_block(body)
+    detail: list[str] = []
+    if fault:
+        return "block-damaged", [fault]
+    if block is None:
+        return "absent", ["this issue carries no generated context block"]
+
+    detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        detail.append(
+            "the block's own text has been edited since it was generated; a refresh "
+            "would overwrite that edit and is refused"
+        )
+        return "block-edited", detail
+
+    source_name = block.meta.get("source", "-")
+    if source_name in ("-", ""):
+        return "source-unresolved", detail + [
+            "no source was resolved when this block was written; its notes say why"
+        ]
+    source = root / source_name
+    if not source.is_file():
+        return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    source_text = source.read_text(encoding="utf-8")
+    source_now = digest(source_text)
+    source_then = block.meta.get("source-digest", "")
+    for recorded, ref in recorded_revisions(body, block):
+        detail.append(
+            f"recorded revision: source-digest={recorded} ref={ref or '-'} "
+            "(a record found in the issue body; this helper does not judge whether it "
+            "was authorised - resolve it under the existing authority model)"
+        )
+        if recorded == source_now:
+            detail.append("that record names the CURRENT source version")
+
+    if source_now == source_then:
+        return "current", detail + ["source bytes are unchanged since generation"]
+
+    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
+    task_id = block.meta.get("task", "")
+    scope_now = ""
+    if task_id and stories:
+        tasks_path = source.parent / "tasks.md"
+        if tasks_path.is_file():
+            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if scope_now and scope_now != block.meta.get("scope-digest", ""):
+        return "changed-in-scope", detail + [
+            "bytes changed inside the sections this task maps to. That is a byte "
+            "difference, not a ruling that acceptance changed - assess it against the "
+            "source before continuing."
+        ]
+    return "changed-outside-scope", detail + [
+        "the source file changed, but not inside the sections this task maps to. The "
+        "change may still matter (cross-cutting requirements carry no story mapping), "
+        "so read it; nothing here claims it is relevant to this task."
+    ]
+
+
+def refresh(body: str, block_text: str) -> tuple[str | None, str]:
+    """Replace ONLY the managed block. Any doubt leaves the body byte-identical."""
+    block, fault = find_block(body)
+    if fault:
+        return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
+    if block is None:
+        return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        return None, (
+            "refused: the block's text was edited after it was generated. The body is "
+            "unchanged. Move the edit outside the block, or delete the block to have it "
+            "regenerated, if you want the cache refreshed."
+        )
+    updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
+    if updated == body:
+        return updated, "unchanged: the regenerated block is identical"
+    return updated, "refreshed: the block was replaced; text outside it is untouched"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_render = sub.add_parser("render", help="print the managed block for one task")
+    p_render.add_argument("--tasks", type=Path, required=True)
+    p_render.add_argument("--task", required=True)
+    p_render.add_argument("--feature", default="")
+
+    p_check = sub.add_parser("check", help="report cache freshness for an issue body")
+    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--root", type=Path, default=Path("."))
+
+    p_refresh = sub.add_parser("refresh", help="replace only the managed block")
+    p_refresh.add_argument("--body-file", type=Path, required=True)
+    p_refresh.add_argument("--tasks", type=Path, required=True)
+    p_refresh.add_argument("--task", required=True)
+    p_refresh.add_argument("--feature", default="")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        resolution = resolve(args.tasks, args.task)
+        sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
+        return 0
+
+    if args.command == "check":
+        body = args.body_file.read_text(encoding="utf-8")
+        state, detail = check(body, args.root)
+        for line in detail:
+            print(f"  {line}")
+        print(f"SPECKIT_CONTEXT_STATE: {state}")
+        return 0 if state in ("current", "absent") else 3
+
+    body = args.body_file.read_text(encoding="utf-8")
+    resolution = resolve(args.tasks, args.task)
+    block_text = render(resolution, args.feature or str(args.tasks))
+    updated, message = refresh(body, block_text)
+    print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)
+    if updated is None:
+        return 4
+    sys.stdout.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/evaluate-issue/scripts/speckit-context.py
+++ b/codex/skills/evaluate-issue/scripts/speckit-context.py
@@ -61,6 +61,11 @@ STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
 ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
 BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+# `---` under an acceptance list is a horizontal rule, and `- -` is how a naive
+# bullet regex reads it: the real shipped template produced a phantom acceptance
+# item of "--". Rules end a list, they are never items in it.
+HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
+FENCE_RE = re.compile(r"^(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -75,6 +80,9 @@ CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
 # of copying, and says that it did (an incomplete extract is never silence).
 MAX_ITEMS = 12
 MAX_ITEM_CHARS = 300
+MAX_PROSE_CHARS = 600
+MAX_BLOCK_CHARS = 8000
+REQUIRED_META = ("feature", "task", "tasks", "source", "integrity")
 
 
 def digest(text: str) -> str:
@@ -97,6 +105,9 @@ class Resolution:
     truncated: list[str] = field(default_factory=list)
     scope_text: str = ""
     source_text: str = ""
+    task_text: str = ""
+    tasks_rel: str | None = None
+    source_rel: str | None = None
 
 
 def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
@@ -115,15 +126,19 @@ def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
     return spans
 
 
-def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+def _story_spans(lines: list[str], story_id: str) -> list[tuple[int, int]]:
+    """Every span declaring this story. More than one is ambiguity, not a choice."""
+    spans: list[tuple[int, int]] = []
     for index, line in enumerate(lines):
         match = STORY_HEADING_RE.match(line)
         if match and match.group(1).upper() == story_id.upper():
-            for end in range(index + 1, len(lines)):
-                if ANY_HEADING_RE.match(lines[end]):
-                    return (index, end)
-            return (index, len(lines))
-    return None
+            end = len(lines)
+            for candidate in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[candidate]):
+                    end = candidate
+                    break
+            spans.append((index, end))
+    return spans
 
 
 def _story_outcome(block: list[str]) -> str:
@@ -141,6 +156,19 @@ def _story_outcome(block: list[str]) -> str:
     return " ".join(parts).strip()
 
 
+def _strip_fences(lines: list[str]) -> list[str]:
+    """Blank out fenced blocks: a sample inside a fence is an example, not a declaration."""
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside = not inside
+            out.append("")
+            continue
+        out.append("" if inside else line)
+    return out
+
+
 def _story_acceptance(block: list[str]) -> list[str]:
     items: list[str] = []
     collecting = False
@@ -149,6 +177,8 @@ def _story_acceptance(block: list[str]) -> list[str]:
             collecting = True
             continue
         if collecting:
+            if HRULE_RE.match(line):
+                break
             if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
                 break
             bullet = BULLET_RE.match(line)
@@ -200,8 +230,36 @@ def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str,
     return rows
 
 
-def resolve(tasks_path: Path, task_id: str) -> Resolution:
+def project_root(start: Path, explicit: Path | None = None) -> Path:
+    """The root every persisted path is relative to.
+
+    Persisting the path as GIVEN was a defect: an absolute source recorded by the
+    producer's checkout kept resolving back to that checkout, so a consumer in a
+    different clone checked the wrong tree and was told `current` while its own
+    spec had changed. Paths are stored relative to this root and re-resolved
+    against the consumer's `--root`.
+    """
+    if explicit is not None:
+        return explicit.resolve()
+    here = start.resolve()
+    here = here if here.is_dir() else here.parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return here
+
+
+def relative_to_root(path: Path, root: Path) -> str | None:
+    """Project-relative spelling, or None when the path escapes the root."""
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolution:
     """Resolve one task's declared context, disclosing whatever does not resolve."""
+    base = project_root(tasks_path, root)
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
@@ -218,6 +276,16 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    resolution.tasks_rel = relative_to_root(tasks_path, base)
+    if resolution.tasks_rel is None:
+        resolution.unresolved.append(
+            f"{tasks_path} lies outside the project root {base}; its location cannot be "
+            "recorded portably, so a consumer in another checkout cannot re-resolve it"
+        )
+    # The task line is a governing input in its own right: its wording can carry a
+    # constraint, and its [USn] tag decides which requirements apply. A digest over
+    # the spec alone left a re-tagged or re-worded task reading as unchanged.
+    resolution.task_text = f"{task_id.upper()}|{','.join(sorted(set(story_ids)))}|{wording}"
     if not found:
         resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
         return resolution
@@ -229,8 +297,9 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         )
         return resolution
     resolution.source = source
+    resolution.source_rel = relative_to_root(source, base)
     resolution.source_text = source.read_text(encoding="utf-8")
-    lines = resolution.source_text.splitlines()
+    lines = _strip_fences(resolution.source_text.splitlines())
 
     if not story_ids:
         resolution.unresolved.append(
@@ -240,13 +309,20 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
 
     scope_parts: list[str] = []
     for story_id in dict.fromkeys(story_ids):
-        span = _story_span(lines, story_id)
-        if span is None:
+        spans = _story_spans(lines, story_id)
+        if not spans:
             resolution.unresolved.append(
                 f"{story_id} is tagged on the task but has no '### {story_id}:' "
                 f"section in {source.name}"
             )
             continue
+        if len(spans) > 1:
+            resolution.unresolved.append(
+                f"{story_id} is declared {len(spans)} times in {source.name}; the "
+                "ambiguity is reported rather than resolved here - read the source"
+            )
+            continue
+        span = spans[0]
         block = lines[span[0] : span[1]]
         scope_parts.append("\n".join(block))
         heading = STORY_HEADING_RE.match(block[0])
@@ -282,6 +358,24 @@ def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list
     return capped
 
 
+def _clip(text: str, limit: int, label: str, truncated: list[str]) -> str:
+    if len(text) <= limit:
+        return text
+    truncated.append(f"{label}: shortened to {limit} characters - read the source")
+    return text[:limit].rstrip() + " [...]"
+
+
+def _meta_digest(meta: dict[str, str], content: str) -> str:
+    """Integrity over the MANAGED METADATA and the content, minus the field itself.
+
+    Covering only the visible text left `task:`, `source:` and the other digests
+    editable in place: the block could be re-pointed at another task's source and
+    a refresh would accept it as its own.
+    """
+    payload = "\n".join(f"{k}={meta[k]}" for k in sorted(meta) if k != "integrity")
+    return digest(payload + "\n--\n" + content)
+
+
 def render(resolution: Resolution, feature: str) -> str:
     """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
     truncated: list[str] = list(resolution.truncated)
@@ -291,7 +385,7 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
             "below there before planning. This block is a task-scoped extract kept for "
             "convenience; where the two differ, the source governs."
         )
@@ -302,7 +396,10 @@ def render(resolution: Resolution, feature: str) -> str:
     body.append("")
 
     for story_id, outcome in resolution.outcomes:
-        body.append(f"**Outcome ({story_id}):** {outcome}")
+        body.append(
+            f"**Outcome ({story_id}):** "
+            + _clip(outcome, MAX_PROSE_CHARS, f"outcome {story_id}", truncated)
+        )
     if resolution.outcomes:
         body.append("")
 
@@ -325,7 +422,8 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     if resolution.task_wording:
-        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        wording = _clip(resolution.task_wording, MAX_PROSE_CHARS, "task wording", truncated)
+        body.append(f'**Task wording (from tasks.md):** "{wording}"')
         body.append(
             "  Resolve its authority against the sections above before acting on it. It "
             "may propose an approach you are free to replace, or it may restate a binding "
@@ -352,17 +450,26 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     content = "\n".join(body).rstrip() + "\n"
-    header = [
-        BLOCK_BEGIN,
-        f"feature: {feature}",
-        f"task: {resolution.task_id}",
-        f"source: {resolution.source if resolution.source else '-'}",
-        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
-        f"scope-digest: {digest(resolution.scope_text)}",
-        f"source-digest: {digest(resolution.source_text)}",
-        f"block-digest: {digest(content)}",
-        "-->",
-    ]
+    if len(content) > MAX_BLOCK_CHARS:
+        keep = content[:MAX_BLOCK_CHARS].rstrip()
+        content = (
+            keep
+            + "\n\n**Capped for size - this extract is INCOMPLETE.** Read the "
+            "authoritative source named above before planning; the constraints that "
+            "make the decision are not guaranteed to be among the lines kept here.\n"
+        )
+    meta = {
+        "feature": feature,
+        "task": resolution.task_id,
+        "tasks": resolution.tasks_rel or "-",
+        "source": resolution.source_rel or "-",
+        "stories": ",".join(story for story, _ in resolution.outcomes) or "-",
+        "task-digest": digest(resolution.task_text),
+        "scope-digest": digest(resolution.scope_text),
+        "source-digest": digest(resolution.source_text),
+    }
+    meta["integrity"] = _meta_digest(meta, content)
+    header = [BLOCK_BEGIN] + [f"{k}: {meta[k]}" for k in meta] + ["-->"]
     return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
 
 
@@ -392,9 +499,16 @@ def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
         return None, "damaged context block: header is unterminated"
     meta: dict[str, str] = {}
     for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
-        if ":" in line:
-            key, _, value = line.partition(":")
-            meta[key.strip()] = value.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in meta:
+            return None, f"damaged context block: duplicate metadata field '{key}'"
+        meta[key] = value.strip()
+    missing = [name for name in REQUIRED_META if name not in meta]
+    if missing:
+        return None, "damaged context block: missing metadata " + ", ".join(missing)
     content = body[header_end + len("-->") : end].lstrip("\n")
     return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
 
@@ -420,10 +534,11 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         return "absent", ["this issue carries no generated context block"]
 
     detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         detail.append(
-            "the block's own text has been edited since it was generated; a refresh "
-            "would overwrite that edit and is refused"
+            "the block has been edited since it was generated - its text, or the "
+            "metadata naming its task and source. A refresh would overwrite that edit "
+            "and is refused"
         )
         return "block-edited", detail
 
@@ -435,6 +550,28 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
     source = root / source_name
     if not source.is_file():
         return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    # The task line is a governing input too: a re-tagged or re-worded task changes
+    # which requirements apply, without touching the spec at all.
+    tasks_name = block.meta.get("tasks", "-")
+    task_id = block.meta.get("task", "")
+    tasks_path = root / tasks_name if tasks_name not in ("-", "") else None
+    task_state: str | None = None
+    if tasks_path is None or not tasks_path.is_file():
+        detail.append(
+            f"the tasks file recorded for this block ({tasks_name}) is not present under "
+            "this root, so the task side of the mapping cannot be re-checked"
+        )
+        task_state = "tasks-missing"
+    else:
+        current = resolve(tasks_path, task_id, root)
+        if digest(current.task_text) != block.meta.get("task-digest", ""):
+            detail.append(
+                "the task line itself changed - its wording, or the [USn] tag that "
+                "decides which requirements apply. The mapping this block was built "
+                "from no longer matches the plan."
+            )
+            task_state = "changed-task"
 
     source_text = source.read_text(encoding="utf-8")
     source_now = digest(source_text)
@@ -448,16 +585,15 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
 
-    if source_now == source_then:
-        return "current", detail + ["source bytes are unchanged since generation"]
+    if task_state is not None:
+        return task_state, detail
 
-    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
-    task_id = block.meta.get("task", "")
+    if source_now == source_then:
+        return "current", detail + ["source and task bytes are unchanged since generation"]
+
     scope_now = ""
-    if task_id and stories:
-        tasks_path = source.parent / "tasks.md"
-        if tasks_path.is_file():
-            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if tasks_path is not None and tasks_path.is_file():
+        scope_now = digest(resolve(tasks_path, task_id, root).scope_text)
     if scope_now and scope_now != block.meta.get("scope-digest", ""):
         return "changed-in-scope", detail + [
             "bytes changed inside the sections this task maps to. That is a byte "
@@ -478,12 +614,23 @@ def refresh(body: str, block_text: str) -> tuple[str | None, str]:
         return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
     if block is None:
         return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         return None, (
             "refused: the block's text was edited after it was generated. The body is "
             "unchanged. Move the edit outside the block, or delete the block to have it "
             "regenerated, if you want the cache refreshed."
         )
+    incoming, fault = find_block(block_text)
+    if incoming is None:
+        return None, f"refused: the replacement block is unusable ({fault})"
+    for key in ("feature", "task"):
+        if block.meta.get(key) != incoming.meta.get(key):
+            return None, (
+                f"refused: identity mismatch - this block is {key}="
+                f"{block.meta.get(key)} and the replacement is {key}="
+                f"{incoming.meta.get(key)}. The body is unchanged; refreshing one "
+                "task's context with another's is never a refresh."
+            )
     updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
     if updated == body:
         return updated, "unchanged: the regenerated block is identical"
@@ -498,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--tasks", type=Path, required=True)
     p_render.add_argument("--task", required=True)
     p_render.add_argument("--feature", default="")
+    p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
     p_check.add_argument("--body-file", type=Path, required=True)
@@ -508,11 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     p_refresh.add_argument("--tasks", type=Path, required=True)
     p_refresh.add_argument("--task", required=True)
     p_refresh.add_argument("--feature", default="")
+    p_refresh.add_argument("--root", type=Path, default=None)
 
     args = parser.parse_args(argv)
 
     if args.command == "render":
-        resolution = resolve(args.tasks, args.task)
+        resolution = resolve(args.tasks, args.task, args.root)
         sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
         return 0
 
@@ -525,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if state in ("current", "absent") else 3
 
     body = args.body_file.read_text(encoding="utf-8")
-    resolution = resolve(args.tasks, args.task)
+    resolution = resolve(args.tasks, args.task, args.root)
     block_text = render(resolution, args.feature or str(args.tasks))
     updated, message = refresh(body, block_text)
     print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)

--- a/codex/skills/evaluate-issue/scripts/speckit-context.py
+++ b/codex/skills/evaluate-issue/scripts/speckit-context.py
@@ -65,7 +65,7 @@ BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
 # bullet regex reads it: the real shipped template produced a phantom acceptance
 # item of "--". Rules end a list, they are never items in it.
 HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
-FENCE_RE = re.compile(r"^(?:```|~~~)")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -263,19 +263,30 @@ def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolut
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
+    duplicates = 0
     found = False
-    for line in tasks_text.splitlines():
+    # A task line inside a fence is an EXAMPLE. Reading declarations out of fenced
+    # samples let a documentation snippet outrank the real task and supply the wrong
+    # story mapping, so tasks.md gets the same fence handling as the spec.
+    for line in _strip_fences(tasks_text.splitlines()):
         match = TASK_LINE_RE.match(line)
         if not match or match.group(1).upper() != task_id.upper():
+            continue
+        if found:
+            duplicates += 1
             continue
         found = True
         rest = match.group(2)
         for tag in STORY_TAG_RE.findall(rest):
             story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
         wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
-        break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if duplicates:
+        resolution.unresolved.append(
+            f"{task_id.upper()} is declared {duplicates + 1} times in {tasks_path.name}; "
+            "the first was used and the ambiguity is reported rather than resolved here"
+        )
     resolution.tasks_rel = relative_to_root(tasks_path, base)
     if resolution.tasks_rel is None:
         resolution.unresolved.append(
@@ -385,13 +396,15 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
-            "below there before planning. This block is a task-scoped extract kept for "
-            "convenience; where the two differ, the source governs."
+            f"**Reference source:** `{resolution.source_rel or resolution.source}` - read "
+            "the sections named below there before planning. This block is a task-scoped "
+            "extract taken at the version recorded above. A difference between the two is "
+            "a CHANGED VERSION to resolve under the existing authority model - it does not "
+            "by itself override a constraint or plan already accepted on this issue."
         )
     else:
         body.append(
-            "**Authoritative source:** none resolved. See the unresolved notes below."
+            "**Reference source:** none resolved. See the unresolved notes below."
         )
     body.append("")
 
@@ -584,6 +597,17 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         )
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
+        elif recorded == source_then:
+            detail.append(
+                "that record names the version THIS BLOCK CACHED, not the current source - "
+                "so the decision it records predates the change below and must be resolved, "
+                "not assumed to cover it"
+            )
+        else:
+            detail.append(
+                "that record names neither the current source nor the cached version; it "
+                "refers to some third version and cannot be matched automatically"
+            )
 
     if task_state is not None:
         return task_state, detail
@@ -648,7 +672,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
-    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--body-file", type=Path, required=True, help="'-' reads stdin")
     p_check.add_argument("--root", type=Path, default=Path("."))
 
     p_refresh = sub.add_parser("refresh", help="replace only the managed block")
@@ -666,7 +690,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        body = args.body_file.read_text(encoding="utf-8")
+        body = (
+            sys.stdin.read()
+            if str(args.body_file) == "-"
+            else args.body_file.read_text(encoding="utf-8")
+        )
         state, detail = check(body, args.root)
         for line in detail:
             print(f"  {line}")

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -165,6 +165,16 @@ normalize_source_path() {
     printf '%s' "$path"
 }
 
+# scripts/speckit-context.py renders the task-context cache (#858). It ships in the
+# same directory as this script, including inside a generated Codex skill bundle, so
+# it is resolved relative to THIS file rather than to the caller's cwd. Absent or
+# unusable, the converter keeps working and simply writes no context block.
+CONTEXT_HELPER=""
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+    CONTEXT_HELPER="$_self_dir/speckit-context.py"
+fi
+
 TASKS_NORM="$(normalize_source_path "$TASKS")"
 TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
 
@@ -467,6 +477,19 @@ for i in "${!TIDS[@]}"; do
     issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
     if [ -n "${DEPS[$i]}" ]; then
         issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
+    fi
+    # Task context (issue #857 -> #858). A generated issue used to carry its
+    # provenance, its marker and its dependencies, and nothing about the behaviour
+    # it was meant to produce - so the receiving agent had only the title, and no
+    # pointer to the document that governs the work. The helper renders a bounded,
+    # fingerprinted cache of the task's DECLARED context; the spec stays
+    # authoritative. Conditional by design: with no helper and no resolvable spec
+    # the issue body is the whole contract, exactly as before.
+    if [ -n "$CONTEXT_HELPER" ]; then
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
+        if [ -n "$context_block" ]; then
+            issue_body+=$'\n\n'"$context_block"
+        fi
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -26,6 +26,8 @@
 #                    or they are no longer recognised and get filed again. A new
 #                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
+#   --no-context     Do not render task-context blocks. The deliberate opt-out; a
+#                    helper that is missing or fails is an ERROR, not a silent skip.
 #   -h, --help       Show this help.
 #
 # Exit codes:
@@ -38,6 +40,7 @@
 #   5  one or more tasks have an ambiguous legacy identity awaiting resolution
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
+#   7  the task-context helper is missing or failed (use --no-context to opt out)
 set -euo pipefail
 
 DRY_RUN=0
@@ -45,6 +48,7 @@ TASKS=""
 REPO=""
 FEATURE=""
 LIMIT=1000
+NO_CONTEXT=0
 
 usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
@@ -55,6 +59,7 @@ while [ $# -gt 0 ]; do
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
         --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
         --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
+        --no-context) NO_CONTEXT=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -171,7 +176,19 @@ normalize_source_path() {
 # unusable, the converter keeps working and simply writes no context block.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+if [ "$NO_CONTEXT" -eq 0 ]; then
+    if ! command -v python3 > /dev/null 2>&1; then
+        echo "ERROR: python3 is required to render task context and was not found." >&2
+        echo "Install python3, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
+    if [ ! -f "$_self_dir/speckit-context.py" ]; then
+        echo "ERROR: speckit-context.py is missing from $_self_dir." >&2
+        echo "It ships beside this script, including inside a generated skill bundle; a" >&2
+        echo "packaging that separates them is broken, not a context-free installation." >&2
+        echo "Reinstall, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
     CONTEXT_HELPER="$_self_dir/speckit-context.py"
 fi
 
@@ -485,11 +502,20 @@ for i in "${!TIDS[@]}"; do
     # fingerprinted cache of the task's DECLARED context; the spec stays
     # authoritative. Conditional by design: with no helper and no resolvable spec
     # the issue body is the whole contract, exactly as before.
-    if [ -n "$CONTEXT_HELPER" ]; then
-        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
-        if [ -n "$context_block" ]; then
-            issue_body+=$'\n\n'"$context_block"
+    if [ "$NO_CONTEXT" -eq 0 ]; then
+        context_status=0
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
+        if [ "$context_status" -ne 0 ] || [ -z "$context_block" ]; then
+            # A broken helper is not a lightweight issue. Swallowing this produced a
+            # context-free issue that looked like a successful conversion, which is
+            # the failure this whole change exists to remove - so it stops here,
+            # before any further write. `--no-context` is the deliberate opt-out.
+            echo "ERROR: could not render the task context for ${tid} (helper exited ${context_status})." >&2
+            printf '  %s\n' "$context_block" >&2
+            echo "Fix the helper or pass --no-context to convert without context blocks." >&2
+            exit 7
         fi
+        issue_body+=$'\n\n'"$context_block"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -41,6 +41,7 @@
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
 #   7  the task-context helper is missing or failed (use --no-context to opt out)
+#   8  an existing issue's context could not be read or checked on a re-run
 set -euo pipefail
 
 DRY_RUN=0
@@ -173,7 +174,8 @@ normalize_source_path() {
 # scripts/speckit-context.py renders the task-context cache (#858). It ships in the
 # same directory as this script, including inside a generated Codex skill bundle, so
 # it is resolved relative to THIS file rather than to the caller's cwd. Absent or
-# unusable, the converter keeps working and simply writes no context block.
+# unusable, the run STOPS: a packaging fault that silently produced context-free
+# issues would look exactly like a successful conversion. `--no-context` opts out.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$NO_CONTEXT" -eq 0 ]; then
@@ -475,7 +477,7 @@ if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
 fi
 
 # --- Create pass -----------------------------------------------------------------
-created=0; skipped=0; adopted=0
+created=0; skipped=0; adopted=0; context_checks_failed=0
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
@@ -485,13 +487,29 @@ for i in "${!TIDS[@]}"; do
         # invisible until somebody happened to re-read it. Reporting only: this
         # never edits an issue, and a refresh is the explicit documented workflow.
         if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
-            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
-                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
-                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
-            case "$ctx_state" in
-                ""|current|absent) : ;;
-                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
-            esac
+            ctx_read_status=0
+            ctx_body="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || ctx_read_status=$?
+            if [ "$ctx_read_status" -ne 0 ]; then
+                echo "WARN: could not read issue #${FILED_NUM[$tid]} to check ${tid}'s context (gh exited ${ctx_read_status})." >&2
+                printf '  %s\n' "$ctx_body" >&2
+                context_checks_failed=$((context_checks_failed + 1))
+            else
+                ctx_check_status=0
+                ctx_report="$(printf '%s' "$ctx_body" | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>&1)" || ctx_check_status=$?
+                ctx_state="$(printf '%s' "$ctx_report" | sed -n 's/^SPECKIT_CONTEXT_STATE: //p')"
+                # `check` exits 3 for any state other than current/absent; anything
+                # else is a broken checker, not a verdict.
+                if { [ "$ctx_check_status" -ne 0 ] && [ "$ctx_check_status" -ne 3 ]; } || [ -z "$ctx_state" ]; then
+                    echo "WARN: the context check for ${tid} (issue #${FILED_NUM[$tid]}) failed (exit ${ctx_check_status})." >&2
+                    printf '  %s\n' "$ctx_report" >&2
+                    context_checks_failed=$((context_checks_failed + 1))
+                else
+                    case "$ctx_state" in
+                        current|absent) : ;;
+                        *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+                    esac
+                fi
+            fi
         fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
@@ -513,8 +531,9 @@ for i in "${!TIDS[@]}"; do
     # it was meant to produce - so the receiving agent had only the title, and no
     # pointer to the document that governs the work. The helper renders a bounded,
     # fingerprinted cache of the task's DECLARED context; the spec stays
-    # authoritative. Conditional by design: with no helper and no resolvable spec
-    # the issue body is the whole contract, exactly as before.
+    # authoritative. Conditional on the INPUT, not on the installation: a tasks file
+    # with no resolvable spec still gets a block disclosing what did not resolve,
+    # while a missing or failing helper is an error rather than a quiet omission.
     if [ "$NO_CONTEXT" -eq 0 ]; then
         context_status=0
         context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
@@ -611,6 +630,12 @@ done
 echo "---"
 echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
 [ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$context_checks_failed" -gt 0 ]; then
+    echo "ERROR: ${context_checks_failed} context check(s) could not be completed; their" >&2
+    echo "diagnostics are above. An unreadable issue or a broken checker is not the same" >&2
+    echo "as an issue with no context block, and is not reported as one." >&2
+    exit 8
+fi
 if [ "$edges_failed" -gt 0 ]; then
     echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
     echo "command to reconcile the missing edges - it will not create duplicates." >&2

--- a/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh
@@ -480,6 +480,19 @@ for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
     if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        # Drift visibility on a re-run (#858). An already-filed task used to skip
+        # straight past its context, so a spec that moved under a filed issue was
+        # invisible until somebody happened to re-read it. Reporting only: this
+        # never edits an issue, and a refresh is the explicit documented workflow.
+        if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
+            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
+                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
+                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
+            case "$ctx_state" in
+                ""|current|absent) : ;;
+                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+            esac
+        fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
                  "add '$(marker_for "$tid")' to its body to make the identity explicit)"

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -343,8 +343,10 @@ Working from the worktree, analyze the issue and codebase to form an implementat
    The block's **Task wording** line is the task's own sentence, not a ruling: resolve
    whether it proposes an approach you may replace or restates a binding constraint
    against the sections the block names. An **Unresolved** or **Capped** note means the
-   context is incomplete and must be resolved before planning - never that the task has
-   no constraints.
+   context is incomplete - never that the task has no constraints. Apply the same
+   material-ambiguity standard as everywhere else: resolve what would change the work,
+   surface the rest in the Step 3 report, and plan from what you have. Missing optional
+   structure is not a gate.
 
 2. **Explore the codebase:**
    - Read files referenced in the issue

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -289,6 +289,37 @@ Working from the worktree, analyze the issue and codebase to form an implementat
    - Identify referenced files, components, or areas
    - Note any dependencies or constraints mentioned
 
+   **If the body carries a `speckit-context` block** (issue #858), it is a generated
+   issue and the block is a bounded CACHE of the task's declared context - not the
+   authority. Before forming a plan:
+
+   ```bash
+   scripts/speckit-context.py check --body-file <(gh issue view "$ISSUE_NUM" --json body --jq .body)
+   ```
+
+   Act on `SPECKIT_CONTEXT_STATE`:
+   - `current` - the cache matches its source; read the **Authoritative source** named
+     in the block, including the cross-cutting sections it lists, then plan.
+   - `changed-in-scope` / `changed-outside-scope` - bytes changed in the source since
+     the issue was written. That is a byte difference, NOT a ruling that acceptance
+     changed. Read the source, decide whether it matters under the existing authority
+     model, and say so in the Step 3 report. It is not a new approval gate, and it is
+     not permission to overwrite an accepted decision.
+   - `block-edited` / `block-damaged` - someone edited inside the block or its
+     boundaries are broken. Treat the block as unreliable, read the source directly,
+     and do not refresh it as a side effect of this run.
+   - `source-missing` / `source-unresolved` - plan from the issue body and say plainly
+     that the governing source could not be read.
+   - `absent` - an ordinary issue. Its body IS the contract (see
+     [the issue contract](../../../docs/agents/issue-contract.md)); no spec, story tag
+     or digest is required and none is owed.
+
+   The block's **Task wording** line is the task's own sentence, not a ruling: resolve
+   whether it proposes an approach you may replace or restates a binding constraint
+   against the sections the block names. An **Unresolved** or **Capped** note means the
+   context is incomplete and must be resolved before planning - never that the task has
+   no constraints.
+
 2. **Explore the codebase:**
    - Read files referenced in the issue
    - Understand existing patterns and conventions

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -293,9 +293,21 @@ Working from the worktree, analyze the issue and codebase to form an implementat
    issue and the block is a bounded CACHE of the task's declared context - not the
    authority. Before forming a plan:
 
+   Fetch the body to a FILE first and check that the fetch succeeded. A process
+   substitution hides a failed `gh` behind an empty body, and an empty body reads
+   as `absent` - a successful-looking "this issue has no context block" produced by
+   a network error. Resolve the helper from CPP's own tooling, not from a
+   `scripts/` directory in the target project, which may not have one:
+
    ```bash
-   scripts/speckit-context.py check --body-file <(gh issue view "$ISSUE_NUM" --json body --jq .body)
+   gh issue view "$ISSUE_NUM" --json body --jq .body > /tmp/issue-body.md
+   ~/.claude/scripts/speckit-context.py check --body-file /tmp/issue-body.md --root .
    ```
+
+   (Exit 127 - helper not installed at the stable path: fall back to
+   `${CLAUDE_PLUGIN_ROOT}/scripts/speckit-context.py`, else the CPP-checkout copy;
+   tell the user to run **`/flow-repair`**. If the `gh` fetch fails, STOP and report
+   it - do not run the check against an empty file.)
 
    Act on `SPECKIT_CONTEXT_STATE`:
    - `current` - the cache matches its source; read the **Authoritative source** named

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -291,37 +291,51 @@ Working from the worktree, analyze the issue and codebase to form an implementat
 
    **If the body carries a `speckit-context` block** (issue #858), it is a generated
    issue and the block is a bounded CACHE of the task's declared context - not the
-   authority. Before forming a plan:
-
-   Fetch the body to a FILE first and check that the fetch succeeded. A process
-   substitution hides a failed `gh` behind an empty body, and an empty body reads
-   as `absent` - a successful-looking "this issue has no context block" produced by
-   a network error. Resolve the helper from CPP's own tooling, not from a
-   `scripts/` directory in the target project, which may not have one:
+   authority. Fetch the body to a UNIQUE file, check that the fetch succeeded, and
+   only then run the checker: a failed `gh` leaves an empty body, and an empty body
+   reports `absent`, which reads exactly like a healthy issue that simply has no
+   block. A fixed `/tmp` name also collides between concurrent wave workers.
 
    ```bash
-   gh issue view "$ISSUE_NUM" --json body --jq .body > /tmp/issue-body.md
-   ~/.claude/scripts/speckit-context.py check --body-file /tmp/issue-body.md --root .
+   BODY_FILE="$(mktemp -t flow-auto-body-XXXXXX.md)"
+   if ! gh issue view "$ISSUE_NUM" --json body --jq .body > "$BODY_FILE"; then
+       echo "STOP: could not fetch issue #$ISSUE_NUM; not checking context against an empty body."
+       exit 1
+   fi
+   ~/.claude/scripts/speckit-context.py check --body-file "$BODY_FILE" --root .
    ```
 
-   (Exit 127 - helper not installed at the stable path: fall back to
-   `${CLAUDE_PLUGIN_ROOT}/scripts/speckit-context.py`, else the CPP-checkout copy;
-   tell the user to run **`/flow-repair`**. If the `gh` fetch fails, STOP and report
-   it - do not run the check against an empty file.)
+   Helper resolution: `~/.claude/scripts/speckit-context.py` is the stable path
+   (`/flow-repair` installs it). On exit 127 fall back to
+   `${CLAUDE_PLUGIN_ROOT}/scripts/speckit-context.py`, else the CPP-checkout copy.
+   Running inside a generated Codex skill, use the copy bundled in that skill's own
+   `scripts/` directory - never a `scripts/` directory in the target project, which
+   has no reason to contain CPP tooling.
 
    Act on `SPECKIT_CONTEXT_STATE`:
-   - `current` - the cache matches its source; read the **Authoritative source** named
-     in the block, including the cross-cutting sections it lists, then plan.
-   - `changed-in-scope` / `changed-outside-scope` - bytes changed in the source since
-     the issue was written. That is a byte difference, NOT a ruling that acceptance
+   - `current` - the cache matches its source. Read the **Reference source** named in
+     the block, including the cross-cutting sections it lists, then plan.
+   - `changed-in-scope` / `changed-outside-scope` - source bytes changed since the
+     issue was written. That is a byte difference, NOT a ruling that acceptance
      changed. Read the source, decide whether it matters under the existing authority
-     model, and say so in the Step 3 report. It is not a new approval gate, and it is
-     not permission to overwrite an accepted decision.
-   - `block-edited` / `block-damaged` - someone edited inside the block or its
+     model, and say so in the Step 3 report. Newer bytes do not by themselves override
+     a constraint or plan already accepted on the issue; a recorded
+     `Acceptance-revision:` line is reported with the version it names, and whether it
+     predates the change is part of what you must resolve.
+   - `changed-task` - the task line itself changed: its wording, or the `[USn]` tag
+     that decides which requirements apply. The cached mapping no longer matches the
+     plan, so re-read the task line and its story before planning, and treat the
+     block's requirement list as provisional.
+   - `tasks-missing` - the tasks file the block was built from is not present under
+     this root. Plan from the issue body and the source if one resolves, and report
+     that the task-side mapping could not be re-checked.
+   - `block-edited` / `block-damaged` - someone edited inside the block, or its
      boundaries are broken. Treat the block as unreliable, read the source directly,
      and do not refresh it as a side effect of this run.
-   - `source-missing` / `source-unresolved` - plan from the issue body and say plainly
-     that the governing source could not be read.
+   - `source-missing` / `source-unresolved` - no governing source could be read. Plan
+     from the issue body, which is the contract in that case, and surface any
+     ambiguity that is material to the work rather than trying to resolve everything
+     first.
    - `absent` - an ordinary issue. Its body IS the contract (see
      [the issue contract](../../../docs/agents/issue-contract.md)); no spec, story tag
      or digest is required and none is owed.

--- a/codex/skills/flow-auto/scripts/speckit-context.py
+++ b/codex/skills/flow-auto/scripts/speckit-context.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Resolve, render and refresh the task-context cache in a generated issue (#858).
+
+A generated issue used to carry its provenance, its identity marker and its
+dependencies - and nothing about the behaviour it was meant to produce. The task
+title was the whole description, so a receiving agent could not tell which words
+were the goal and which were somebody's suggested mechanism, and had nothing
+pointing at the document that actually governs the work.
+
+This helper resolves a task's DECLARED context and renders it into a bounded,
+fingerprinted block. The block is a CACHE, not a second authority: the spec named
+inside it stays authoritative, everything in it is traceable to a source section,
+and every part carries a digest so drift is visible instead of silent.
+
+What is declared, and therefore used:
+
+  * the story tag on the task line (`- [ ] **T001** [US1] ...`), which names a
+    `### US1:` section in the sibling spec.md
+  * the Functional Requirements table's `User Story` column, which maps
+    individual requirements to that story
+
+What is NOT inferred: nothing is derived from task NUMBERS, and requirements with
+no declared story mapping are never claimed as this task's. Non-Functional
+Requirements and Out of Scope carry no story mapping at all, so they are indexed
+as cross-cutting sections the consumer must read in the source - and they are
+covered by the whole-file digest, so a changed global security or compatibility
+constraint is visible even though it is not attributed to this task.
+
+What a digest establishes, and what it does not: a differing digest means those
+BYTES changed since the block was written. It is not a ruling that acceptance
+changed, that the change is material to this task, or that anything was approved.
+A reflow or a typo fix reads as a change. The states this helper reports are
+deliberately named for what they observe.
+
+Usage:
+    speckit-context.py render  --tasks PATH --task T001 [--feature SLUG]
+    speckit-context.py check   --body-file PATH [--root DIR]
+    speckit-context.py refresh --body-file PATH --tasks PATH --task T001 [--feature SLUG]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BLOCK_BEGIN = "<!-- speckit-context:v1"
+BLOCK_END = "<!-- speckit-context:end -->"
+DIGEST_LEN = 12
+
+# Declared task -> story mapping, written by .specify/templates/tasks-template.md.
+STORY_TAG_RE = re.compile(r"\[(US\d+(?:\s*,\s*US?\d+)*)\]", re.IGNORECASE)
+STORY_ID_RE = re.compile(r"US\d+", re.IGNORECASE)
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
+STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
+ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
+BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# A structured, reviewable record that a requirements revision was accepted. The
+# helper REPORTS it; it never decides that it is authorised, and a free-text
+# "acknowledged" somewhere in the body is not this.
+REVISION_RE = re.compile(
+    r"^\s*Acceptance-revision:\s*source-digest=([0-9a-f]{6,64})\s*(?:ref=(\S.*))?$",
+    re.MULTILINE,
+)
+
+CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
+# A cap keeps the cache bounded; beyond it the block points at the source instead
+# of copying, and says that it did (an incomplete extract is never silence).
+MAX_ITEMS = 12
+MAX_ITEM_CHARS = 300
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:DIGEST_LEN]
+
+
+@dataclass
+class Resolution:
+    """What the declared mappings produced for one task."""
+
+    task_id: str
+    task_wording: str
+    source: Path | None = None
+    story_ids: list[str] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+    acceptance: list[tuple[str, str]] = field(default_factory=list)
+    requirements: list[tuple[str, str]] = field(default_factory=list)
+    cross_cutting: list[str] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    truncated: list[str] = field(default_factory=list)
+    scope_text: str = ""
+    source_text: str = ""
+
+
+def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Heading text -> (start, end) line span, for top-level `##`/`###` headings."""
+    spans: dict[str, tuple[int, int]] = {}
+    current: str | None = None
+    start = 0
+    for index, line in enumerate(lines):
+        if ANY_HEADING_RE.match(line):
+            if current is not None:
+                spans[current] = (start, index)
+            current = line.lstrip("#").strip()
+            start = index
+    if current is not None:
+        spans[current] = (start, len(lines))
+    return spans
+
+
+def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = STORY_HEADING_RE.match(line)
+        if match and match.group(1).upper() == story_id.upper():
+            for end in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[end]):
+                    return (index, end)
+            return (index, len(lines))
+    return None
+
+
+def _story_outcome(block: list[str]) -> str:
+    """The story's own sentence: the heading text plus its As/I want/So that lines."""
+    parts: list[str] = []
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if parts:
+                break
+            continue
+        if stripped.startswith("**Acceptance") or ANY_HEADING_RE.match(line):
+            break
+        parts.append(stripped)
+    return " ".join(parts).strip()
+
+
+def _story_acceptance(block: list[str]) -> list[str]:
+    items: list[str] = []
+    collecting = False
+    for line in block:
+        if ACCEPTANCE_HEADING_RE.match(line.strip()):
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
+                break
+            bullet = BULLET_RE.match(line)
+            if bullet:
+                items.append(bullet.group(1))
+            elif line.strip() and items:
+                items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
+def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str, str]]:
+    """FR rows whose declared `User Story` column names one of these stories.
+
+    The mapping is read from the table the spec template ships; a row with no
+    story column, or one naming another story, is never attributed to this task.
+    """
+    wanted = {s.upper() for s in story_ids}
+    spans = _sections(lines)
+    span = spans.get("Functional Requirements")
+    if span is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    header: list[str] | None = None
+    for line in lines[span[0] : span[1]]:
+        match = TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in match.group(1).split("|")]
+        if header is None:
+            header = [c.lower() for c in cells]
+            continue
+        if all(set(c) <= {"-", ":"} for c in cells if c):
+            continue
+        if "user story" not in header:
+            continue
+        story_index = header.index("user story")
+        if story_index >= len(cells):
+            continue
+        declared = {s.upper() for s in STORY_ID_RE.findall(cells[story_index])}
+        if not declared & wanted:
+            continue
+        ident = cells[0] if cells else ""
+        text_index = header.index("requirement") if "requirement" in header else 1
+        text = cells[text_index] if text_index < len(cells) else ""
+        priority_index = header.index("priority") if "priority" in header else None
+        if priority_index is not None and priority_index < len(cells):
+            text = f"{text} ({cells[priority_index]})"
+        rows.append((ident, text))
+    return rows
+
+
+def resolve(tasks_path: Path, task_id: str) -> Resolution:
+    """Resolve one task's declared context, disclosing whatever does not resolve."""
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    wording = ""
+    story_ids: list[str] = []
+    found = False
+    for line in tasks_text.splitlines():
+        match = TASK_LINE_RE.match(line)
+        if not match or match.group(1).upper() != task_id.upper():
+            continue
+        found = True
+        rest = match.group(2)
+        for tag in STORY_TAG_RE.findall(rest):
+            story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
+        wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
+        break
+
+    resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if not found:
+        resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
+        return resolution
+
+    source = tasks_path.parent / "spec.md"
+    if not source.is_file():
+        resolution.unresolved.append(
+            f"no spec.md beside {tasks_path} - no declared source to resolve against"
+        )
+        return resolution
+    resolution.source = source
+    resolution.source_text = source.read_text(encoding="utf-8")
+    lines = resolution.source_text.splitlines()
+
+    if not story_ids:
+        resolution.unresolved.append(
+            f"{resolution.task_id} declares no [USn] story tag, so its governing "
+            "requirement is not resolvable from the task line"
+        )
+
+    scope_parts: list[str] = []
+    for story_id in dict.fromkeys(story_ids):
+        span = _story_span(lines, story_id)
+        if span is None:
+            resolution.unresolved.append(
+                f"{story_id} is tagged on the task but has no '### {story_id}:' "
+                f"section in {source.name}"
+            )
+            continue
+        block = lines[span[0] : span[1]]
+        scope_parts.append("\n".join(block))
+        heading = STORY_HEADING_RE.match(block[0])
+        title = heading.group(2) if heading else story_id
+        outcome = _story_outcome(block)
+        resolution.outcomes.append((story_id, f"{title}. {outcome}".strip()))
+        for item in _story_acceptance(block):
+            resolution.acceptance.append((story_id, item))
+
+    for ident, text in _requirements_for(lines, story_ids):
+        resolution.requirements.append((ident, text))
+        scope_parts.append(f"{ident}|{text}")
+
+    spans = _sections(lines)
+    for heading in CROSS_CUTTING_HEADINGS:
+        if heading in spans:
+            resolution.cross_cutting.append(heading)
+
+    resolution.scope_text = "\n".join(scope_parts)
+    return resolution
+
+
+def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list[tuple[str, str]]:
+    if len(items) > MAX_ITEMS:
+        truncated.append(f"{label}: showing {MAX_ITEMS} of {len(items)}")
+        items = items[:MAX_ITEMS]
+    capped: list[tuple[str, str]] = []
+    for ident, text in items:
+        if len(text) > MAX_ITEM_CHARS:
+            text = text[:MAX_ITEM_CHARS].rstrip() + " [...]"
+            truncated.append(f"{label} {ident}: shortened")
+        capped.append((ident, text))
+    return capped
+
+
+def render(resolution: Resolution, feature: str) -> str:
+    """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
+    truncated: list[str] = list(resolution.truncated)
+    acceptance = _cap(resolution.acceptance, "acceptance", truncated)
+    requirements = _cap(resolution.requirements, "requirements", truncated)
+
+    body: list[str] = ["### Governing context (generated cache)", ""]
+    if resolution.source is not None:
+        body.append(
+            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            "below there before planning. This block is a task-scoped extract kept for "
+            "convenience; where the two differ, the source governs."
+        )
+    else:
+        body.append(
+            "**Authoritative source:** none resolved. See the unresolved notes below."
+        )
+    body.append("")
+
+    for story_id, outcome in resolution.outcomes:
+        body.append(f"**Outcome ({story_id}):** {outcome}")
+    if resolution.outcomes:
+        body.append("")
+
+    if acceptance:
+        body.append("**Acceptance, as declared by the story:**")
+        body.extend(f"- ({story_id}) {item}" for story_id, item in acceptance)
+        body.append("")
+
+    if requirements:
+        body.append("**Requirements declared against this story:**")
+        body.extend(f"- {ident}: {text}" for ident, text in requirements)
+        body.append("")
+
+    if resolution.cross_cutting:
+        body.append(
+            "**Cross-cutting sections to read in the source before planning** - these "
+            "carry no story mapping, so they are named rather than attributed to this "
+            "task: " + ", ".join(f"`{h}`" for h in resolution.cross_cutting)
+        )
+        body.append("")
+
+    if resolution.task_wording:
+        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        body.append(
+            "  Resolve its authority against the sections above before acting on it. It "
+            "may propose an approach you are free to replace, or it may restate a binding "
+            "constraint; the line alone does not say which."
+        )
+        body.append("")
+
+    if resolution.outcomes:
+        body.append(
+            "**Granularity:** acceptance is declared at user-story level, so the items "
+            "above may also cover sibling tasks of the same story. Narrow them to this "
+            "task yourself; this block does not decide that for you."
+        )
+        body.append("")
+
+    if resolution.unresolved:
+        body.append("**Unresolved - incomplete context, not an absence of constraints:**")
+        body.extend(f"- {note}" for note in resolution.unresolved)
+        body.append("")
+
+    if truncated:
+        body.append("**Capped for size - read the source for the rest:**")
+        body.extend(f"- {note}" for note in truncated)
+        body.append("")
+
+    content = "\n".join(body).rstrip() + "\n"
+    header = [
+        BLOCK_BEGIN,
+        f"feature: {feature}",
+        f"task: {resolution.task_id}",
+        f"source: {resolution.source if resolution.source else '-'}",
+        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
+        f"scope-digest: {digest(resolution.scope_text)}",
+        f"source-digest: {digest(resolution.source_text)}",
+        f"block-digest: {digest(content)}",
+        "-->",
+    ]
+    return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
+
+
+@dataclass
+class ParsedBlock:
+    start: int
+    end: int
+    meta: dict[str, str]
+    content: str
+
+
+def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
+    """Locate the managed block. Returns (block, fault); a fault forbids rewriting."""
+    starts = [m.start() for m in re.finditer(re.escape(BLOCK_BEGIN), body)]
+    ends = [m.start() for m in re.finditer(re.escape(BLOCK_END), body)]
+    if not starts and not ends:
+        return None, None
+    if len(starts) > 1 or len(ends) > 1:
+        return None, "duplicate context block boundaries"
+    if not starts or not ends:
+        return None, "damaged context block: one boundary is missing"
+    start, end = starts[0], ends[0]
+    if end < start:
+        return None, "damaged context block: boundaries are out of order"
+    header_end = body.find("-->", start)
+    if header_end == -1 or header_end > end:
+        return None, "damaged context block: header is unterminated"
+    meta: dict[str, str] = {}
+    for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    content = body[header_end + len("-->") : end].lstrip("\n")
+    return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
+
+
+def recorded_revisions(body: str, block: ParsedBlock | None) -> list[tuple[str, str]]:
+    """Structured revision records OUTSIDE the managed block.
+
+    Reported, never judged: this helper cannot tell whether a record was written
+    by someone with the authority to accept a requirements change, and a
+    free-text "acknowledged" is deliberately not matched.
+    """
+    outside = body if block is None else body[: block.start] + body[block.end :]
+    return [(m.group(1), (m.group(2) or "").strip()) for m in REVISION_RE.finditer(outside)]
+
+
+def check(body: str, root: Path) -> tuple[str, list[str]]:
+    """Freshness of the cache against its source. Returns (state, detail lines)."""
+    block, fault = find_block(body)
+    detail: list[str] = []
+    if fault:
+        return "block-damaged", [fault]
+    if block is None:
+        return "absent", ["this issue carries no generated context block"]
+
+    detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        detail.append(
+            "the block's own text has been edited since it was generated; a refresh "
+            "would overwrite that edit and is refused"
+        )
+        return "block-edited", detail
+
+    source_name = block.meta.get("source", "-")
+    if source_name in ("-", ""):
+        return "source-unresolved", detail + [
+            "no source was resolved when this block was written; its notes say why"
+        ]
+    source = root / source_name
+    if not source.is_file():
+        return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    source_text = source.read_text(encoding="utf-8")
+    source_now = digest(source_text)
+    source_then = block.meta.get("source-digest", "")
+    for recorded, ref in recorded_revisions(body, block):
+        detail.append(
+            f"recorded revision: source-digest={recorded} ref={ref or '-'} "
+            "(a record found in the issue body; this helper does not judge whether it "
+            "was authorised - resolve it under the existing authority model)"
+        )
+        if recorded == source_now:
+            detail.append("that record names the CURRENT source version")
+
+    if source_now == source_then:
+        return "current", detail + ["source bytes are unchanged since generation"]
+
+    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
+    task_id = block.meta.get("task", "")
+    scope_now = ""
+    if task_id and stories:
+        tasks_path = source.parent / "tasks.md"
+        if tasks_path.is_file():
+            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if scope_now and scope_now != block.meta.get("scope-digest", ""):
+        return "changed-in-scope", detail + [
+            "bytes changed inside the sections this task maps to. That is a byte "
+            "difference, not a ruling that acceptance changed - assess it against the "
+            "source before continuing."
+        ]
+    return "changed-outside-scope", detail + [
+        "the source file changed, but not inside the sections this task maps to. The "
+        "change may still matter (cross-cutting requirements carry no story mapping), "
+        "so read it; nothing here claims it is relevant to this task."
+    ]
+
+
+def refresh(body: str, block_text: str) -> tuple[str | None, str]:
+    """Replace ONLY the managed block. Any doubt leaves the body byte-identical."""
+    block, fault = find_block(body)
+    if fault:
+        return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
+    if block is None:
+        return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        return None, (
+            "refused: the block's text was edited after it was generated. The body is "
+            "unchanged. Move the edit outside the block, or delete the block to have it "
+            "regenerated, if you want the cache refreshed."
+        )
+    updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
+    if updated == body:
+        return updated, "unchanged: the regenerated block is identical"
+    return updated, "refreshed: the block was replaced; text outside it is untouched"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_render = sub.add_parser("render", help="print the managed block for one task")
+    p_render.add_argument("--tasks", type=Path, required=True)
+    p_render.add_argument("--task", required=True)
+    p_render.add_argument("--feature", default="")
+
+    p_check = sub.add_parser("check", help="report cache freshness for an issue body")
+    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--root", type=Path, default=Path("."))
+
+    p_refresh = sub.add_parser("refresh", help="replace only the managed block")
+    p_refresh.add_argument("--body-file", type=Path, required=True)
+    p_refresh.add_argument("--tasks", type=Path, required=True)
+    p_refresh.add_argument("--task", required=True)
+    p_refresh.add_argument("--feature", default="")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        resolution = resolve(args.tasks, args.task)
+        sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
+        return 0
+
+    if args.command == "check":
+        body = args.body_file.read_text(encoding="utf-8")
+        state, detail = check(body, args.root)
+        for line in detail:
+            print(f"  {line}")
+        print(f"SPECKIT_CONTEXT_STATE: {state}")
+        return 0 if state in ("current", "absent") else 3
+
+    body = args.body_file.read_text(encoding="utf-8")
+    resolution = resolve(args.tasks, args.task)
+    block_text = render(resolution, args.feature or str(args.tasks))
+    updated, message = refresh(body, block_text)
+    print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)
+    if updated is None:
+        return 4
+    sys.stdout.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/flow-auto/scripts/speckit-context.py
+++ b/codex/skills/flow-auto/scripts/speckit-context.py
@@ -61,6 +61,11 @@ STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
 ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
 BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+# `---` under an acceptance list is a horizontal rule, and `- -` is how a naive
+# bullet regex reads it: the real shipped template produced a phantom acceptance
+# item of "--". Rules end a list, they are never items in it.
+HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
+FENCE_RE = re.compile(r"^(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -75,6 +80,9 @@ CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
 # of copying, and says that it did (an incomplete extract is never silence).
 MAX_ITEMS = 12
 MAX_ITEM_CHARS = 300
+MAX_PROSE_CHARS = 600
+MAX_BLOCK_CHARS = 8000
+REQUIRED_META = ("feature", "task", "tasks", "source", "integrity")
 
 
 def digest(text: str) -> str:
@@ -97,6 +105,9 @@ class Resolution:
     truncated: list[str] = field(default_factory=list)
     scope_text: str = ""
     source_text: str = ""
+    task_text: str = ""
+    tasks_rel: str | None = None
+    source_rel: str | None = None
 
 
 def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
@@ -115,15 +126,19 @@ def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
     return spans
 
 
-def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+def _story_spans(lines: list[str], story_id: str) -> list[tuple[int, int]]:
+    """Every span declaring this story. More than one is ambiguity, not a choice."""
+    spans: list[tuple[int, int]] = []
     for index, line in enumerate(lines):
         match = STORY_HEADING_RE.match(line)
         if match and match.group(1).upper() == story_id.upper():
-            for end in range(index + 1, len(lines)):
-                if ANY_HEADING_RE.match(lines[end]):
-                    return (index, end)
-            return (index, len(lines))
-    return None
+            end = len(lines)
+            for candidate in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[candidate]):
+                    end = candidate
+                    break
+            spans.append((index, end))
+    return spans
 
 
 def _story_outcome(block: list[str]) -> str:
@@ -141,6 +156,19 @@ def _story_outcome(block: list[str]) -> str:
     return " ".join(parts).strip()
 
 
+def _strip_fences(lines: list[str]) -> list[str]:
+    """Blank out fenced blocks: a sample inside a fence is an example, not a declaration."""
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside = not inside
+            out.append("")
+            continue
+        out.append("" if inside else line)
+    return out
+
+
 def _story_acceptance(block: list[str]) -> list[str]:
     items: list[str] = []
     collecting = False
@@ -149,6 +177,8 @@ def _story_acceptance(block: list[str]) -> list[str]:
             collecting = True
             continue
         if collecting:
+            if HRULE_RE.match(line):
+                break
             if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
                 break
             bullet = BULLET_RE.match(line)
@@ -200,8 +230,36 @@ def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str,
     return rows
 
 
-def resolve(tasks_path: Path, task_id: str) -> Resolution:
+def project_root(start: Path, explicit: Path | None = None) -> Path:
+    """The root every persisted path is relative to.
+
+    Persisting the path as GIVEN was a defect: an absolute source recorded by the
+    producer's checkout kept resolving back to that checkout, so a consumer in a
+    different clone checked the wrong tree and was told `current` while its own
+    spec had changed. Paths are stored relative to this root and re-resolved
+    against the consumer's `--root`.
+    """
+    if explicit is not None:
+        return explicit.resolve()
+    here = start.resolve()
+    here = here if here.is_dir() else here.parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return here
+
+
+def relative_to_root(path: Path, root: Path) -> str | None:
+    """Project-relative spelling, or None when the path escapes the root."""
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolution:
     """Resolve one task's declared context, disclosing whatever does not resolve."""
+    base = project_root(tasks_path, root)
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
@@ -218,6 +276,16 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    resolution.tasks_rel = relative_to_root(tasks_path, base)
+    if resolution.tasks_rel is None:
+        resolution.unresolved.append(
+            f"{tasks_path} lies outside the project root {base}; its location cannot be "
+            "recorded portably, so a consumer in another checkout cannot re-resolve it"
+        )
+    # The task line is a governing input in its own right: its wording can carry a
+    # constraint, and its [USn] tag decides which requirements apply. A digest over
+    # the spec alone left a re-tagged or re-worded task reading as unchanged.
+    resolution.task_text = f"{task_id.upper()}|{','.join(sorted(set(story_ids)))}|{wording}"
     if not found:
         resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
         return resolution
@@ -229,8 +297,9 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         )
         return resolution
     resolution.source = source
+    resolution.source_rel = relative_to_root(source, base)
     resolution.source_text = source.read_text(encoding="utf-8")
-    lines = resolution.source_text.splitlines()
+    lines = _strip_fences(resolution.source_text.splitlines())
 
     if not story_ids:
         resolution.unresolved.append(
@@ -240,13 +309,20 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
 
     scope_parts: list[str] = []
     for story_id in dict.fromkeys(story_ids):
-        span = _story_span(lines, story_id)
-        if span is None:
+        spans = _story_spans(lines, story_id)
+        if not spans:
             resolution.unresolved.append(
                 f"{story_id} is tagged on the task but has no '### {story_id}:' "
                 f"section in {source.name}"
             )
             continue
+        if len(spans) > 1:
+            resolution.unresolved.append(
+                f"{story_id} is declared {len(spans)} times in {source.name}; the "
+                "ambiguity is reported rather than resolved here - read the source"
+            )
+            continue
+        span = spans[0]
         block = lines[span[0] : span[1]]
         scope_parts.append("\n".join(block))
         heading = STORY_HEADING_RE.match(block[0])
@@ -282,6 +358,24 @@ def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list
     return capped
 
 
+def _clip(text: str, limit: int, label: str, truncated: list[str]) -> str:
+    if len(text) <= limit:
+        return text
+    truncated.append(f"{label}: shortened to {limit} characters - read the source")
+    return text[:limit].rstrip() + " [...]"
+
+
+def _meta_digest(meta: dict[str, str], content: str) -> str:
+    """Integrity over the MANAGED METADATA and the content, minus the field itself.
+
+    Covering only the visible text left `task:`, `source:` and the other digests
+    editable in place: the block could be re-pointed at another task's source and
+    a refresh would accept it as its own.
+    """
+    payload = "\n".join(f"{k}={meta[k]}" for k in sorted(meta) if k != "integrity")
+    return digest(payload + "\n--\n" + content)
+
+
 def render(resolution: Resolution, feature: str) -> str:
     """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
     truncated: list[str] = list(resolution.truncated)
@@ -291,7 +385,7 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
             "below there before planning. This block is a task-scoped extract kept for "
             "convenience; where the two differ, the source governs."
         )
@@ -302,7 +396,10 @@ def render(resolution: Resolution, feature: str) -> str:
     body.append("")
 
     for story_id, outcome in resolution.outcomes:
-        body.append(f"**Outcome ({story_id}):** {outcome}")
+        body.append(
+            f"**Outcome ({story_id}):** "
+            + _clip(outcome, MAX_PROSE_CHARS, f"outcome {story_id}", truncated)
+        )
     if resolution.outcomes:
         body.append("")
 
@@ -325,7 +422,8 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     if resolution.task_wording:
-        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        wording = _clip(resolution.task_wording, MAX_PROSE_CHARS, "task wording", truncated)
+        body.append(f'**Task wording (from tasks.md):** "{wording}"')
         body.append(
             "  Resolve its authority against the sections above before acting on it. It "
             "may propose an approach you are free to replace, or it may restate a binding "
@@ -352,17 +450,26 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     content = "\n".join(body).rstrip() + "\n"
-    header = [
-        BLOCK_BEGIN,
-        f"feature: {feature}",
-        f"task: {resolution.task_id}",
-        f"source: {resolution.source if resolution.source else '-'}",
-        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
-        f"scope-digest: {digest(resolution.scope_text)}",
-        f"source-digest: {digest(resolution.source_text)}",
-        f"block-digest: {digest(content)}",
-        "-->",
-    ]
+    if len(content) > MAX_BLOCK_CHARS:
+        keep = content[:MAX_BLOCK_CHARS].rstrip()
+        content = (
+            keep
+            + "\n\n**Capped for size - this extract is INCOMPLETE.** Read the "
+            "authoritative source named above before planning; the constraints that "
+            "make the decision are not guaranteed to be among the lines kept here.\n"
+        )
+    meta = {
+        "feature": feature,
+        "task": resolution.task_id,
+        "tasks": resolution.tasks_rel or "-",
+        "source": resolution.source_rel or "-",
+        "stories": ",".join(story for story, _ in resolution.outcomes) or "-",
+        "task-digest": digest(resolution.task_text),
+        "scope-digest": digest(resolution.scope_text),
+        "source-digest": digest(resolution.source_text),
+    }
+    meta["integrity"] = _meta_digest(meta, content)
+    header = [BLOCK_BEGIN] + [f"{k}: {meta[k]}" for k in meta] + ["-->"]
     return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
 
 
@@ -392,9 +499,16 @@ def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
         return None, "damaged context block: header is unterminated"
     meta: dict[str, str] = {}
     for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
-        if ":" in line:
-            key, _, value = line.partition(":")
-            meta[key.strip()] = value.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in meta:
+            return None, f"damaged context block: duplicate metadata field '{key}'"
+        meta[key] = value.strip()
+    missing = [name for name in REQUIRED_META if name not in meta]
+    if missing:
+        return None, "damaged context block: missing metadata " + ", ".join(missing)
     content = body[header_end + len("-->") : end].lstrip("\n")
     return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
 
@@ -420,10 +534,11 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         return "absent", ["this issue carries no generated context block"]
 
     detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         detail.append(
-            "the block's own text has been edited since it was generated; a refresh "
-            "would overwrite that edit and is refused"
+            "the block has been edited since it was generated - its text, or the "
+            "metadata naming its task and source. A refresh would overwrite that edit "
+            "and is refused"
         )
         return "block-edited", detail
 
@@ -435,6 +550,28 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
     source = root / source_name
     if not source.is_file():
         return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    # The task line is a governing input too: a re-tagged or re-worded task changes
+    # which requirements apply, without touching the spec at all.
+    tasks_name = block.meta.get("tasks", "-")
+    task_id = block.meta.get("task", "")
+    tasks_path = root / tasks_name if tasks_name not in ("-", "") else None
+    task_state: str | None = None
+    if tasks_path is None or not tasks_path.is_file():
+        detail.append(
+            f"the tasks file recorded for this block ({tasks_name}) is not present under "
+            "this root, so the task side of the mapping cannot be re-checked"
+        )
+        task_state = "tasks-missing"
+    else:
+        current = resolve(tasks_path, task_id, root)
+        if digest(current.task_text) != block.meta.get("task-digest", ""):
+            detail.append(
+                "the task line itself changed - its wording, or the [USn] tag that "
+                "decides which requirements apply. The mapping this block was built "
+                "from no longer matches the plan."
+            )
+            task_state = "changed-task"
 
     source_text = source.read_text(encoding="utf-8")
     source_now = digest(source_text)
@@ -448,16 +585,15 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
 
-    if source_now == source_then:
-        return "current", detail + ["source bytes are unchanged since generation"]
+    if task_state is not None:
+        return task_state, detail
 
-    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
-    task_id = block.meta.get("task", "")
+    if source_now == source_then:
+        return "current", detail + ["source and task bytes are unchanged since generation"]
+
     scope_now = ""
-    if task_id and stories:
-        tasks_path = source.parent / "tasks.md"
-        if tasks_path.is_file():
-            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if tasks_path is not None and tasks_path.is_file():
+        scope_now = digest(resolve(tasks_path, task_id, root).scope_text)
     if scope_now and scope_now != block.meta.get("scope-digest", ""):
         return "changed-in-scope", detail + [
             "bytes changed inside the sections this task maps to. That is a byte "
@@ -478,12 +614,23 @@ def refresh(body: str, block_text: str) -> tuple[str | None, str]:
         return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
     if block is None:
         return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         return None, (
             "refused: the block's text was edited after it was generated. The body is "
             "unchanged. Move the edit outside the block, or delete the block to have it "
             "regenerated, if you want the cache refreshed."
         )
+    incoming, fault = find_block(block_text)
+    if incoming is None:
+        return None, f"refused: the replacement block is unusable ({fault})"
+    for key in ("feature", "task"):
+        if block.meta.get(key) != incoming.meta.get(key):
+            return None, (
+                f"refused: identity mismatch - this block is {key}="
+                f"{block.meta.get(key)} and the replacement is {key}="
+                f"{incoming.meta.get(key)}. The body is unchanged; refreshing one "
+                "task's context with another's is never a refresh."
+            )
     updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
     if updated == body:
         return updated, "unchanged: the regenerated block is identical"
@@ -498,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--tasks", type=Path, required=True)
     p_render.add_argument("--task", required=True)
     p_render.add_argument("--feature", default="")
+    p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
     p_check.add_argument("--body-file", type=Path, required=True)
@@ -508,11 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     p_refresh.add_argument("--tasks", type=Path, required=True)
     p_refresh.add_argument("--task", required=True)
     p_refresh.add_argument("--feature", default="")
+    p_refresh.add_argument("--root", type=Path, default=None)
 
     args = parser.parse_args(argv)
 
     if args.command == "render":
-        resolution = resolve(args.tasks, args.task)
+        resolution = resolve(args.tasks, args.task, args.root)
         sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
         return 0
 
@@ -525,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if state in ("current", "absent") else 3
 
     body = args.body_file.read_text(encoding="utf-8")
-    resolution = resolve(args.tasks, args.task)
+    resolution = resolve(args.tasks, args.task, args.root)
     block_text = render(resolution, args.feature or str(args.tasks))
     updated, message = refresh(body, block_text)
     print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)

--- a/codex/skills/flow-auto/scripts/speckit-context.py
+++ b/codex/skills/flow-auto/scripts/speckit-context.py
@@ -65,7 +65,7 @@ BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
 # bullet regex reads it: the real shipped template produced a phantom acceptance
 # item of "--". Rules end a list, they are never items in it.
 HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
-FENCE_RE = re.compile(r"^(?:```|~~~)")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -263,19 +263,30 @@ def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolut
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
+    duplicates = 0
     found = False
-    for line in tasks_text.splitlines():
+    # A task line inside a fence is an EXAMPLE. Reading declarations out of fenced
+    # samples let a documentation snippet outrank the real task and supply the wrong
+    # story mapping, so tasks.md gets the same fence handling as the spec.
+    for line in _strip_fences(tasks_text.splitlines()):
         match = TASK_LINE_RE.match(line)
         if not match or match.group(1).upper() != task_id.upper():
+            continue
+        if found:
+            duplicates += 1
             continue
         found = True
         rest = match.group(2)
         for tag in STORY_TAG_RE.findall(rest):
             story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
         wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
-        break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if duplicates:
+        resolution.unresolved.append(
+            f"{task_id.upper()} is declared {duplicates + 1} times in {tasks_path.name}; "
+            "the first was used and the ambiguity is reported rather than resolved here"
+        )
     resolution.tasks_rel = relative_to_root(tasks_path, base)
     if resolution.tasks_rel is None:
         resolution.unresolved.append(
@@ -385,13 +396,15 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
-            "below there before planning. This block is a task-scoped extract kept for "
-            "convenience; where the two differ, the source governs."
+            f"**Reference source:** `{resolution.source_rel or resolution.source}` - read "
+            "the sections named below there before planning. This block is a task-scoped "
+            "extract taken at the version recorded above. A difference between the two is "
+            "a CHANGED VERSION to resolve under the existing authority model - it does not "
+            "by itself override a constraint or plan already accepted on this issue."
         )
     else:
         body.append(
-            "**Authoritative source:** none resolved. See the unresolved notes below."
+            "**Reference source:** none resolved. See the unresolved notes below."
         )
     body.append("")
 
@@ -584,6 +597,17 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         )
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
+        elif recorded == source_then:
+            detail.append(
+                "that record names the version THIS BLOCK CACHED, not the current source - "
+                "so the decision it records predates the change below and must be resolved, "
+                "not assumed to cover it"
+            )
+        else:
+            detail.append(
+                "that record names neither the current source nor the cached version; it "
+                "refers to some third version and cannot be matched automatically"
+            )
 
     if task_state is not None:
         return task_state, detail
@@ -648,7 +672,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
-    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--body-file", type=Path, required=True, help="'-' reads stdin")
     p_check.add_argument("--root", type=Path, default=Path("."))
 
     p_refresh = sub.add_parser("refresh", help="replace only the managed block")
@@ -666,7 +690,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        body = args.body_file.read_text(encoding="utf-8")
+        body = (
+            sys.stdin.read()
+            if str(args.body_file) == "-"
+            else args.body_file.read_text(encoding="utf-8")
+        )
         state, detail = check(body, args.root)
         for line in detail:
             print(f"  {line}")

--- a/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-doctor/scripts/flow-helpers-install.sh
@@ -62,6 +62,7 @@ HELPERS=(
     flow-wave-mailbox.sh
     flow-wave-lexicon.sh
     flow-wave-plan.py
+    speckit-context.py
     flow-driver-capability.sh
     flow-finish-gate.sh
     flow-ci-status.sh

--- a/codex/skills/flow-repair/scripts/flow-helpers-install.sh
+++ b/codex/skills/flow-repair/scripts/flow-helpers-install.sh
@@ -62,6 +62,7 @@ HELPERS=(
     flow-wave-mailbox.sh
     flow-wave-lexicon.sh
     flow-wave-plan.py
+    speckit-context.py
     flow-driver-capability.sh
     flow-finish-gate.sh
     flow-ci-status.sh

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -336,13 +336,26 @@ the escape when a prose line happens to open with a reserved word.
   issue untouched:
 
   ```bash
-  gh issue view "$N" --json body --jq .body > /tmp/body.md || exit 1   # never skip this check
-  ~/.claude/scripts/speckit-context.py refresh --body-file /tmp/body.md \
-      --tasks .specify/specs/<feature>/tasks.md --task T001 \
-      --feature .specify/specs/<feature>/tasks.md --root . > /tmp/new-body.md
-  # exit 0: write it back.   exit 4: REFUSED - read the message, change nothing.
-  gh issue edit "$N" --body-file /tmp/new-body.md
+  CUR="$(mktemp -t wave-body-XXXXXX.md)"; NEW="$(mktemp -t wave-new-XXXXXX.md)"
+  status=0
+  if ! gh issue view "$N" --json body --jq .body > "$CUR"; then
+      echo "STOP: could not fetch issue #$N; nothing was changed."
+      status=1
+  elif ~/.claude/scripts/speckit-context.py refresh --body-file "$CUR" \
+           --tasks .specify/specs/<feature>/tasks.md --task T001 \
+           --feature .specify/specs/<feature>/tasks.md --root . > "$NEW"; then
+      gh issue edit "$N" --body-file "$NEW" || status=$?
+  else
+      echo "REFUSED: $N was not changed. Read the reason above and resolve it by hand."
+      status=4
+  fi
+  rm -f "$CUR" "$NEW"
+  exit "$status"   # cleanup succeeds; it must not report a failed write as success
   ```
+
+  Every retry starts from a freshly fetched body in its own scratch files: reusing a
+  stale copy would write back a body that has moved on, and a shared path collides
+  between concurrent workers.
 
   It refuses when the block's text or metadata was edited after generation, when the
   boundaries are damaged or duplicated, and when the replacement names a different
@@ -361,7 +374,7 @@ the escape when a prose line happens to open with a reserved word.
 - **No spec:** take the `--issues` label/milestone/list as the set; edges are
   whatever `- Blocked by #N` lines the bodies already carry.
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 ## Phase 2: The orchestration loop

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -323,10 +323,13 @@ the escape when a prose line happens to open with a reserved word.
 
 ## Phase 1: Scaffold the issue set
 
-- **Spec-kit repo:** run `scripts/speckit-tasks-to-issues.sh` (dedup-safe) to
-  emit one issue per task, then add the dependency edges - that script emits no
-  `- Blocked by #N` lines itself. Derive edges from `tasks.md` ordering/notes
-  and write them with `gh issue edit`.
+- **Spec-kit repo:** run `scripts/speckit-tasks-to-issues.sh` (dedup-safe) to emit
+  one issue per task. It ALSO writes the dependency edges itself: a task's
+  `(depends on T00N)` clause becomes a `Depends on:` line plus `- Blocked by #N`
+  bullets, and every filed task is reconciled on each run, so a forward reference
+  or an edge whose write failed earlier is completed rather than lost (#607, #857).
+  It also attaches a `speckit-context` block carrying the task's declared context
+  (#858). Add edges by hand only for relationships `tasks.md` does not declare.
 - **Edge edits are ADDITIVE and IDEMPOTENT** (#637 gate condition): read the
   current body, append a `- Blocked by #N` line ONLY when no equivalent edge
   line is already present, and never rewrite or reflow the surrounding body
@@ -336,6 +339,9 @@ the escape when a prose line happens to open with a reserved word.
   body plus the appended line - no other diff.)
 - **No spec:** take the `--issues` label/milestone/list as the set; edges are
   whatever `- Blocked by #N` lines the bodies already carry.
+
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
 
 ## Phase 2: The orchestration loop
 

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -330,6 +330,27 @@ the escape when a prose line happens to open with a reserved word.
   or an edge whose write failed earlier is completed rather than lost (#607, #857).
   It also attaches a `speckit-context` block carrying the task's declared context
   (#858). Add edges by hand only for relationships `tasks.md` does not declare.
+- **Refreshing an EXISTING issue's context block** (#858), including attaching one
+  to an issue filed before the block existed. Fetch, refresh, and write back only
+  on success - the helper refuses rather than guessing, and a refusal must leave the
+  issue untouched:
+
+  ```bash
+  gh issue view "$N" --json body --jq .body > /tmp/body.md || exit 1   # never skip this check
+  ~/.claude/scripts/speckit-context.py refresh --body-file /tmp/body.md \
+      --tasks .specify/specs/<feature>/tasks.md --task T001 \
+      --feature .specify/specs/<feature>/tasks.md --root . > /tmp/new-body.md
+  # exit 0: write it back.   exit 4: REFUSED - read the message, change nothing.
+  gh issue edit "$N" --body-file /tmp/new-body.md
+  ```
+
+  It refuses when the block's text or metadata was edited after generation, when the
+  boundaries are damaged or duplicated, and when the replacement names a different
+  feature or task. An issue with NO block gains one additively with its existing body
+  preserved; that legitimate first attachment is not permission to repair a truncated
+  block by rewriting it. A refresh updates the cached extract - it is NOT a record
+  that a requirements change was acknowledged by anyone.
+
 - **Edge edits are ADDITIVE and IDEMPOTENT** (#637 gate condition): read the
   current body, append a `- Blocked by #N` line ONLY when no equivalent edge
   line is already present, and never rewrite or reflow the surrounding body

--- a/codex/skills/flow-wave/scripts/speckit-context.py
+++ b/codex/skills/flow-wave/scripts/speckit-context.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Resolve, render and refresh the task-context cache in a generated issue (#858).
+
+A generated issue used to carry its provenance, its identity marker and its
+dependencies - and nothing about the behaviour it was meant to produce. The task
+title was the whole description, so a receiving agent could not tell which words
+were the goal and which were somebody's suggested mechanism, and had nothing
+pointing at the document that actually governs the work.
+
+This helper resolves a task's DECLARED context and renders it into a bounded,
+fingerprinted block. The block is a CACHE, not a second authority: the spec named
+inside it stays authoritative, everything in it is traceable to a source section,
+and every part carries a digest so drift is visible instead of silent.
+
+What is declared, and therefore used:
+
+  * the story tag on the task line (`- [ ] **T001** [US1] ...`), which names a
+    `### US1:` section in the sibling spec.md
+  * the Functional Requirements table's `User Story` column, which maps
+    individual requirements to that story
+
+What is NOT inferred: nothing is derived from task NUMBERS, and requirements with
+no declared story mapping are never claimed as this task's. Non-Functional
+Requirements and Out of Scope carry no story mapping at all, so they are indexed
+as cross-cutting sections the consumer must read in the source - and they are
+covered by the whole-file digest, so a changed global security or compatibility
+constraint is visible even though it is not attributed to this task.
+
+What a digest establishes, and what it does not: a differing digest means those
+BYTES changed since the block was written. It is not a ruling that acceptance
+changed, that the change is material to this task, or that anything was approved.
+A reflow or a typo fix reads as a change. The states this helper reports are
+deliberately named for what they observe.
+
+Usage:
+    speckit-context.py render  --tasks PATH --task T001 [--feature SLUG]
+    speckit-context.py check   --body-file PATH [--root DIR]
+    speckit-context.py refresh --body-file PATH --tasks PATH --task T001 [--feature SLUG]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BLOCK_BEGIN = "<!-- speckit-context:v1"
+BLOCK_END = "<!-- speckit-context:end -->"
+DIGEST_LEN = 12
+
+# Declared task -> story mapping, written by .specify/templates/tasks-template.md.
+STORY_TAG_RE = re.compile(r"\[(US\d+(?:\s*,\s*US?\d+)*)\]", re.IGNORECASE)
+STORY_ID_RE = re.compile(r"US\d+", re.IGNORECASE)
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
+STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
+ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
+BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# A structured, reviewable record that a requirements revision was accepted. The
+# helper REPORTS it; it never decides that it is authorised, and a free-text
+# "acknowledged" somewhere in the body is not this.
+REVISION_RE = re.compile(
+    r"^\s*Acceptance-revision:\s*source-digest=([0-9a-f]{6,64})\s*(?:ref=(\S.*))?$",
+    re.MULTILINE,
+)
+
+CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
+# A cap keeps the cache bounded; beyond it the block points at the source instead
+# of copying, and says that it did (an incomplete extract is never silence).
+MAX_ITEMS = 12
+MAX_ITEM_CHARS = 300
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:DIGEST_LEN]
+
+
+@dataclass
+class Resolution:
+    """What the declared mappings produced for one task."""
+
+    task_id: str
+    task_wording: str
+    source: Path | None = None
+    story_ids: list[str] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+    acceptance: list[tuple[str, str]] = field(default_factory=list)
+    requirements: list[tuple[str, str]] = field(default_factory=list)
+    cross_cutting: list[str] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    truncated: list[str] = field(default_factory=list)
+    scope_text: str = ""
+    source_text: str = ""
+
+
+def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Heading text -> (start, end) line span, for top-level `##`/`###` headings."""
+    spans: dict[str, tuple[int, int]] = {}
+    current: str | None = None
+    start = 0
+    for index, line in enumerate(lines):
+        if ANY_HEADING_RE.match(line):
+            if current is not None:
+                spans[current] = (start, index)
+            current = line.lstrip("#").strip()
+            start = index
+    if current is not None:
+        spans[current] = (start, len(lines))
+    return spans
+
+
+def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = STORY_HEADING_RE.match(line)
+        if match and match.group(1).upper() == story_id.upper():
+            for end in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[end]):
+                    return (index, end)
+            return (index, len(lines))
+    return None
+
+
+def _story_outcome(block: list[str]) -> str:
+    """The story's own sentence: the heading text plus its As/I want/So that lines."""
+    parts: list[str] = []
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if parts:
+                break
+            continue
+        if stripped.startswith("**Acceptance") or ANY_HEADING_RE.match(line):
+            break
+        parts.append(stripped)
+    return " ".join(parts).strip()
+
+
+def _story_acceptance(block: list[str]) -> list[str]:
+    items: list[str] = []
+    collecting = False
+    for line in block:
+        if ACCEPTANCE_HEADING_RE.match(line.strip()):
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
+                break
+            bullet = BULLET_RE.match(line)
+            if bullet:
+                items.append(bullet.group(1))
+            elif line.strip() and items:
+                items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
+def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str, str]]:
+    """FR rows whose declared `User Story` column names one of these stories.
+
+    The mapping is read from the table the spec template ships; a row with no
+    story column, or one naming another story, is never attributed to this task.
+    """
+    wanted = {s.upper() for s in story_ids}
+    spans = _sections(lines)
+    span = spans.get("Functional Requirements")
+    if span is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    header: list[str] | None = None
+    for line in lines[span[0] : span[1]]:
+        match = TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in match.group(1).split("|")]
+        if header is None:
+            header = [c.lower() for c in cells]
+            continue
+        if all(set(c) <= {"-", ":"} for c in cells if c):
+            continue
+        if "user story" not in header:
+            continue
+        story_index = header.index("user story")
+        if story_index >= len(cells):
+            continue
+        declared = {s.upper() for s in STORY_ID_RE.findall(cells[story_index])}
+        if not declared & wanted:
+            continue
+        ident = cells[0] if cells else ""
+        text_index = header.index("requirement") if "requirement" in header else 1
+        text = cells[text_index] if text_index < len(cells) else ""
+        priority_index = header.index("priority") if "priority" in header else None
+        if priority_index is not None and priority_index < len(cells):
+            text = f"{text} ({cells[priority_index]})"
+        rows.append((ident, text))
+    return rows
+
+
+def resolve(tasks_path: Path, task_id: str) -> Resolution:
+    """Resolve one task's declared context, disclosing whatever does not resolve."""
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    wording = ""
+    story_ids: list[str] = []
+    found = False
+    for line in tasks_text.splitlines():
+        match = TASK_LINE_RE.match(line)
+        if not match or match.group(1).upper() != task_id.upper():
+            continue
+        found = True
+        rest = match.group(2)
+        for tag in STORY_TAG_RE.findall(rest):
+            story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
+        wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
+        break
+
+    resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if not found:
+        resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
+        return resolution
+
+    source = tasks_path.parent / "spec.md"
+    if not source.is_file():
+        resolution.unresolved.append(
+            f"no spec.md beside {tasks_path} - no declared source to resolve against"
+        )
+        return resolution
+    resolution.source = source
+    resolution.source_text = source.read_text(encoding="utf-8")
+    lines = resolution.source_text.splitlines()
+
+    if not story_ids:
+        resolution.unresolved.append(
+            f"{resolution.task_id} declares no [USn] story tag, so its governing "
+            "requirement is not resolvable from the task line"
+        )
+
+    scope_parts: list[str] = []
+    for story_id in dict.fromkeys(story_ids):
+        span = _story_span(lines, story_id)
+        if span is None:
+            resolution.unresolved.append(
+                f"{story_id} is tagged on the task but has no '### {story_id}:' "
+                f"section in {source.name}"
+            )
+            continue
+        block = lines[span[0] : span[1]]
+        scope_parts.append("\n".join(block))
+        heading = STORY_HEADING_RE.match(block[0])
+        title = heading.group(2) if heading else story_id
+        outcome = _story_outcome(block)
+        resolution.outcomes.append((story_id, f"{title}. {outcome}".strip()))
+        for item in _story_acceptance(block):
+            resolution.acceptance.append((story_id, item))
+
+    for ident, text in _requirements_for(lines, story_ids):
+        resolution.requirements.append((ident, text))
+        scope_parts.append(f"{ident}|{text}")
+
+    spans = _sections(lines)
+    for heading in CROSS_CUTTING_HEADINGS:
+        if heading in spans:
+            resolution.cross_cutting.append(heading)
+
+    resolution.scope_text = "\n".join(scope_parts)
+    return resolution
+
+
+def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list[tuple[str, str]]:
+    if len(items) > MAX_ITEMS:
+        truncated.append(f"{label}: showing {MAX_ITEMS} of {len(items)}")
+        items = items[:MAX_ITEMS]
+    capped: list[tuple[str, str]] = []
+    for ident, text in items:
+        if len(text) > MAX_ITEM_CHARS:
+            text = text[:MAX_ITEM_CHARS].rstrip() + " [...]"
+            truncated.append(f"{label} {ident}: shortened")
+        capped.append((ident, text))
+    return capped
+
+
+def render(resolution: Resolution, feature: str) -> str:
+    """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
+    truncated: list[str] = list(resolution.truncated)
+    acceptance = _cap(resolution.acceptance, "acceptance", truncated)
+    requirements = _cap(resolution.requirements, "requirements", truncated)
+
+    body: list[str] = ["### Governing context (generated cache)", ""]
+    if resolution.source is not None:
+        body.append(
+            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            "below there before planning. This block is a task-scoped extract kept for "
+            "convenience; where the two differ, the source governs."
+        )
+    else:
+        body.append(
+            "**Authoritative source:** none resolved. See the unresolved notes below."
+        )
+    body.append("")
+
+    for story_id, outcome in resolution.outcomes:
+        body.append(f"**Outcome ({story_id}):** {outcome}")
+    if resolution.outcomes:
+        body.append("")
+
+    if acceptance:
+        body.append("**Acceptance, as declared by the story:**")
+        body.extend(f"- ({story_id}) {item}" for story_id, item in acceptance)
+        body.append("")
+
+    if requirements:
+        body.append("**Requirements declared against this story:**")
+        body.extend(f"- {ident}: {text}" for ident, text in requirements)
+        body.append("")
+
+    if resolution.cross_cutting:
+        body.append(
+            "**Cross-cutting sections to read in the source before planning** - these "
+            "carry no story mapping, so they are named rather than attributed to this "
+            "task: " + ", ".join(f"`{h}`" for h in resolution.cross_cutting)
+        )
+        body.append("")
+
+    if resolution.task_wording:
+        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        body.append(
+            "  Resolve its authority against the sections above before acting on it. It "
+            "may propose an approach you are free to replace, or it may restate a binding "
+            "constraint; the line alone does not say which."
+        )
+        body.append("")
+
+    if resolution.outcomes:
+        body.append(
+            "**Granularity:** acceptance is declared at user-story level, so the items "
+            "above may also cover sibling tasks of the same story. Narrow them to this "
+            "task yourself; this block does not decide that for you."
+        )
+        body.append("")
+
+    if resolution.unresolved:
+        body.append("**Unresolved - incomplete context, not an absence of constraints:**")
+        body.extend(f"- {note}" for note in resolution.unresolved)
+        body.append("")
+
+    if truncated:
+        body.append("**Capped for size - read the source for the rest:**")
+        body.extend(f"- {note}" for note in truncated)
+        body.append("")
+
+    content = "\n".join(body).rstrip() + "\n"
+    header = [
+        BLOCK_BEGIN,
+        f"feature: {feature}",
+        f"task: {resolution.task_id}",
+        f"source: {resolution.source if resolution.source else '-'}",
+        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
+        f"scope-digest: {digest(resolution.scope_text)}",
+        f"source-digest: {digest(resolution.source_text)}",
+        f"block-digest: {digest(content)}",
+        "-->",
+    ]
+    return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
+
+
+@dataclass
+class ParsedBlock:
+    start: int
+    end: int
+    meta: dict[str, str]
+    content: str
+
+
+def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
+    """Locate the managed block. Returns (block, fault); a fault forbids rewriting."""
+    starts = [m.start() for m in re.finditer(re.escape(BLOCK_BEGIN), body)]
+    ends = [m.start() for m in re.finditer(re.escape(BLOCK_END), body)]
+    if not starts and not ends:
+        return None, None
+    if len(starts) > 1 or len(ends) > 1:
+        return None, "duplicate context block boundaries"
+    if not starts or not ends:
+        return None, "damaged context block: one boundary is missing"
+    start, end = starts[0], ends[0]
+    if end < start:
+        return None, "damaged context block: boundaries are out of order"
+    header_end = body.find("-->", start)
+    if header_end == -1 or header_end > end:
+        return None, "damaged context block: header is unterminated"
+    meta: dict[str, str] = {}
+    for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    content = body[header_end + len("-->") : end].lstrip("\n")
+    return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
+
+
+def recorded_revisions(body: str, block: ParsedBlock | None) -> list[tuple[str, str]]:
+    """Structured revision records OUTSIDE the managed block.
+
+    Reported, never judged: this helper cannot tell whether a record was written
+    by someone with the authority to accept a requirements change, and a
+    free-text "acknowledged" is deliberately not matched.
+    """
+    outside = body if block is None else body[: block.start] + body[block.end :]
+    return [(m.group(1), (m.group(2) or "").strip()) for m in REVISION_RE.finditer(outside)]
+
+
+def check(body: str, root: Path) -> tuple[str, list[str]]:
+    """Freshness of the cache against its source. Returns (state, detail lines)."""
+    block, fault = find_block(body)
+    detail: list[str] = []
+    if fault:
+        return "block-damaged", [fault]
+    if block is None:
+        return "absent", ["this issue carries no generated context block"]
+
+    detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        detail.append(
+            "the block's own text has been edited since it was generated; a refresh "
+            "would overwrite that edit and is refused"
+        )
+        return "block-edited", detail
+
+    source_name = block.meta.get("source", "-")
+    if source_name in ("-", ""):
+        return "source-unresolved", detail + [
+            "no source was resolved when this block was written; its notes say why"
+        ]
+    source = root / source_name
+    if not source.is_file():
+        return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    source_text = source.read_text(encoding="utf-8")
+    source_now = digest(source_text)
+    source_then = block.meta.get("source-digest", "")
+    for recorded, ref in recorded_revisions(body, block):
+        detail.append(
+            f"recorded revision: source-digest={recorded} ref={ref or '-'} "
+            "(a record found in the issue body; this helper does not judge whether it "
+            "was authorised - resolve it under the existing authority model)"
+        )
+        if recorded == source_now:
+            detail.append("that record names the CURRENT source version")
+
+    if source_now == source_then:
+        return "current", detail + ["source bytes are unchanged since generation"]
+
+    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
+    task_id = block.meta.get("task", "")
+    scope_now = ""
+    if task_id and stories:
+        tasks_path = source.parent / "tasks.md"
+        if tasks_path.is_file():
+            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if scope_now and scope_now != block.meta.get("scope-digest", ""):
+        return "changed-in-scope", detail + [
+            "bytes changed inside the sections this task maps to. That is a byte "
+            "difference, not a ruling that acceptance changed - assess it against the "
+            "source before continuing."
+        ]
+    return "changed-outside-scope", detail + [
+        "the source file changed, but not inside the sections this task maps to. The "
+        "change may still matter (cross-cutting requirements carry no story mapping), "
+        "so read it; nothing here claims it is relevant to this task."
+    ]
+
+
+def refresh(body: str, block_text: str) -> tuple[str | None, str]:
+    """Replace ONLY the managed block. Any doubt leaves the body byte-identical."""
+    block, fault = find_block(body)
+    if fault:
+        return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
+    if block is None:
+        return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        return None, (
+            "refused: the block's text was edited after it was generated. The body is "
+            "unchanged. Move the edit outside the block, or delete the block to have it "
+            "regenerated, if you want the cache refreshed."
+        )
+    updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
+    if updated == body:
+        return updated, "unchanged: the regenerated block is identical"
+    return updated, "refreshed: the block was replaced; text outside it is untouched"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_render = sub.add_parser("render", help="print the managed block for one task")
+    p_render.add_argument("--tasks", type=Path, required=True)
+    p_render.add_argument("--task", required=True)
+    p_render.add_argument("--feature", default="")
+
+    p_check = sub.add_parser("check", help="report cache freshness for an issue body")
+    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--root", type=Path, default=Path("."))
+
+    p_refresh = sub.add_parser("refresh", help="replace only the managed block")
+    p_refresh.add_argument("--body-file", type=Path, required=True)
+    p_refresh.add_argument("--tasks", type=Path, required=True)
+    p_refresh.add_argument("--task", required=True)
+    p_refresh.add_argument("--feature", default="")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        resolution = resolve(args.tasks, args.task)
+        sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
+        return 0
+
+    if args.command == "check":
+        body = args.body_file.read_text(encoding="utf-8")
+        state, detail = check(body, args.root)
+        for line in detail:
+            print(f"  {line}")
+        print(f"SPECKIT_CONTEXT_STATE: {state}")
+        return 0 if state in ("current", "absent") else 3
+
+    body = args.body_file.read_text(encoding="utf-8")
+    resolution = resolve(args.tasks, args.task)
+    block_text = render(resolution, args.feature or str(args.tasks))
+    updated, message = refresh(body, block_text)
+    print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)
+    if updated is None:
+        return 4
+    sys.stdout.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/flow-wave/scripts/speckit-context.py
+++ b/codex/skills/flow-wave/scripts/speckit-context.py
@@ -61,6 +61,11 @@ STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
 ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
 BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+# `---` under an acceptance list is a horizontal rule, and `- -` is how a naive
+# bullet regex reads it: the real shipped template produced a phantom acceptance
+# item of "--". Rules end a list, they are never items in it.
+HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
+FENCE_RE = re.compile(r"^(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -75,6 +80,9 @@ CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
 # of copying, and says that it did (an incomplete extract is never silence).
 MAX_ITEMS = 12
 MAX_ITEM_CHARS = 300
+MAX_PROSE_CHARS = 600
+MAX_BLOCK_CHARS = 8000
+REQUIRED_META = ("feature", "task", "tasks", "source", "integrity")
 
 
 def digest(text: str) -> str:
@@ -97,6 +105,9 @@ class Resolution:
     truncated: list[str] = field(default_factory=list)
     scope_text: str = ""
     source_text: str = ""
+    task_text: str = ""
+    tasks_rel: str | None = None
+    source_rel: str | None = None
 
 
 def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
@@ -115,15 +126,19 @@ def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
     return spans
 
 
-def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+def _story_spans(lines: list[str], story_id: str) -> list[tuple[int, int]]:
+    """Every span declaring this story. More than one is ambiguity, not a choice."""
+    spans: list[tuple[int, int]] = []
     for index, line in enumerate(lines):
         match = STORY_HEADING_RE.match(line)
         if match and match.group(1).upper() == story_id.upper():
-            for end in range(index + 1, len(lines)):
-                if ANY_HEADING_RE.match(lines[end]):
-                    return (index, end)
-            return (index, len(lines))
-    return None
+            end = len(lines)
+            for candidate in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[candidate]):
+                    end = candidate
+                    break
+            spans.append((index, end))
+    return spans
 
 
 def _story_outcome(block: list[str]) -> str:
@@ -141,6 +156,19 @@ def _story_outcome(block: list[str]) -> str:
     return " ".join(parts).strip()
 
 
+def _strip_fences(lines: list[str]) -> list[str]:
+    """Blank out fenced blocks: a sample inside a fence is an example, not a declaration."""
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside = not inside
+            out.append("")
+            continue
+        out.append("" if inside else line)
+    return out
+
+
 def _story_acceptance(block: list[str]) -> list[str]:
     items: list[str] = []
     collecting = False
@@ -149,6 +177,8 @@ def _story_acceptance(block: list[str]) -> list[str]:
             collecting = True
             continue
         if collecting:
+            if HRULE_RE.match(line):
+                break
             if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
                 break
             bullet = BULLET_RE.match(line)
@@ -200,8 +230,36 @@ def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str,
     return rows
 
 
-def resolve(tasks_path: Path, task_id: str) -> Resolution:
+def project_root(start: Path, explicit: Path | None = None) -> Path:
+    """The root every persisted path is relative to.
+
+    Persisting the path as GIVEN was a defect: an absolute source recorded by the
+    producer's checkout kept resolving back to that checkout, so a consumer in a
+    different clone checked the wrong tree and was told `current` while its own
+    spec had changed. Paths are stored relative to this root and re-resolved
+    against the consumer's `--root`.
+    """
+    if explicit is not None:
+        return explicit.resolve()
+    here = start.resolve()
+    here = here if here.is_dir() else here.parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return here
+
+
+def relative_to_root(path: Path, root: Path) -> str | None:
+    """Project-relative spelling, or None when the path escapes the root."""
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolution:
     """Resolve one task's declared context, disclosing whatever does not resolve."""
+    base = project_root(tasks_path, root)
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
@@ -218,6 +276,16 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    resolution.tasks_rel = relative_to_root(tasks_path, base)
+    if resolution.tasks_rel is None:
+        resolution.unresolved.append(
+            f"{tasks_path} lies outside the project root {base}; its location cannot be "
+            "recorded portably, so a consumer in another checkout cannot re-resolve it"
+        )
+    # The task line is a governing input in its own right: its wording can carry a
+    # constraint, and its [USn] tag decides which requirements apply. A digest over
+    # the spec alone left a re-tagged or re-worded task reading as unchanged.
+    resolution.task_text = f"{task_id.upper()}|{','.join(sorted(set(story_ids)))}|{wording}"
     if not found:
         resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
         return resolution
@@ -229,8 +297,9 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         )
         return resolution
     resolution.source = source
+    resolution.source_rel = relative_to_root(source, base)
     resolution.source_text = source.read_text(encoding="utf-8")
-    lines = resolution.source_text.splitlines()
+    lines = _strip_fences(resolution.source_text.splitlines())
 
     if not story_ids:
         resolution.unresolved.append(
@@ -240,13 +309,20 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
 
     scope_parts: list[str] = []
     for story_id in dict.fromkeys(story_ids):
-        span = _story_span(lines, story_id)
-        if span is None:
+        spans = _story_spans(lines, story_id)
+        if not spans:
             resolution.unresolved.append(
                 f"{story_id} is tagged on the task but has no '### {story_id}:' "
                 f"section in {source.name}"
             )
             continue
+        if len(spans) > 1:
+            resolution.unresolved.append(
+                f"{story_id} is declared {len(spans)} times in {source.name}; the "
+                "ambiguity is reported rather than resolved here - read the source"
+            )
+            continue
+        span = spans[0]
         block = lines[span[0] : span[1]]
         scope_parts.append("\n".join(block))
         heading = STORY_HEADING_RE.match(block[0])
@@ -282,6 +358,24 @@ def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list
     return capped
 
 
+def _clip(text: str, limit: int, label: str, truncated: list[str]) -> str:
+    if len(text) <= limit:
+        return text
+    truncated.append(f"{label}: shortened to {limit} characters - read the source")
+    return text[:limit].rstrip() + " [...]"
+
+
+def _meta_digest(meta: dict[str, str], content: str) -> str:
+    """Integrity over the MANAGED METADATA and the content, minus the field itself.
+
+    Covering only the visible text left `task:`, `source:` and the other digests
+    editable in place: the block could be re-pointed at another task's source and
+    a refresh would accept it as its own.
+    """
+    payload = "\n".join(f"{k}={meta[k]}" for k in sorted(meta) if k != "integrity")
+    return digest(payload + "\n--\n" + content)
+
+
 def render(resolution: Resolution, feature: str) -> str:
     """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
     truncated: list[str] = list(resolution.truncated)
@@ -291,7 +385,7 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
             "below there before planning. This block is a task-scoped extract kept for "
             "convenience; where the two differ, the source governs."
         )
@@ -302,7 +396,10 @@ def render(resolution: Resolution, feature: str) -> str:
     body.append("")
 
     for story_id, outcome in resolution.outcomes:
-        body.append(f"**Outcome ({story_id}):** {outcome}")
+        body.append(
+            f"**Outcome ({story_id}):** "
+            + _clip(outcome, MAX_PROSE_CHARS, f"outcome {story_id}", truncated)
+        )
     if resolution.outcomes:
         body.append("")
 
@@ -325,7 +422,8 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     if resolution.task_wording:
-        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        wording = _clip(resolution.task_wording, MAX_PROSE_CHARS, "task wording", truncated)
+        body.append(f'**Task wording (from tasks.md):** "{wording}"')
         body.append(
             "  Resolve its authority against the sections above before acting on it. It "
             "may propose an approach you are free to replace, or it may restate a binding "
@@ -352,17 +450,26 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     content = "\n".join(body).rstrip() + "\n"
-    header = [
-        BLOCK_BEGIN,
-        f"feature: {feature}",
-        f"task: {resolution.task_id}",
-        f"source: {resolution.source if resolution.source else '-'}",
-        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
-        f"scope-digest: {digest(resolution.scope_text)}",
-        f"source-digest: {digest(resolution.source_text)}",
-        f"block-digest: {digest(content)}",
-        "-->",
-    ]
+    if len(content) > MAX_BLOCK_CHARS:
+        keep = content[:MAX_BLOCK_CHARS].rstrip()
+        content = (
+            keep
+            + "\n\n**Capped for size - this extract is INCOMPLETE.** Read the "
+            "authoritative source named above before planning; the constraints that "
+            "make the decision are not guaranteed to be among the lines kept here.\n"
+        )
+    meta = {
+        "feature": feature,
+        "task": resolution.task_id,
+        "tasks": resolution.tasks_rel or "-",
+        "source": resolution.source_rel or "-",
+        "stories": ",".join(story for story, _ in resolution.outcomes) or "-",
+        "task-digest": digest(resolution.task_text),
+        "scope-digest": digest(resolution.scope_text),
+        "source-digest": digest(resolution.source_text),
+    }
+    meta["integrity"] = _meta_digest(meta, content)
+    header = [BLOCK_BEGIN] + [f"{k}: {meta[k]}" for k in meta] + ["-->"]
     return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
 
 
@@ -392,9 +499,16 @@ def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
         return None, "damaged context block: header is unterminated"
     meta: dict[str, str] = {}
     for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
-        if ":" in line:
-            key, _, value = line.partition(":")
-            meta[key.strip()] = value.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in meta:
+            return None, f"damaged context block: duplicate metadata field '{key}'"
+        meta[key] = value.strip()
+    missing = [name for name in REQUIRED_META if name not in meta]
+    if missing:
+        return None, "damaged context block: missing metadata " + ", ".join(missing)
     content = body[header_end + len("-->") : end].lstrip("\n")
     return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
 
@@ -420,10 +534,11 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         return "absent", ["this issue carries no generated context block"]
 
     detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         detail.append(
-            "the block's own text has been edited since it was generated; a refresh "
-            "would overwrite that edit and is refused"
+            "the block has been edited since it was generated - its text, or the "
+            "metadata naming its task and source. A refresh would overwrite that edit "
+            "and is refused"
         )
         return "block-edited", detail
 
@@ -435,6 +550,28 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
     source = root / source_name
     if not source.is_file():
         return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    # The task line is a governing input too: a re-tagged or re-worded task changes
+    # which requirements apply, without touching the spec at all.
+    tasks_name = block.meta.get("tasks", "-")
+    task_id = block.meta.get("task", "")
+    tasks_path = root / tasks_name if tasks_name not in ("-", "") else None
+    task_state: str | None = None
+    if tasks_path is None or not tasks_path.is_file():
+        detail.append(
+            f"the tasks file recorded for this block ({tasks_name}) is not present under "
+            "this root, so the task side of the mapping cannot be re-checked"
+        )
+        task_state = "tasks-missing"
+    else:
+        current = resolve(tasks_path, task_id, root)
+        if digest(current.task_text) != block.meta.get("task-digest", ""):
+            detail.append(
+                "the task line itself changed - its wording, or the [USn] tag that "
+                "decides which requirements apply. The mapping this block was built "
+                "from no longer matches the plan."
+            )
+            task_state = "changed-task"
 
     source_text = source.read_text(encoding="utf-8")
     source_now = digest(source_text)
@@ -448,16 +585,15 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
 
-    if source_now == source_then:
-        return "current", detail + ["source bytes are unchanged since generation"]
+    if task_state is not None:
+        return task_state, detail
 
-    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
-    task_id = block.meta.get("task", "")
+    if source_now == source_then:
+        return "current", detail + ["source and task bytes are unchanged since generation"]
+
     scope_now = ""
-    if task_id and stories:
-        tasks_path = source.parent / "tasks.md"
-        if tasks_path.is_file():
-            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if tasks_path is not None and tasks_path.is_file():
+        scope_now = digest(resolve(tasks_path, task_id, root).scope_text)
     if scope_now and scope_now != block.meta.get("scope-digest", ""):
         return "changed-in-scope", detail + [
             "bytes changed inside the sections this task maps to. That is a byte "
@@ -478,12 +614,23 @@ def refresh(body: str, block_text: str) -> tuple[str | None, str]:
         return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
     if block is None:
         return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         return None, (
             "refused: the block's text was edited after it was generated. The body is "
             "unchanged. Move the edit outside the block, or delete the block to have it "
             "regenerated, if you want the cache refreshed."
         )
+    incoming, fault = find_block(block_text)
+    if incoming is None:
+        return None, f"refused: the replacement block is unusable ({fault})"
+    for key in ("feature", "task"):
+        if block.meta.get(key) != incoming.meta.get(key):
+            return None, (
+                f"refused: identity mismatch - this block is {key}="
+                f"{block.meta.get(key)} and the replacement is {key}="
+                f"{incoming.meta.get(key)}. The body is unchanged; refreshing one "
+                "task's context with another's is never a refresh."
+            )
     updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
     if updated == body:
         return updated, "unchanged: the regenerated block is identical"
@@ -498,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--tasks", type=Path, required=True)
     p_render.add_argument("--task", required=True)
     p_render.add_argument("--feature", default="")
+    p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
     p_check.add_argument("--body-file", type=Path, required=True)
@@ -508,11 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     p_refresh.add_argument("--tasks", type=Path, required=True)
     p_refresh.add_argument("--task", required=True)
     p_refresh.add_argument("--feature", default="")
+    p_refresh.add_argument("--root", type=Path, default=None)
 
     args = parser.parse_args(argv)
 
     if args.command == "render":
-        resolution = resolve(args.tasks, args.task)
+        resolution = resolve(args.tasks, args.task, args.root)
         sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
         return 0
 
@@ -525,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if state in ("current", "absent") else 3
 
     body = args.body_file.read_text(encoding="utf-8")
-    resolution = resolve(args.tasks, args.task)
+    resolution = resolve(args.tasks, args.task, args.root)
     block_text = render(resolution, args.feature or str(args.tasks))
     updated, message = refresh(body, block_text)
     print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)

--- a/codex/skills/flow-wave/scripts/speckit-context.py
+++ b/codex/skills/flow-wave/scripts/speckit-context.py
@@ -65,7 +65,7 @@ BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
 # bullet regex reads it: the real shipped template produced a phantom acceptance
 # item of "--". Rules end a list, they are never items in it.
 HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
-FENCE_RE = re.compile(r"^(?:```|~~~)")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -263,19 +263,30 @@ def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolut
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
+    duplicates = 0
     found = False
-    for line in tasks_text.splitlines():
+    # A task line inside a fence is an EXAMPLE. Reading declarations out of fenced
+    # samples let a documentation snippet outrank the real task and supply the wrong
+    # story mapping, so tasks.md gets the same fence handling as the spec.
+    for line in _strip_fences(tasks_text.splitlines()):
         match = TASK_LINE_RE.match(line)
         if not match or match.group(1).upper() != task_id.upper():
+            continue
+        if found:
+            duplicates += 1
             continue
         found = True
         rest = match.group(2)
         for tag in STORY_TAG_RE.findall(rest):
             story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
         wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
-        break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if duplicates:
+        resolution.unresolved.append(
+            f"{task_id.upper()} is declared {duplicates + 1} times in {tasks_path.name}; "
+            "the first was used and the ambiguity is reported rather than resolved here"
+        )
     resolution.tasks_rel = relative_to_root(tasks_path, base)
     if resolution.tasks_rel is None:
         resolution.unresolved.append(
@@ -385,13 +396,15 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
-            "below there before planning. This block is a task-scoped extract kept for "
-            "convenience; where the two differ, the source governs."
+            f"**Reference source:** `{resolution.source_rel or resolution.source}` - read "
+            "the sections named below there before planning. This block is a task-scoped "
+            "extract taken at the version recorded above. A difference between the two is "
+            "a CHANGED VERSION to resolve under the existing authority model - it does not "
+            "by itself override a constraint or plan already accepted on this issue."
         )
     else:
         body.append(
-            "**Authoritative source:** none resolved. See the unresolved notes below."
+            "**Reference source:** none resolved. See the unresolved notes below."
         )
     body.append("")
 
@@ -584,6 +597,17 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         )
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
+        elif recorded == source_then:
+            detail.append(
+                "that record names the version THIS BLOCK CACHED, not the current source - "
+                "so the decision it records predates the change below and must be resolved, "
+                "not assumed to cover it"
+            )
+        else:
+            detail.append(
+                "that record names neither the current source nor the cached version; it "
+                "refers to some third version and cannot be matched automatically"
+            )
 
     if task_state is not None:
         return task_state, detail
@@ -648,7 +672,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
-    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--body-file", type=Path, required=True, help="'-' reads stdin")
     p_check.add_argument("--root", type=Path, default=Path("."))
 
     p_refresh = sub.add_parser("refresh", help="replace only the managed block")
@@ -666,7 +690,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        body = args.body_file.read_text(encoding="utf-8")
+        body = (
+            sys.stdin.read()
+            if str(args.body_file) == "-"
+            else args.body_file.read_text(encoding="utf-8")
+        )
         state, detail = check(body, args.root)
         for line in detail:
             print(f"  {line}")

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -165,6 +165,16 @@ normalize_source_path() {
     printf '%s' "$path"
 }
 
+# scripts/speckit-context.py renders the task-context cache (#858). It ships in the
+# same directory as this script, including inside a generated Codex skill bundle, so
+# it is resolved relative to THIS file rather than to the caller's cwd. Absent or
+# unusable, the converter keeps working and simply writes no context block.
+CONTEXT_HELPER=""
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+    CONTEXT_HELPER="$_self_dir/speckit-context.py"
+fi
+
 TASKS_NORM="$(normalize_source_path "$TASKS")"
 TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
 
@@ -467,6 +477,19 @@ for i in "${!TIDS[@]}"; do
     issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
     if [ -n "${DEPS[$i]}" ]; then
         issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
+    fi
+    # Task context (issue #857 -> #858). A generated issue used to carry its
+    # provenance, its marker and its dependencies, and nothing about the behaviour
+    # it was meant to produce - so the receiving agent had only the title, and no
+    # pointer to the document that governs the work. The helper renders a bounded,
+    # fingerprinted cache of the task's DECLARED context; the spec stays
+    # authoritative. Conditional by design: with no helper and no resolvable spec
+    # the issue body is the whole contract, exactly as before.
+    if [ -n "$CONTEXT_HELPER" ]; then
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
+        if [ -n "$context_block" ]; then
+            issue_body+=$'\n\n'"$context_block"
+        fi
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -26,6 +26,8 @@
 #                    or they are no longer recognised and get filed again. A new
 #                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
+#   --no-context     Do not render task-context blocks. The deliberate opt-out; a
+#                    helper that is missing or fails is an ERROR, not a silent skip.
 #   -h, --help       Show this help.
 #
 # Exit codes:
@@ -38,6 +40,7 @@
 #   5  one or more tasks have an ambiguous legacy identity awaiting resolution
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
+#   7  the task-context helper is missing or failed (use --no-context to opt out)
 set -euo pipefail
 
 DRY_RUN=0
@@ -45,6 +48,7 @@ TASKS=""
 REPO=""
 FEATURE=""
 LIMIT=1000
+NO_CONTEXT=0
 
 usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
@@ -55,6 +59,7 @@ while [ $# -gt 0 ]; do
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
         --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
         --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
+        --no-context) NO_CONTEXT=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -171,7 +176,19 @@ normalize_source_path() {
 # unusable, the converter keeps working and simply writes no context block.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+if [ "$NO_CONTEXT" -eq 0 ]; then
+    if ! command -v python3 > /dev/null 2>&1; then
+        echo "ERROR: python3 is required to render task context and was not found." >&2
+        echo "Install python3, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
+    if [ ! -f "$_self_dir/speckit-context.py" ]; then
+        echo "ERROR: speckit-context.py is missing from $_self_dir." >&2
+        echo "It ships beside this script, including inside a generated skill bundle; a" >&2
+        echo "packaging that separates them is broken, not a context-free installation." >&2
+        echo "Reinstall, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
     CONTEXT_HELPER="$_self_dir/speckit-context.py"
 fi
 
@@ -485,11 +502,20 @@ for i in "${!TIDS[@]}"; do
     # fingerprinted cache of the task's DECLARED context; the spec stays
     # authoritative. Conditional by design: with no helper and no resolvable spec
     # the issue body is the whole contract, exactly as before.
-    if [ -n "$CONTEXT_HELPER" ]; then
-        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
-        if [ -n "$context_block" ]; then
-            issue_body+=$'\n\n'"$context_block"
+    if [ "$NO_CONTEXT" -eq 0 ]; then
+        context_status=0
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
+        if [ "$context_status" -ne 0 ] || [ -z "$context_block" ]; then
+            # A broken helper is not a lightweight issue. Swallowing this produced a
+            # context-free issue that looked like a successful conversion, which is
+            # the failure this whole change exists to remove - so it stops here,
+            # before any further write. `--no-context` is the deliberate opt-out.
+            echo "ERROR: could not render the task context for ${tid} (helper exited ${context_status})." >&2
+            printf '  %s\n' "$context_block" >&2
+            echo "Fix the helper or pass --no-context to convert without context blocks." >&2
+            exit 7
         fi
+        issue_body+=$'\n\n'"$context_block"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -41,6 +41,7 @@
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
 #   7  the task-context helper is missing or failed (use --no-context to opt out)
+#   8  an existing issue's context could not be read or checked on a re-run
 set -euo pipefail
 
 DRY_RUN=0
@@ -173,7 +174,8 @@ normalize_source_path() {
 # scripts/speckit-context.py renders the task-context cache (#858). It ships in the
 # same directory as this script, including inside a generated Codex skill bundle, so
 # it is resolved relative to THIS file rather than to the caller's cwd. Absent or
-# unusable, the converter keeps working and simply writes no context block.
+# unusable, the run STOPS: a packaging fault that silently produced context-free
+# issues would look exactly like a successful conversion. `--no-context` opts out.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$NO_CONTEXT" -eq 0 ]; then
@@ -475,7 +477,7 @@ if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
 fi
 
 # --- Create pass -----------------------------------------------------------------
-created=0; skipped=0; adopted=0
+created=0; skipped=0; adopted=0; context_checks_failed=0
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
@@ -485,13 +487,29 @@ for i in "${!TIDS[@]}"; do
         # invisible until somebody happened to re-read it. Reporting only: this
         # never edits an issue, and a refresh is the explicit documented workflow.
         if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
-            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
-                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
-                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
-            case "$ctx_state" in
-                ""|current|absent) : ;;
-                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
-            esac
+            ctx_read_status=0
+            ctx_body="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || ctx_read_status=$?
+            if [ "$ctx_read_status" -ne 0 ]; then
+                echo "WARN: could not read issue #${FILED_NUM[$tid]} to check ${tid}'s context (gh exited ${ctx_read_status})." >&2
+                printf '  %s\n' "$ctx_body" >&2
+                context_checks_failed=$((context_checks_failed + 1))
+            else
+                ctx_check_status=0
+                ctx_report="$(printf '%s' "$ctx_body" | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>&1)" || ctx_check_status=$?
+                ctx_state="$(printf '%s' "$ctx_report" | sed -n 's/^SPECKIT_CONTEXT_STATE: //p')"
+                # `check` exits 3 for any state other than current/absent; anything
+                # else is a broken checker, not a verdict.
+                if { [ "$ctx_check_status" -ne 0 ] && [ "$ctx_check_status" -ne 3 ]; } || [ -z "$ctx_state" ]; then
+                    echo "WARN: the context check for ${tid} (issue #${FILED_NUM[$tid]}) failed (exit ${ctx_check_status})." >&2
+                    printf '  %s\n' "$ctx_report" >&2
+                    context_checks_failed=$((context_checks_failed + 1))
+                else
+                    case "$ctx_state" in
+                        current|absent) : ;;
+                        *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+                    esac
+                fi
+            fi
         fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
@@ -513,8 +531,9 @@ for i in "${!TIDS[@]}"; do
     # it was meant to produce - so the receiving agent had only the title, and no
     # pointer to the document that governs the work. The helper renders a bounded,
     # fingerprinted cache of the task's DECLARED context; the spec stays
-    # authoritative. Conditional by design: with no helper and no resolvable spec
-    # the issue body is the whole contract, exactly as before.
+    # authoritative. Conditional on the INPUT, not on the installation: a tasks file
+    # with no resolvable spec still gets a block disclosing what did not resolve,
+    # while a missing or failing helper is an error rather than a quiet omission.
     if [ "$NO_CONTEXT" -eq 0 ]; then
         context_status=0
         context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
@@ -611,6 +630,12 @@ done
 echo "---"
 echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
 [ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$context_checks_failed" -gt 0 ]; then
+    echo "ERROR: ${context_checks_failed} context check(s) could not be completed; their" >&2
+    echo "diagnostics are above. An unreadable issue or a broken checker is not the same" >&2
+    echo "as an issue with no context block, and is not reported as one." >&2
+    exit 8
+fi
 if [ "$edges_failed" -gt 0 ]; then
     echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
     echo "command to reconcile the missing edges - it will not create duplicates." >&2

--- a/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/flow-wave/scripts/speckit-tasks-to-issues.sh
@@ -480,6 +480,19 @@ for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
     if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        # Drift visibility on a re-run (#858). An already-filed task used to skip
+        # straight past its context, so a spec that moved under a filed issue was
+        # invisible until somebody happened to re-read it. Reporting only: this
+        # never edits an issue, and a refresh is the explicit documented workflow.
+        if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
+            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
+                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
+                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
+            case "$ctx_state" in
+                ""|current|absent) : ;;
+                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+            esac
+        fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
                  "add '$(marker_for "$tid")' to its body to make the identity explicit)"

--- a/codex/skills/project-init/reference.md
+++ b/codex/skills/project-init/reference.md
@@ -579,7 +579,7 @@ Then ask: "Sync tasks to GitHub issues now?"
 - **Yes** → run `./scripts/speckit-tasks-to-issues.sh`
 - **Skip** → sync later
 
-> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together: if the helper is missing or fails, the converter stops with an error before creating anything, because a packaging fault is not a context-free installation. `--no-context` is the explicit opt-out.
 
 
 Report: `Step 5/6: Initial spec created` or `Step 5/6: Skipped`

--- a/codex/skills/project-init/reference.md
+++ b/codex/skills/project-init/reference.md
@@ -579,6 +579,9 @@ Then ask: "Sync tasks to GitHub issues now?"
 - **Yes** → run `./scripts/speckit-tasks-to-issues.sh`
 - **Skip** → sync later
 
+> Dependency: `scripts/speckit-tasks-to-issues.sh` calls `scripts/speckit-context.py` at runtime to render each issue's task-context block (#858). Both ship together; the converter still runs without the helper and simply writes no context block.
+
+
 Report: `Step 5/6: Initial spec created` or `Step 5/6: Skipped`
 
 ---

--- a/codex/skills/project-init/scripts/speckit-context.py
+++ b/codex/skills/project-init/scripts/speckit-context.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Resolve, render and refresh the task-context cache in a generated issue (#858).
+
+A generated issue used to carry its provenance, its identity marker and its
+dependencies - and nothing about the behaviour it was meant to produce. The task
+title was the whole description, so a receiving agent could not tell which words
+were the goal and which were somebody's suggested mechanism, and had nothing
+pointing at the document that actually governs the work.
+
+This helper resolves a task's DECLARED context and renders it into a bounded,
+fingerprinted block. The block is a CACHE, not a second authority: the spec named
+inside it stays authoritative, everything in it is traceable to a source section,
+and every part carries a digest so drift is visible instead of silent.
+
+What is declared, and therefore used:
+
+  * the story tag on the task line (`- [ ] **T001** [US1] ...`), which names a
+    `### US1:` section in the sibling spec.md
+  * the Functional Requirements table's `User Story` column, which maps
+    individual requirements to that story
+
+What is NOT inferred: nothing is derived from task NUMBERS, and requirements with
+no declared story mapping are never claimed as this task's. Non-Functional
+Requirements and Out of Scope carry no story mapping at all, so they are indexed
+as cross-cutting sections the consumer must read in the source - and they are
+covered by the whole-file digest, so a changed global security or compatibility
+constraint is visible even though it is not attributed to this task.
+
+What a digest establishes, and what it does not: a differing digest means those
+BYTES changed since the block was written. It is not a ruling that acceptance
+changed, that the change is material to this task, or that anything was approved.
+A reflow or a typo fix reads as a change. The states this helper reports are
+deliberately named for what they observe.
+
+Usage:
+    speckit-context.py render  --tasks PATH --task T001 [--feature SLUG]
+    speckit-context.py check   --body-file PATH [--root DIR]
+    speckit-context.py refresh --body-file PATH --tasks PATH --task T001 [--feature SLUG]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BLOCK_BEGIN = "<!-- speckit-context:v1"
+BLOCK_END = "<!-- speckit-context:end -->"
+DIGEST_LEN = 12
+
+# Declared task -> story mapping, written by .specify/templates/tasks-template.md.
+STORY_TAG_RE = re.compile(r"\[(US\d+(?:\s*,\s*US?\d+)*)\]", re.IGNORECASE)
+STORY_ID_RE = re.compile(r"US\d+", re.IGNORECASE)
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
+STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
+ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
+BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# A structured, reviewable record that a requirements revision was accepted. The
+# helper REPORTS it; it never decides that it is authorised, and a free-text
+# "acknowledged" somewhere in the body is not this.
+REVISION_RE = re.compile(
+    r"^\s*Acceptance-revision:\s*source-digest=([0-9a-f]{6,64})\s*(?:ref=(\S.*))?$",
+    re.MULTILINE,
+)
+
+CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
+# A cap keeps the cache bounded; beyond it the block points at the source instead
+# of copying, and says that it did (an incomplete extract is never silence).
+MAX_ITEMS = 12
+MAX_ITEM_CHARS = 300
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:DIGEST_LEN]
+
+
+@dataclass
+class Resolution:
+    """What the declared mappings produced for one task."""
+
+    task_id: str
+    task_wording: str
+    source: Path | None = None
+    story_ids: list[str] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+    acceptance: list[tuple[str, str]] = field(default_factory=list)
+    requirements: list[tuple[str, str]] = field(default_factory=list)
+    cross_cutting: list[str] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    truncated: list[str] = field(default_factory=list)
+    scope_text: str = ""
+    source_text: str = ""
+
+
+def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Heading text -> (start, end) line span, for top-level `##`/`###` headings."""
+    spans: dict[str, tuple[int, int]] = {}
+    current: str | None = None
+    start = 0
+    for index, line in enumerate(lines):
+        if ANY_HEADING_RE.match(line):
+            if current is not None:
+                spans[current] = (start, index)
+            current = line.lstrip("#").strip()
+            start = index
+    if current is not None:
+        spans[current] = (start, len(lines))
+    return spans
+
+
+def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = STORY_HEADING_RE.match(line)
+        if match and match.group(1).upper() == story_id.upper():
+            for end in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[end]):
+                    return (index, end)
+            return (index, len(lines))
+    return None
+
+
+def _story_outcome(block: list[str]) -> str:
+    """The story's own sentence: the heading text plus its As/I want/So that lines."""
+    parts: list[str] = []
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if parts:
+                break
+            continue
+        if stripped.startswith("**Acceptance") or ANY_HEADING_RE.match(line):
+            break
+        parts.append(stripped)
+    return " ".join(parts).strip()
+
+
+def _story_acceptance(block: list[str]) -> list[str]:
+    items: list[str] = []
+    collecting = False
+    for line in block:
+        if ACCEPTANCE_HEADING_RE.match(line.strip()):
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
+                break
+            bullet = BULLET_RE.match(line)
+            if bullet:
+                items.append(bullet.group(1))
+            elif line.strip() and items:
+                items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
+def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str, str]]:
+    """FR rows whose declared `User Story` column names one of these stories.
+
+    The mapping is read from the table the spec template ships; a row with no
+    story column, or one naming another story, is never attributed to this task.
+    """
+    wanted = {s.upper() for s in story_ids}
+    spans = _sections(lines)
+    span = spans.get("Functional Requirements")
+    if span is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    header: list[str] | None = None
+    for line in lines[span[0] : span[1]]:
+        match = TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in match.group(1).split("|")]
+        if header is None:
+            header = [c.lower() for c in cells]
+            continue
+        if all(set(c) <= {"-", ":"} for c in cells if c):
+            continue
+        if "user story" not in header:
+            continue
+        story_index = header.index("user story")
+        if story_index >= len(cells):
+            continue
+        declared = {s.upper() for s in STORY_ID_RE.findall(cells[story_index])}
+        if not declared & wanted:
+            continue
+        ident = cells[0] if cells else ""
+        text_index = header.index("requirement") if "requirement" in header else 1
+        text = cells[text_index] if text_index < len(cells) else ""
+        priority_index = header.index("priority") if "priority" in header else None
+        if priority_index is not None and priority_index < len(cells):
+            text = f"{text} ({cells[priority_index]})"
+        rows.append((ident, text))
+    return rows
+
+
+def resolve(tasks_path: Path, task_id: str) -> Resolution:
+    """Resolve one task's declared context, disclosing whatever does not resolve."""
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    wording = ""
+    story_ids: list[str] = []
+    found = False
+    for line in tasks_text.splitlines():
+        match = TASK_LINE_RE.match(line)
+        if not match or match.group(1).upper() != task_id.upper():
+            continue
+        found = True
+        rest = match.group(2)
+        for tag in STORY_TAG_RE.findall(rest):
+            story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
+        wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
+        break
+
+    resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if not found:
+        resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
+        return resolution
+
+    source = tasks_path.parent / "spec.md"
+    if not source.is_file():
+        resolution.unresolved.append(
+            f"no spec.md beside {tasks_path} - no declared source to resolve against"
+        )
+        return resolution
+    resolution.source = source
+    resolution.source_text = source.read_text(encoding="utf-8")
+    lines = resolution.source_text.splitlines()
+
+    if not story_ids:
+        resolution.unresolved.append(
+            f"{resolution.task_id} declares no [USn] story tag, so its governing "
+            "requirement is not resolvable from the task line"
+        )
+
+    scope_parts: list[str] = []
+    for story_id in dict.fromkeys(story_ids):
+        span = _story_span(lines, story_id)
+        if span is None:
+            resolution.unresolved.append(
+                f"{story_id} is tagged on the task but has no '### {story_id}:' "
+                f"section in {source.name}"
+            )
+            continue
+        block = lines[span[0] : span[1]]
+        scope_parts.append("\n".join(block))
+        heading = STORY_HEADING_RE.match(block[0])
+        title = heading.group(2) if heading else story_id
+        outcome = _story_outcome(block)
+        resolution.outcomes.append((story_id, f"{title}. {outcome}".strip()))
+        for item in _story_acceptance(block):
+            resolution.acceptance.append((story_id, item))
+
+    for ident, text in _requirements_for(lines, story_ids):
+        resolution.requirements.append((ident, text))
+        scope_parts.append(f"{ident}|{text}")
+
+    spans = _sections(lines)
+    for heading in CROSS_CUTTING_HEADINGS:
+        if heading in spans:
+            resolution.cross_cutting.append(heading)
+
+    resolution.scope_text = "\n".join(scope_parts)
+    return resolution
+
+
+def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list[tuple[str, str]]:
+    if len(items) > MAX_ITEMS:
+        truncated.append(f"{label}: showing {MAX_ITEMS} of {len(items)}")
+        items = items[:MAX_ITEMS]
+    capped: list[tuple[str, str]] = []
+    for ident, text in items:
+        if len(text) > MAX_ITEM_CHARS:
+            text = text[:MAX_ITEM_CHARS].rstrip() + " [...]"
+            truncated.append(f"{label} {ident}: shortened")
+        capped.append((ident, text))
+    return capped
+
+
+def render(resolution: Resolution, feature: str) -> str:
+    """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
+    truncated: list[str] = list(resolution.truncated)
+    acceptance = _cap(resolution.acceptance, "acceptance", truncated)
+    requirements = _cap(resolution.requirements, "requirements", truncated)
+
+    body: list[str] = ["### Governing context (generated cache)", ""]
+    if resolution.source is not None:
+        body.append(
+            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            "below there before planning. This block is a task-scoped extract kept for "
+            "convenience; where the two differ, the source governs."
+        )
+    else:
+        body.append(
+            "**Authoritative source:** none resolved. See the unresolved notes below."
+        )
+    body.append("")
+
+    for story_id, outcome in resolution.outcomes:
+        body.append(f"**Outcome ({story_id}):** {outcome}")
+    if resolution.outcomes:
+        body.append("")
+
+    if acceptance:
+        body.append("**Acceptance, as declared by the story:**")
+        body.extend(f"- ({story_id}) {item}" for story_id, item in acceptance)
+        body.append("")
+
+    if requirements:
+        body.append("**Requirements declared against this story:**")
+        body.extend(f"- {ident}: {text}" for ident, text in requirements)
+        body.append("")
+
+    if resolution.cross_cutting:
+        body.append(
+            "**Cross-cutting sections to read in the source before planning** - these "
+            "carry no story mapping, so they are named rather than attributed to this "
+            "task: " + ", ".join(f"`{h}`" for h in resolution.cross_cutting)
+        )
+        body.append("")
+
+    if resolution.task_wording:
+        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        body.append(
+            "  Resolve its authority against the sections above before acting on it. It "
+            "may propose an approach you are free to replace, or it may restate a binding "
+            "constraint; the line alone does not say which."
+        )
+        body.append("")
+
+    if resolution.outcomes:
+        body.append(
+            "**Granularity:** acceptance is declared at user-story level, so the items "
+            "above may also cover sibling tasks of the same story. Narrow them to this "
+            "task yourself; this block does not decide that for you."
+        )
+        body.append("")
+
+    if resolution.unresolved:
+        body.append("**Unresolved - incomplete context, not an absence of constraints:**")
+        body.extend(f"- {note}" for note in resolution.unresolved)
+        body.append("")
+
+    if truncated:
+        body.append("**Capped for size - read the source for the rest:**")
+        body.extend(f"- {note}" for note in truncated)
+        body.append("")
+
+    content = "\n".join(body).rstrip() + "\n"
+    header = [
+        BLOCK_BEGIN,
+        f"feature: {feature}",
+        f"task: {resolution.task_id}",
+        f"source: {resolution.source if resolution.source else '-'}",
+        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
+        f"scope-digest: {digest(resolution.scope_text)}",
+        f"source-digest: {digest(resolution.source_text)}",
+        f"block-digest: {digest(content)}",
+        "-->",
+    ]
+    return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
+
+
+@dataclass
+class ParsedBlock:
+    start: int
+    end: int
+    meta: dict[str, str]
+    content: str
+
+
+def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
+    """Locate the managed block. Returns (block, fault); a fault forbids rewriting."""
+    starts = [m.start() for m in re.finditer(re.escape(BLOCK_BEGIN), body)]
+    ends = [m.start() for m in re.finditer(re.escape(BLOCK_END), body)]
+    if not starts and not ends:
+        return None, None
+    if len(starts) > 1 or len(ends) > 1:
+        return None, "duplicate context block boundaries"
+    if not starts or not ends:
+        return None, "damaged context block: one boundary is missing"
+    start, end = starts[0], ends[0]
+    if end < start:
+        return None, "damaged context block: boundaries are out of order"
+    header_end = body.find("-->", start)
+    if header_end == -1 or header_end > end:
+        return None, "damaged context block: header is unterminated"
+    meta: dict[str, str] = {}
+    for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    content = body[header_end + len("-->") : end].lstrip("\n")
+    return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
+
+
+def recorded_revisions(body: str, block: ParsedBlock | None) -> list[tuple[str, str]]:
+    """Structured revision records OUTSIDE the managed block.
+
+    Reported, never judged: this helper cannot tell whether a record was written
+    by someone with the authority to accept a requirements change, and a
+    free-text "acknowledged" is deliberately not matched.
+    """
+    outside = body if block is None else body[: block.start] + body[block.end :]
+    return [(m.group(1), (m.group(2) or "").strip()) for m in REVISION_RE.finditer(outside)]
+
+
+def check(body: str, root: Path) -> tuple[str, list[str]]:
+    """Freshness of the cache against its source. Returns (state, detail lines)."""
+    block, fault = find_block(body)
+    detail: list[str] = []
+    if fault:
+        return "block-damaged", [fault]
+    if block is None:
+        return "absent", ["this issue carries no generated context block"]
+
+    detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        detail.append(
+            "the block's own text has been edited since it was generated; a refresh "
+            "would overwrite that edit and is refused"
+        )
+        return "block-edited", detail
+
+    source_name = block.meta.get("source", "-")
+    if source_name in ("-", ""):
+        return "source-unresolved", detail + [
+            "no source was resolved when this block was written; its notes say why"
+        ]
+    source = root / source_name
+    if not source.is_file():
+        return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    source_text = source.read_text(encoding="utf-8")
+    source_now = digest(source_text)
+    source_then = block.meta.get("source-digest", "")
+    for recorded, ref in recorded_revisions(body, block):
+        detail.append(
+            f"recorded revision: source-digest={recorded} ref={ref or '-'} "
+            "(a record found in the issue body; this helper does not judge whether it "
+            "was authorised - resolve it under the existing authority model)"
+        )
+        if recorded == source_now:
+            detail.append("that record names the CURRENT source version")
+
+    if source_now == source_then:
+        return "current", detail + ["source bytes are unchanged since generation"]
+
+    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
+    task_id = block.meta.get("task", "")
+    scope_now = ""
+    if task_id and stories:
+        tasks_path = source.parent / "tasks.md"
+        if tasks_path.is_file():
+            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if scope_now and scope_now != block.meta.get("scope-digest", ""):
+        return "changed-in-scope", detail + [
+            "bytes changed inside the sections this task maps to. That is a byte "
+            "difference, not a ruling that acceptance changed - assess it against the "
+            "source before continuing."
+        ]
+    return "changed-outside-scope", detail + [
+        "the source file changed, but not inside the sections this task maps to. The "
+        "change may still matter (cross-cutting requirements carry no story mapping), "
+        "so read it; nothing here claims it is relevant to this task."
+    ]
+
+
+def refresh(body: str, block_text: str) -> tuple[str | None, str]:
+    """Replace ONLY the managed block. Any doubt leaves the body byte-identical."""
+    block, fault = find_block(body)
+    if fault:
+        return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
+    if block is None:
+        return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        return None, (
+            "refused: the block's text was edited after it was generated. The body is "
+            "unchanged. Move the edit outside the block, or delete the block to have it "
+            "regenerated, if you want the cache refreshed."
+        )
+    updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
+    if updated == body:
+        return updated, "unchanged: the regenerated block is identical"
+    return updated, "refreshed: the block was replaced; text outside it is untouched"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_render = sub.add_parser("render", help="print the managed block for one task")
+    p_render.add_argument("--tasks", type=Path, required=True)
+    p_render.add_argument("--task", required=True)
+    p_render.add_argument("--feature", default="")
+
+    p_check = sub.add_parser("check", help="report cache freshness for an issue body")
+    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--root", type=Path, default=Path("."))
+
+    p_refresh = sub.add_parser("refresh", help="replace only the managed block")
+    p_refresh.add_argument("--body-file", type=Path, required=True)
+    p_refresh.add_argument("--tasks", type=Path, required=True)
+    p_refresh.add_argument("--task", required=True)
+    p_refresh.add_argument("--feature", default="")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        resolution = resolve(args.tasks, args.task)
+        sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
+        return 0
+
+    if args.command == "check":
+        body = args.body_file.read_text(encoding="utf-8")
+        state, detail = check(body, args.root)
+        for line in detail:
+            print(f"  {line}")
+        print(f"SPECKIT_CONTEXT_STATE: {state}")
+        return 0 if state in ("current", "absent") else 3
+
+    body = args.body_file.read_text(encoding="utf-8")
+    resolution = resolve(args.tasks, args.task)
+    block_text = render(resolution, args.feature or str(args.tasks))
+    updated, message = refresh(body, block_text)
+    print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)
+    if updated is None:
+        return 4
+    sys.stdout.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/project-init/scripts/speckit-context.py
+++ b/codex/skills/project-init/scripts/speckit-context.py
@@ -61,6 +61,11 @@ STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
 ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
 BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+# `---` under an acceptance list is a horizontal rule, and `- -` is how a naive
+# bullet regex reads it: the real shipped template produced a phantom acceptance
+# item of "--". Rules end a list, they are never items in it.
+HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
+FENCE_RE = re.compile(r"^(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -75,6 +80,9 @@ CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
 # of copying, and says that it did (an incomplete extract is never silence).
 MAX_ITEMS = 12
 MAX_ITEM_CHARS = 300
+MAX_PROSE_CHARS = 600
+MAX_BLOCK_CHARS = 8000
+REQUIRED_META = ("feature", "task", "tasks", "source", "integrity")
 
 
 def digest(text: str) -> str:
@@ -97,6 +105,9 @@ class Resolution:
     truncated: list[str] = field(default_factory=list)
     scope_text: str = ""
     source_text: str = ""
+    task_text: str = ""
+    tasks_rel: str | None = None
+    source_rel: str | None = None
 
 
 def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
@@ -115,15 +126,19 @@ def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
     return spans
 
 
-def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+def _story_spans(lines: list[str], story_id: str) -> list[tuple[int, int]]:
+    """Every span declaring this story. More than one is ambiguity, not a choice."""
+    spans: list[tuple[int, int]] = []
     for index, line in enumerate(lines):
         match = STORY_HEADING_RE.match(line)
         if match and match.group(1).upper() == story_id.upper():
-            for end in range(index + 1, len(lines)):
-                if ANY_HEADING_RE.match(lines[end]):
-                    return (index, end)
-            return (index, len(lines))
-    return None
+            end = len(lines)
+            for candidate in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[candidate]):
+                    end = candidate
+                    break
+            spans.append((index, end))
+    return spans
 
 
 def _story_outcome(block: list[str]) -> str:
@@ -141,6 +156,19 @@ def _story_outcome(block: list[str]) -> str:
     return " ".join(parts).strip()
 
 
+def _strip_fences(lines: list[str]) -> list[str]:
+    """Blank out fenced blocks: a sample inside a fence is an example, not a declaration."""
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside = not inside
+            out.append("")
+            continue
+        out.append("" if inside else line)
+    return out
+
+
 def _story_acceptance(block: list[str]) -> list[str]:
     items: list[str] = []
     collecting = False
@@ -149,6 +177,8 @@ def _story_acceptance(block: list[str]) -> list[str]:
             collecting = True
             continue
         if collecting:
+            if HRULE_RE.match(line):
+                break
             if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
                 break
             bullet = BULLET_RE.match(line)
@@ -200,8 +230,36 @@ def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str,
     return rows
 
 
-def resolve(tasks_path: Path, task_id: str) -> Resolution:
+def project_root(start: Path, explicit: Path | None = None) -> Path:
+    """The root every persisted path is relative to.
+
+    Persisting the path as GIVEN was a defect: an absolute source recorded by the
+    producer's checkout kept resolving back to that checkout, so a consumer in a
+    different clone checked the wrong tree and was told `current` while its own
+    spec had changed. Paths are stored relative to this root and re-resolved
+    against the consumer's `--root`.
+    """
+    if explicit is not None:
+        return explicit.resolve()
+    here = start.resolve()
+    here = here if here.is_dir() else here.parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return here
+
+
+def relative_to_root(path: Path, root: Path) -> str | None:
+    """Project-relative spelling, or None when the path escapes the root."""
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolution:
     """Resolve one task's declared context, disclosing whatever does not resolve."""
+    base = project_root(tasks_path, root)
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
@@ -218,6 +276,16 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    resolution.tasks_rel = relative_to_root(tasks_path, base)
+    if resolution.tasks_rel is None:
+        resolution.unresolved.append(
+            f"{tasks_path} lies outside the project root {base}; its location cannot be "
+            "recorded portably, so a consumer in another checkout cannot re-resolve it"
+        )
+    # The task line is a governing input in its own right: its wording can carry a
+    # constraint, and its [USn] tag decides which requirements apply. A digest over
+    # the spec alone left a re-tagged or re-worded task reading as unchanged.
+    resolution.task_text = f"{task_id.upper()}|{','.join(sorted(set(story_ids)))}|{wording}"
     if not found:
         resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
         return resolution
@@ -229,8 +297,9 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         )
         return resolution
     resolution.source = source
+    resolution.source_rel = relative_to_root(source, base)
     resolution.source_text = source.read_text(encoding="utf-8")
-    lines = resolution.source_text.splitlines()
+    lines = _strip_fences(resolution.source_text.splitlines())
 
     if not story_ids:
         resolution.unresolved.append(
@@ -240,13 +309,20 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
 
     scope_parts: list[str] = []
     for story_id in dict.fromkeys(story_ids):
-        span = _story_span(lines, story_id)
-        if span is None:
+        spans = _story_spans(lines, story_id)
+        if not spans:
             resolution.unresolved.append(
                 f"{story_id} is tagged on the task but has no '### {story_id}:' "
                 f"section in {source.name}"
             )
             continue
+        if len(spans) > 1:
+            resolution.unresolved.append(
+                f"{story_id} is declared {len(spans)} times in {source.name}; the "
+                "ambiguity is reported rather than resolved here - read the source"
+            )
+            continue
+        span = spans[0]
         block = lines[span[0] : span[1]]
         scope_parts.append("\n".join(block))
         heading = STORY_HEADING_RE.match(block[0])
@@ -282,6 +358,24 @@ def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list
     return capped
 
 
+def _clip(text: str, limit: int, label: str, truncated: list[str]) -> str:
+    if len(text) <= limit:
+        return text
+    truncated.append(f"{label}: shortened to {limit} characters - read the source")
+    return text[:limit].rstrip() + " [...]"
+
+
+def _meta_digest(meta: dict[str, str], content: str) -> str:
+    """Integrity over the MANAGED METADATA and the content, minus the field itself.
+
+    Covering only the visible text left `task:`, `source:` and the other digests
+    editable in place: the block could be re-pointed at another task's source and
+    a refresh would accept it as its own.
+    """
+    payload = "\n".join(f"{k}={meta[k]}" for k in sorted(meta) if k != "integrity")
+    return digest(payload + "\n--\n" + content)
+
+
 def render(resolution: Resolution, feature: str) -> str:
     """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
     truncated: list[str] = list(resolution.truncated)
@@ -291,7 +385,7 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
             "below there before planning. This block is a task-scoped extract kept for "
             "convenience; where the two differ, the source governs."
         )
@@ -302,7 +396,10 @@ def render(resolution: Resolution, feature: str) -> str:
     body.append("")
 
     for story_id, outcome in resolution.outcomes:
-        body.append(f"**Outcome ({story_id}):** {outcome}")
+        body.append(
+            f"**Outcome ({story_id}):** "
+            + _clip(outcome, MAX_PROSE_CHARS, f"outcome {story_id}", truncated)
+        )
     if resolution.outcomes:
         body.append("")
 
@@ -325,7 +422,8 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     if resolution.task_wording:
-        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        wording = _clip(resolution.task_wording, MAX_PROSE_CHARS, "task wording", truncated)
+        body.append(f'**Task wording (from tasks.md):** "{wording}"')
         body.append(
             "  Resolve its authority against the sections above before acting on it. It "
             "may propose an approach you are free to replace, or it may restate a binding "
@@ -352,17 +450,26 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     content = "\n".join(body).rstrip() + "\n"
-    header = [
-        BLOCK_BEGIN,
-        f"feature: {feature}",
-        f"task: {resolution.task_id}",
-        f"source: {resolution.source if resolution.source else '-'}",
-        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
-        f"scope-digest: {digest(resolution.scope_text)}",
-        f"source-digest: {digest(resolution.source_text)}",
-        f"block-digest: {digest(content)}",
-        "-->",
-    ]
+    if len(content) > MAX_BLOCK_CHARS:
+        keep = content[:MAX_BLOCK_CHARS].rstrip()
+        content = (
+            keep
+            + "\n\n**Capped for size - this extract is INCOMPLETE.** Read the "
+            "authoritative source named above before planning; the constraints that "
+            "make the decision are not guaranteed to be among the lines kept here.\n"
+        )
+    meta = {
+        "feature": feature,
+        "task": resolution.task_id,
+        "tasks": resolution.tasks_rel or "-",
+        "source": resolution.source_rel or "-",
+        "stories": ",".join(story for story, _ in resolution.outcomes) or "-",
+        "task-digest": digest(resolution.task_text),
+        "scope-digest": digest(resolution.scope_text),
+        "source-digest": digest(resolution.source_text),
+    }
+    meta["integrity"] = _meta_digest(meta, content)
+    header = [BLOCK_BEGIN] + [f"{k}: {meta[k]}" for k in meta] + ["-->"]
     return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
 
 
@@ -392,9 +499,16 @@ def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
         return None, "damaged context block: header is unterminated"
     meta: dict[str, str] = {}
     for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
-        if ":" in line:
-            key, _, value = line.partition(":")
-            meta[key.strip()] = value.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in meta:
+            return None, f"damaged context block: duplicate metadata field '{key}'"
+        meta[key] = value.strip()
+    missing = [name for name in REQUIRED_META if name not in meta]
+    if missing:
+        return None, "damaged context block: missing metadata " + ", ".join(missing)
     content = body[header_end + len("-->") : end].lstrip("\n")
     return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
 
@@ -420,10 +534,11 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         return "absent", ["this issue carries no generated context block"]
 
     detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         detail.append(
-            "the block's own text has been edited since it was generated; a refresh "
-            "would overwrite that edit and is refused"
+            "the block has been edited since it was generated - its text, or the "
+            "metadata naming its task and source. A refresh would overwrite that edit "
+            "and is refused"
         )
         return "block-edited", detail
 
@@ -435,6 +550,28 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
     source = root / source_name
     if not source.is_file():
         return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    # The task line is a governing input too: a re-tagged or re-worded task changes
+    # which requirements apply, without touching the spec at all.
+    tasks_name = block.meta.get("tasks", "-")
+    task_id = block.meta.get("task", "")
+    tasks_path = root / tasks_name if tasks_name not in ("-", "") else None
+    task_state: str | None = None
+    if tasks_path is None or not tasks_path.is_file():
+        detail.append(
+            f"the tasks file recorded for this block ({tasks_name}) is not present under "
+            "this root, so the task side of the mapping cannot be re-checked"
+        )
+        task_state = "tasks-missing"
+    else:
+        current = resolve(tasks_path, task_id, root)
+        if digest(current.task_text) != block.meta.get("task-digest", ""):
+            detail.append(
+                "the task line itself changed - its wording, or the [USn] tag that "
+                "decides which requirements apply. The mapping this block was built "
+                "from no longer matches the plan."
+            )
+            task_state = "changed-task"
 
     source_text = source.read_text(encoding="utf-8")
     source_now = digest(source_text)
@@ -448,16 +585,15 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
 
-    if source_now == source_then:
-        return "current", detail + ["source bytes are unchanged since generation"]
+    if task_state is not None:
+        return task_state, detail
 
-    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
-    task_id = block.meta.get("task", "")
+    if source_now == source_then:
+        return "current", detail + ["source and task bytes are unchanged since generation"]
+
     scope_now = ""
-    if task_id and stories:
-        tasks_path = source.parent / "tasks.md"
-        if tasks_path.is_file():
-            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if tasks_path is not None and tasks_path.is_file():
+        scope_now = digest(resolve(tasks_path, task_id, root).scope_text)
     if scope_now and scope_now != block.meta.get("scope-digest", ""):
         return "changed-in-scope", detail + [
             "bytes changed inside the sections this task maps to. That is a byte "
@@ -478,12 +614,23 @@ def refresh(body: str, block_text: str) -> tuple[str | None, str]:
         return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
     if block is None:
         return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         return None, (
             "refused: the block's text was edited after it was generated. The body is "
             "unchanged. Move the edit outside the block, or delete the block to have it "
             "regenerated, if you want the cache refreshed."
         )
+    incoming, fault = find_block(block_text)
+    if incoming is None:
+        return None, f"refused: the replacement block is unusable ({fault})"
+    for key in ("feature", "task"):
+        if block.meta.get(key) != incoming.meta.get(key):
+            return None, (
+                f"refused: identity mismatch - this block is {key}="
+                f"{block.meta.get(key)} and the replacement is {key}="
+                f"{incoming.meta.get(key)}. The body is unchanged; refreshing one "
+                "task's context with another's is never a refresh."
+            )
     updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
     if updated == body:
         return updated, "unchanged: the regenerated block is identical"
@@ -498,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--tasks", type=Path, required=True)
     p_render.add_argument("--task", required=True)
     p_render.add_argument("--feature", default="")
+    p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
     p_check.add_argument("--body-file", type=Path, required=True)
@@ -508,11 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     p_refresh.add_argument("--tasks", type=Path, required=True)
     p_refresh.add_argument("--task", required=True)
     p_refresh.add_argument("--feature", default="")
+    p_refresh.add_argument("--root", type=Path, default=None)
 
     args = parser.parse_args(argv)
 
     if args.command == "render":
-        resolution = resolve(args.tasks, args.task)
+        resolution = resolve(args.tasks, args.task, args.root)
         sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
         return 0
 
@@ -525,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if state in ("current", "absent") else 3
 
     body = args.body_file.read_text(encoding="utf-8")
-    resolution = resolve(args.tasks, args.task)
+    resolution = resolve(args.tasks, args.task, args.root)
     block_text = render(resolution, args.feature or str(args.tasks))
     updated, message = refresh(body, block_text)
     print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)

--- a/codex/skills/project-init/scripts/speckit-context.py
+++ b/codex/skills/project-init/scripts/speckit-context.py
@@ -65,7 +65,7 @@ BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
 # bullet regex reads it: the real shipped template produced a phantom acceptance
 # item of "--". Rules end a list, they are never items in it.
 HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
-FENCE_RE = re.compile(r"^(?:```|~~~)")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -263,19 +263,30 @@ def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolut
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
+    duplicates = 0
     found = False
-    for line in tasks_text.splitlines():
+    # A task line inside a fence is an EXAMPLE. Reading declarations out of fenced
+    # samples let a documentation snippet outrank the real task and supply the wrong
+    # story mapping, so tasks.md gets the same fence handling as the spec.
+    for line in _strip_fences(tasks_text.splitlines()):
         match = TASK_LINE_RE.match(line)
         if not match or match.group(1).upper() != task_id.upper():
+            continue
+        if found:
+            duplicates += 1
             continue
         found = True
         rest = match.group(2)
         for tag in STORY_TAG_RE.findall(rest):
             story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
         wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
-        break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if duplicates:
+        resolution.unresolved.append(
+            f"{task_id.upper()} is declared {duplicates + 1} times in {tasks_path.name}; "
+            "the first was used and the ambiguity is reported rather than resolved here"
+        )
     resolution.tasks_rel = relative_to_root(tasks_path, base)
     if resolution.tasks_rel is None:
         resolution.unresolved.append(
@@ -385,13 +396,15 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
-            "below there before planning. This block is a task-scoped extract kept for "
-            "convenience; where the two differ, the source governs."
+            f"**Reference source:** `{resolution.source_rel or resolution.source}` - read "
+            "the sections named below there before planning. This block is a task-scoped "
+            "extract taken at the version recorded above. A difference between the two is "
+            "a CHANGED VERSION to resolve under the existing authority model - it does not "
+            "by itself override a constraint or plan already accepted on this issue."
         )
     else:
         body.append(
-            "**Authoritative source:** none resolved. See the unresolved notes below."
+            "**Reference source:** none resolved. See the unresolved notes below."
         )
     body.append("")
 
@@ -584,6 +597,17 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         )
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
+        elif recorded == source_then:
+            detail.append(
+                "that record names the version THIS BLOCK CACHED, not the current source - "
+                "so the decision it records predates the change below and must be resolved, "
+                "not assumed to cover it"
+            )
+        else:
+            detail.append(
+                "that record names neither the current source nor the cached version; it "
+                "refers to some third version and cannot be matched automatically"
+            )
 
     if task_state is not None:
         return task_state, detail
@@ -648,7 +672,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
-    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--body-file", type=Path, required=True, help="'-' reads stdin")
     p_check.add_argument("--root", type=Path, default=Path("."))
 
     p_refresh = sub.add_parser("refresh", help="replace only the managed block")
@@ -666,7 +690,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        body = args.body_file.read_text(encoding="utf-8")
+        body = (
+            sys.stdin.read()
+            if str(args.body_file) == "-"
+            else args.body_file.read_text(encoding="utf-8")
+        )
         state, detail = check(body, args.root)
         for line in detail:
             print(f"  {line}")

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -165,6 +165,16 @@ normalize_source_path() {
     printf '%s' "$path"
 }
 
+# scripts/speckit-context.py renders the task-context cache (#858). It ships in the
+# same directory as this script, including inside a generated Codex skill bundle, so
+# it is resolved relative to THIS file rather than to the caller's cwd. Absent or
+# unusable, the converter keeps working and simply writes no context block.
+CONTEXT_HELPER=""
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+    CONTEXT_HELPER="$_self_dir/speckit-context.py"
+fi
+
 TASKS_NORM="$(normalize_source_path "$TASKS")"
 TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
 
@@ -467,6 +477,19 @@ for i in "${!TIDS[@]}"; do
     issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
     if [ -n "${DEPS[$i]}" ]; then
         issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
+    fi
+    # Task context (issue #857 -> #858). A generated issue used to carry its
+    # provenance, its marker and its dependencies, and nothing about the behaviour
+    # it was meant to produce - so the receiving agent had only the title, and no
+    # pointer to the document that governs the work. The helper renders a bounded,
+    # fingerprinted cache of the task's DECLARED context; the spec stays
+    # authoritative. Conditional by design: with no helper and no resolvable spec
+    # the issue body is the whole contract, exactly as before.
+    if [ -n "$CONTEXT_HELPER" ]; then
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
+        if [ -n "$context_block" ]; then
+            issue_body+=$'\n\n'"$context_block"
+        fi
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -26,6 +26,8 @@
 #                    or they are no longer recognised and get filed again. A new
 #                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
+#   --no-context     Do not render task-context blocks. The deliberate opt-out; a
+#                    helper that is missing or fails is an ERROR, not a silent skip.
 #   -h, --help       Show this help.
 #
 # Exit codes:
@@ -38,6 +40,7 @@
 #   5  one or more tasks have an ambiguous legacy identity awaiting resolution
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
+#   7  the task-context helper is missing or failed (use --no-context to opt out)
 set -euo pipefail
 
 DRY_RUN=0
@@ -45,6 +48,7 @@ TASKS=""
 REPO=""
 FEATURE=""
 LIMIT=1000
+NO_CONTEXT=0
 
 usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
@@ -55,6 +59,7 @@ while [ $# -gt 0 ]; do
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
         --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
         --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
+        --no-context) NO_CONTEXT=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -171,7 +176,19 @@ normalize_source_path() {
 # unusable, the converter keeps working and simply writes no context block.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+if [ "$NO_CONTEXT" -eq 0 ]; then
+    if ! command -v python3 > /dev/null 2>&1; then
+        echo "ERROR: python3 is required to render task context and was not found." >&2
+        echo "Install python3, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
+    if [ ! -f "$_self_dir/speckit-context.py" ]; then
+        echo "ERROR: speckit-context.py is missing from $_self_dir." >&2
+        echo "It ships beside this script, including inside a generated skill bundle; a" >&2
+        echo "packaging that separates them is broken, not a context-free installation." >&2
+        echo "Reinstall, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
     CONTEXT_HELPER="$_self_dir/speckit-context.py"
 fi
 
@@ -485,11 +502,20 @@ for i in "${!TIDS[@]}"; do
     # fingerprinted cache of the task's DECLARED context; the spec stays
     # authoritative. Conditional by design: with no helper and no resolvable spec
     # the issue body is the whole contract, exactly as before.
-    if [ -n "$CONTEXT_HELPER" ]; then
-        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
-        if [ -n "$context_block" ]; then
-            issue_body+=$'\n\n'"$context_block"
+    if [ "$NO_CONTEXT" -eq 0 ]; then
+        context_status=0
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
+        if [ "$context_status" -ne 0 ] || [ -z "$context_block" ]; then
+            # A broken helper is not a lightweight issue. Swallowing this produced a
+            # context-free issue that looked like a successful conversion, which is
+            # the failure this whole change exists to remove - so it stops here,
+            # before any further write. `--no-context` is the deliberate opt-out.
+            echo "ERROR: could not render the task context for ${tid} (helper exited ${context_status})." >&2
+            printf '  %s\n' "$context_block" >&2
+            echo "Fix the helper or pass --no-context to convert without context blocks." >&2
+            exit 7
         fi
+        issue_body+=$'\n\n'"$context_block"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -41,6 +41,7 @@
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
 #   7  the task-context helper is missing or failed (use --no-context to opt out)
+#   8  an existing issue's context could not be read or checked on a re-run
 set -euo pipefail
 
 DRY_RUN=0
@@ -173,7 +174,8 @@ normalize_source_path() {
 # scripts/speckit-context.py renders the task-context cache (#858). It ships in the
 # same directory as this script, including inside a generated Codex skill bundle, so
 # it is resolved relative to THIS file rather than to the caller's cwd. Absent or
-# unusable, the converter keeps working and simply writes no context block.
+# unusable, the run STOPS: a packaging fault that silently produced context-free
+# issues would look exactly like a successful conversion. `--no-context` opts out.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$NO_CONTEXT" -eq 0 ]; then
@@ -475,7 +477,7 @@ if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
 fi
 
 # --- Create pass -----------------------------------------------------------------
-created=0; skipped=0; adopted=0
+created=0; skipped=0; adopted=0; context_checks_failed=0
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
@@ -485,13 +487,29 @@ for i in "${!TIDS[@]}"; do
         # invisible until somebody happened to re-read it. Reporting only: this
         # never edits an issue, and a refresh is the explicit documented workflow.
         if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
-            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
-                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
-                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
-            case "$ctx_state" in
-                ""|current|absent) : ;;
-                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
-            esac
+            ctx_read_status=0
+            ctx_body="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || ctx_read_status=$?
+            if [ "$ctx_read_status" -ne 0 ]; then
+                echo "WARN: could not read issue #${FILED_NUM[$tid]} to check ${tid}'s context (gh exited ${ctx_read_status})." >&2
+                printf '  %s\n' "$ctx_body" >&2
+                context_checks_failed=$((context_checks_failed + 1))
+            else
+                ctx_check_status=0
+                ctx_report="$(printf '%s' "$ctx_body" | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>&1)" || ctx_check_status=$?
+                ctx_state="$(printf '%s' "$ctx_report" | sed -n 's/^SPECKIT_CONTEXT_STATE: //p')"
+                # `check` exits 3 for any state other than current/absent; anything
+                # else is a broken checker, not a verdict.
+                if { [ "$ctx_check_status" -ne 0 ] && [ "$ctx_check_status" -ne 3 ]; } || [ -z "$ctx_state" ]; then
+                    echo "WARN: the context check for ${tid} (issue #${FILED_NUM[$tid]}) failed (exit ${ctx_check_status})." >&2
+                    printf '  %s\n' "$ctx_report" >&2
+                    context_checks_failed=$((context_checks_failed + 1))
+                else
+                    case "$ctx_state" in
+                        current|absent) : ;;
+                        *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+                    esac
+                fi
+            fi
         fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
@@ -513,8 +531,9 @@ for i in "${!TIDS[@]}"; do
     # it was meant to produce - so the receiving agent had only the title, and no
     # pointer to the document that governs the work. The helper renders a bounded,
     # fingerprinted cache of the task's DECLARED context; the spec stays
-    # authoritative. Conditional by design: with no helper and no resolvable spec
-    # the issue body is the whole contract, exactly as before.
+    # authoritative. Conditional on the INPUT, not on the installation: a tasks file
+    # with no resolvable spec still gets a block disclosing what did not resolve,
+    # while a missing or failing helper is an error rather than a quiet omission.
     if [ "$NO_CONTEXT" -eq 0 ]; then
         context_status=0
         context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
@@ -611,6 +630,12 @@ done
 echo "---"
 echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
 [ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$context_checks_failed" -gt 0 ]; then
+    echo "ERROR: ${context_checks_failed} context check(s) could not be completed; their" >&2
+    echo "diagnostics are above. An unreadable issue or a broken checker is not the same" >&2
+    echo "as an issue with no context block, and is not reported as one." >&2
+    exit 8
+fi
 if [ "$edges_failed" -gt 0 ]; then
     echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
     echo "command to reconcile the missing edges - it will not create duplicates." >&2

--- a/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
+++ b/codex/skills/project-init/scripts/speckit-tasks-to-issues.sh
@@ -480,6 +480,19 @@ for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
     if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        # Drift visibility on a re-run (#858). An already-filed task used to skip
+        # straight past its context, so a spec that moved under a filed issue was
+        # invisible until somebody happened to re-read it. Reporting only: this
+        # never edits an issue, and a refresh is the explicit documented workflow.
+        if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
+            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
+                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
+                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
+            case "$ctx_state" in
+                ""|current|absent) : ;;
+                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+            esac
+        fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
                  "add '$(marker_for "$tid")' to its body to make the identity explicit)"

--- a/docs/agents/issue-contract.md
+++ b/docs/agents/issue-contract.md
@@ -84,6 +84,25 @@ them.** A copied spec becomes a second, drifting description of the same
 requirement - the same failure the
 [knowledge lifecycle](knowledge-lifecycle.md) prevents after delivery.
 
+**The one exception is a machine-generated cache, and it is narrow.** An issue
+created by `scripts/speckit-tasks-to-issues.sh` carries a `speckit-context` block:
+a bounded extract of the task's declared context, produced by
+`scripts/speckit-context.py`. That is a CACHE, not a second authority, and it earns
+the exception only by staying all four of these:
+
+- **Bounded.** Only what the task's own `[USn]` tag and the spec's declared
+  requirement-to-story mapping select, capped in size. Never the whole spec.
+- **Sourced.** It names the authoritative file and the sections to read there, and
+  says that the source governs where the two differ.
+- **Drift-detectable.** It records digests of the mapped sections and of the source
+  file, so a reader can be told the bytes changed rather than discovering it later.
+- **Honest about its gaps.** An unresolved mapping or a capped extract is stated as
+  incomplete context to resolve, never as an absence of constraints.
+
+A human writing an issue still does not copy the spec: this exception exists because
+a generated issue has no author to make the judgement, not because copying became
+acceptable.
+
 **Existing issues remain usable.** Read an older issue by inferring these
 distinctions from what it says, and surface material ambiguity instead of guessing.
 There is no migration: do not reformat issues into this shape, and do not reject work

--- a/docs/agents/issue-contract.md
+++ b/docs/agents/issue-contract.md
@@ -92,8 +92,10 @@ the exception only by staying all four of these:
 
 - **Bounded.** Only what the task's own `[USn]` tag and the spec's declared
   requirement-to-story mapping select, capped in size. Never the whole spec.
-- **Sourced.** It names the authoritative file and the sections to read there, and
-  says that the source governs where the two differ.
+- **Sourced.** It names the reference file and the sections to read there, and
+  records the source version it was taken at. A difference between cache and source
+  is a changed VERSION to resolve under the existing authority model - newer bytes do
+  not by themselves override a constraint or plan already accepted on the issue.
 - **Drift-detectable.** It records digests of the mapped sections and of the source
   file, so a reader can be told the bytes changed rather than discovering it later.
 - **Honest about its gaps.** An unresolved mapping or a capped extract is stated as

--- a/scripts/flow-helpers-install.sh
+++ b/scripts/flow-helpers-install.sh
@@ -62,6 +62,7 @@ HELPERS=(
     flow-wave-mailbox.sh
     flow-wave-lexicon.sh
     flow-wave-plan.py
+    speckit-context.py
     flow-driver-capability.sh
     flow-finish-gate.sh
     flow-ci-status.sh

--- a/scripts/speckit-context.py
+++ b/scripts/speckit-context.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Resolve, render and refresh the task-context cache in a generated issue (#858).
+
+A generated issue used to carry its provenance, its identity marker and its
+dependencies - and nothing about the behaviour it was meant to produce. The task
+title was the whole description, so a receiving agent could not tell which words
+were the goal and which were somebody's suggested mechanism, and had nothing
+pointing at the document that actually governs the work.
+
+This helper resolves a task's DECLARED context and renders it into a bounded,
+fingerprinted block. The block is a CACHE, not a second authority: the spec named
+inside it stays authoritative, everything in it is traceable to a source section,
+and every part carries a digest so drift is visible instead of silent.
+
+What is declared, and therefore used:
+
+  * the story tag on the task line (`- [ ] **T001** [US1] ...`), which names a
+    `### US1:` section in the sibling spec.md
+  * the Functional Requirements table's `User Story` column, which maps
+    individual requirements to that story
+
+What is NOT inferred: nothing is derived from task NUMBERS, and requirements with
+no declared story mapping are never claimed as this task's. Non-Functional
+Requirements and Out of Scope carry no story mapping at all, so they are indexed
+as cross-cutting sections the consumer must read in the source - and they are
+covered by the whole-file digest, so a changed global security or compatibility
+constraint is visible even though it is not attributed to this task.
+
+What a digest establishes, and what it does not: a differing digest means those
+BYTES changed since the block was written. It is not a ruling that acceptance
+changed, that the change is material to this task, or that anything was approved.
+A reflow or a typo fix reads as a change. The states this helper reports are
+deliberately named for what they observe.
+
+Usage:
+    speckit-context.py render  --tasks PATH --task T001 [--feature SLUG]
+    speckit-context.py check   --body-file PATH [--root DIR]
+    speckit-context.py refresh --body-file PATH --tasks PATH --task T001 [--feature SLUG]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BLOCK_BEGIN = "<!-- speckit-context:v1"
+BLOCK_END = "<!-- speckit-context:end -->"
+DIGEST_LEN = 12
+
+# Declared task -> story mapping, written by .specify/templates/tasks-template.md.
+STORY_TAG_RE = re.compile(r"\[(US\d+(?:\s*,\s*US?\d+)*)\]", re.IGNORECASE)
+STORY_ID_RE = re.compile(r"US\d+", re.IGNORECASE)
+TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[[ xX]\]\s*(?:\*\*|__)?(T\d{3})(?:\*\*|__)?(?![0-9A-Za-z])(.*)$"
+)
+STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
+ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
+BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# A structured, reviewable record that a requirements revision was accepted. The
+# helper REPORTS it; it never decides that it is authorised, and a free-text
+# "acknowledged" somewhere in the body is not this.
+REVISION_RE = re.compile(
+    r"^\s*Acceptance-revision:\s*source-digest=([0-9a-f]{6,64})\s*(?:ref=(\S.*))?$",
+    re.MULTILINE,
+)
+
+CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
+# A cap keeps the cache bounded; beyond it the block points at the source instead
+# of copying, and says that it did (an incomplete extract is never silence).
+MAX_ITEMS = 12
+MAX_ITEM_CHARS = 300
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:DIGEST_LEN]
+
+
+@dataclass
+class Resolution:
+    """What the declared mappings produced for one task."""
+
+    task_id: str
+    task_wording: str
+    source: Path | None = None
+    story_ids: list[str] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+    acceptance: list[tuple[str, str]] = field(default_factory=list)
+    requirements: list[tuple[str, str]] = field(default_factory=list)
+    cross_cutting: list[str] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    truncated: list[str] = field(default_factory=list)
+    scope_text: str = ""
+    source_text: str = ""
+
+
+def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Heading text -> (start, end) line span, for top-level `##`/`###` headings."""
+    spans: dict[str, tuple[int, int]] = {}
+    current: str | None = None
+    start = 0
+    for index, line in enumerate(lines):
+        if ANY_HEADING_RE.match(line):
+            if current is not None:
+                spans[current] = (start, index)
+            current = line.lstrip("#").strip()
+            start = index
+    if current is not None:
+        spans[current] = (start, len(lines))
+    return spans
+
+
+def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = STORY_HEADING_RE.match(line)
+        if match and match.group(1).upper() == story_id.upper():
+            for end in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[end]):
+                    return (index, end)
+            return (index, len(lines))
+    return None
+
+
+def _story_outcome(block: list[str]) -> str:
+    """The story's own sentence: the heading text plus its As/I want/So that lines."""
+    parts: list[str] = []
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if parts:
+                break
+            continue
+        if stripped.startswith("**Acceptance") or ANY_HEADING_RE.match(line):
+            break
+        parts.append(stripped)
+    return " ".join(parts).strip()
+
+
+def _story_acceptance(block: list[str]) -> list[str]:
+    items: list[str] = []
+    collecting = False
+    for line in block:
+        if ACCEPTANCE_HEADING_RE.match(line.strip()):
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
+                break
+            bullet = BULLET_RE.match(line)
+            if bullet:
+                items.append(bullet.group(1))
+            elif line.strip() and items:
+                items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
+def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str, str]]:
+    """FR rows whose declared `User Story` column names one of these stories.
+
+    The mapping is read from the table the spec template ships; a row with no
+    story column, or one naming another story, is never attributed to this task.
+    """
+    wanted = {s.upper() for s in story_ids}
+    spans = _sections(lines)
+    span = spans.get("Functional Requirements")
+    if span is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    header: list[str] | None = None
+    for line in lines[span[0] : span[1]]:
+        match = TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in match.group(1).split("|")]
+        if header is None:
+            header = [c.lower() for c in cells]
+            continue
+        if all(set(c) <= {"-", ":"} for c in cells if c):
+            continue
+        if "user story" not in header:
+            continue
+        story_index = header.index("user story")
+        if story_index >= len(cells):
+            continue
+        declared = {s.upper() for s in STORY_ID_RE.findall(cells[story_index])}
+        if not declared & wanted:
+            continue
+        ident = cells[0] if cells else ""
+        text_index = header.index("requirement") if "requirement" in header else 1
+        text = cells[text_index] if text_index < len(cells) else ""
+        priority_index = header.index("priority") if "priority" in header else None
+        if priority_index is not None and priority_index < len(cells):
+            text = f"{text} ({cells[priority_index]})"
+        rows.append((ident, text))
+    return rows
+
+
+def resolve(tasks_path: Path, task_id: str) -> Resolution:
+    """Resolve one task's declared context, disclosing whatever does not resolve."""
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    wording = ""
+    story_ids: list[str] = []
+    found = False
+    for line in tasks_text.splitlines():
+        match = TASK_LINE_RE.match(line)
+        if not match or match.group(1).upper() != task_id.upper():
+            continue
+        found = True
+        rest = match.group(2)
+        for tag in STORY_TAG_RE.findall(rest):
+            story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
+        wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
+        break
+
+    resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if not found:
+        resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
+        return resolution
+
+    source = tasks_path.parent / "spec.md"
+    if not source.is_file():
+        resolution.unresolved.append(
+            f"no spec.md beside {tasks_path} - no declared source to resolve against"
+        )
+        return resolution
+    resolution.source = source
+    resolution.source_text = source.read_text(encoding="utf-8")
+    lines = resolution.source_text.splitlines()
+
+    if not story_ids:
+        resolution.unresolved.append(
+            f"{resolution.task_id} declares no [USn] story tag, so its governing "
+            "requirement is not resolvable from the task line"
+        )
+
+    scope_parts: list[str] = []
+    for story_id in dict.fromkeys(story_ids):
+        span = _story_span(lines, story_id)
+        if span is None:
+            resolution.unresolved.append(
+                f"{story_id} is tagged on the task but has no '### {story_id}:' "
+                f"section in {source.name}"
+            )
+            continue
+        block = lines[span[0] : span[1]]
+        scope_parts.append("\n".join(block))
+        heading = STORY_HEADING_RE.match(block[0])
+        title = heading.group(2) if heading else story_id
+        outcome = _story_outcome(block)
+        resolution.outcomes.append((story_id, f"{title}. {outcome}".strip()))
+        for item in _story_acceptance(block):
+            resolution.acceptance.append((story_id, item))
+
+    for ident, text in _requirements_for(lines, story_ids):
+        resolution.requirements.append((ident, text))
+        scope_parts.append(f"{ident}|{text}")
+
+    spans = _sections(lines)
+    for heading in CROSS_CUTTING_HEADINGS:
+        if heading in spans:
+            resolution.cross_cutting.append(heading)
+
+    resolution.scope_text = "\n".join(scope_parts)
+    return resolution
+
+
+def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list[tuple[str, str]]:
+    if len(items) > MAX_ITEMS:
+        truncated.append(f"{label}: showing {MAX_ITEMS} of {len(items)}")
+        items = items[:MAX_ITEMS]
+    capped: list[tuple[str, str]] = []
+    for ident, text in items:
+        if len(text) > MAX_ITEM_CHARS:
+            text = text[:MAX_ITEM_CHARS].rstrip() + " [...]"
+            truncated.append(f"{label} {ident}: shortened")
+        capped.append((ident, text))
+    return capped
+
+
+def render(resolution: Resolution, feature: str) -> str:
+    """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
+    truncated: list[str] = list(resolution.truncated)
+    acceptance = _cap(resolution.acceptance, "acceptance", truncated)
+    requirements = _cap(resolution.requirements, "requirements", truncated)
+
+    body: list[str] = ["### Governing context (generated cache)", ""]
+    if resolution.source is not None:
+        body.append(
+            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            "below there before planning. This block is a task-scoped extract kept for "
+            "convenience; where the two differ, the source governs."
+        )
+    else:
+        body.append(
+            "**Authoritative source:** none resolved. See the unresolved notes below."
+        )
+    body.append("")
+
+    for story_id, outcome in resolution.outcomes:
+        body.append(f"**Outcome ({story_id}):** {outcome}")
+    if resolution.outcomes:
+        body.append("")
+
+    if acceptance:
+        body.append("**Acceptance, as declared by the story:**")
+        body.extend(f"- ({story_id}) {item}" for story_id, item in acceptance)
+        body.append("")
+
+    if requirements:
+        body.append("**Requirements declared against this story:**")
+        body.extend(f"- {ident}: {text}" for ident, text in requirements)
+        body.append("")
+
+    if resolution.cross_cutting:
+        body.append(
+            "**Cross-cutting sections to read in the source before planning** - these "
+            "carry no story mapping, so they are named rather than attributed to this "
+            "task: " + ", ".join(f"`{h}`" for h in resolution.cross_cutting)
+        )
+        body.append("")
+
+    if resolution.task_wording:
+        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        body.append(
+            "  Resolve its authority against the sections above before acting on it. It "
+            "may propose an approach you are free to replace, or it may restate a binding "
+            "constraint; the line alone does not say which."
+        )
+        body.append("")
+
+    if resolution.outcomes:
+        body.append(
+            "**Granularity:** acceptance is declared at user-story level, so the items "
+            "above may also cover sibling tasks of the same story. Narrow them to this "
+            "task yourself; this block does not decide that for you."
+        )
+        body.append("")
+
+    if resolution.unresolved:
+        body.append("**Unresolved - incomplete context, not an absence of constraints:**")
+        body.extend(f"- {note}" for note in resolution.unresolved)
+        body.append("")
+
+    if truncated:
+        body.append("**Capped for size - read the source for the rest:**")
+        body.extend(f"- {note}" for note in truncated)
+        body.append("")
+
+    content = "\n".join(body).rstrip() + "\n"
+    header = [
+        BLOCK_BEGIN,
+        f"feature: {feature}",
+        f"task: {resolution.task_id}",
+        f"source: {resolution.source if resolution.source else '-'}",
+        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
+        f"scope-digest: {digest(resolution.scope_text)}",
+        f"source-digest: {digest(resolution.source_text)}",
+        f"block-digest: {digest(content)}",
+        "-->",
+    ]
+    return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
+
+
+@dataclass
+class ParsedBlock:
+    start: int
+    end: int
+    meta: dict[str, str]
+    content: str
+
+
+def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
+    """Locate the managed block. Returns (block, fault); a fault forbids rewriting."""
+    starts = [m.start() for m in re.finditer(re.escape(BLOCK_BEGIN), body)]
+    ends = [m.start() for m in re.finditer(re.escape(BLOCK_END), body)]
+    if not starts and not ends:
+        return None, None
+    if len(starts) > 1 or len(ends) > 1:
+        return None, "duplicate context block boundaries"
+    if not starts or not ends:
+        return None, "damaged context block: one boundary is missing"
+    start, end = starts[0], ends[0]
+    if end < start:
+        return None, "damaged context block: boundaries are out of order"
+    header_end = body.find("-->", start)
+    if header_end == -1 or header_end > end:
+        return None, "damaged context block: header is unterminated"
+    meta: dict[str, str] = {}
+    for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    content = body[header_end + len("-->") : end].lstrip("\n")
+    return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
+
+
+def recorded_revisions(body: str, block: ParsedBlock | None) -> list[tuple[str, str]]:
+    """Structured revision records OUTSIDE the managed block.
+
+    Reported, never judged: this helper cannot tell whether a record was written
+    by someone with the authority to accept a requirements change, and a
+    free-text "acknowledged" is deliberately not matched.
+    """
+    outside = body if block is None else body[: block.start] + body[block.end :]
+    return [(m.group(1), (m.group(2) or "").strip()) for m in REVISION_RE.finditer(outside)]
+
+
+def check(body: str, root: Path) -> tuple[str, list[str]]:
+    """Freshness of the cache against its source. Returns (state, detail lines)."""
+    block, fault = find_block(body)
+    detail: list[str] = []
+    if fault:
+        return "block-damaged", [fault]
+    if block is None:
+        return "absent", ["this issue carries no generated context block"]
+
+    detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        detail.append(
+            "the block's own text has been edited since it was generated; a refresh "
+            "would overwrite that edit and is refused"
+        )
+        return "block-edited", detail
+
+    source_name = block.meta.get("source", "-")
+    if source_name in ("-", ""):
+        return "source-unresolved", detail + [
+            "no source was resolved when this block was written; its notes say why"
+        ]
+    source = root / source_name
+    if not source.is_file():
+        return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    source_text = source.read_text(encoding="utf-8")
+    source_now = digest(source_text)
+    source_then = block.meta.get("source-digest", "")
+    for recorded, ref in recorded_revisions(body, block):
+        detail.append(
+            f"recorded revision: source-digest={recorded} ref={ref or '-'} "
+            "(a record found in the issue body; this helper does not judge whether it "
+            "was authorised - resolve it under the existing authority model)"
+        )
+        if recorded == source_now:
+            detail.append("that record names the CURRENT source version")
+
+    if source_now == source_then:
+        return "current", detail + ["source bytes are unchanged since generation"]
+
+    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
+    task_id = block.meta.get("task", "")
+    scope_now = ""
+    if task_id and stories:
+        tasks_path = source.parent / "tasks.md"
+        if tasks_path.is_file():
+            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if scope_now and scope_now != block.meta.get("scope-digest", ""):
+        return "changed-in-scope", detail + [
+            "bytes changed inside the sections this task maps to. That is a byte "
+            "difference, not a ruling that acceptance changed - assess it against the "
+            "source before continuing."
+        ]
+    return "changed-outside-scope", detail + [
+        "the source file changed, but not inside the sections this task maps to. The "
+        "change may still matter (cross-cutting requirements carry no story mapping), "
+        "so read it; nothing here claims it is relevant to this task."
+    ]
+
+
+def refresh(body: str, block_text: str) -> tuple[str | None, str]:
+    """Replace ONLY the managed block. Any doubt leaves the body byte-identical."""
+    block, fault = find_block(body)
+    if fault:
+        return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
+    if block is None:
+        return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
+    if digest(block.content) != block.meta.get("block-digest", ""):
+        return None, (
+            "refused: the block's text was edited after it was generated. The body is "
+            "unchanged. Move the edit outside the block, or delete the block to have it "
+            "regenerated, if you want the cache refreshed."
+        )
+    updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
+    if updated == body:
+        return updated, "unchanged: the regenerated block is identical"
+    return updated, "refreshed: the block was replaced; text outside it is untouched"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_render = sub.add_parser("render", help="print the managed block for one task")
+    p_render.add_argument("--tasks", type=Path, required=True)
+    p_render.add_argument("--task", required=True)
+    p_render.add_argument("--feature", default="")
+
+    p_check = sub.add_parser("check", help="report cache freshness for an issue body")
+    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--root", type=Path, default=Path("."))
+
+    p_refresh = sub.add_parser("refresh", help="replace only the managed block")
+    p_refresh.add_argument("--body-file", type=Path, required=True)
+    p_refresh.add_argument("--tasks", type=Path, required=True)
+    p_refresh.add_argument("--task", required=True)
+    p_refresh.add_argument("--feature", default="")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        resolution = resolve(args.tasks, args.task)
+        sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
+        return 0
+
+    if args.command == "check":
+        body = args.body_file.read_text(encoding="utf-8")
+        state, detail = check(body, args.root)
+        for line in detail:
+            print(f"  {line}")
+        print(f"SPECKIT_CONTEXT_STATE: {state}")
+        return 0 if state in ("current", "absent") else 3
+
+    body = args.body_file.read_text(encoding="utf-8")
+    resolution = resolve(args.tasks, args.task)
+    block_text = render(resolution, args.feature or str(args.tasks))
+    updated, message = refresh(body, block_text)
+    print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)
+    if updated is None:
+        return 4
+    sys.stdout.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/speckit-context.py
+++ b/scripts/speckit-context.py
@@ -61,6 +61,11 @@ STORY_HEADING_RE = re.compile(r"^###\s+(US\d+)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 ANY_HEADING_RE = re.compile(r"^#{1,6}\s")
 ACCEPTANCE_HEADING_RE = re.compile(r"^\*\*Acceptance Criteria:?\*\*\s*$", re.IGNORECASE)
 BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
+# `---` under an acceptance list is a horizontal rule, and `- -` is how a naive
+# bullet regex reads it: the real shipped template produced a phantom acceptance
+# item of "--". Rules end a list, they are never items in it.
+HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
+FENCE_RE = re.compile(r"^(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -75,6 +80,9 @@ CROSS_CUTTING_HEADINGS = ("Non-Functional Requirements", "Out of Scope")
 # of copying, and says that it did (an incomplete extract is never silence).
 MAX_ITEMS = 12
 MAX_ITEM_CHARS = 300
+MAX_PROSE_CHARS = 600
+MAX_BLOCK_CHARS = 8000
+REQUIRED_META = ("feature", "task", "tasks", "source", "integrity")
 
 
 def digest(text: str) -> str:
@@ -97,6 +105,9 @@ class Resolution:
     truncated: list[str] = field(default_factory=list)
     scope_text: str = ""
     source_text: str = ""
+    task_text: str = ""
+    tasks_rel: str | None = None
+    source_rel: str | None = None
 
 
 def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
@@ -115,15 +126,19 @@ def _sections(lines: list[str]) -> dict[str, tuple[int, int]]:
     return spans
 
 
-def _story_span(lines: list[str], story_id: str) -> tuple[int, int] | None:
+def _story_spans(lines: list[str], story_id: str) -> list[tuple[int, int]]:
+    """Every span declaring this story. More than one is ambiguity, not a choice."""
+    spans: list[tuple[int, int]] = []
     for index, line in enumerate(lines):
         match = STORY_HEADING_RE.match(line)
         if match and match.group(1).upper() == story_id.upper():
-            for end in range(index + 1, len(lines)):
-                if ANY_HEADING_RE.match(lines[end]):
-                    return (index, end)
-            return (index, len(lines))
-    return None
+            end = len(lines)
+            for candidate in range(index + 1, len(lines)):
+                if ANY_HEADING_RE.match(lines[candidate]):
+                    end = candidate
+                    break
+            spans.append((index, end))
+    return spans
 
 
 def _story_outcome(block: list[str]) -> str:
@@ -141,6 +156,19 @@ def _story_outcome(block: list[str]) -> str:
     return " ".join(parts).strip()
 
 
+def _strip_fences(lines: list[str]) -> list[str]:
+    """Blank out fenced blocks: a sample inside a fence is an example, not a declaration."""
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            inside = not inside
+            out.append("")
+            continue
+        out.append("" if inside else line)
+    return out
+
+
 def _story_acceptance(block: list[str]) -> list[str]:
     items: list[str] = []
     collecting = False
@@ -149,6 +177,8 @@ def _story_acceptance(block: list[str]) -> list[str]:
             collecting = True
             continue
         if collecting:
+            if HRULE_RE.match(line):
+                break
             if line.strip().startswith("**") or ANY_HEADING_RE.match(line):
                 break
             bullet = BULLET_RE.match(line)
@@ -200,8 +230,36 @@ def _requirements_for(lines: list[str], story_ids: list[str]) -> list[tuple[str,
     return rows
 
 
-def resolve(tasks_path: Path, task_id: str) -> Resolution:
+def project_root(start: Path, explicit: Path | None = None) -> Path:
+    """The root every persisted path is relative to.
+
+    Persisting the path as GIVEN was a defect: an absolute source recorded by the
+    producer's checkout kept resolving back to that checkout, so a consumer in a
+    different clone checked the wrong tree and was told `current` while its own
+    spec had changed. Paths are stored relative to this root and re-resolved
+    against the consumer's `--root`.
+    """
+    if explicit is not None:
+        return explicit.resolve()
+    here = start.resolve()
+    here = here if here.is_dir() else here.parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return here
+
+
+def relative_to_root(path: Path, root: Path) -> str | None:
+    """Project-relative spelling, or None when the path escapes the root."""
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolution:
     """Resolve one task's declared context, disclosing whatever does not resolve."""
+    base = project_root(tasks_path, root)
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
@@ -218,6 +276,16 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    resolution.tasks_rel = relative_to_root(tasks_path, base)
+    if resolution.tasks_rel is None:
+        resolution.unresolved.append(
+            f"{tasks_path} lies outside the project root {base}; its location cannot be "
+            "recorded portably, so a consumer in another checkout cannot re-resolve it"
+        )
+    # The task line is a governing input in its own right: its wording can carry a
+    # constraint, and its [USn] tag decides which requirements apply. A digest over
+    # the spec alone left a re-tagged or re-worded task reading as unchanged.
+    resolution.task_text = f"{task_id.upper()}|{','.join(sorted(set(story_ids)))}|{wording}"
     if not found:
         resolution.unresolved.append(f"{task_id} is not a task line in {tasks_path}")
         return resolution
@@ -229,8 +297,9 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
         )
         return resolution
     resolution.source = source
+    resolution.source_rel = relative_to_root(source, base)
     resolution.source_text = source.read_text(encoding="utf-8")
-    lines = resolution.source_text.splitlines()
+    lines = _strip_fences(resolution.source_text.splitlines())
 
     if not story_ids:
         resolution.unresolved.append(
@@ -240,13 +309,20 @@ def resolve(tasks_path: Path, task_id: str) -> Resolution:
 
     scope_parts: list[str] = []
     for story_id in dict.fromkeys(story_ids):
-        span = _story_span(lines, story_id)
-        if span is None:
+        spans = _story_spans(lines, story_id)
+        if not spans:
             resolution.unresolved.append(
                 f"{story_id} is tagged on the task but has no '### {story_id}:' "
                 f"section in {source.name}"
             )
             continue
+        if len(spans) > 1:
+            resolution.unresolved.append(
+                f"{story_id} is declared {len(spans)} times in {source.name}; the "
+                "ambiguity is reported rather than resolved here - read the source"
+            )
+            continue
+        span = spans[0]
         block = lines[span[0] : span[1]]
         scope_parts.append("\n".join(block))
         heading = STORY_HEADING_RE.match(block[0])
@@ -282,6 +358,24 @@ def _cap(items: list[tuple[str, str]], label: str, truncated: list[str]) -> list
     return capped
 
 
+def _clip(text: str, limit: int, label: str, truncated: list[str]) -> str:
+    if len(text) <= limit:
+        return text
+    truncated.append(f"{label}: shortened to {limit} characters - read the source")
+    return text[:limit].rstrip() + " [...]"
+
+
+def _meta_digest(meta: dict[str, str], content: str) -> str:
+    """Integrity over the MANAGED METADATA and the content, minus the field itself.
+
+    Covering only the visible text left `task:`, `source:` and the other digests
+    editable in place: the block could be re-pointed at another task's source and
+    a refresh would accept it as its own.
+    """
+    payload = "\n".join(f"{k}={meta[k]}" for k in sorted(meta) if k != "integrity")
+    return digest(payload + "\n--\n" + content)
+
+
 def render(resolution: Resolution, feature: str) -> str:
     """The managed block: bounded, sourced, fingerprinted, and honest about gaps."""
     truncated: list[str] = list(resolution.truncated)
@@ -291,7 +385,7 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source}` - read the sections named "
+            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
             "below there before planning. This block is a task-scoped extract kept for "
             "convenience; where the two differ, the source governs."
         )
@@ -302,7 +396,10 @@ def render(resolution: Resolution, feature: str) -> str:
     body.append("")
 
     for story_id, outcome in resolution.outcomes:
-        body.append(f"**Outcome ({story_id}):** {outcome}")
+        body.append(
+            f"**Outcome ({story_id}):** "
+            + _clip(outcome, MAX_PROSE_CHARS, f"outcome {story_id}", truncated)
+        )
     if resolution.outcomes:
         body.append("")
 
@@ -325,7 +422,8 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     if resolution.task_wording:
-        body.append(f'**Task wording (from tasks.md):** "{resolution.task_wording}"')
+        wording = _clip(resolution.task_wording, MAX_PROSE_CHARS, "task wording", truncated)
+        body.append(f'**Task wording (from tasks.md):** "{wording}"')
         body.append(
             "  Resolve its authority against the sections above before acting on it. It "
             "may propose an approach you are free to replace, or it may restate a binding "
@@ -352,17 +450,26 @@ def render(resolution: Resolution, feature: str) -> str:
         body.append("")
 
     content = "\n".join(body).rstrip() + "\n"
-    header = [
-        BLOCK_BEGIN,
-        f"feature: {feature}",
-        f"task: {resolution.task_id}",
-        f"source: {resolution.source if resolution.source else '-'}",
-        f"stories: {','.join(s for s, _ in resolution.outcomes) or '-'}",
-        f"scope-digest: {digest(resolution.scope_text)}",
-        f"source-digest: {digest(resolution.source_text)}",
-        f"block-digest: {digest(content)}",
-        "-->",
-    ]
+    if len(content) > MAX_BLOCK_CHARS:
+        keep = content[:MAX_BLOCK_CHARS].rstrip()
+        content = (
+            keep
+            + "\n\n**Capped for size - this extract is INCOMPLETE.** Read the "
+            "authoritative source named above before planning; the constraints that "
+            "make the decision are not guaranteed to be among the lines kept here.\n"
+        )
+    meta = {
+        "feature": feature,
+        "task": resolution.task_id,
+        "tasks": resolution.tasks_rel or "-",
+        "source": resolution.source_rel or "-",
+        "stories": ",".join(story for story, _ in resolution.outcomes) or "-",
+        "task-digest": digest(resolution.task_text),
+        "scope-digest": digest(resolution.scope_text),
+        "source-digest": digest(resolution.source_text),
+    }
+    meta["integrity"] = _meta_digest(meta, content)
+    header = [BLOCK_BEGIN] + [f"{k}: {meta[k]}" for k in meta] + ["-->"]
     return "\n".join(header) + "\n" + content + BLOCK_END + "\n"
 
 
@@ -392,9 +499,16 @@ def find_block(body: str) -> tuple[ParsedBlock | None, str | None]:
         return None, "damaged context block: header is unterminated"
     meta: dict[str, str] = {}
     for line in body[start + len(BLOCK_BEGIN) : header_end].splitlines():
-        if ":" in line:
-            key, _, value = line.partition(":")
-            meta[key.strip()] = value.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key in meta:
+            return None, f"damaged context block: duplicate metadata field '{key}'"
+        meta[key] = value.strip()
+    missing = [name for name in REQUIRED_META if name not in meta]
+    if missing:
+        return None, "damaged context block: missing metadata " + ", ".join(missing)
     content = body[header_end + len("-->") : end].lstrip("\n")
     return ParsedBlock(start, end + len(BLOCK_END), meta, content), None
 
@@ -420,10 +534,11 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         return "absent", ["this issue carries no generated context block"]
 
     detail.append(f"task={block.meta.get('task', '-')} source={block.meta.get('source', '-')}")
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         detail.append(
-            "the block's own text has been edited since it was generated; a refresh "
-            "would overwrite that edit and is refused"
+            "the block has been edited since it was generated - its text, or the "
+            "metadata naming its task and source. A refresh would overwrite that edit "
+            "and is refused"
         )
         return "block-edited", detail
 
@@ -435,6 +550,28 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
     source = root / source_name
     if not source.is_file():
         return "source-missing", detail + [f"{source_name} is no longer present"]
+
+    # The task line is a governing input too: a re-tagged or re-worded task changes
+    # which requirements apply, without touching the spec at all.
+    tasks_name = block.meta.get("tasks", "-")
+    task_id = block.meta.get("task", "")
+    tasks_path = root / tasks_name if tasks_name not in ("-", "") else None
+    task_state: str | None = None
+    if tasks_path is None or not tasks_path.is_file():
+        detail.append(
+            f"the tasks file recorded for this block ({tasks_name}) is not present under "
+            "this root, so the task side of the mapping cannot be re-checked"
+        )
+        task_state = "tasks-missing"
+    else:
+        current = resolve(tasks_path, task_id, root)
+        if digest(current.task_text) != block.meta.get("task-digest", ""):
+            detail.append(
+                "the task line itself changed - its wording, or the [USn] tag that "
+                "decides which requirements apply. The mapping this block was built "
+                "from no longer matches the plan."
+            )
+            task_state = "changed-task"
 
     source_text = source.read_text(encoding="utf-8")
     source_now = digest(source_text)
@@ -448,16 +585,15 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
 
-    if source_now == source_then:
-        return "current", detail + ["source bytes are unchanged since generation"]
+    if task_state is not None:
+        return task_state, detail
 
-    stories = [s for s in block.meta.get("stories", "").split(",") if s and s != "-"]
-    task_id = block.meta.get("task", "")
+    if source_now == source_then:
+        return "current", detail + ["source and task bytes are unchanged since generation"]
+
     scope_now = ""
-    if task_id and stories:
-        tasks_path = source.parent / "tasks.md"
-        if tasks_path.is_file():
-            scope_now = digest(resolve(tasks_path, task_id).scope_text)
+    if tasks_path is not None and tasks_path.is_file():
+        scope_now = digest(resolve(tasks_path, task_id, root).scope_text)
     if scope_now and scope_now != block.meta.get("scope-digest", ""):
         return "changed-in-scope", detail + [
             "bytes changed inside the sections this task maps to. That is a byte "
@@ -478,12 +614,23 @@ def refresh(body: str, block_text: str) -> tuple[str | None, str]:
         return None, f"refused: {fault}. The body is unchanged; repair the block by hand."
     if block is None:
         return body.rstrip("\n") + "\n\n" + block_text, "attached: the issue had no block"
-    if digest(block.content) != block.meta.get("block-digest", ""):
+    if _meta_digest(block.meta, block.content) != block.meta.get("integrity", ""):
         return None, (
             "refused: the block's text was edited after it was generated. The body is "
             "unchanged. Move the edit outside the block, or delete the block to have it "
             "regenerated, if you want the cache refreshed."
         )
+    incoming, fault = find_block(block_text)
+    if incoming is None:
+        return None, f"refused: the replacement block is unusable ({fault})"
+    for key in ("feature", "task"):
+        if block.meta.get(key) != incoming.meta.get(key):
+            return None, (
+                f"refused: identity mismatch - this block is {key}="
+                f"{block.meta.get(key)} and the replacement is {key}="
+                f"{incoming.meta.get(key)}. The body is unchanged; refreshing one "
+                "task's context with another's is never a refresh."
+            )
     updated = body[: block.start] + block_text.rstrip("\n") + body[block.end :]
     if updated == body:
         return updated, "unchanged: the regenerated block is identical"
@@ -498,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--tasks", type=Path, required=True)
     p_render.add_argument("--task", required=True)
     p_render.add_argument("--feature", default="")
+    p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
     p_check.add_argument("--body-file", type=Path, required=True)
@@ -508,11 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     p_refresh.add_argument("--tasks", type=Path, required=True)
     p_refresh.add_argument("--task", required=True)
     p_refresh.add_argument("--feature", default="")
+    p_refresh.add_argument("--root", type=Path, default=None)
 
     args = parser.parse_args(argv)
 
     if args.command == "render":
-        resolution = resolve(args.tasks, args.task)
+        resolution = resolve(args.tasks, args.task, args.root)
         sys.stdout.write(render(resolution, args.feature or str(args.tasks)))
         return 0
 
@@ -525,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if state in ("current", "absent") else 3
 
     body = args.body_file.read_text(encoding="utf-8")
-    resolution = resolve(args.tasks, args.task)
+    resolution = resolve(args.tasks, args.task, args.root)
     block_text = render(resolution, args.feature or str(args.tasks))
     updated, message = refresh(body, block_text)
     print(f"SPECKIT_CONTEXT_REFRESH: {message}", file=sys.stderr)

--- a/scripts/speckit-context.py
+++ b/scripts/speckit-context.py
@@ -65,7 +65,7 @@ BULLET_RE = re.compile(r"^\s*-\s*(?:\[[ xX]\]\s*)?(.+?)\s*$")
 # bullet regex reads it: the real shipped template produced a phantom acceptance
 # item of "--". Rules end a list, they are never items in it.
 HRULE_RE = re.compile(r"^\s*([-*_])\s*(?:\1\s*){2,}$")
-FENCE_RE = re.compile(r"^(?:```|~~~)")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # A structured, reviewable record that a requirements revision was accepted. The
 # helper REPORTS it; it never decides that it is authorised, and a free-text
@@ -263,19 +263,30 @@ def resolve(tasks_path: Path, task_id: str, root: Path | None = None) -> Resolut
     tasks_text = tasks_path.read_text(encoding="utf-8")
     wording = ""
     story_ids: list[str] = []
+    duplicates = 0
     found = False
-    for line in tasks_text.splitlines():
+    # A task line inside a fence is an EXAMPLE. Reading declarations out of fenced
+    # samples let a documentation snippet outrank the real task and supply the wrong
+    # story mapping, so tasks.md gets the same fence handling as the spec.
+    for line in _strip_fences(tasks_text.splitlines()):
         match = TASK_LINE_RE.match(line)
         if not match or match.group(1).upper() != task_id.upper():
+            continue
+        if found:
+            duplicates += 1
             continue
         found = True
         rest = match.group(2)
         for tag in STORY_TAG_RE.findall(rest):
             story_ids.extend(s.upper() for s in STORY_ID_RE.findall(tag))
         wording = STORY_TAG_RE.sub("", rest).replace("[P]", "").strip(" :\t")
-        break
 
     resolution = Resolution(task_id=task_id.upper(), task_wording=wording)
+    if duplicates:
+        resolution.unresolved.append(
+            f"{task_id.upper()} is declared {duplicates + 1} times in {tasks_path.name}; "
+            "the first was used and the ambiguity is reported rather than resolved here"
+        )
     resolution.tasks_rel = relative_to_root(tasks_path, base)
     if resolution.tasks_rel is None:
         resolution.unresolved.append(
@@ -385,13 +396,15 @@ def render(resolution: Resolution, feature: str) -> str:
     body: list[str] = ["### Governing context (generated cache)", ""]
     if resolution.source is not None:
         body.append(
-            f"**Authoritative source:** `{resolution.source_rel or resolution.source}` - read the sections named "
-            "below there before planning. This block is a task-scoped extract kept for "
-            "convenience; where the two differ, the source governs."
+            f"**Reference source:** `{resolution.source_rel or resolution.source}` - read "
+            "the sections named below there before planning. This block is a task-scoped "
+            "extract taken at the version recorded above. A difference between the two is "
+            "a CHANGED VERSION to resolve under the existing authority model - it does not "
+            "by itself override a constraint or plan already accepted on this issue."
         )
     else:
         body.append(
-            "**Authoritative source:** none resolved. See the unresolved notes below."
+            "**Reference source:** none resolved. See the unresolved notes below."
         )
     body.append("")
 
@@ -584,6 +597,17 @@ def check(body: str, root: Path) -> tuple[str, list[str]]:
         )
         if recorded == source_now:
             detail.append("that record names the CURRENT source version")
+        elif recorded == source_then:
+            detail.append(
+                "that record names the version THIS BLOCK CACHED, not the current source - "
+                "so the decision it records predates the change below and must be resolved, "
+                "not assumed to cover it"
+            )
+        else:
+            detail.append(
+                "that record names neither the current source nor the cached version; it "
+                "refers to some third version and cannot be matched automatically"
+            )
 
     if task_state is not None:
         return task_state, detail
@@ -648,7 +672,7 @@ def main(argv: list[str] | None = None) -> int:
     p_render.add_argument("--root", type=Path, default=None)
 
     p_check = sub.add_parser("check", help="report cache freshness for an issue body")
-    p_check.add_argument("--body-file", type=Path, required=True)
+    p_check.add_argument("--body-file", type=Path, required=True, help="'-' reads stdin")
     p_check.add_argument("--root", type=Path, default=Path("."))
 
     p_refresh = sub.add_parser("refresh", help="replace only the managed block")
@@ -666,7 +690,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        body = args.body_file.read_text(encoding="utf-8")
+        body = (
+            sys.stdin.read()
+            if str(args.body_file) == "-"
+            else args.body_file.read_text(encoding="utf-8")
+        )
         state, detail = check(body, args.root)
         for line in detail:
             print(f"  {line}")

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -165,6 +165,16 @@ normalize_source_path() {
     printf '%s' "$path"
 }
 
+# scripts/speckit-context.py renders the task-context cache (#858). It ships in the
+# same directory as this script, including inside a generated Codex skill bundle, so
+# it is resolved relative to THIS file rather than to the caller's cwd. Absent or
+# unusable, the converter keeps working and simply writes no context block.
+CONTEXT_HELPER=""
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+    CONTEXT_HELPER="$_self_dir/speckit-context.py"
+fi
+
 TASKS_NORM="$(normalize_source_path "$TASKS")"
 TASKS_REL_NORM="$(normalize_source_path "$TASKS_REL")"
 
@@ -467,6 +477,19 @@ for i in "${!TIDS[@]}"; do
     issue_body="$(provenance_for "$tid")"$'\n\n'"$(marker_for "$tid")"
     if [ -n "${DEPS[$i]}" ]; then
         issue_body+=$'\n\n'"Depends on: $(printf '%s' "${DEPS[$i]}" | sed 's/ /, /g')"
+    fi
+    # Task context (issue #857 -> #858). A generated issue used to carry its
+    # provenance, its marker and its dependencies, and nothing about the behaviour
+    # it was meant to produce - so the receiving agent had only the title, and no
+    # pointer to the document that governs the work. The helper renders a bounded,
+    # fingerprinted cache of the task's DECLARED context; the spec stays
+    # authoritative. Conditional by design: with no helper and no resolvable spec
+    # the issue body is the whole contract, exactly as before.
+    if [ -n "$CONTEXT_HELPER" ]; then
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
+        if [ -n "$context_block" ]; then
+            issue_body+=$'\n\n'"$context_block"
+        fi
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -26,6 +26,8 @@
 #                    or they are no longer recognised and get filed again. A new
 #                    slug does not prevent that; only the original identity does.
 #   --limit N        Issues to scan for the existing-work inventory (default 1000).
+#   --no-context     Do not render task-context blocks. The deliberate opt-out; a
+#                    helper that is missing or fails is an ERROR, not a silent skip.
 #   -h, --help       Show this help.
 #
 # Exit codes:
@@ -38,6 +40,7 @@
 #   5  one or more tasks have an ambiguous legacy identity awaiting resolution
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
+#   7  the task-context helper is missing or failed (use --no-context to opt out)
 set -euo pipefail
 
 DRY_RUN=0
@@ -45,6 +48,7 @@ TASKS=""
 REPO=""
 FEATURE=""
 LIMIT=1000
+NO_CONTEXT=0
 
 usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
@@ -55,6 +59,7 @@ while [ $# -gt 0 ]; do
         --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
         --feature) FEATURE="${2:?--feature needs a slug}"; shift 2 ;;
         --limit) LIMIT="${2:?--limit needs a number}"; shift 2 ;;
+        --no-context) NO_CONTEXT=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -171,7 +176,19 @@ normalize_source_path() {
 # unusable, the converter keeps working and simply writes no context block.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$_self_dir/speckit-context.py" ] && command -v python3 > /dev/null 2>&1; then
+if [ "$NO_CONTEXT" -eq 0 ]; then
+    if ! command -v python3 > /dev/null 2>&1; then
+        echo "ERROR: python3 is required to render task context and was not found." >&2
+        echo "Install python3, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
+    if [ ! -f "$_self_dir/speckit-context.py" ]; then
+        echo "ERROR: speckit-context.py is missing from $_self_dir." >&2
+        echo "It ships beside this script, including inside a generated skill bundle; a" >&2
+        echo "packaging that separates them is broken, not a context-free installation." >&2
+        echo "Reinstall, or pass --no-context to convert without context blocks." >&2
+        exit 7
+    fi
     CONTEXT_HELPER="$_self_dir/speckit-context.py"
 fi
 
@@ -485,11 +502,20 @@ for i in "${!TIDS[@]}"; do
     # fingerprinted cache of the task's DECLARED context; the spec stays
     # authoritative. Conditional by design: with no helper and no resolvable spec
     # the issue body is the whole contract, exactly as before.
-    if [ -n "$CONTEXT_HELPER" ]; then
-        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>/dev/null || true)"
-        if [ -n "$context_block" ]; then
-            issue_body+=$'\n\n'"$context_block"
+    if [ "$NO_CONTEXT" -eq 0 ]; then
+        context_status=0
+        context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
+        if [ "$context_status" -ne 0 ] || [ -z "$context_block" ]; then
+            # A broken helper is not a lightweight issue. Swallowing this produced a
+            # context-free issue that looked like a successful conversion, which is
+            # the failure this whole change exists to remove - so it stops here,
+            # before any further write. `--no-context` is the deliberate opt-out.
+            echo "ERROR: could not render the task context for ${tid} (helper exited ${context_status})." >&2
+            printf '  %s\n' "$context_block" >&2
+            echo "Fix the helper or pass --no-context to convert without context blocks." >&2
+            exit 7
         fi
+        issue_body+=$'\n\n'"$context_block"
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -41,6 +41,7 @@
 #   6  issues were created but a dependency edge could not be written; re-run to
 #      reconcile
 #   7  the task-context helper is missing or failed (use --no-context to opt out)
+#   8  an existing issue's context could not be read or checked on a re-run
 set -euo pipefail
 
 DRY_RUN=0
@@ -173,7 +174,8 @@ normalize_source_path() {
 # scripts/speckit-context.py renders the task-context cache (#858). It ships in the
 # same directory as this script, including inside a generated Codex skill bundle, so
 # it is resolved relative to THIS file rather than to the caller's cwd. Absent or
-# unusable, the converter keeps working and simply writes no context block.
+# unusable, the run STOPS: a packaging fault that silently produced context-free
+# issues would look exactly like a successful conversion. `--no-context` opts out.
 CONTEXT_HELPER=""
 _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$NO_CONTEXT" -eq 0 ]; then
@@ -475,7 +477,7 @@ if [ "${#AMBIGUOUS[@]}" -gt 0 ]; then
 fi
 
 # --- Create pass -----------------------------------------------------------------
-created=0; skipped=0; adopted=0
+created=0; skipped=0; adopted=0; context_checks_failed=0
 for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
@@ -485,13 +487,29 @@ for i in "${!TIDS[@]}"; do
         # invisible until somebody happened to re-read it. Reporting only: this
         # never edits an issue, and a refresh is the explicit documented workflow.
         if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
-            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
-                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
-                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
-            case "$ctx_state" in
-                ""|current|absent) : ;;
-                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
-            esac
+            ctx_read_status=0
+            ctx_body="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>&1)" || ctx_read_status=$?
+            if [ "$ctx_read_status" -ne 0 ]; then
+                echo "WARN: could not read issue #${FILED_NUM[$tid]} to check ${tid}'s context (gh exited ${ctx_read_status})." >&2
+                printf '  %s\n' "$ctx_body" >&2
+                context_checks_failed=$((context_checks_failed + 1))
+            else
+                ctx_check_status=0
+                ctx_report="$(printf '%s' "$ctx_body" | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>&1)" || ctx_check_status=$?
+                ctx_state="$(printf '%s' "$ctx_report" | sed -n 's/^SPECKIT_CONTEXT_STATE: //p')"
+                # `check` exits 3 for any state other than current/absent; anything
+                # else is a broken checker, not a verdict.
+                if { [ "$ctx_check_status" -ne 0 ] && [ "$ctx_check_status" -ne 3 ]; } || [ -z "$ctx_state" ]; then
+                    echo "WARN: the context check for ${tid} (issue #${FILED_NUM[$tid]}) failed (exit ${ctx_check_status})." >&2
+                    printf '  %s\n' "$ctx_report" >&2
+                    context_checks_failed=$((context_checks_failed + 1))
+                else
+                    case "$ctx_state" in
+                        current|absent) : ;;
+                        *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+                    esac
+                fi
+            fi
         fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
@@ -513,8 +531,9 @@ for i in "${!TIDS[@]}"; do
     # it was meant to produce - so the receiving agent had only the title, and no
     # pointer to the document that governs the work. The helper renders a bounded,
     # fingerprinted cache of the task's DECLARED context; the spec stays
-    # authoritative. Conditional by design: with no helper and no resolvable spec
-    # the issue body is the whole contract, exactly as before.
+    # authoritative. Conditional on the INPUT, not on the installation: a tasks file
+    # with no resolvable spec still gets a block disclosing what did not resolve,
+    # while a missing or failing helper is an error rather than a quiet omission.
     if [ "$NO_CONTEXT" -eq 0 ]; then
         context_status=0
         context_block="$(python3 "$CONTEXT_HELPER" render --tasks "$TASKS" --task "$tid" --feature "$FEATURE" 2>&1)" || context_status=$?
@@ -611,6 +630,12 @@ done
 echo "---"
 echo "Done. ${created} $([ "$DRY_RUN" -eq 1 ] && echo 'to create' || echo 'created'), ${skipped} skipped (already exist), ${edges_written} dependency edge(s) written."
 [ "$adopted" -gt 0 ] && echo "${adopted} issue(s) were matched by recorded source path; add their markers to make the identity explicit."
+if [ "$context_checks_failed" -gt 0 ]; then
+    echo "ERROR: ${context_checks_failed} context check(s) could not be completed; their" >&2
+    echo "diagnostics are above. An unreadable issue or a broken checker is not the same" >&2
+    echo "as an issue with no context block, and is not reported as one." >&2
+    exit 8
+fi
 if [ "$edges_failed" -gt 0 ]; then
     echo "ERROR: ${edges_failed} dependency edge update(s) failed. The issues exist; re-run this" >&2
     echo "command to reconcile the missing edges - it will not create duplicates." >&2

--- a/scripts/speckit-tasks-to-issues.sh
+++ b/scripts/speckit-tasks-to-issues.sh
@@ -480,6 +480,19 @@ for i in "${!TIDS[@]}"; do
     tid="${TIDS[$i]}"
     title="${tid} (${FEATURE}): ${DESCS[$i]}"
     if [ -n "${FILED_NUM[$tid]:-}" ]; then
+        # Drift visibility on a re-run (#858). An already-filed task used to skip
+        # straight past its context, so a spec that moved under a filed issue was
+        # invisible until somebody happened to re-read it. Reporting only: this
+        # never edits an issue, and a refresh is the explicit documented workflow.
+        if [ "$NO_CONTEXT" -eq 0 ] && [ -n "${FILED_NUM[$tid]:-}" ]; then
+            ctx_state="$(gh issue view "${FILED_NUM[$tid]}" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null \
+                | python3 "$CONTEXT_HELPER" check --body-file - --root . 2>/dev/null \
+                | sed -n 's/^SPECKIT_CONTEXT_STATE: //p' || true)"
+            case "$ctx_state" in
+                ""|current|absent) : ;;
+                *) echo "stale ${tid} (context: ${ctx_state}) - see flow:wave Phase 1 for the refresh workflow" ;;
+            esac
+        fi
         if [ "${FILED_VIA[$tid]}" = "provenance" ]; then
             echo "skip  ${tid} (issue #${FILED_NUM[$tid]}, matched by recorded source path;" \
                  "add '$(marker_for "$tid")' to its body to make the identity explicit)"

--- a/tests/test_speckit_context.py
+++ b/tests/test_speckit_context.py
@@ -110,8 +110,12 @@ def feature(tmp_path: Path) -> Path:
     return directory
 
 
-def _block(feature: Path, task: str = "T001") -> str:
-    return CTX.render(CTX.resolve(feature / "tasks.md", task), "specs/exports/tasks.md")
+def _block(feature: Path, task: str = "T001", root: Path | None = None) -> str:
+    """Render with an explicit project root, the contract `check --root` relies on."""
+    base = root if root is not None else feature.parent.parent
+    return CTX.render(
+        CTX.resolve(feature / "tasks.md", task, base), "specs/exports/tasks.md"
+    )
 
 
 class TestDeclaredMappingOnly:
@@ -357,3 +361,198 @@ class TestRefreshSafety:
 
         assert second is not None, message
         assert "A human note moved outside." in second
+
+
+class TestPortableAcrossCheckouts:
+    """The cache must be re-resolvable by whoever RECEIVES the issue."""
+
+    def test_a_consumer_checks_its_own_checkout_not_the_producers(
+        self, tmp_path: Path
+    ) -> None:
+        """Persisting the producer's path made the consumer check the wrong tree.
+
+        Producer A renders, B is a separate clone of the same project, and B's
+        acceptance then changes. Reported against B, the answer must describe B -
+        even though A still exists on disk with its original content.
+        """
+        producer = tmp_path / "A"
+        (producer / "specs" / "exports").mkdir(parents=True)
+        (producer / "specs" / "exports" / "spec.md").write_text(SPEC, encoding="utf-8")
+        (producer / "specs" / "exports" / "tasks.md").write_text(TASKS, encoding="utf-8")
+        body = CTX.render(
+            CTX.resolve(producer / "specs" / "exports" / "tasks.md", "T001", producer),
+            "specs/exports/tasks.md",
+        )
+
+        consumer = tmp_path / "B"
+        (consumer / "specs" / "exports").mkdir(parents=True)
+        (consumer / "specs" / "exports" / "spec.md").write_text(
+            SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+        (consumer / "specs" / "exports" / "tasks.md").write_text(TASKS, encoding="utf-8")
+        assert (producer / "specs" / "exports" / "spec.md").read_text().count("200ms") == 1, (
+            "the producer checkout must still hold the ORIGINAL text, or this proves nothing"
+        )
+
+        state, _ = CTX.check(body, consumer)
+
+        assert state == "changed-in-scope", (
+            "the check followed the producer's path instead of the consumer's root"
+        )
+
+    def test_a_path_outside_the_root_is_disclosed(self, tmp_path: Path) -> None:
+        outside = tmp_path / "elsewhere" / "exports"
+        outside.mkdir(parents=True)
+        (outside / "spec.md").write_text(SPEC, encoding="utf-8")
+        (outside / "tasks.md").write_text(TASKS, encoding="utf-8")
+        root = tmp_path / "project"
+        root.mkdir()
+
+        block = CTX.render(CTX.resolve(outside / "tasks.md", "T001", root), "f")
+
+        assert "lies outside the project root" in block
+
+
+class TestTaskSideChanges:
+    """The task line is a governing input, not just an index into the spec."""
+
+    def test_a_changed_story_tag_is_not_reported_as_current(self, feature: Path, tmp_path: Path) -> None:
+        body = "Top.\n\n" + _block(feature, "T001")
+        (feature / "tasks.md").write_text(
+            TASKS.replace(
+                "- [ ] **T001** [US1] Use a background queue",
+                "- [ ] **T001** [US2] Use a background queue",
+            ),
+            encoding="utf-8",
+        )
+        assert "spec.md" in [p.name for p in feature.iterdir()], "spec is untouched here"
+
+        state, detail = CTX.check(body, tmp_path)
+
+        assert state == "changed-task"
+        assert any("[USn] tag" in line for line in detail)
+
+    def test_changed_task_wording_is_not_reported_as_current(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        body = "Top.\n\n" + _block(feature, "T005")
+        (feature / "tasks.md").write_text(
+            TASKS.replace("Must use PostgreSQL", "May use any database"), encoding="utf-8"
+        )
+
+        state, _ = CTX.check(body, tmp_path)
+
+        assert state == "changed-task", (
+            "a task line that stopped carrying its constraint must not read as current"
+        )
+
+    def test_a_missing_tasks_file_is_named(self, feature: Path, tmp_path: Path) -> None:
+        body = "Top.\n\n" + _block(feature, "T001")
+        (feature / "tasks.md").unlink()
+        assert not (feature / "tasks.md").exists(), "fixture must remove the tasks file"
+
+        state, _ = CTX.check(body, tmp_path)
+
+        assert state == "tasks-missing"
+
+
+class TestMetadataIntegrity:
+    def test_editing_the_task_field_is_detected(self, feature: Path, tmp_path: Path) -> None:
+        """Covering only visible text left the identity metadata rewritable."""
+        body = _block(feature, "T001").replace("task: T001", "task: T999")
+        assert "task: T999" in body, "fixture must carry the metadata edit under test"
+
+        state, _ = CTX.check(body, tmp_path)
+        updated, message = CTX.refresh(body, _block(feature, "T001"))
+
+        assert state == "block-edited"
+        assert updated is None and "edited" in message
+
+    def test_a_missing_required_field_refuses(self, feature: Path) -> None:
+        body = "\n".join(
+            line for line in _block(feature).splitlines() if not line.startswith("source:")
+        )
+        assert "\nsource: " not in body, "fixture must omit the header field under test"
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is None and "missing metadata" in message
+
+    def test_refreshing_with_another_tasks_block_refuses(self, feature: Path) -> None:
+        body = "Top.\n\n" + _block(feature, "T001")
+
+        updated, message = CTX.refresh(body, _block(feature, "T002"))
+
+        assert updated is None
+        assert "identity mismatch" in message
+
+
+class TestRealTemplateShape:
+    """The simplified fixture hid a defect the shipped template exposes."""
+
+    def test_a_horizontal_rule_is_not_an_acceptance_item(self, tmp_path: Path) -> None:
+        real = ROOT / ".specify" / "specs" / "wave-6-polish-quality-dx"
+        if not (real / "tasks.md").is_file():
+            pytest.skip("the in-tree reference spec is no longer present")
+
+        resolution = CTX.resolve(real / "tasks.md", "T001", ROOT)
+
+        assert resolution.acceptance, "the reference task should resolve some acceptance"
+        assert all(
+            item.strip(" -*_") for _, item in resolution.acceptance
+        ), f"a separator was read as an acceptance item: {resolution.acceptance}"
+
+    def test_a_fenced_example_does_not_declare_a_story(self, tmp_path: Path) -> None:
+        directory = tmp_path / "specs" / "fenced"
+        directory.mkdir(parents=True)
+        (directory / "tasks.md").write_text(
+            "- [ ] **T001** [US1] Real task\n", encoding="utf-8"
+        )
+        (directory / "spec.md").write_text(
+            "# S\n\n```\n### US1: Example inside a fence\n\n"
+            "**Acceptance Criteria:**\n- [ ] Sample only\n```\n",
+            encoding="utf-8",
+        )
+
+        block = CTX.render(CTX.resolve(directory / "tasks.md", "T001", tmp_path), "f")
+
+        assert "Sample only" not in block
+        assert "has no '### US1:' section" in block
+
+    def test_a_duplicated_story_is_disclosed_not_chosen(self, tmp_path: Path) -> None:
+        directory = tmp_path / "specs" / "dup"
+        directory.mkdir(parents=True)
+        (directory / "tasks.md").write_text(
+            "- [ ] **T001** [US1] Real task\n", encoding="utf-8"
+        )
+        (directory / "spec.md").write_text(
+            "# S\n\n### US1: First\n\n**Acceptance Criteria:**\n- [ ] One\n\n"
+            "### US1: Second\n\n**Acceptance Criteria:**\n- [ ] Two\n",
+            encoding="utf-8",
+        )
+
+        block = CTX.render(CTX.resolve(directory / "tasks.md", "T001", tmp_path), "f")
+
+        assert "declared 2 times" in block
+        assert "One" not in block and "Two" not in block
+
+
+class TestBounded:
+    def test_a_huge_outcome_does_not_produce_an_unbounded_block(
+        self, tmp_path: Path
+    ) -> None:
+        directory = tmp_path / "specs" / "big"
+        directory.mkdir(parents=True)
+        (directory / "tasks.md").write_text(
+            "- [ ] **T001** [US1] Do it\n", encoding="utf-8"
+        )
+        (directory / "spec.md").write_text(
+            "# S\n\n### US1: Huge\n\n" + ("padding " * 4000) + "\n\n"
+            "**Acceptance Criteria:**\n- [ ] Something\n",
+            encoding="utf-8",
+        )
+
+        block = CTX.render(CTX.resolve(directory / "tasks.md", "T001", tmp_path), "f")
+
+        assert len(block) <= CTX.MAX_BLOCK_CHARS + 1000, f"block is {len(block)} chars"
+        assert "shortened" in block or "INCOMPLETE" in block

--- a/tests/test_speckit_context.py
+++ b/tests/test_speckit_context.py
@@ -26,6 +26,7 @@ text and file state.
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -173,7 +174,7 @@ class TestUnresolvedIsDisclosed:
         block = CTX.render(CTX.resolve(directory / "tasks.md", "T001"), "f")
 
         assert "no spec.md beside" in block
-        assert "Authoritative source:** none resolved" in block
+        assert "Reference source:** none resolved" in block
 
 
 class TestTaskWordingAuthority:
@@ -556,3 +557,157 @@ class TestBounded:
 
         assert len(block) <= CTX.MAX_BLOCK_CHARS + 1000, f"block is {len(block)} chars"
         assert "shortened" in block or "INCOMPLETE" in block
+
+
+class TestRefreshWorkflowCli:
+    """The documented existing-issue workflow, driven through the real CLI.
+
+    `flow:wave` Phase 1 tells an orchestrator to fetch the body, run `refresh`, and
+    write back only on exit 0. These pin that contract at the process boundary: a
+    success prints a complete replacement body on stdout, and a refusal prints
+    nothing to stdout and exits non-zero, so a `gh issue edit` guarded on exit status
+    cannot write a half-formed body.
+    """
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args], capture_output=True, text=True
+        )
+
+    def test_a_pre_858_issue_gains_its_block_and_keeps_its_body(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        body_file = tmp_path / "body.md"
+        body_file.write_text(
+            "Auto-created from specs/exports/tasks.md (T001).\n\nDepends on: T002\n",
+            encoding="utf-8",
+        )
+        assert "speckit-context" not in body_file.read_text(), "fixture must have no block"
+
+        result = self._run(
+            "refresh",
+            "--body-file", str(body_file),
+            "--tasks", str(feature / "tasks.md"),
+            "--task", "T001",
+            "--feature", "specs/exports/tasks.md",
+            "--root", str(tmp_path),
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "Depends on: T002" in result.stdout
+        assert "speckit-context:v1" in result.stdout
+        assert "attached" in result.stderr
+
+    def test_a_refusal_writes_nothing_to_stdout(self, feature: Path, tmp_path: Path) -> None:
+        body_file = tmp_path / "edited.md"
+        body_file.write_text(_block(feature, "T001", tmp_path).replace("200ms", "500ms"))
+        assert "500ms" in body_file.read_text(), "fixture must carry the in-block edit"
+
+        result = self._run(
+            "refresh",
+            "--body-file", str(body_file),
+            "--tasks", str(feature / "tasks.md"),
+            "--task", "T001",
+            "--feature", "specs/exports/tasks.md",
+            "--root", str(tmp_path),
+        )
+
+        assert result.returncode == 4
+        assert result.stdout == "", (
+            "a refusal that still printed a body could be written back by a caller "
+            "that checked only for output"
+        )
+        assert "refused" in result.stderr
+
+
+class TestFencedTasksAndDuplicates:
+    """Finding 4's boundary: tasks.md needs the same fence handling as the spec."""
+
+    def test_a_fenced_example_task_does_not_outrank_the_real_one(
+        self, tmp_path: Path
+    ) -> None:
+        directory = tmp_path / "specs" / "fencedtasks"
+        directory.mkdir(parents=True)
+        (directory / "spec.md").write_text(SPEC, encoding="utf-8")
+        (directory / "tasks.md").write_text(
+            "# Tasks\n\n```markdown\n- [ ] **T001** [US2] Example from the docs\n```\n\n"
+            + TASKS,
+            encoding="utf-8",
+        )
+
+        resolution = CTX.resolve(directory / "tasks.md", "T001", tmp_path)
+
+        assert "Use a background queue" in resolution.task_wording, (
+            f"the fenced sample won: {resolution.task_wording!r}"
+        )
+        assert resolution.outcomes and resolution.outcomes[0][0] == "US1"
+
+    def test_an_indented_fence_is_still_a_fence(self, tmp_path: Path) -> None:
+        directory = tmp_path / "specs" / "indented"
+        directory.mkdir(parents=True)
+        (directory / "spec.md").write_text(SPEC, encoding="utf-8")
+        (directory / "tasks.md").write_text(
+            "# Tasks\n\n  ```\n  - [ ] **T001** [US2] Indented example\n  ```\n\n" + TASKS,
+            encoding="utf-8",
+        )
+
+        resolution = CTX.resolve(directory / "tasks.md", "T001", tmp_path)
+
+        assert "Use a background queue" in resolution.task_wording
+
+    def test_a_task_declared_twice_is_disclosed(self, tmp_path: Path) -> None:
+        directory = tmp_path / "specs" / "duptask"
+        directory.mkdir(parents=True)
+        (directory / "spec.md").write_text(SPEC, encoding="utf-8")
+        (directory / "tasks.md").write_text(
+            "- [ ] **T001** [US1] First declaration\n"
+            "- [ ] **T001** [US2] Second declaration\n",
+            encoding="utf-8",
+        )
+
+        block = CTX.render(CTX.resolve(directory / "tasks.md", "T001", tmp_path), "f")
+
+        assert "declared 2 times" in block
+
+
+class TestSourceIsReferenceNotOverride:
+    """Finding 8: newer bytes do not silently supersede an accepted decision."""
+
+    def test_the_block_does_not_claim_the_source_governs(self, feature: Path) -> None:
+        block = _block(feature)
+
+        assert "the source governs" not in block
+        assert "does not by itself override" in block
+
+    def test_a_decision_naming_the_cached_version_is_flagged_as_predating(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        block = _block(feature)
+        cached = [
+            line.split(": ", 1)[1]
+            for line in block.splitlines()
+            if line.startswith("source-digest: ")
+        ][0]
+        body = block + f"\n\nAcceptance-revision: source-digest={cached} ref=#42\n"
+        (feature / "spec.md").write_text(
+            SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        _, detail = CTX.check(body, tmp_path)
+
+        joined = " ".join(detail)
+        assert "THIS BLOCK CACHED" in joined
+        assert "predates the change" in joined
+
+    def test_a_decision_record_survives_a_refresh(self, feature: Path) -> None:
+        record = "Acceptance-revision: source-digest=abc123def456 ref=#42"
+        body = _block(feature) + f"\n\n{record}\n"
+        (feature / "spec.md").write_text(
+            SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is not None, message
+        assert record in updated, "a refresh must not drop the decision record"
+        assert "within 100ms" in updated

--- a/tests/test_speckit_context.py
+++ b/tests/test_speckit_context.py
@@ -1,0 +1,359 @@
+"""Tests for the generated-issue context cache (issue #858).
+
+`scripts/speckit-context.py` resolves a task's DECLARED context - its `[USn]`
+story tag, and the Functional Requirements rows whose `User Story` column names
+that story - and renders a bounded, fingerprinted block into the issue body.
+
+The properties under test are the ones a string can actually carry:
+
+  * only DECLARED relationships are used, and anything that does not resolve is
+    disclosed rather than invented
+  * requirements belonging to another story stay out
+  * cross-cutting sections (no story mapping) are named for the reader to inspect,
+    never attributed to this task
+  * the task's own wording is labelled as task wording whose authority must be
+    resolved, not blanket-labelled replaceable
+  * a refresh touches only the managed block, and declines outright when the block
+    was edited or its boundaries are damaged
+  * freshness states describe BYTES that changed, not materiality
+
+What these tests CANNOT establish, and what #861's pilots exist for: that a
+receiving agent actually reads the source, correctly separates a proposal from a
+binding constraint, or plans accordingly. Every assertion here is about generated
+text and file state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "speckit-context.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("speckit_context", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["speckit_context"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CTX = _load()
+
+SPEC = """# Feature Specification: Exports
+
+## User Stories
+
+### US1: Responsive exports [P1]
+
+**As a** analyst,
+**I want** the page to stay usable while an export runs,
+**So that** I can keep working.
+
+**Acceptance Criteria:**
+- [ ] The page responds within 200ms while an export of 50k rows runs
+- [ ] Progress is visible and updates at least every 2 seconds
+
+### US2: Scheduled exports [P2]
+
+**As a** manager,
+**I want** exports on a schedule,
+**So that** reports arrive without me asking.
+
+**Acceptance Criteria:**
+- [ ] A schedule can be set per report
+
+## Out of Scope
+
+- Export formats other than CSV
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Priority | User Story |
+|----|-------------|----------|------------|
+| R1 | Export runs without holding a request thread | Must | US1 |
+| R2 | Progress endpoint returns percent complete | Should | US1 |
+| R3 | Schedules persist across restarts | Could | US2 |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Metric |
+|----|-------------|--------|
+| NFR1 | No new infrastructure service | zero new containers |
+"""
+
+TASKS = """# Tasks: Exports
+
+- [ ] **T001** [US1] Use a background queue so the page stays responsive
+- [ ] **T002** [US2] Add the schedule table
+- [ ] **T003** Untagged task with no story
+- [ ] **T004** [US9] Tagged with a story the spec does not have
+- [ ] **T005** [US1] Must use PostgreSQL to integrate with the supported database
+"""
+
+
+@pytest.fixture
+def feature(tmp_path: Path) -> Path:
+    """A spec-kit feature directory with a spec and its tasks."""
+    directory = tmp_path / "specs" / "exports"
+    directory.mkdir(parents=True)
+    (directory / "spec.md").write_text(SPEC, encoding="utf-8")
+    (directory / "tasks.md").write_text(TASKS, encoding="utf-8")
+    return directory
+
+
+def _block(feature: Path, task: str = "T001") -> str:
+    return CTX.render(CTX.resolve(feature / "tasks.md", task), "specs/exports/tasks.md")
+
+
+class TestDeclaredMappingOnly:
+    def test_story_acceptance_is_carried(self, feature: Path) -> None:
+        block = _block(feature)
+
+        assert "The page responds within 200ms" in block
+        assert "Progress is visible" in block
+
+    def test_another_storys_acceptance_stays_out(self, feature: Path) -> None:
+        """US2 is in the same spec and must not leak into a US1 task."""
+        block = _block(feature)
+
+        assert "A schedule can be set per report" not in block
+        assert "Scheduled exports" not in block
+
+    def test_requirements_follow_the_declared_user_story_column(self, feature: Path) -> None:
+        block = _block(feature)
+
+        assert "R1" in block and "R2" in block
+        assert "R3" not in block, "R3 is declared against US2 and is not this task's"
+
+    def test_cross_cutting_sections_are_named_not_attributed(self, feature: Path) -> None:
+        """NFR and Out of Scope carry no story mapping, so they are pointers."""
+        block = _block(feature)
+
+        assert "Non-Functional Requirements" in block
+        assert "Out of Scope" in block
+        assert "No new infrastructure service" not in block, (
+            "an unmapped requirement must not be copied in as though it were this task's"
+        )
+
+    def test_granularity_is_disclosed(self, feature: Path) -> None:
+        assert "user-story level" in _block(feature)
+
+
+class TestUnresolvedIsDisclosed:
+    def test_task_without_a_story_tag(self, feature: Path) -> None:
+        block = _block(feature, "T003")
+
+        assert "declares no [USn] story tag" in block
+        assert "incomplete context, not an absence of constraints" in block
+
+    def test_story_tag_with_no_matching_section(self, feature: Path) -> None:
+        block = _block(feature, "T004")
+
+        assert "US9" in block and "has no '### US9:' section" in block
+
+    def test_no_sibling_spec(self, tmp_path: Path) -> None:
+        directory = tmp_path / "specs" / "lonely"
+        directory.mkdir(parents=True)
+        (directory / "tasks.md").write_text(TASKS, encoding="utf-8")
+        assert not (directory / "spec.md").exists(), "fixture must omit the spec"
+
+        block = CTX.render(CTX.resolve(directory / "tasks.md", "T001"), "f")
+
+        assert "no spec.md beside" in block
+        assert "Authoritative source:** none resolved" in block
+
+
+class TestTaskWordingAuthority:
+    def test_a_proposal_is_not_declared_replaceable_by_the_block(self, feature: Path) -> None:
+        """#856's distinction survives: the block does not rule on the line."""
+        block = _block(feature, "T001")
+
+        assert '"Use a background queue so the page stays responsive"' in block
+        assert "Resolve its authority against the sections above" in block
+
+    def test_an_explicit_mechanism_constraint_is_not_labelled_revisable(
+        self, feature: Path
+    ) -> None:
+        """A task line CAN carry a binding constraint; the block must not demote it."""
+        block = _block(feature, "T005")
+
+        assert "Must use PostgreSQL" in block
+        assert "revisable" not in block.lower(), (
+            "the block must not label task wording replaceable - that is the consumer's "
+            "resolution against the source, not a rendering decision"
+        )
+
+
+class TestFreshness:
+    def _issue_body(self, feature: Path, task: str = "T001") -> str:
+        return "Auto-created from specs/exports/tasks.md.\n\n" + _block(feature, task)
+
+    def test_unchanged_source_reads_current(self, feature: Path, tmp_path: Path) -> None:
+        state, _ = CTX.check(self._issue_body(feature), tmp_path)
+
+        assert state == "current"
+
+    def test_change_inside_the_mapped_sections(self, feature: Path, tmp_path: Path) -> None:
+        body = self._issue_body(feature)
+        (feature / "spec.md").write_text(
+            SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        state, detail = CTX.check(body, tmp_path)
+
+        assert state == "changed-in-scope"
+        assert any("not a ruling that acceptance changed" in line for line in detail)
+
+    def test_change_outside_the_story_is_reported_as_such(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        """A cross-cutting constraint change is visible without invented relevance."""
+        body = self._issue_body(feature)
+        (feature / "spec.md").write_text(
+            SPEC.replace("No new infrastructure service", "One managed queue is allowed"),
+            encoding="utf-8",
+        )
+
+        state, detail = CTX.check(body, tmp_path)
+
+        assert state == "changed-outside-scope"
+        assert any("nothing here claims it is relevant" in line for line in detail)
+
+    def test_irrelevant_story_only_change_is_also_outside_scope(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        body = self._issue_body(feature)
+        (feature / "spec.md").write_text(
+            SPEC.replace("A schedule can be set per report", "A schedule can be set per user"),
+            encoding="utf-8",
+        )
+
+        state, _ = CTX.check(body, tmp_path)
+
+        assert state == "changed-outside-scope"
+
+    def test_missing_source_is_named(self, feature: Path, tmp_path: Path) -> None:
+        body = self._issue_body(feature)
+        (feature / "spec.md").unlink()
+        assert not (feature / "spec.md").exists(), "fixture must remove the source"
+
+        state, _ = CTX.check(body, tmp_path)
+
+        assert state == "source-missing"
+
+    def test_issue_without_a_block_is_not_a_fault(self, tmp_path: Path) -> None:
+        """Lightweight issues stay first-class: no block is a normal state."""
+        state, _ = CTX.check("A plain issue body with its own acceptance.\n", tmp_path)
+
+        assert state == "absent"
+
+
+class TestRecordedRevision:
+    def test_a_structured_record_is_surfaced_but_not_judged(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        body = _block(feature) + "\n\nAcceptance-revision: source-digest=deadbeef01 ref=#99\n"
+
+        _, detail = CTX.check(body, tmp_path)
+
+        joined = " ".join(detail)
+        assert "recorded revision" in joined
+        assert "does not judge whether it" in joined
+
+    def test_free_text_acknowledgement_is_not_a_record(
+        self, feature: Path, tmp_path: Path
+    ) -> None:
+        body = _block(feature) + "\n\nWe acknowledged the new requirement in standup.\n"
+
+        _, detail = CTX.check(body, tmp_path)
+
+        assert not any("recorded revision" in line for line in detail)
+
+
+class TestRefreshSafety:
+    def test_text_outside_the_block_is_preserved(self, feature: Path) -> None:
+        body = (
+            "Human notes at the top.\n\n"
+            + _block(feature)
+            + "\nA human decision written afterwards.\n"
+        )
+        (feature / "spec.md").write_text(
+            SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is not None, message
+        assert "Human notes at the top." in updated
+        assert "A human decision written afterwards." in updated
+        assert "within 100ms" in updated
+
+    def test_an_edit_inside_the_block_refuses_and_changes_nothing(
+        self, feature: Path
+    ) -> None:
+        """Delimiters mark where generated text began, not that it is untouched."""
+        body = _block(feature).replace("200ms", "500ms")
+        assert "500ms" in body, "fixture must carry the in-block edit under test"
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is None
+        assert "refused" in message and "edited" in message
+
+    def test_duplicate_boundaries_refuse(self, feature: Path) -> None:
+        body = _block(feature) + "\n" + _block(feature)
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is None
+        assert "duplicate" in message
+
+    def test_a_truncated_block_refuses_rather_than_rewriting(self, feature: Path) -> None:
+        body = _block(feature).replace(CTX.BLOCK_END, "")
+        assert CTX.BLOCK_END not in body, "fixture must be missing its end boundary"
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is None
+        assert "missing" in message
+
+    def test_an_issue_with_no_block_gains_one_additively(self, feature: Path) -> None:
+        """A pre-#858 issue may receive its first block; its body is preserved."""
+        body = "Auto-created from specs/exports/tasks.md.\n\nDepends on: T002\n"
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated is not None
+        assert updated.startswith(body.rstrip("\n"))
+        assert "attached" in message
+
+    def test_an_unchanged_rerun_is_byte_identical(self, feature: Path) -> None:
+        body = "Top.\n\n" + _block(feature) + "\nBottom.\n"
+
+        updated, message = CTX.refresh(body, _block(feature))
+
+        assert updated == body
+        assert "unchanged" in message
+
+    def test_a_refused_refresh_can_be_retried_after_the_edit_moves_out(
+        self, feature: Path
+    ) -> None:
+        """Failure then retry must not corrupt the body along the way."""
+        edited = _block(feature).replace("200ms", "500ms")
+        first, _ = CTX.refresh(edited, _block(feature))
+        assert first is None
+
+        recovered = "A human note moved outside.\n\n" + _block(feature)
+        second, message = CTX.refresh(recovered, _block(feature))
+
+        assert second is not None, message
+        assert "A human note moved outside." in second

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -103,6 +103,9 @@ if argv[:2] == ["issue", "create"]:
     sys.exit(0)
 
 if argv[:2] == ["issue", "view"]:
+    if os.environ.get("GH_STUB_VIEW_FAIL") == "1":
+        sys.stderr.write("gh: could not read issue\n")
+        sys.exit(1)
     for issue in load()["issues"]:
         if str(issue["number"]) == argv[2]:
             print(issue["body"])
@@ -179,6 +182,7 @@ def _run(
     *args: str,
     list_fails: bool = False,
     edit_fails: bool = False,
+    view_fails: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     env = {
         "PATH": f"{bindir}:{os.environ['PATH']}",
@@ -189,6 +193,8 @@ def _run(
         env["GH_STUB_LIST_FAIL"] = "1"
     if edit_fails:
         env["GH_STUB_EDIT_FAIL"] = "1"
+    if view_fails:
+        env["GH_STUB_VIEW_FAIL"] = "1"
     return subprocess.run(
         ["bash", str(SCRIPT), *args],
         cwd=repo,
@@ -1082,3 +1088,153 @@ class TestExistingIssueRefreshWorkflow:
 
         assert retried is not None and retried.returncode == 0
         assert "within 100ms" in _issues(state)[0]["body"]
+
+
+class TestDriftCheckFailuresAreNotAbsence:
+    """A read or checker failure is not "this issue has no context block" (#858 rev27).
+
+    The first drift report collapsed fetch, check and parse into one pipeline ending
+    in `2>/dev/null ... || true`, so an unreadable issue produced the same quiet
+    nothing as a healthy block-free one - the failure-as-absence defect this change
+    exists to remove, reintroduced in the code that reports drift.
+    """
+
+    TASKS = "- [ ] **T001** [US1] Use a background queue\n"
+
+    def test_an_unreadable_issue_is_reported_not_swallowed(self, project) -> None:
+        repo, bindir, state = project(
+            {
+                ".specify/specs/exports/tasks.md": self.TASKS,
+                ".specify/specs/exports/spec.md": SPEC_FIXTURE,
+            }
+        )
+        first = _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+        assert first.returncode == 0, first.stderr
+
+        again = _run(
+            repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md", view_fails=True
+        )
+
+        assert again.returncode == 8, again.stdout + again.stderr
+        assert "could not read issue" in again.stderr
+        assert "could not read issue" in again.stderr and "gh: could not read issue" in again.stderr, (
+            "the underlying diagnostic must be preserved, not just a summary"
+        )
+
+    def test_a_genuinely_block_free_issue_stays_normal(self, project) -> None:
+        """The control: a successful lookup of an issue with no block is not an error."""
+        repo, bindir, state = project(
+            {
+                ".specify/specs/exports/tasks.md": self.TASKS,
+                ".specify/specs/exports/spec.md": SPEC_FIXTURE,
+            },
+            issues=[
+                {
+                    "number": 7,
+                    "title": "T001 (.specify/specs/exports/tasks.md): Use a background queue",
+                    "body": "<!-- speckit-task:v1:.specify/specs/exports/tasks.md:T001 -->\n",
+                    "state": "OPEN",
+                }
+            ],
+        )
+
+        result = _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "stale T001" not in result.stdout
+        assert "WARN" not in result.stderr
+
+
+class TestDocumentedRefreshGuardIsExecutable:
+    """Run the shell `flow:wave` Phase 1 actually publishes, not a paraphrase of it.
+
+    The guard shipped as a trailing COMMENT, so following the example literally wrote
+    the empty redirect output back over the issue body after a refused refresh - the
+    documented workflow destroying what it was meant to protect.
+    """
+
+    def _documented_script(self) -> str:
+        doc = (ROOT / ".claude" / "commands" / "flow" / "wave.md").read_text(encoding="utf-8")
+        marker = 'CUR="$(mktemp'
+        start = doc.index(marker)
+        end = doc.index("```", start)
+        return doc[start:end]
+
+    def test_a_refused_refresh_does_not_edit_the_issue(self, project) -> None:
+        repo, bindir, state = project(
+            {
+                ".specify/specs/exports/tasks.md": "- [ ] **T001** [US1] Use a background queue\n",
+                ".specify/specs/exports/spec.md": SPEC_FIXTURE,
+            }
+        )
+        _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+        # Edit inside the managed block: the refresh must refuse.
+        issues = json.loads(state.read_text())
+        issues["issues"][0]["body"] = issues["issues"][0]["body"].replace("200ms", "500ms")
+        state.write_text(json.dumps(issues))
+        original = _issues(state)[0]["body"]
+        assert "500ms" in original, "fixture must carry the in-block edit that forces a refusal"
+
+        script = (
+            self._documented_script()
+            .replace("~/.claude/scripts/speckit-context.py", f"{sys.executable} {ROOT}/scripts/speckit-context.py")
+            .replace("<feature>", "exports")
+            .replace('"$N"', '"100"')
+        )
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "HOME": str(repo.parent),
+                "GH_STUB_STATE": str(state),
+                "N": "100",
+            },
+        )
+
+        assert "REFUSED" in result.stdout, result.stdout + result.stderr
+        assert result.returncode != 0, "a refusal must not report success"
+        assert _issues(state)[0]["body"] == original, (
+            "the documented example edited the issue after a refused refresh"
+        )
+
+    def test_a_failed_write_is_not_masked_by_cleanup(self, project) -> None:
+        """`rm -f` succeeds, so ending on it reported a failed write as success."""
+        repo, bindir, state = project(
+            {
+                ".specify/specs/exports/tasks.md": "- [ ] **T001** [US1] Use a background queue\n",
+                ".specify/specs/exports/spec.md": SPEC_FIXTURE,
+            }
+        )
+        _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+        (repo / ".specify/specs/exports/spec.md").write_text(
+            SPEC_FIXTURE.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+        original = _issues(state)[0]["body"]
+
+        script = (
+            self._documented_script()
+            .replace("~/.claude/scripts/speckit-context.py", f"{sys.executable} {ROOT}/scripts/speckit-context.py")
+            .replace("<feature>", "exports")
+            .replace('"$N"', '"100"')
+        )
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "HOME": str(repo.parent),
+                "GH_STUB_STATE": str(state),
+                "GH_STUB_EDIT_FAIL": "1",
+                "N": "100",
+            },
+        )
+
+        assert result.returncode != 0, (
+            "the documented script reported success after `gh issue edit` failed"
+        )
+        assert _issues(state)[0]["body"] == original, "a failed write must change nothing"

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -31,6 +31,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -946,3 +947,138 @@ def test_no_whitespace_ifs_read_remains_in_scripts() -> None:
     assert not offenders, (
         "whitespace-IFS read(s) reintroduced (#698/#700):\n" + "\n".join(offenders)
     )
+
+
+class TestExistingIssueRefreshWorkflow:
+    """The documented existing-issue path, end to end against the stub (#858 finding 7).
+
+    Finding 7 was that the refresh existed only as a pure function: nothing surfaced
+    stale context on a re-run, and nothing exercised the fetch-refresh-write cycle
+    against GitHub. These drive the workflow `flow:wave` Phase 1 documents, including
+    its failure and retry.
+    """
+
+    SPEC = SPEC_FIXTURE
+    TASKS = "- [ ] **T001** [US1] Use a background queue\n"
+
+    def _feature(self, project, spec: str | None = None):
+        return project(
+            {
+                ".specify/specs/exports/tasks.md": self.TASKS,
+                ".specify/specs/exports/spec.md": spec or self.SPEC,
+            }
+        )
+
+    def _refresh(self, repo: Path, number: int, state: Path, bindir: Path, *, edit_fails=False):
+        """The documented cycle: fetch, refresh, write back only on success."""
+        env = {
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "HOME": str(repo.parent),
+            "GH_STUB_STATE": str(state),
+        }
+        if edit_fails:
+            env["GH_STUB_EDIT_FAIL"] = "1"
+        fetched = subprocess.run(
+            ["gh", "issue", "view", str(number), "--json", "body", "--jq", ".body"],
+            cwd=repo, capture_output=True, text=True, env=env,
+        )
+        assert fetched.returncode == 0, fetched.stderr
+        body_file = repo / f"body-{number}.md"
+        body_file.write_text(fetched.stdout, encoding="utf-8")
+        refreshed = subprocess.run(
+            [
+                sys.executable, str(ROOT / "scripts" / "speckit-context.py"), "refresh",
+                "--body-file", str(body_file),
+                "--tasks", ".specify/specs/exports/tasks.md",
+                "--task", "T001",
+                "--feature", ".specify/specs/exports/tasks.md",
+                "--root", ".",
+            ],
+            cwd=repo, capture_output=True, text=True, env=env,
+        )
+        if refreshed.returncode != 0:
+            return refreshed, None
+        new_body = repo / f"new-{number}.md"
+        new_body.write_text(refreshed.stdout, encoding="utf-8")
+        written = subprocess.run(
+            ["gh", "issue", "edit", str(number), "--body-file", str(new_body)],
+            cwd=repo, capture_output=True, text=True, env=env,
+        )
+        return refreshed, written
+
+    def test_a_pre_858_issue_gains_its_block_through_the_workflow(self, project) -> None:
+        repo, bindir, state = self._feature(project)
+        json.loads(state.read_text())
+        issues = {"next": 101, "issues": [{
+            "number": 100,
+            "title": "T001 (.specify/specs/exports/tasks.md): Use a background queue",
+            "body": "Auto-created from .specify/specs/exports/tasks.md (T001) by CPP "
+                    "speckit-tasks-to-issues.\n\n"
+                    "<!-- speckit-task:v1:.specify/specs/exports/tasks.md:T001 -->\n\n"
+                    "A human decision recorded here.\n",
+            "state": "OPEN",
+        }]}
+        state.write_text(json.dumps(issues))
+        assert "speckit-context" not in _issues(state)[0]["body"], "fixture predates the block"
+
+        _, written = self._refresh(repo, 100, state, bindir)
+
+        assert written is not None and written.returncode == 0, "the write back must succeed"
+        body = _issues(state)[0]["body"]
+        assert "speckit-context:v1" in body
+        assert "A human decision recorded here." in body, "the existing body must survive"
+
+    def test_a_rerun_reports_stale_context_without_editing(self, project) -> None:
+        repo, bindir, state = self._feature(project)
+        first = _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+        assert first.returncode == 0, first.stderr
+        before = _issues(state)[0]["body"]
+        (repo / ".specify/specs/exports/spec.md").write_text(
+            self.SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        again = _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+
+        assert again.returncode == 0, again.stderr
+        assert "stale T001 (context: changed-in-scope)" in again.stdout
+        assert _issues(state)[0]["body"] == before, "a re-run reports drift; it never edits"
+
+    def test_the_refresh_carries_the_new_acceptance_and_keeps_the_decision(
+        self, project
+    ) -> None:
+        repo, bindir, state = self._feature(project)
+        _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+        issues = json.loads(state.read_text())
+        issues["issues"][0]["body"] += "\nAcceptance-revision: source-digest=abc123def456 ref=#7\n"
+        state.write_text(json.dumps(issues))
+        (repo / ".specify/specs/exports/spec.md").write_text(
+            self.SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        _, written = self._refresh(repo, 100, state, bindir)
+
+        assert written is not None and written.returncode == 0
+        body = _issues(state)[0]["body"]
+        assert "within 100ms" in body, "the refreshed acceptance must be carried forward"
+        assert "Acceptance-revision: source-digest=abc123def456" in body, (
+            "the decision record lives outside the block and must survive"
+        )
+
+    def test_a_failed_github_write_leaves_the_issue_and_retries_cleanly(
+        self, project
+    ) -> None:
+        repo, bindir, state = self._feature(project)
+        _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+        original = _issues(state)[0]["body"]
+        (repo / ".specify/specs/exports/spec.md").write_text(
+            self.SPEC.replace("within 200ms", "within 100ms"), encoding="utf-8"
+        )
+
+        _, failed = self._refresh(repo, 100, state, bindir, edit_fails=True)
+        assert failed is not None and failed.returncode != 0, "the stubbed write must fail"
+        assert _issues(state)[0]["body"] == original, "a failed write must change nothing"
+
+        _, retried = self._refresh(repo, 100, state, bindir)
+
+        assert retried is not None and retried.returncode == 0
+        assert "within 100ms" in _issues(state)[0]["body"]

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -760,6 +760,99 @@ class TestDependencies:
         assert "- Blocked by" not in _issues(state)[0]["body"]
 
 
+SPEC_FIXTURE = """# Feature Specification: Exports
+
+## User Stories
+
+### US1: Responsive exports [P1]
+
+**As a** analyst,
+**I want** the page to stay usable while an export runs,
+**So that** I can keep working.
+
+**Acceptance Criteria:**
+- [ ] The page responds within 200ms while an export of 50k rows runs
+
+### US2: Scheduled exports [P2]
+
+**Acceptance Criteria:**
+- [ ] A schedule can be set per report
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Priority | User Story |
+|----|-------------|----------|------------|
+| R1 | Export runs without holding a request thread | Must | US1 |
+| R3 | Schedules persist across restarts | Could | US2 |
+"""
+
+
+class TestGeneratedContext:
+    """Issue #858: a generated issue carries its declared context, or says it cannot."""
+
+    def test_context_block_is_attached_when_a_spec_resolves(self, project) -> None:
+        repo, bindir, state = project(
+            {
+                ".specify/specs/exports/tasks.md": (
+                    "- [ ] **T001** [US1] Use a background queue\n"
+                ),
+                ".specify/specs/exports/spec.md": SPEC_FIXTURE,
+            }
+        )
+
+        result = _run(repo, bindir, state, "--tasks", ".specify/specs/exports/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        body = _issues(state)[0]["body"]
+        assert "speckit-context:v1" in body
+        assert "The page responds within 200ms" in body
+        assert "R1" in body
+        assert "A schedule can be set per report" not in body, (
+            "another story's acceptance must not be carried into this task"
+        )
+        assert "R3" not in body, "R3 is declared against US2"
+
+    def test_no_spec_still_produces_a_usable_issue(self, project) -> None:
+        """The lightweight path is untouched: no spec, no block, no failure."""
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
+        assert not (repo / "a" / "spec.md").exists(), "fixture must have no sibling spec"
+
+        result = _run(repo, bindir, state, "--tasks", "a/tasks.md")
+
+        assert result.returncode == 0, result.stderr
+        body = _issues(state)[0]["body"]
+        assert "Auto-created from" in body
+        assert "speckit-context:v1" in body, (
+            "the block is still attached and should disclose that no source resolved"
+        )
+        assert "no spec.md beside" in body
+
+
+def test_every_packaged_converter_ships_its_context_helper() -> None:
+    """Packaging tripwire (#858).
+
+    `scripts/codex-skill-sync.py` bundles a script into a generated skill when the
+    COMMAND BODY names `scripts/<file>`. It does not follow what a bundled script
+    calls at runtime, so the converter can be packaged without the helper it
+    invokes - and byte parity against the source checkout still looks clean while
+    every generated skill carries a converter that cannot render context.
+    """
+    bundles = sorted((ROOT / "codex" / "skills").glob("*/scripts/speckit-tasks-to-issues.sh"))
+    assert bundles, "no packaged converter found; this tripwire is stale"
+
+    missing = [
+        str(path.parent.relative_to(ROOT))
+        for path in bundles
+        if not (path.parent / "speckit-context.py").is_file()
+    ]
+
+    assert not missing, (
+        "packaged converter without its runtime helper in: " + ", ".join(missing)
+    )
+
+
 def test_no_whitespace_ifs_read_remains_in_scripts() -> None:
     """Class guard: no shell reader in scripts/ splits on an IFS-whitespace delimiter.
 

--- a/tests/test_speckit_tasks_to_issues.py
+++ b/tests/test_speckit_tasks_to_issues.py
@@ -830,6 +830,68 @@ class TestGeneratedContext:
         assert "no spec.md beside" in body
 
 
+class TestContextFailuresAreNotSilent:
+    """A broken installation is not an ordinary lightweight issue (#858)."""
+
+    def test_a_missing_helper_stops_before_any_write(self, project, tmp_path: Path) -> None:
+        """Copy the converter WITHOUT its helper and run it: no issues, loud error."""
+        lone = tmp_path / "lone"
+        lone.mkdir()
+        (lone / "speckit-tasks-to-issues.sh").write_text(
+            SCRIPT.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        assert not (lone / "speckit-context.py").exists(), (
+            "fixture must separate the converter from its helper"
+        )
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
+
+        result = subprocess.run(
+            ["bash", str(lone / "speckit-tasks-to-issues.sh"), "--tasks", "a/tasks.md"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "HOME": str(repo.parent),
+                "GH_STUB_STATE": str(state),
+            },
+        )
+
+        assert result.returncode == 7, result.stdout + result.stderr
+        assert "speckit-context.py is missing" in result.stderr
+        assert _issues(state) == [], "nothing may be created on a broken installation"
+
+    def test_no_context_is_the_documented_opt_out(self, project, tmp_path: Path) -> None:
+        lone = tmp_path / "lone2"
+        lone.mkdir()
+        (lone / "speckit-tasks-to-issues.sh").write_text(
+            SCRIPT.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        repo, bindir, state = project({"a/tasks.md": BOLD_TASKS})
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(lone / "speckit-tasks-to-issues.sh"),
+                "--tasks",
+                "a/tasks.md",
+                "--no-context",
+            ],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "HOME": str(repo.parent),
+                "GH_STUB_STATE": str(state),
+            },
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert len(_issues(state)) == 1
+        assert "speckit-context:v1" not in _issues(state)[0]["body"]
+
+
 def test_every_packaged_converter_ships_its_context_helper() -> None:
     """Packaging tripwire (#858).
 


### PR DESCRIPTION
## What was wrong

A generated issue carried its provenance, its identity marker and its dependencies - and nothing about the behaviour it was meant to produce. The task title was the whole description, so a receiving agent could not tell which words were the goal and which were a suggested mechanism, and had nothing pointing at the document that governs the work. `flow:auto` Step 2 told it to extract checkbox acceptance criteria that a generated issue does not have.

`.claude/commands/flow/wave.md` also still claimed the converter "emits no `- Blocked by #N` lines itself". True when written (#637), false the same day (#607), and the file already contradicted itself fifty lines later.

## The design

`scripts/speckit-context.py` resolves only **declared** relationships - the task's `[USn]` tag, and the Functional Requirements rows whose `User Story` column names that story - and renders a bounded, fingerprinted block into the issue body. Nothing is inferred from task numbers.

It is a **cache, not a second authority**: the spec is named as authoritative, cross-cutting sections that carry no story mapping (Non-Functional Requirements, Out of Scope) are listed for the reader rather than attributed to the task, and anything that does not resolve is disclosed as incomplete context. `docs/agents/issue-contract.md` gains a narrow amendment explaining that exception, since its "does not copy" rule would otherwise contradict what ships.

The task's own wording is labelled as **task wording whose authority must be resolved against the source** - never blanket-labelled replaceable, because a task line can restate a binding constraint.

The source is named as the **reference**, not as an automatic override: a difference between cache and source is a changed *version* to resolve under the existing authority model, and newer bytes do not by themselves supersede a constraint or plan already accepted on the issue.

## Portability, tamper-evidence and bounds

- paths are stored relative to a declared project root, so a consumer in a different clone checks **its own** tree - persisting the producer's path made it check the producer's
- the task line is fingerprinted too: retagging `[US1]`→`[US2]`, or dropping a constraint from the wording, reports `changed-task` instead of `current`
- integrity covers the managed **metadata** as well as the visible text, so `task:`/`source:`/digests cannot be edited in place; required fields are validated, duplicates refuse, and a refresh naming another feature or task refuses rather than re-pointing the block
- outcome, task wording and total block size are bounded, and a capped extract says it is incomplete
- the shipped template's horizontal rule no longer parses as an acceptance item of `--`; fenced samples are examples, not declarations; a story declared twice is disclosed, not silently resolved

## Freshness on the receiving path

`flow:auto` Step 2 runs `speckit-context.py check` **before planning**. States name what was observed - `current`, `changed-in-scope`, `changed-outside-scope`, `changed-task`, `source-missing`, `tasks-missing`, `block-edited`, `block-damaged`, `absent` - and never claim acceptance changed or that anything was approved. A changed source is evidence to assess under existing authority; it is not a new approval gate.

**Refreshing an existing issue** is an explicit fetch-refresh-write workflow documented in `flow:wave` Phase 1, not a converter flag. A converter re-run only *reports* the context state of each already-filed task - it never rewrites a context block. (Dependency reconciliation is separate and unchanged: a re-run still appends missing `Blocked by` edges.) The refresh itself is `speckit-context.py refresh`, which declines rather than guessing and writes back only on exit 0.

It is a content refresh and cannot mark a requirements change acknowledged: a structured `Acceptance-revision:` record is surfaced with the version it names - current source, the cached version (flagged as predating the change), or neither - and explicitly not judged. A free-text "acknowledged" is not a record.

A read or check failure during a re-run is reported with its diagnostic and exits non-zero. An unreadable issue is not the same as an issue with no context block, and is never reported as one.

## Lightweight issues stay first-class

No block, no spec, no story tag, no digest: the issue body is the whole contract and `absent` is a normal state, not a fault. An unresolved or capped extract means the context is incomplete - never that there are no constraints - and it is handled under the same material-ambiguity rule as everything else: resolve what would change the work, surface the rest, and plan from what you have. Missing optional structure is not a gate.

## Packaging

`codex-skill-sync` bundles scripts named in a command **body** and does not follow runtime calls, so regenerating alone would have shipped four skills with a converter that could not render context while source parity looked clean. The helper is now declared alongside the converter in every routing command doc, a tripwire test pins that every packaged converter ships it, and the bundled converter was **executed** from each generated skill in an isolated project rather than compared for parity.

A missing or failing helper is an error before any write (`--no-context` is the deliberate opt-out); a broken installation is not an ordinary lightweight issue.

## Verification

- `make verify`: **exit 0** - 2909 passed, mypy clean on 198 source files, all repo checks ok
- `flow-finish-gate.sh`: `FLOW_FINISH_GATE: ok`
- 45 helper tests and 51 converter tests, covering the cross-checkout handoff, the changed story tag and wording, the in-block metadata edit, the real in-tree spec's horizontal rule, a fenced example task, the unbounded outcome, the separated-helper installation, and the full existing-issue refresh cycle with a failed GitHub write and its retry
- **the published shell is executed by test**, not paraphrased: the `flow:wave` refresh snippet is extracted from the command document and run, so a refused refresh must leave the issue byte-identical and a failed `gh issue edit` must not be masked by the cleanup that follows it. Reverting either guard fails the test
- read and check failures during a converter re-run are proven visible with failing stubs
- the installed consumer path exercised from `~/.claude/scripts/` after `flow-helpers-install.sh`, in a project that is not CPP and has no `scripts/` of its own
- bundled execution verified from `flow-wave`, `evaluate-issue`, `project-init` and `evaluate-help`

## What tests establish, and what they do not

These tests assert generated text and file state: that the block is produced, that another story's acceptance stays out, that unresolved mappings are disclosed, that human text survives a refresh, and that drift is surfaced. **No test here establishes that a receiving agent read the source, separated a proposal from a binding constraint, or planned accordingly.** That is agent judgment and belongs to the #861 pilots.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQUjuiK5LmADM7ejk1FJ5