### PR TITLE
Account for delivered outcomes and agreed revisions in PR completion evidence

### DIFF
--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -700,10 +700,9 @@ fi
    squash that carries one incidentally (exits 5 and 7).
    **Acceptance disposition before closing (issue #860).** Account for the material
    acceptance items first - demonstrated, revised with evidence, or deferred - and
-   record `Acceptance-disposition: complete` or `Acceptance-disposition: unresolved -
-   <what remains>` in the PR body. When it is unresolved, use `Refs #N` in the commit
+   record the accounting in the PR body as ordinary prose. When it is unresolved, use `Refs #N` in the commit
    message, the PR title and the PR body instead of `Closes #N`, and check the earlier
-   branch commits too (`git log origin/main..HEAD --format=%B | grep -in 'closes #'`),
+   branch commits too (read `git log origin/main..HEAD --format=%B` and the PR text yourself),
    since the squash text is derived from them. A delegated run that delivered part of
    the work is still mergeable; it just must not close the promise. The canonical rule
    is docs/agents/issue-contract.md.
@@ -718,13 +717,14 @@ fi
 3. **Create PR** if no PR exists:
    ```bash
    gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
+   # ... or (Refs #ISSUE_NUM) when the acceptance accounting is not complete.
    ```
    - PR body includes:
      - Summary of changes
      - Note that implementation was delegated to Codex CLI
      - Claude Code review findings
      - Test plan
-     - `Closes #N`
+     - `Closes #N` when the accounting is complete, otherwise `Refs #N`
 
 Report: `Step 7/8: Finish complete - PR #{N} created`
 

--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -717,7 +717,9 @@ fi
    record the accounting in the PR body as ordinary prose. When it is unresolved, use `Refs #N` in the commit
    message, the PR title and the PR body instead of `Closes #N`, and check the earlier
    branch commits too (read `git log origin/main..HEAD --format=%B` and the PR text yourself),
-   since the squash text is derived from them. A delegated run that delivered part of
+   since the squash text may be derived from them - `gh-pr-merge.sh`
+   passes an explicit subject and body from the PR (#655), so check which sources are
+   actually in play rather than assuming a rewrite is needed. A delegated run that delivered part of
    the work is still mergeable; it just must not close the promise. The canonical rule
    is docs/agents/issue-contract.md.
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`

--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -702,7 +702,7 @@ fi
        ISSUE_REF="Closes #${ISSUE_NUM}"
    fi
    ```
-   
+
    `$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
    incomplete accounting cannot publish a closing reference anywhere.
 

--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -689,7 +689,24 @@ fi
 ```
 
 1. **Commit** the changes:
-   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Conventional commit format, with the closing reference decided by the
+     accounting below: `type(scope): Description (Closes #N)` when complete,
+     `type(scope): Description (Refs #N)` when it is not.
+   The closing reference follows the acceptance accounting: use it only when every
+   material item is demonstrated, revised with evidence, or resolved by a recorded
+   transfer. Otherwise reference the issue without a closing keyword (`Refs #N`), in
+   the commit message, the PR title and the PR body alike. Do not print a closing
+   keyword beside an issue number even as an illustration - the merge helper refuses a
+   squash that carries one incidentally (exits 5 and 7).
+   **Acceptance disposition before closing (issue #860).** Account for the material
+   acceptance items first - demonstrated, revised with evidence, or deferred - and
+   record `Acceptance-disposition: complete` or `Acceptance-disposition: unresolved -
+   <what remains>` in the PR body. When it is unresolved, use `Refs #N` in the commit
+   message, the PR title and the PR body instead of `Closes #N`, and check the earlier
+   branch commits too (`git log origin/main..HEAD --format=%B | grep -in 'closes #'`),
+   since the squash text is derived from them. A delegated run that delivered part of
+   the work is still mergeable; it just must not close the promise. The canonical rule
+   is docs/agents/issue-contract.md.
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
    - Note Codex as implementer in the commit body
 

--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -689,9 +689,23 @@ fi
 ```
 
 1. **Commit** the changes:
-   - Conventional commit format, with the closing reference decided by the
-     accounting below: `type(scope): Description (Closes #N)` when complete,
-     `type(scope): Description (Refs #N)` when it is not.
+   - Conventional commit format using the selected reference:
+     `type(scope): Description (${ISSUE_REF})`
+   ```bash
+   # Reference selection (issue #860). Default to a NON-closing reference; a closing one
+   # is used only after your own acceptance accounting for THIS issue. Reset it here
+   # rather than inheriting a value from an earlier run.
+   ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                              # revised with evidence, or resolved by a recorded transfer
+   ISSUE_REF="Refs #${ISSUE_NUM}"
+   if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+       ISSUE_REF="Closes #${ISSUE_NUM}"
+   fi
+   ```
+   
+   `$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+   incomplete accounting cannot publish a closing reference anywhere.
+
    The closing reference follows the acceptance accounting: use it only when every
    material item is demonstrated, revised with evidence, or resolved by a recorded
    transfer. Otherwise reference the issue without a closing keyword (`Refs #N`), in
@@ -716,15 +730,15 @@ fi
 
 3. **Create PR** if no PR exists:
    ```bash
-   gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
-   # ... or (Refs #ISSUE_NUM) when the acceptance accounting is not complete.
+   gh pr create --title "type(scope): Description (${ISSUE_REF})" --body "..."
    ```
    - PR body includes:
      - Summary of changes
      - Note that implementation was delegated to Codex CLI
      - Claude Code review findings
      - Test plan
-     - `Closes #N` when the accounting is complete, otherwise `Refs #N`
+     - `${ISSUE_REF}` - the selected reference, non-closing unless the
+       accounting is complete
 
 Report: `Step 7/8: Finish complete - PR #{N} created`
 

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -1071,7 +1071,9 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    # parsed out of the report: a quoted example or a truncated read must never be able
    # to authorise a close. "yes" only when every material item is demonstrated, revised
    # WITH evidence, or resolved by a recorded transfer/withdrawal; unset cannot close.
-   ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+   # Restate the judgement you reached in Step 6 for THIS issue. It is set here
+   # rather than inherited, so a value left over from earlier work cannot decide it.
+   ACCEPTANCE_COMPLETE=""
 
    if [[ -n "$ISSUE_NUM" ]]; then
        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -674,6 +674,46 @@ if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
 fi
 ```
 
+**Acceptance accounting (issue #860).** The quality gates above are evidence about
+CHECKS. Before opening the PR, account for what was actually delivered: every
+material acceptance item is demonstrated (name the behavioural test, experiment or
+reviewed observation), revised (give the reason and the agreement it needed), or
+deferred (and still owed). A couple of sentences of prose is enough for a small
+change - there is no required per-item line and no separate artifact. Silence is not
+delivery: an item nobody mentions is unresolved.
+
+Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
+evidence that satisfied the earlier promise has to be reassessed against the new
+one - sometimes it still suffices, often it does not, and that judgement belongs in
+the report rather than being assumed either way. A revision record on its own is
+never delivery evidence, and
+a revision record on its own is not delivery evidence.
+
+The report stays ordinary prose - there is no field to fill in, and nothing is
+parsed out of it. Carry the judgement into the one place it has to act: the closing
+step sets `ACCEPTANCE_COMPLETE=yes` ONLY when every material item is demonstrated,
+revised with evidence for the revised behaviour, or resolved by a transfer or
+withdrawal that recorded its authority and destination. Anything else - including
+"mostly done" - leaves it unset, and unset cannot close.
+
+**Closing must agree with that line.** When the disposition is `unresolved`, use
+`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
+so the merge cannot close a promise the report says was not kept. Check the earlier
+commits on the branch too, since the squash text comes from them:
+
+```bash
+git log origin/main..HEAD --format=%B
+gh pr view "$PR_NUMBER" --json title,body --jq '.title, .body' 2>/dev/null
+```
+
+Read the closing references there yourself rather than grepping for one spelling -
+the merge helper rejects negated and incidental forms too, and a narrow pattern
+misses exactly the ones that surprise you.
+
+The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
+this is where it is executed. Partial delivery stays reviewable and mergeable - the
+disposition changes what CLOSES, not what may merge.
+
 **Collapsing the branch to one commit - the SAFE recipe (issue #657).** Prefer
 NO collapse at all: since #655 the merge helper passes an explicit
 `--subject`/`--body` derived from the PR, so a WIP-first branch squashes with
@@ -689,7 +729,8 @@ merged 2,085-line feature to exactly this on 2026-08-11). The safe shape:
 git reset --soft "$(git merge-base HEAD origin/main)"
 # Before committing, prove the collapse deletes nothing you did not delete:
 git diff --staged --diff-filter=D --name-only   # MUST be empty unless intended
-git commit -m "type(scope): Description (Closes #N)"
+git commit -m "type(scope): Description (Closes #N)"   # (Refs #N) if the
+                                                      # accounting is not complete
 # THEN bring the moved base in:
 git merge --no-edit origin/main
 ```
@@ -773,46 +814,10 @@ git merge --no-edit origin/main
    git push -u origin "$BRANCH"
    ```
 
-**Acceptance accounting (issue #860).** The quality gates above are evidence about
-CHECKS. Before opening the PR, account for what was actually delivered: every
-material acceptance item is demonstrated (name the behavioural test, experiment or
-reviewed observation), revised (give the reason and the agreement it needed), or
-deferred (and still owed). A couple of sentences of prose is enough for a small
-change - there is no required per-item line and no separate artifact. Silence is not
-delivery: an item nobody mentions is unresolved.
-
-Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
-evidence that satisfied the earlier promise no longer demonstrates the new one, and
-a revision record on its own is not delivery evidence.
-
-Record the outcome as one line the later steps can act on:
-
-```
-Acceptance-disposition: complete
-Acceptance-disposition: unresolved - <what remains, in a few words>
-```
-
-`complete` means every material item is demonstrated, or revised WITH evidence for
-the revised behaviour, or resolved by a transfer/withdrawal that recorded its
-authority and destination. Anything else is `unresolved`, including "mostly done".
-
-**Closing must agree with that line.** When the disposition is `unresolved`, use
-`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
-so the merge cannot close a promise the report says was not kept. Check the earlier
-commits on the branch too, since the squash text comes from them:
-
-```bash
-git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
-    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
-```
-
-The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
-this is where it is executed. Partial delivery stays reviewable and mergeable - the
-disposition changes what CLOSES, not what may merge.
-
 4. **Create PR** - if no PR exists:
    ```bash
    gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
+   # ... or (Refs #ISSUE_NUM) when the acceptance accounting is not complete.
    ```
    - If PR already exists, report its URL and continue.
    - PR body: Summary of changes + test plan + `Closes #N`

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -696,16 +696,17 @@ revised with evidence for the revised behaviour, or resolved by a transfer or
 withdrawal that recorded its authority and destination. Anything else - including
 "mostly done" - leaves it unset, and unset cannot close.
 
-**Closing must agree with that line.** When the disposition is `unresolved`, use
-`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
-so the merge cannot close a promise the report says was not kept. Check the earlier
-review whatever will actually become the
-merge text: the PR title and body, and the branch commits where they feed the squash.
-`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
-that path an older commit's wording does not reach the squash - but a plain
-`gh pr merge --squash` can compose it from the commits, and that is when a stale
-closing reference still matters. Check the sources in play rather than rewriting
-history on the assumption that it always does:
+**Closing must agree with that judgement.** When the accounting is not complete, the
+selected reference is the non-closing `Refs #N` - in the commit message, the PR title
+and the PR body alike, never `Closes #N` - so the merge cannot close a promise the
+report says was not kept.
+
+Then review whatever will actually become the merge text: the PR title and body, and
+the branch commits where they feed the squash. `gh-pr-merge.sh` passes an explicit
+subject and body derived from the PR (#655), so on that path an older commit's wording
+does not reach the squash - but a plain `gh pr merge --squash` can compose it from the
+commits, and that is when a stale closing reference still matters. Check the sources in
+play rather than rewriting history on the assumption that they always feed it:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -699,7 +699,13 @@ withdrawal that recorded its authority and destination. Anything else - includin
 **Closing must agree with that line.** When the disposition is `unresolved`, use
 `Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
 so the merge cannot close a promise the report says was not kept. Check the earlier
-commits on the branch too, since the squash text comes from them:
+review whatever will actually become the
+merge text: the PR title and body, and the branch commits where they feed the squash.
+`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
+that path an older commit's wording does not reach the squash - but a plain
+`gh pr merge --squash` can compose it from the commits, and that is when a stale
+closing reference still matters. Check the sources in play rather than rewriting
+history on the assumption that it always does:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -773,6 +773,43 @@ git merge --no-edit origin/main
    git push -u origin "$BRANCH"
    ```
 
+**Acceptance accounting (issue #860).** The quality gates above are evidence about
+CHECKS. Before opening the PR, account for what was actually delivered: every
+material acceptance item is demonstrated (name the behavioural test, experiment or
+reviewed observation), revised (give the reason and the agreement it needed), or
+deferred (and still owed). A couple of sentences of prose is enough for a small
+change - there is no required per-item line and no separate artifact. Silence is not
+delivery: an item nobody mentions is unresolved.
+
+Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
+evidence that satisfied the earlier promise no longer demonstrates the new one, and
+a revision record on its own is not delivery evidence.
+
+Record the outcome as one line the later steps can act on:
+
+```
+Acceptance-disposition: complete
+Acceptance-disposition: unresolved - <what remains, in a few words>
+```
+
+`complete` means every material item is demonstrated, or revised WITH evidence for
+the revised behaviour, or resolved by a transfer/withdrawal that recorded its
+authority and destination. Anything else is `unresolved`, including "mostly done".
+
+**Closing must agree with that line.** When the disposition is `unresolved`, use
+`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
+so the merge cannot close a promise the report says was not kept. Check the earlier
+commits on the branch too, since the squash text comes from them:
+
+```bash
+git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
+    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
+```
+
+The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
+this is where it is executed. Partial delivery stays reviewable and mergeable - the
+disposition changes what CLOSES, not what may merge.
+
 4. **Create PR** - if no PR exists:
    ```bash
    gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
@@ -1011,10 +1048,20 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 
 6. **Close issue** (if still open):
    ```bash
+   # Set from YOUR acceptance accounting (docs/agents/issue-contract.md). Nothing is
+   # parsed out of the report: a quoted example or a truncated read must never be able
+   # to authorise a close. "yes" only when every material item is demonstrated, revised
+   # WITH evidence, or resolved by a recorded transfer/withdrawal; unset cannot close.
+   ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+
    if [[ -n "$ISSUE_NUM" ]]; then
        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
-       if [[ "$ISSUE_STATE" == "OPEN" ]]; then
-           gh issue close "$ISSUE_NUM" --comment "Closed via /flow:auto - PR #${PR_NUMBER} merged."
+       if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+           if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+               gh issue close "$ISSUE_NUM" --comment "Closed via /flow:auto - PR #${PR_NUMBER} merged."
+           fi
+       else
+           echo "Acceptance not recorded complete - leaving #${ISSUE_NUM} open."
        fi
    fi
    ```

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -714,6 +714,21 @@ The canonical rule is [the issue contract](../../../docs/agents/issue-contract.m
 this is where it is executed. Partial delivery stays reviewable and mergeable - the
 disposition changes what CLOSES, not what may merge.
 
+```bash
+# Reference selection (issue #860). Default to a NON-closing reference; a closing one
+# is used only after your own acceptance accounting for THIS issue. Reset it here
+# rather than inheriting a value from an earlier run.
+ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                           # revised with evidence, or resolved by a recorded transfer
+ISSUE_REF="Refs #${ISSUE_NUM}"
+if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+    ISSUE_REF="Closes #${ISSUE_NUM}"
+fi
+```
+
+`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+incomplete accounting cannot publish a closing reference anywhere.
+
 **Collapsing the branch to one commit - the SAFE recipe (issue #657).** Prefer
 NO collapse at all: since #655 the merge helper passes an explicit
 `--subject`/`--body` derived from the PR, so a WIP-first branch squashes with
@@ -729,8 +744,7 @@ merged 2,085-line feature to exactly this on 2026-08-11). The safe shape:
 git reset --soft "$(git merge-base HEAD origin/main)"
 # Before committing, prove the collapse deletes nothing you did not delete:
 git diff --staged --diff-filter=D --name-only   # MUST be empty unless intended
-git commit -m "type(scope): Description (Closes #N)"   # (Refs #N) if the
-                                                      # accounting is not complete
+git commit -m "type(scope): Description (${ISSUE_REF})"
 # THEN bring the moved base in:
 git merge --no-edit origin/main
 ```
@@ -800,7 +814,8 @@ git merge --no-edit origin/main
    cannot block what it cannot run).
 
 2. **Commit** - if there are uncommitted changes:
-   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Conventional commit format, using the selected reference:
+     `type(scope): Description (${ISSUE_REF})`
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
    - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
      #635): when the stale-base merge above ran, the Step-4 work is already on
@@ -816,11 +831,10 @@ git merge --no-edit origin/main
 
 4. **Create PR** - if no PR exists:
    ```bash
-   gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
-   # ... or (Refs #ISSUE_NUM) when the acceptance accounting is not complete.
+   gh pr create --title "type(scope): Description (${ISSUE_REF})" --body "..."
    ```
    - If PR already exists, report its URL and continue.
-   - PR body: Summary of changes + test plan + `Closes #N`
+   - PR body: Summary of changes + test plan + `${ISSUE_REF}`
    - Analyze all commits on the branch to draft the summary.
 
 Report: `Step 6/9: Finish complete - PR #XX created`

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -219,7 +219,13 @@ withdrawal that recorded its authority and destination. Anything else - includin
 **Closing must agree with that line.** When the disposition is `unresolved`, use
 `Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
 so the merge cannot close a promise the report says was not kept. Check the earlier
-commits on the branch too, since the squash text comes from them:
+review whatever will actually become the
+merge text: the PR title and body, and the branch commits where they feed the squash.
+`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
+that path an older commit's wording does not reach the squash - but a plain
+`gh pr merge --squash` can compose it from the commits, and that is when a stale
+closing reference still matters. Check the sources in play rather than rewriting
+history on the assumption that it always does:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -216,16 +216,17 @@ revised with evidence for the revised behaviour, or resolved by a transfer or
 withdrawal that recorded its authority and destination. Anything else - including
 "mostly done" - leaves it unset, and unset cannot close.
 
-**Closing must agree with that line.** When the disposition is `unresolved`, use
-`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
-so the merge cannot close a promise the report says was not kept. Check the earlier
-review whatever will actually become the
-merge text: the PR title and body, and the branch commits where they feed the squash.
-`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
-that path an older commit's wording does not reach the squash - but a plain
-`gh pr merge --squash` can compose it from the commits, and that is when a stale
-closing reference still matters. Check the sources in play rather than rewriting
-history on the assumption that it always does:
+**Closing must agree with that judgement.** When the accounting is not complete, the
+selected reference is the non-closing `Refs #N` - in the commit message, the PR title
+and the PR body alike, never `Closes #N` - so the merge cannot close a promise the
+report says was not kept.
+
+Then review whatever will actually become the merge text: the PR title and body, and
+the branch commits where they feed the squash. `gh-pr-merge.sh` passes an explicit
+subject and body derived from the PR (#655), so on that path an older commit's wording
+does not reach the squash - but a plain `gh pr merge --squash` can compose it from the
+commits, and that is when a stale closing reference still matters. Check the sources in
+play rather than rewriting history on the assumption that they always feed it:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -194,6 +194,50 @@ BARE (#581 discipline):
 
 **This step never blocks the flow** - it is purely informational.
 
+**Acceptance accounting (issue #860).** The quality gates above are evidence about
+CHECKS. Before opening the PR, account for what was actually delivered: every
+material acceptance item is demonstrated (name the behavioural test, experiment or
+reviewed observation), revised (give the reason and the agreement it needed), or
+deferred (and still owed). A couple of sentences of prose is enough for a small
+change - there is no required per-item line and no separate artifact. Silence is not
+delivery: an item nobody mentions is unresolved.
+
+Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
+evidence that satisfied the earlier promise no longer demonstrates the new one, and
+a revision record on its own is not delivery evidence.
+
+Record the outcome as one line the later steps can act on:
+
+```
+Acceptance-disposition: complete
+Acceptance-disposition: unresolved - <what remains, in a few words>
+```
+
+`complete` means every material item is demonstrated, or revised WITH evidence for
+the revised behaviour, or resolved by a transfer/withdrawal that recorded its
+authority and destination. Anything else is `unresolved`, including "mostly done".
+
+**Closing must agree with that line.** When the disposition is `unresolved`, use
+`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
+so the merge cannot close a promise the report says was not kept. Check the earlier
+commits on the branch too, since the squash text comes from them:
+
+```bash
+git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
+    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
+```
+
+The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
+this is where it is executed. Partial delivery stays reviewable and mergeable - the
+disposition changes what CLOSES, not what may merge.
+
+**Wording an unresolved report.** Reword closing references to a plain mention -
+`Refs #N`, or "part of #N" - in the commit messages, the PR title and the PR body. Do
+not print a closing keyword beside an issue number even to illustrate what to remove:
+`gh-pr-merge.sh` refuses a squash carrying a negated or incidental closing keyword next
+to an issue number (exits 5 and 7), and it cannot tell an example from an instruction.
+A report that demonstrates the mistake interrupts the merge it was trying to protect.
+
 ### Step 3: Check for Changes
 
 ```bash

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -203,19 +203,18 @@ change - there is no required per-item line and no separate artifact. Silence is
 delivery: an item nobody mentions is unresolved.
 
 Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
-evidence that satisfied the earlier promise no longer demonstrates the new one, and
+evidence that satisfied the earlier promise has to be reassessed against the new
+one - sometimes it still suffices, often it does not, and that judgement belongs in
+the report rather than being assumed either way. A revision record on its own is
+never delivery evidence, and
 a revision record on its own is not delivery evidence.
 
-Record the outcome as one line the later steps can act on:
-
-```
-Acceptance-disposition: complete
-Acceptance-disposition: unresolved - <what remains, in a few words>
-```
-
-`complete` means every material item is demonstrated, or revised WITH evidence for
-the revised behaviour, or resolved by a transfer/withdrawal that recorded its
-authority and destination. Anything else is `unresolved`, including "mostly done".
+The report stays ordinary prose - there is no field to fill in, and nothing is
+parsed out of it. Carry the judgement into the one place it has to act: the closing
+step sets `ACCEPTANCE_COMPLETE=yes` ONLY when every material item is demonstrated,
+revised with evidence for the revised behaviour, or resolved by a transfer or
+withdrawal that recorded its authority and destination. Anything else - including
+"mostly done" - leaves it unset, and unset cannot close.
 
 **Closing must agree with that line.** When the disposition is `unresolved`, use
 `Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
@@ -223,9 +222,13 @@ so the merge cannot close a promise the report says was not kept. Check the earl
 commits on the branch too, since the squash text comes from them:
 
 ```bash
-git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
-    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
+git log origin/main..HEAD --format=%B
+gh pr view "$PR_NUMBER" --json title,body --jq '.title, .body' 2>/dev/null
 ```
+
+Read the closing references there yourself rather than grepping for one spelling -
+the merge helper rejects negated and incidental forms too, and a narrow pattern
+misses exactly the ones that surprise you.
 
 The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
 this is where it is executed. Partial delivery stays reviewable and mergeable - the
@@ -292,6 +295,7 @@ Use standard PR creation:
 ```bash
 gh pr create \
   --title "type(scope): Description (Closes #ISSUE_NUM)" \
+  `# use (Refs #ISSUE_NUM) instead when the acceptance accounting is not complete` \
   --body "## Summary
 - <bullet points>
 
@@ -300,6 +304,8 @@ gh pr create \
 - [ ] Linting passes
 
 Closes #ISSUE_NUM"
+# When the accounting is not complete, reference the issue without a closing
+# keyword instead, in the title, the body and the commit message alike.
 ```
 
 - Title: Conventional commit style, derived from changes

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -264,7 +264,8 @@ discipline; on exit 127 skip it):
   rule) and re-stage before committing.
 
 - If there are uncommitted changes, help the user commit them using standard git commit workflow.
-- Use conventional commit format: `type(scope): Description (Closes #N)`
+- Conventional commit format, using the selected reference:
+  `type(scope): Description (${ISSUE_REF})`
 - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` if Claude helped write the code.
 - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
   #635): when the Step-1 stale-base merge ran, the work is already on the
@@ -290,12 +291,26 @@ EXISTING_PR=$(gh pr list --head "$BRANCH" --json number,url --jq '.[0]' 2>/dev/n
 
 ### Step 6: Create PR
 
+```bash
+# Reference selection (issue #860). Default to a NON-closing reference; a closing one
+# is used only after your own acceptance accounting for THIS issue. Reset it here
+# rather than inheriting a value from an earlier run.
+ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                           # revised with evidence, or resolved by a recorded transfer
+ISSUE_REF="Refs #${ISSUE_NUM}"
+if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+    ISSUE_REF="Closes #${ISSUE_NUM}"
+fi
+```
+
+`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+incomplete accounting cannot publish a closing reference anywhere.
+
 Use standard PR creation:
 
 ```bash
 gh pr create \
-  --title "type(scope): Description (Closes #ISSUE_NUM)" \
-  `# use (Refs #ISSUE_NUM) instead when the acceptance accounting is not complete` \
+  --title "type(scope): Description (${ISSUE_REF})" \
   --body "## Summary
 - <bullet points>
 
@@ -303,13 +318,11 @@ gh pr create \
 - [ ] Tests pass
 - [ ] Linting passes
 
-Closes #ISSUE_NUM"
-# When the accounting is not complete, reference the issue without a closing
-# keyword instead, in the title, the body and the commit message alike.
+${ISSUE_REF}"
 ```
 
 - Title: Conventional commit style, derived from changes
-- Body: Summary of changes + test plan + `Closes #N`
+- Body: Summary of changes + test plan + `${ISSUE_REF}`
 - Analyze all commits on the branch to draft the summary
 
 ### Step 7: Output

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -241,6 +241,21 @@ not print a closing keyword beside an issue number even to illustrate what to re
 to an issue number (exits 5 and 7), and it cannot tell an example from an instruction.
 A report that demonstrates the mistake interrupts the merge it was trying to protect.
 
+```bash
+# Reference selection (issue #860). Default to a NON-closing reference; a closing one
+# is used only after your own acceptance accounting for THIS issue. Reset it here
+# rather than inheriting a value from an earlier run.
+ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                           # revised with evidence, or resolved by a recorded transfer
+ISSUE_REF="Refs #${ISSUE_NUM}"
+if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+    ISSUE_REF="Closes #${ISSUE_NUM}"
+fi
+```
+
+`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+incomplete accounting cannot publish a closing reference anywhere.
+
 ### Step 3: Check for Changes
 
 ```bash
@@ -291,21 +306,6 @@ EXISTING_PR=$(gh pr list --head "$BRANCH" --json number,url --jq '.[0]' 2>/dev/n
 
 ### Step 6: Create PR
 
-```bash
-# Reference selection (issue #860). Default to a NON-closing reference; a closing one
-# is used only after your own acceptance accounting for THIS issue. Reset it here
-# rather than inheriting a value from an earlier run.
-ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
-                           # revised with evidence, or resolved by a recorded transfer
-ISSUE_REF="Refs #${ISSUE_NUM}"
-if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
-    ISSUE_REF="Closes #${ISSUE_NUM}"
-fi
-```
-
-`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
-incomplete accounting cannot publish a closing reference anywhere.
-
 Use standard PR creation:
 
 ```bash
@@ -344,7 +344,7 @@ PR created: https://github.com/owner/repo/pull/78
 - **Lint/test failure:** Stop, show output, ask user to fix
 - **Push failure:** Report error (likely needs `git pull --rebase`)
 - **PR already exists:** Report URL, offer to update
-- **No issue number in branch:** Create PR without `Closes #N` reference
+- **No issue number in branch:** Create PR with no issue reference at all
 - **No Makefile:** Skip quality gates, warn user
 
 ## Notes

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -259,7 +259,9 @@ Carry that judgement into the one place it has to act:
 # revised behaviour, or resolved by a transfer/withdrawal that recorded its authority
 # and destination. Anything else - including "not sure" - leaves it unset, and unset
 # cannot close.
-ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+# Reset for THIS issue: /flow:merge can run standalone, and an exported "yes" from
+# earlier work in the same shell must not decide this one.
+ACCEPTANCE_COMPLETE=""
 
 if [[ -n "$ISSUE_NUM" ]]; then
     ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -102,6 +102,24 @@ tree before squashing:
 git push origin "$BRANCH"
 ```
 
+**Before merging: make the closing text agree with the accounting.** The squash
+message is derived from the branch commits and the PR, so a stale closing reference in
+an earlier commit still closes the issue - and once the merge has run, the branch is
+gone and the close has already happened. Check while it can still be changed:
+
+```bash
+git log origin/main..HEAD --format=%B
+gh pr view "$PR_NUMBER" --json title,body --jq '.title, .body'
+```
+
+If the acceptance accounting is not complete, reword any closing reference to a plain
+mention - `Refs #N`, or "part of #N" - in the commit messages, the PR title and the PR
+body, so nothing in the merge text can close the promise. Do not write a closing
+keyword next to an issue number even as an illustration: `gh-pr-merge.sh` refuses a
+squash whose text carries a negated or incidental closing keyword beside an issue
+number (exits 5 and 7), and that guard cannot tell an example from an instruction. It
+is a backstop, not this decision.
+
 Then merge the PR:
 
 ```bash
@@ -224,12 +242,34 @@ git branch -D "$BRANCH" 2>/dev/null || true
 
 ### Step 6: Close Issue (if linked)
 
+Closing is a decision, not a formality: an issue closes when its promises were kept.
+Account for the material acceptance items first - demonstrated, revised WITH evidence
+for the revised behaviour, or deferred - per
+[the issue contract](../../../docs/agents/issue-contract.md). The report itself stays
+ordinary prose; nothing is parsed out of it.
+
+Carry that judgement into the one place it has to act:
+
 ```bash
+# Set this from YOUR acceptance accounting. There is no machine field in the report
+# and nothing is read out of prose - a quoted example or a truncated fetch must never
+# be able to authorise a close.
+#
+# "yes" ONLY when every material item is demonstrated, revised with evidence for the
+# revised behaviour, or resolved by a transfer/withdrawal that recorded its authority
+# and destination. Anything else - including "not sure" - leaves it unset, and unset
+# cannot close.
+ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+
 if [[ -n "$ISSUE_NUM" ]]; then
-    # Check if issue is still open (gh pr merge with Closes # may have closed it)
     ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
-    if [[ "$ISSUE_STATE" == "OPEN" ]]; then
-        gh issue close "$ISSUE_NUM" --comment "Closed via /flow:merge - PR #${PR_NUMBER} merged."
+    if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+        if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+            gh issue close "$ISSUE_NUM" --comment "Closed via /flow:merge - PR #${PR_NUMBER} merged."
+        fi
+    else
+        echo "Acceptance not recorded complete - leaving #${ISSUE_NUM} open."
+        echo "Say what remains in a comment on the issue if it is not already clear."
     fi
 fi
 ```

--- a/.claude/commands/flow/merge.md
+++ b/.claude/commands/flow/merge.md
@@ -102,10 +102,14 @@ tree before squashing:
 git push origin "$BRANCH"
 ```
 
-**Before merging: make the closing text agree with the accounting.** The squash
-message is derived from the branch commits and the PR, so a stale closing reference in
-an earlier commit still closes the issue - and once the merge has run, the branch is
-gone and the close has already happened. Check while it can still be changed:
+**Before merging: make the closing text agree with the accounting.** Review whatever
+will actually become the merge text. `gh-pr-merge.sh` passes an explicit subject and
+body derived from the PR (#655), so on that path an older commit's wording does not
+reach the squash; a plain `gh pr merge --squash` can compose it from the commits, and
+there a stale closing reference still closes the issue. Once the merge has run the
+branch is gone and the close has already happened, so check while it can still be
+changed - and check the sources in play rather than rewriting history on the
+assumption that the commits always feed it:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -738,7 +738,7 @@ fi
        ISSUE_REF="Closes #${ISSUE_NUM}"
    fi
    ```
-   
+
    `$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
    incomplete accounting cannot publish a closing reference anywhere.
 

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -725,9 +725,23 @@ fi
 ```
 
 1. **Commit** the changes:
-   - Conventional commit format, with the closing reference decided by the
-     accounting below: `type(scope): Description (Closes #N)` when complete,
-     `type(scope): Description (Refs #N)` when it is not.
+   - Conventional commit format using the selected reference:
+     `type(scope): Description (${ISSUE_REF})`
+   ```bash
+   # Reference selection (issue #860). Default to a NON-closing reference; a closing one
+   # is used only after your own acceptance accounting for THIS issue. Reset it here
+   # rather than inheriting a value from an earlier run.
+   ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                              # revised with evidence, or resolved by a recorded transfer
+   ISSUE_REF="Refs #${ISSUE_NUM}"
+   if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+       ISSUE_REF="Closes #${ISSUE_NUM}"
+   fi
+   ```
+   
+   `$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+   incomplete accounting cannot publish a closing reference anywhere.
+
    The closing reference follows the acceptance accounting: use it only when every
    material item is demonstrated, revised with evidence, or resolved by a recorded
    transfer. Otherwise reference the issue without a closing keyword (`Refs #N`), in
@@ -752,7 +766,8 @@ fi
    - Note that implementation was delegated to a local Gemma model
    - Claude Code review findings
    - Test plan
-   - `Closes #N` when the accounting is complete, otherwise `Refs #N`
+   - `${ISSUE_REF}` - the selected reference, non-closing unless the
+     accounting is complete
 
 Report: `Step 7/8: Finish complete - PR #{N} created`
 

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -725,7 +725,24 @@ fi
 ```
 
 1. **Commit** the changes:
-   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Conventional commit format, with the closing reference decided by the
+     accounting below: `type(scope): Description (Closes #N)` when complete,
+     `type(scope): Description (Refs #N)` when it is not.
+   The closing reference follows the acceptance accounting: use it only when every
+   material item is demonstrated, revised with evidence, or resolved by a recorded
+   transfer. Otherwise reference the issue without a closing keyword (`Refs #N`), in
+   the commit message, the PR title and the PR body alike. Do not print a closing
+   keyword beside an issue number even as an illustration - the merge helper refuses a
+   squash that carries one incidentally (exits 5 and 7).
+   **Acceptance disposition before closing (issue #860).** Account for the material
+   acceptance items first - demonstrated, revised with evidence, or deferred - and
+   record `Acceptance-disposition: complete` or `Acceptance-disposition: unresolved -
+   <what remains>` in the PR body. When it is unresolved, use `Refs #N` in the commit
+   message, the PR title and the PR body instead of `Closes #N`, and check the earlier
+   branch commits too (`git log origin/main..HEAD --format=%B | grep -in 'closes #'`),
+   since the squash text is derived from them. A delegated run that delivered part of
+   the work is still mergeable; it just must not close the promise. The canonical rule
+   is docs/agents/issue-contract.md.
    - Note the Gemma model tag as implementer in the commit body
      (e.g., `Implemented-By: gemma4-code:latest via OpenCode (headless)`)
 

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -753,7 +753,9 @@ fi
    record the accounting in the PR body as ordinary prose. When it is unresolved, use `Refs #N` in the commit
    message, the PR title and the PR body instead of `Closes #N`, and check the earlier
    branch commits too (read `git log origin/main..HEAD --format=%B` and the PR text yourself),
-   since the squash text is derived from them. A delegated run that delivered part of
+   since the squash text may be derived from them - `gh-pr-merge.sh`
+   passes an explicit subject and body from the PR (#655), so check which sources are
+   actually in play rather than assuming a rewrite is needed. A delegated run that delivered part of
    the work is still mergeable; it just must not close the promise. The canonical rule
    is docs/agents/issue-contract.md.
    - Note the Gemma model tag as implementer in the commit body

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -736,10 +736,9 @@ fi
    squash that carries one incidentally (exits 5 and 7).
    **Acceptance disposition before closing (issue #860).** Account for the material
    acceptance items first - demonstrated, revised with evidence, or deferred - and
-   record `Acceptance-disposition: complete` or `Acceptance-disposition: unresolved -
-   <what remains>` in the PR body. When it is unresolved, use `Refs #N` in the commit
+   record the accounting in the PR body as ordinary prose. When it is unresolved, use `Refs #N` in the commit
    message, the PR title and the PR body instead of `Closes #N`, and check the earlier
-   branch commits too (`git log origin/main..HEAD --format=%B | grep -in 'closes #'`),
+   branch commits too (read `git log origin/main..HEAD --format=%B` and the PR text yourself),
    since the squash text is derived from them. A delegated run that delivered part of
    the work is still mergeable; it just must not close the promise. The canonical rule
    is docs/agents/issue-contract.md.
@@ -753,7 +752,7 @@ fi
    - Note that implementation was delegated to a local Gemma model
    - Claude Code review findings
    - Test plan
-   - `Closes #N`
+   - `Closes #N` when the accounting is complete, otherwise `Refs #N`
 
 Report: `Step 7/8: Finish complete - PR #{N} created`
 

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -704,7 +704,7 @@ fi
        ISSUE_REF="Closes #${ISSUE_NUM}"
    fi
    ```
-   
+
    `$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
    incomplete accounting cannot publish a closing reference anywhere.
 

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -719,7 +719,9 @@ fi
    record the accounting in the PR body as ordinary prose. When it is unresolved, use `Refs #N` in the commit
    message, the PR title and the PR body instead of `Closes #N`, and check the earlier
    branch commits too (read `git log origin/main..HEAD --format=%B` and the PR text yourself),
-   since the squash text is derived from them. A delegated run that delivered part of
+   since the squash text may be derived from them - `gh-pr-merge.sh`
+   passes an explicit subject and body from the PR (#655), so check which sources are
+   actually in play rather than assuming a rewrite is needed. A delegated run that delivered part of
    the work is still mergeable; it just must not close the promise. The canonical rule
    is docs/agents/issue-contract.md.
    - Note the Qwen model tag as implementer in the commit body

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -702,10 +702,9 @@ fi
    squash that carries one incidentally (exits 5 and 7).
    **Acceptance disposition before closing (issue #860).** Account for the material
    acceptance items first - demonstrated, revised with evidence, or deferred - and
-   record `Acceptance-disposition: complete` or `Acceptance-disposition: unresolved -
-   <what remains>` in the PR body. When it is unresolved, use `Refs #N` in the commit
+   record the accounting in the PR body as ordinary prose. When it is unresolved, use `Refs #N` in the commit
    message, the PR title and the PR body instead of `Closes #N`, and check the earlier
-   branch commits too (`git log origin/main..HEAD --format=%B | grep -in 'closes #'`),
+   branch commits too (read `git log origin/main..HEAD --format=%B` and the PR text yourself),
    since the squash text is derived from them. A delegated run that delivered part of
    the work is still mergeable; it just must not close the promise. The canonical rule
    is docs/agents/issue-contract.md.
@@ -719,7 +718,7 @@ fi
    - Note that implementation was delegated to a local Qwen model
    - Claude Code review findings
    - Test plan
-   - `Closes #N`
+   - `Closes #N` when the accounting is complete, otherwise `Refs #N`
 
 Report: `Step 7/8: Finish complete - PR #{N} created`
 

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -691,9 +691,23 @@ fi
 ```
 
 1. **Commit** the changes:
-   - Conventional commit format, with the closing reference decided by the
-     accounting below: `type(scope): Description (Closes #N)` when complete,
-     `type(scope): Description (Refs #N)` when it is not.
+   - Conventional commit format using the selected reference:
+     `type(scope): Description (${ISSUE_REF})`
+   ```bash
+   # Reference selection (issue #860). Default to a NON-closing reference; a closing one
+   # is used only after your own acceptance accounting for THIS issue. Reset it here
+   # rather than inheriting a value from an earlier run.
+   ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                              # revised with evidence, or resolved by a recorded transfer
+   ISSUE_REF="Refs #${ISSUE_NUM}"
+   if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+       ISSUE_REF="Closes #${ISSUE_NUM}"
+   fi
+   ```
+   
+   `$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+   incomplete accounting cannot publish a closing reference anywhere.
+
    The closing reference follows the acceptance accounting: use it only when every
    material item is demonstrated, revised with evidence, or resolved by a recorded
    transfer. Otherwise reference the issue without a closing keyword (`Refs #N`), in
@@ -718,7 +732,8 @@ fi
    - Note that implementation was delegated to a local Qwen model
    - Claude Code review findings
    - Test plan
-   - `Closes #N` when the accounting is complete, otherwise `Refs #N`
+   - `${ISSUE_REF}` - the selected reference, non-closing unless the
+     accounting is complete
 
 Report: `Step 7/8: Finish complete - PR #{N} created`
 

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -691,7 +691,24 @@ fi
 ```
 
 1. **Commit** the changes:
-   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Conventional commit format, with the closing reference decided by the
+     accounting below: `type(scope): Description (Closes #N)` when complete,
+     `type(scope): Description (Refs #N)` when it is not.
+   The closing reference follows the acceptance accounting: use it only when every
+   material item is demonstrated, revised with evidence, or resolved by a recorded
+   transfer. Otherwise reference the issue without a closing keyword (`Refs #N`), in
+   the commit message, the PR title and the PR body alike. Do not print a closing
+   keyword beside an issue number even as an illustration - the merge helper refuses a
+   squash that carries one incidentally (exits 5 and 7).
+   **Acceptance disposition before closing (issue #860).** Account for the material
+   acceptance items first - demonstrated, revised with evidence, or deferred - and
+   record `Acceptance-disposition: complete` or `Acceptance-disposition: unresolved -
+   <what remains>` in the PR body. When it is unresolved, use `Refs #N` in the commit
+   message, the PR title and the PR body instead of `Closes #N`, and check the earlier
+   branch commits too (`git log origin/main..HEAD --format=%B | grep -in 'closes #'`),
+   since the squash text is derived from them. A delegated run that delivered part of
+   the work is still mergeable; it just must not close the promise. The canonical rule
+   is docs/agents/issue-contract.md.
    - Note the Qwen model tag as implementer in the commit body
      (e.g., `Implemented-By: qwen3.8-code:latest via Qwen Code CLI (headless)`)
 

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -775,6 +775,43 @@ git merge --no-edit origin/main
    git push -u origin "$BRANCH"
    ```
 
+**Acceptance accounting (issue #860).** The quality gates above are evidence about
+CHECKS. Before opening the PR, account for what was actually delivered: every
+material acceptance item is demonstrated (name the behavioural test, experiment or
+reviewed observation), revised (give the reason and the agreement it needed), or
+deferred (and still owed). A couple of sentences of prose is enough for a small
+change - there is no required per-item line and no separate artifact. Silence is not
+delivery: an item nobody mentions is unresolved.
+
+Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
+evidence that satisfied the earlier promise no longer demonstrates the new one, and
+a revision record on its own is not delivery evidence.
+
+Record the outcome as one line the later steps can act on:
+
+```
+Acceptance-disposition: complete
+Acceptance-disposition: unresolved - <what remains, in a few words>
+```
+
+`complete` means every material item is demonstrated, or revised WITH evidence for
+the revised behaviour, or resolved by a transfer/withdrawal that recorded its
+authority and destination. Anything else is `unresolved`, including "mostly done".
+
+**Closing must agree with that line.** When the disposition is `unresolved`, use
+`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
+so the merge cannot close a promise the report says was not kept. Check the earlier
+commits on the branch too, since the squash text comes from them:
+
+```bash
+git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
+    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
+```
+
+The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
+this is where it is executed. Partial delivery stays reviewable and mergeable - the
+disposition changes what CLOSES, not what may merge.
+
 4. **Create PR** - if no PR exists:
    ```bash
    gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
@@ -1013,10 +1050,20 @@ Report: `Step 6/9: Finish complete - PR #XX created`
 
 6. **Close issue** (if still open):
    ```bash
+   # Set from YOUR acceptance accounting (docs/agents/issue-contract.md). Nothing is
+   # parsed out of the report: a quoted example or a truncated read must never be able
+   # to authorise a close. "yes" only when every material item is demonstrated, revised
+   # WITH evidence, or resolved by a recorded transfer/withdrawal; unset cannot close.
+   ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+
    if [[ -n "$ISSUE_NUM" ]]; then
        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
-       if [[ "$ISSUE_STATE" == "OPEN" ]]; then
-           gh issue close "$ISSUE_NUM" --comment "Closed via /flow-auto - PR #${PR_NUMBER} merged."
+       if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+           if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+               gh issue close "$ISSUE_NUM" --comment "Closed via /flow-auto - PR #${PR_NUMBER} merged."
+           fi
+       else
+           echo "Acceptance not recorded complete - leaving #${ISSUE_NUM} open."
        fi
    fi
    ```

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -676,6 +676,46 @@ if [ "$(git rev-list --count HEAD..origin/main)" -gt 0 ]; then
 fi
 ```
 
+**Acceptance accounting (issue #860).** The quality gates above are evidence about
+CHECKS. Before opening the PR, account for what was actually delivered: every
+material acceptance item is demonstrated (name the behavioural test, experiment or
+reviewed observation), revised (give the reason and the agreement it needed), or
+deferred (and still owed). A couple of sentences of prose is enough for a small
+change - there is no required per-item line and no separate artifact. Silence is not
+delivery: an item nobody mentions is unresolved.
+
+Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
+evidence that satisfied the earlier promise has to be reassessed against the new
+one - sometimes it still suffices, often it does not, and that judgement belongs in
+the report rather than being assumed either way. A revision record on its own is
+never delivery evidence, and
+a revision record on its own is not delivery evidence.
+
+The report stays ordinary prose - there is no field to fill in, and nothing is
+parsed out of it. Carry the judgement into the one place it has to act: the closing
+step sets `ACCEPTANCE_COMPLETE=yes` ONLY when every material item is demonstrated,
+revised with evidence for the revised behaviour, or resolved by a transfer or
+withdrawal that recorded its authority and destination. Anything else - including
+"mostly done" - leaves it unset, and unset cannot close.
+
+**Closing must agree with that line.** When the disposition is `unresolved`, use
+`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
+so the merge cannot close a promise the report says was not kept. Check the earlier
+commits on the branch too, since the squash text comes from them:
+
+```bash
+git log origin/main..HEAD --format=%B
+gh pr view "$PR_NUMBER" --json title,body --jq '.title, .body' 2>/dev/null
+```
+
+Read the closing references there yourself rather than grepping for one spelling -
+the merge helper rejects negated and incidental forms too, and a narrow pattern
+misses exactly the ones that surprise you.
+
+The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
+this is where it is executed. Partial delivery stays reviewable and mergeable - the
+disposition changes what CLOSES, not what may merge.
+
 **Collapsing the branch to one commit - the SAFE recipe (issue #657).** Prefer
 NO collapse at all: since #655 the merge helper passes an explicit
 `--subject`/`--body` derived from the PR, so a WIP-first branch squashes with
@@ -691,7 +731,8 @@ merged 2,085-line feature to exactly this on 2026-08-11). The safe shape:
 git reset --soft "$(git merge-base HEAD origin/main)"
 # Before committing, prove the collapse deletes nothing you did not delete:
 git diff --staged --diff-filter=D --name-only   # MUST be empty unless intended
-git commit -m "type(scope): Description (Closes #N)"
+git commit -m "type(scope): Description (Closes #N)"   # (Refs #N) if the
+                                                      # accounting is not complete
 # THEN bring the moved base in:
 git merge --no-edit origin/main
 ```
@@ -775,46 +816,10 @@ git merge --no-edit origin/main
    git push -u origin "$BRANCH"
    ```
 
-**Acceptance accounting (issue #860).** The quality gates above are evidence about
-CHECKS. Before opening the PR, account for what was actually delivered: every
-material acceptance item is demonstrated (name the behavioural test, experiment or
-reviewed observation), revised (give the reason and the agreement it needed), or
-deferred (and still owed). A couple of sentences of prose is enough for a small
-change - there is no required per-item line and no separate artifact. Silence is not
-delivery: an item nobody mentions is unresolved.
-
-Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
-evidence that satisfied the earlier promise no longer demonstrates the new one, and
-a revision record on its own is not delivery evidence.
-
-Record the outcome as one line the later steps can act on:
-
-```
-Acceptance-disposition: complete
-Acceptance-disposition: unresolved - <what remains, in a few words>
-```
-
-`complete` means every material item is demonstrated, or revised WITH evidence for
-the revised behaviour, or resolved by a transfer/withdrawal that recorded its
-authority and destination. Anything else is `unresolved`, including "mostly done".
-
-**Closing must agree with that line.** When the disposition is `unresolved`, use
-`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
-so the merge cannot close a promise the report says was not kept. Check the earlier
-commits on the branch too, since the squash text comes from them:
-
-```bash
-git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
-    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
-```
-
-The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
-this is where it is executed. Partial delivery stays reviewable and mergeable - the
-disposition changes what CLOSES, not what may merge.
-
 4. **Create PR** - if no PR exists:
    ```bash
    gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
+   # ... or (Refs #ISSUE_NUM) when the acceptance accounting is not complete.
    ```
    - If PR already exists, report its URL and continue.
    - PR body: Summary of changes + test plan + `Closes #N`

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -1073,7 +1073,9 @@ Report: `Step 6/9: Finish complete - PR #XX created`
    # parsed out of the report: a quoted example or a truncated read must never be able
    # to authorise a close. "yes" only when every material item is demonstrated, revised
    # WITH evidence, or resolved by a recorded transfer/withdrawal; unset cannot close.
-   ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+   # Restate the judgement you reached in Step 6 for THIS issue. It is set here
+   # rather than inherited, so a value left over from earlier work cannot decide it.
+   ACCEPTANCE_COMPLETE=""
 
    if [[ -n "$ISSUE_NUM" ]]; then
        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -701,7 +701,13 @@ withdrawal that recorded its authority and destination. Anything else - includin
 **Closing must agree with that line.** When the disposition is `unresolved`, use
 `Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
 so the merge cannot close a promise the report says was not kept. Check the earlier
-commits on the branch too, since the squash text comes from them:
+review whatever will actually become the
+merge text: the PR title and body, and the branch commits where they feed the squash.
+`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
+that path an older commit's wording does not reach the squash - but a plain
+`gh pr merge --squash` can compose it from the commits, and that is when a stale
+closing reference still matters. Check the sources in play rather than rewriting
+history on the assumption that it always does:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -698,16 +698,17 @@ revised with evidence for the revised behaviour, or resolved by a transfer or
 withdrawal that recorded its authority and destination. Anything else - including
 "mostly done" - leaves it unset, and unset cannot close.
 
-**Closing must agree with that line.** When the disposition is `unresolved`, use
-`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
-so the merge cannot close a promise the report says was not kept. Check the earlier
-review whatever will actually become the
-merge text: the PR title and body, and the branch commits where they feed the squash.
-`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
-that path an older commit's wording does not reach the squash - but a plain
-`gh pr merge --squash` can compose it from the commits, and that is when a stale
-closing reference still matters. Check the sources in play rather than rewriting
-history on the assumption that it always does:
+**Closing must agree with that judgement.** When the accounting is not complete, the
+selected reference is the non-closing `Refs #N` - in the commit message, the PR title
+and the PR body alike, never `Closes #N` - so the merge cannot close a promise the
+report says was not kept.
+
+Then review whatever will actually become the merge text: the PR title and body, and
+the branch commits where they feed the squash. `gh-pr-merge.sh` passes an explicit
+subject and body derived from the PR (#655), so on that path an older commit's wording
+does not reach the squash - but a plain `gh pr merge --squash` can compose it from the
+commits, and that is when a stale closing reference still matters. Check the sources in
+play rather than rewriting history on the assumption that they always feed it:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -716,6 +716,21 @@ The canonical rule is [the issue contract](../../../docs/agents/issue-contract.m
 this is where it is executed. Partial delivery stays reviewable and mergeable - the
 disposition changes what CLOSES, not what may merge.
 
+```bash
+# Reference selection (issue #860). Default to a NON-closing reference; a closing one
+# is used only after your own acceptance accounting for THIS issue. Reset it here
+# rather than inheriting a value from an earlier run.
+ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                           # revised with evidence, or resolved by a recorded transfer
+ISSUE_REF="Refs #${ISSUE_NUM}"
+if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+    ISSUE_REF="Closes #${ISSUE_NUM}"
+fi
+```
+
+`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+incomplete accounting cannot publish a closing reference anywhere.
+
 **Collapsing the branch to one commit - the SAFE recipe (issue #657).** Prefer
 NO collapse at all: since #655 the merge helper passes an explicit
 `--subject`/`--body` derived from the PR, so a WIP-first branch squashes with
@@ -731,8 +746,7 @@ merged 2,085-line feature to exactly this on 2026-08-11). The safe shape:
 git reset --soft "$(git merge-base HEAD origin/main)"
 # Before committing, prove the collapse deletes nothing you did not delete:
 git diff --staged --diff-filter=D --name-only   # MUST be empty unless intended
-git commit -m "type(scope): Description (Closes #N)"   # (Refs #N) if the
-                                                      # accounting is not complete
+git commit -m "type(scope): Description (${ISSUE_REF})"
 # THEN bring the moved base in:
 git merge --no-edit origin/main
 ```
@@ -802,7 +816,8 @@ git merge --no-edit origin/main
    cannot block what it cannot run).
 
 2. **Commit** - if there are uncommitted changes:
-   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Conventional commit format, using the selected reference:
+     `type(scope): Description (${ISSUE_REF})`
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
    - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
      #635): when the stale-base merge above ran, the Step-4 work is already on
@@ -818,11 +833,10 @@ git merge --no-edit origin/main
 
 4. **Create PR** - if no PR exists:
    ```bash
-   gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
-   # ... or (Refs #ISSUE_NUM) when the acceptance accounting is not complete.
+   gh pr create --title "type(scope): Description (${ISSUE_REF})" --body "..."
    ```
    - If PR already exists, report its URL and continue.
-   - PR body: Summary of changes + test plan + `Closes #N`
+   - PR body: Summary of changes + test plan + `${ISSUE_REF}`
    - Analyze all commits on the branch to draft the summary.
 
 Report: `Step 6/9: Finish complete - PR #XX created`

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -196,6 +196,50 @@ BARE (#581 discipline):
 
 **This step never blocks the flow** - it is purely informational.
 
+**Acceptance accounting (issue #860).** The quality gates above are evidence about
+CHECKS. Before opening the PR, account for what was actually delivered: every
+material acceptance item is demonstrated (name the behavioural test, experiment or
+reviewed observation), revised (give the reason and the agreement it needed), or
+deferred (and still owed). A couple of sentences of prose is enough for a small
+change - there is no required per-item line and no separate artifact. Silence is not
+delivery: an item nobody mentions is unresolved.
+
+Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
+evidence that satisfied the earlier promise no longer demonstrates the new one, and
+a revision record on its own is not delivery evidence.
+
+Record the outcome as one line the later steps can act on:
+
+```
+Acceptance-disposition: complete
+Acceptance-disposition: unresolved - <what remains, in a few words>
+```
+
+`complete` means every material item is demonstrated, or revised WITH evidence for
+the revised behaviour, or resolved by a transfer/withdrawal that recorded its
+authority and destination. Anything else is `unresolved`, including "mostly done".
+
+**Closing must agree with that line.** When the disposition is `unresolved`, use
+`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
+so the merge cannot close a promise the report says was not kept. Check the earlier
+commits on the branch too, since the squash text comes from them:
+
+```bash
+git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
+    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
+```
+
+The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
+this is where it is executed. Partial delivery stays reviewable and mergeable - the
+disposition changes what CLOSES, not what may merge.
+
+**Wording an unresolved report.** Reword closing references to a plain mention -
+`Refs #N`, or "part of #N" - in the commit messages, the PR title and the PR body. Do
+not print a closing keyword beside an issue number even to illustrate what to remove:
+`gh-pr-merge.sh` refuses a squash carrying a negated or incidental closing keyword next
+to an issue number (exits 5 and 7), and it cannot tell an example from an instruction.
+A report that demonstrates the mistake interrupts the merge it was trying to protect.
+
 ### Step 3: Check for Changes
 
 ```bash

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -266,7 +266,8 @@ discipline; on exit 127 skip it):
   rule) and re-stage before committing.
 
 - If there are uncommitted changes, help the user commit them using standard git commit workflow.
-- Use conventional commit format: `type(scope): Description (Closes #N)`
+- Conventional commit format, using the selected reference:
+  `type(scope): Description (${ISSUE_REF})`
 - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` if Claude helped write the code.
 - **An already-clean tree here is a LEGITIMATE state, not a failure** (issue
   #635): when the Step-1 stale-base merge ran, the work is already on the
@@ -292,12 +293,26 @@ EXISTING_PR=$(gh pr list --head "$BRANCH" --json number,url --jq '.[0]' 2>/dev/n
 
 ### Step 6: Create PR
 
+```bash
+# Reference selection (issue #860). Default to a NON-closing reference; a closing one
+# is used only after your own acceptance accounting for THIS issue. Reset it here
+# rather than inheriting a value from an earlier run.
+ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                           # revised with evidence, or resolved by a recorded transfer
+ISSUE_REF="Refs #${ISSUE_NUM}"
+if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+    ISSUE_REF="Closes #${ISSUE_NUM}"
+fi
+```
+
+`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+incomplete accounting cannot publish a closing reference anywhere.
+
 Use standard PR creation:
 
 ```bash
 gh pr create \
-  --title "type(scope): Description (Closes #ISSUE_NUM)" \
-  `# use (Refs #ISSUE_NUM) instead when the acceptance accounting is not complete` \
+  --title "type(scope): Description (${ISSUE_REF})" \
   --body "## Summary
 - <bullet points>
 
@@ -305,13 +320,11 @@ gh pr create \
 - [ ] Tests pass
 - [ ] Linting passes
 
-Closes #ISSUE_NUM"
-# When the accounting is not complete, reference the issue without a closing
-# keyword instead, in the title, the body and the commit message alike.
+${ISSUE_REF}"
 ```
 
 - Title: Conventional commit style, derived from changes
-- Body: Summary of changes + test plan + `Closes #N`
+- Body: Summary of changes + test plan + `${ISSUE_REF}`
 - Analyze all commits on the branch to draft the summary
 
 ### Step 7: Output

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -205,19 +205,18 @@ change - there is no required per-item line and no separate artifact. Silence is
 delivery: an item nobody mentions is unresolved.
 
 Assess the evidence against the CURRENT agreed behaviour. After a #859 revision,
-evidence that satisfied the earlier promise no longer demonstrates the new one, and
+evidence that satisfied the earlier promise has to be reassessed against the new
+one - sometimes it still suffices, often it does not, and that judgement belongs in
+the report rather than being assumed either way. A revision record on its own is
+never delivery evidence, and
 a revision record on its own is not delivery evidence.
 
-Record the outcome as one line the later steps can act on:
-
-```
-Acceptance-disposition: complete
-Acceptance-disposition: unresolved - <what remains, in a few words>
-```
-
-`complete` means every material item is demonstrated, or revised WITH evidence for
-the revised behaviour, or resolved by a transfer/withdrawal that recorded its
-authority and destination. Anything else is `unresolved`, including "mostly done".
+The report stays ordinary prose - there is no field to fill in, and nothing is
+parsed out of it. Carry the judgement into the one place it has to act: the closing
+step sets `ACCEPTANCE_COMPLETE=yes` ONLY when every material item is demonstrated,
+revised with evidence for the revised behaviour, or resolved by a transfer or
+withdrawal that recorded its authority and destination. Anything else - including
+"mostly done" - leaves it unset, and unset cannot close.
 
 **Closing must agree with that line.** When the disposition is `unresolved`, use
 `Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
@@ -225,9 +224,13 @@ so the merge cannot close a promise the report says was not kept. Check the earl
 commits on the branch too, since the squash text comes from them:
 
 ```bash
-git log origin/main..HEAD --format=%B | grep -in 'closes #' && \
-    echo "NOTE: a branch commit still says Closes - reword it if the disposition is unresolved"
+git log origin/main..HEAD --format=%B
+gh pr view "$PR_NUMBER" --json title,body --jq '.title, .body' 2>/dev/null
 ```
+
+Read the closing references there yourself rather than grepping for one spelling -
+the merge helper rejects negated and incidental forms too, and a narrow pattern
+misses exactly the ones that surprise you.
 
 The canonical rule is [the issue contract](../../../docs/agents/issue-contract.md);
 this is where it is executed. Partial delivery stays reviewable and mergeable - the
@@ -294,6 +297,7 @@ Use standard PR creation:
 ```bash
 gh pr create \
   --title "type(scope): Description (Closes #ISSUE_NUM)" \
+  `# use (Refs #ISSUE_NUM) instead when the acceptance accounting is not complete` \
   --body "## Summary
 - <bullet points>
 
@@ -302,6 +306,8 @@ gh pr create \
 - [ ] Linting passes
 
 Closes #ISSUE_NUM"
+# When the accounting is not complete, reference the issue without a closing
+# keyword instead, in the title, the body and the commit message alike.
 ```
 
 - Title: Conventional commit style, derived from changes

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -221,7 +221,13 @@ withdrawal that recorded its authority and destination. Anything else - includin
 **Closing must agree with that line.** When the disposition is `unresolved`, use
 `Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
 so the merge cannot close a promise the report says was not kept. Check the earlier
-commits on the branch too, since the squash text comes from them:
+review whatever will actually become the
+merge text: the PR title and body, and the branch commits where they feed the squash.
+`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
+that path an older commit's wording does not reach the squash - but a plain
+`gh pr merge --squash` can compose it from the commits, and that is when a stale
+closing reference still matters. Check the sources in play rather than rewriting
+history on the assumption that it always does:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -218,16 +218,17 @@ revised with evidence for the revised behaviour, or resolved by a transfer or
 withdrawal that recorded its authority and destination. Anything else - including
 "mostly done" - leaves it unset, and unset cannot close.
 
-**Closing must agree with that line.** When the disposition is `unresolved`, use
-`Refs #N` in the commit message, the PR title and the PR body - never `Closes #N` -
-so the merge cannot close a promise the report says was not kept. Check the earlier
-review whatever will actually become the
-merge text: the PR title and body, and the branch commits where they feed the squash.
-`gh-pr-merge.sh` passes an explicit subject and body derived from the PR (#655), so on
-that path an older commit's wording does not reach the squash - but a plain
-`gh pr merge --squash` can compose it from the commits, and that is when a stale
-closing reference still matters. Check the sources in play rather than rewriting
-history on the assumption that it always does:
+**Closing must agree with that judgement.** When the accounting is not complete, the
+selected reference is the non-closing `Refs #N` - in the commit message, the PR title
+and the PR body alike, never `Closes #N` - so the merge cannot close a promise the
+report says was not kept.
+
+Then review whatever will actually become the merge text: the PR title and body, and
+the branch commits where they feed the squash. `gh-pr-merge.sh` passes an explicit
+subject and body derived from the PR (#655), so on that path an older commit's wording
+does not reach the squash - but a plain `gh pr merge --squash` can compose it from the
+commits, and that is when a stale closing reference still matters. Check the sources in
+play rather than rewriting history on the assumption that they always feed it:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -243,6 +243,21 @@ not print a closing keyword beside an issue number even to illustrate what to re
 to an issue number (exits 5 and 7), and it cannot tell an example from an instruction.
 A report that demonstrates the mistake interrupts the merge it was trying to protect.
 
+```bash
+# Reference selection (issue #860). Default to a NON-closing reference; a closing one
+# is used only after your own acceptance accounting for THIS issue. Reset it here
+# rather than inheriting a value from an earlier run.
+ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
+                           # revised with evidence, or resolved by a recorded transfer
+ISSUE_REF="Refs #${ISSUE_NUM}"
+if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+    ISSUE_REF="Closes #${ISSUE_NUM}"
+fi
+```
+
+`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
+incomplete accounting cannot publish a closing reference anywhere.
+
 ### Step 3: Check for Changes
 
 ```bash
@@ -293,21 +308,6 @@ EXISTING_PR=$(gh pr list --head "$BRANCH" --json number,url --jq '.[0]' 2>/dev/n
 
 ### Step 6: Create PR
 
-```bash
-# Reference selection (issue #860). Default to a NON-closing reference; a closing one
-# is used only after your own acceptance accounting for THIS issue. Reset it here
-# rather than inheriting a value from an earlier run.
-ACCEPTANCE_COMPLETE=""     # "yes" only when every material item is demonstrated,
-                           # revised with evidence, or resolved by a recorded transfer
-ISSUE_REF="Refs #${ISSUE_NUM}"
-if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
-    ISSUE_REF="Closes #${ISSUE_NUM}"
-fi
-```
-
-`$ISSUE_REF` then feeds the commit message, the PR title and the PR body, so an
-incomplete accounting cannot publish a closing reference anywhere.
-
 Use standard PR creation:
 
 ```bash
@@ -346,7 +346,7 @@ PR created: https://github.com/owner/repo/pull/78
 - **Lint/test failure:** Stop, show output, ask user to fix
 - **Push failure:** Report error (likely needs `git pull --rebase`)
 - **PR already exists:** Report URL, offer to update
-- **No issue number in branch:** Create PR without `Closes #N` reference
+- **No issue number in branch:** Create PR with no issue reference at all
 - **No Makefile:** Skip quality gates, warn user
 
 ## Notes

--- a/codex/skills/flow-merge/reference.md
+++ b/codex/skills/flow-merge/reference.md
@@ -261,7 +261,9 @@ Carry that judgement into the one place it has to act:
 # revised behaviour, or resolved by a transfer/withdrawal that recorded its authority
 # and destination. Anything else - including "not sure" - leaves it unset, and unset
 # cannot close.
-ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+# Reset for THIS issue: /flow-merge can run standalone, and an exported "yes" from
+# earlier work in the same shell must not decide this one.
+ACCEPTANCE_COMPLETE=""
 
 if [[ -n "$ISSUE_NUM" ]]; then
     ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)

--- a/codex/skills/flow-merge/reference.md
+++ b/codex/skills/flow-merge/reference.md
@@ -104,10 +104,14 @@ tree before squashing:
 git push origin "$BRANCH"
 ```
 
-**Before merging: make the closing text agree with the accounting.** The squash
-message is derived from the branch commits and the PR, so a stale closing reference in
-an earlier commit still closes the issue - and once the merge has run, the branch is
-gone and the close has already happened. Check while it can still be changed:
+**Before merging: make the closing text agree with the accounting.** Review whatever
+will actually become the merge text. `gh-pr-merge.sh` passes an explicit subject and
+body derived from the PR (#655), so on that path an older commit's wording does not
+reach the squash; a plain `gh pr merge --squash` can compose it from the commits, and
+there a stale closing reference still closes the issue. Once the merge has run the
+branch is gone and the close has already happened, so check while it can still be
+changed - and check the sources in play rather than rewriting history on the
+assumption that the commits always feed it:
 
 ```bash
 git log origin/main..HEAD --format=%B

--- a/codex/skills/flow-merge/reference.md
+++ b/codex/skills/flow-merge/reference.md
@@ -104,6 +104,24 @@ tree before squashing:
 git push origin "$BRANCH"
 ```
 
+**Before merging: make the closing text agree with the accounting.** The squash
+message is derived from the branch commits and the PR, so a stale closing reference in
+an earlier commit still closes the issue - and once the merge has run, the branch is
+gone and the close has already happened. Check while it can still be changed:
+
+```bash
+git log origin/main..HEAD --format=%B
+gh pr view "$PR_NUMBER" --json title,body --jq '.title, .body'
+```
+
+If the acceptance accounting is not complete, reword any closing reference to a plain
+mention - `Refs #N`, or "part of #N" - in the commit messages, the PR title and the PR
+body, so nothing in the merge text can close the promise. Do not write a closing
+keyword next to an issue number even as an illustration: `gh-pr-merge.sh` refuses a
+squash whose text carries a negated or incidental closing keyword beside an issue
+number (exits 5 and 7), and that guard cannot tell an example from an instruction. It
+is a backstop, not this decision.
+
 Then merge the PR:
 
 ```bash
@@ -226,12 +244,34 @@ git branch -D "$BRANCH" 2>/dev/null || true
 
 ### Step 6: Close Issue (if linked)
 
+Closing is a decision, not a formality: an issue closes when its promises were kept.
+Account for the material acceptance items first - demonstrated, revised WITH evidence
+for the revised behaviour, or deferred - per
+[the issue contract](../../../docs/agents/issue-contract.md). The report itself stays
+ordinary prose; nothing is parsed out of it.
+
+Carry that judgement into the one place it has to act:
+
 ```bash
+# Set this from YOUR acceptance accounting. There is no machine field in the report
+# and nothing is read out of prose - a quoted example or a truncated fetch must never
+# be able to authorise a close.
+#
+# "yes" ONLY when every material item is demonstrated, revised with evidence for the
+# revised behaviour, or resolved by a transfer/withdrawal that recorded its authority
+# and destination. Anything else - including "not sure" - leaves it unset, and unset
+# cannot close.
+ACCEPTANCE_COMPLETE="${ACCEPTANCE_COMPLETE:-}"
+
 if [[ -n "$ISSUE_NUM" ]]; then
-    # Check if issue is still open (gh pr merge with Closes # may have closed it)
     ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
-    if [[ "$ISSUE_STATE" == "OPEN" ]]; then
-        gh issue close "$ISSUE_NUM" --comment "Closed via /flow-merge - PR #${PR_NUMBER} merged."
+    if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then
+        if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+            gh issue close "$ISSUE_NUM" --comment "Closed via /flow-merge - PR #${PR_NUMBER} merged."
+        fi
+    else
+        echo "Acceptance not recorded complete - leaving #${ISSUE_NUM} open."
+        echo "Say what remains in a comment on the issue if it is not already clear."
     fi
 fi
 ```

--- a/docs/agents/issue-contract.md
+++ b/docs/agents/issue-contract.md
@@ -141,8 +141,10 @@ states:
 | Deferred | Deliberately not done | Stays visibly incomplete and is not counted as delivered |
 
 **Assess evidence against the CURRENT agreed behaviour.** After a revision (see the
-revision-authority table above), evidence that satisfied the earlier promise does not
-carry over; it demonstrated something the project no longer asks for.
+revision-authority table above), re-read the existing evidence against what is now
+agreed rather than assuming either way: sometimes it still suffices, often it covers
+only the superseded promise. The judgement - and which way it went - belongs in the
+report. A revision record by itself is never delivery evidence.
 
 **Material, not exhaustive.** This is about promises a reader would care about, not
 every line of a plan. A small fix can discharge the whole accounting in a couple of

--- a/docs/agents/issue-contract.md
+++ b/docs/agents/issue-contract.md
@@ -128,6 +128,50 @@ approval or a standing delegation that actually covers the change IS agreement;
 knowing an approver exists is not. `/flow:auto` Step 4 is where this is executed,
 including the bounded investigation and the record a consequential change earns.
 
+## Accounting for what was delivered
+
+A green suite answers "did the checks pass", never "did we build what was promised".
+When work is reported, every MATERIAL acceptance item ends in one of three honest
+states:
+
+| Disposition | What it claims | What it needs |
+|-------------|----------------|---------------|
+| Demonstrated | This behaviour exists now | The specific behavioural test, experiment or reviewed observation - not the suite as a whole |
+| Revised | The promise changed | The reason, and the agreement that change required. A revision record is NOT delivery evidence: revised-but-unproven is still unresolved |
+| Deferred | Deliberately not done | Stays visibly incomplete and is not counted as delivered |
+
+**Assess evidence against the CURRENT agreed behaviour.** After a revision (see the
+revision-authority table above), evidence that satisfied the earlier promise does not
+carry over; it demonstrated something the project no longer asks for.
+
+**Material, not exhaustive.** This is about promises a reader would care about, not
+every line of a plan. A small fix can discharge the whole accounting in a couple of
+sentences of ordinary prose - there is no required per-item line, no separate
+artifact, no schema and no checkbox gate. What is not allowed is silence: an item
+nobody mentions is unresolved, never delivered by default.
+
+**Say which claims are machine-checked.** "lint and tests pass" is evidence about
+checks. Whether the intended behaviour arrived is a judgement, by an agent or a
+person, and the report should not let the first stand in for the second.
+
+### Closing has to agree with the accounting
+
+An issue closes when its promises were kept. If any material item is revised without
+evidence, deferred, or unmet, the issue stays OPEN and the work carries a
+non-closing reference instead - and that has to hold everywhere the lifecycle can
+close something: the commit messages, the PR title and body, the squash text derived
+from them, and any explicit post-merge `gh issue close`. Changing the final PR body
+alone can leave closing text behind in an earlier commit on the branch.
+
+Partial delivery is still reviewable and mergeable under existing authority. The
+point is not to block it; the point is that merging it must not silently close a
+promise the report says was not kept.
+
+**Transfer or withdrawal can resolve the original issue** - but only with recorded
+authority that actually covers the change, plus a durable destination for the
+remaining work or an explicit agreed withdrawal. Naming an approver, suggesting a
+follow-up, or writing the word "deferred" is none of those.
+
 ## Worked examples
 
 ### A routine bug, Tier 1

--- a/tests/test_acceptance_disposition.py
+++ b/tests/test_acceptance_disposition.py
@@ -135,26 +135,35 @@ class TestCanonicalPolicy:
             assert word in text
 
     def test_a_revision_record_is_not_delivery_evidence(self) -> None:
-        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
+        """Property, not phrasing: a revision must not read as delivery."""
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8")).lower()
 
-        assert "revised-but-unproven is still unresolved" in text
+        assert "revision record" in text
+        assert "never delivery evidence" in text or "not delivery evidence" in text
+
+    def test_revised_evidence_is_reassessed_rather_than_voided(self) -> None:
+        """Older evidence is judged against the new promise, not discarded by rule."""
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8")).lower()
+
+        assert "re-read the existing evidence" in text
+        assert "sometimes it still suffices" in text
 
     def test_silence_is_not_delivery(self) -> None:
         text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
 
-        assert "an item nobody mentions is unresolved, never delivered by default" in text
+        assert "nobody mentions is unresolved" in text
 
     def test_a_small_change_needs_no_artifact_or_checkbox_gate(self) -> None:
         """Criterion 5: the accounting must not become a mandatory form."""
         text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
 
-        assert "no required per-item line, no separate" in text
+        assert "no required per-item line" in text
 
     def test_transfer_needs_authority_and_a_destination(self) -> None:
         text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
 
         assert "durable destination" in text
-        assert 'writing the word "deferred" is none of those' in text
+        assert "is none of those" in text
 
 
 @pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
@@ -244,3 +253,42 @@ def test_partial_delivery_is_not_blocked() -> None:
     text = _flat(_read("flow/finish.md"))
 
     assert "changes what CLOSES, not what may merge" in text
+
+
+@pytest.mark.parametrize("rel", ["flow/finish.md", "flow/auto.md"], ids=lambda r: r)
+def test_the_accounting_precedes_the_commands_it_governs(rel: str) -> None:
+    """Ordering, not presence.
+
+    Twice the accounting landed BELOW the commit and PR commands it is supposed to
+    decide, where an adjacent paragraph cannot change what those commands do.
+    """
+    text = _read(rel)
+    accounting = text.index("**Acceptance accounting (issue #860).**")
+
+    for marker in ("git commit -m \"type(scope)", "gh pr create"):
+        position = text.find(marker)
+        if position == -1:
+            continue
+        assert accounting < position, (
+            f"{rel}: the accounting appears after `{marker}`, which it is meant to govern"
+        )
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
+def test_no_surface_requires_a_machine_field(rel: str) -> None:
+    """The report is ordinary prose; the decision is an execution variable.
+
+    A mandatory field was introduced once and removed from merge.md only, leaving the
+    tree contradicting itself - the partial-propagation failure this wave keeps hitting.
+    """
+    assert "Acceptance-disposition" not in _read(rel), (
+        f"{rel} still requires a machine-readable field in the report"
+    )
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
+def test_no_surface_narrows_the_closing_review_to_one_spelling(rel: str) -> None:
+    """The merge guard rejects negated and incidental forms a literal grep misses."""
+    assert "grep -in 'closes #'" not in _read(rel), (
+        f"{rel} greps for one closing spelling instead of reviewing the text"
+    )

--- a/tests/test_acceptance_disposition.py
+++ b/tests/test_acceptance_disposition.py
@@ -1,0 +1,246 @@
+"""Acceptance accounting and closure alignment (issue #860).
+
+A green suite answers "did the checks pass", never "did we build what was promised".
+#860 adds an honest accounting - each material item demonstrated, revised, or
+deferred - and makes CLOSING agree with it.
+
+**Two kinds of test live here, and they establish different things.**
+
+Structural checks prove ROUTING and FORMAT only: that the canonical policy exists,
+that each lifecycle surface points at it, that the closure guard is present. They
+cannot show an agent judges materiality correctly or reports honestly.
+
+The closure tests are different: they EXECUTE the published post-merge shell against
+a stub `gh`, so they establish actual behaviour of the thing the documentation tells
+a reader to run. A disposition that is unresolved - or missing entirely - must not be
+able to reach `gh issue close`. That is the property a paragraph cannot carry.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS = ROOT / ".claude" / "commands"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="requires bash on PATH"
+)
+
+# The lifecycle surfaces that can emit a closing form. Derived from a search over
+# .claude/commands rather than from memory; `github/issue-close.md` is a deliberate
+# manual command and `flow/eli5.md` closes on a "no longer needed" verdict, which is
+# a different decision from completion accounting.
+LIFECYCLE_SURFACES = (
+    "flow/finish.md",
+    "flow/auto.md",
+    "flow/merge.md",
+    "codex/auto.md",
+    "qwen/auto.md",
+    "gemma/auto.md",
+)
+
+GH_STUB = r'''#!/usr/bin/env python3
+"""Stub gh: serves a PR body and records every issue mutation."""
+import json, os, sys
+from pathlib import Path
+
+state = Path(os.environ["GH_STUB_STATE"])
+data = json.loads(state.read_text())
+argv = sys.argv[1:]
+
+if argv[:3] == ["pr", "view", "100"]:
+    print(data["pr_body"])
+    sys.exit(0)
+
+if argv[:3] == ["issue", "view", "42"]:
+    print(data["issue_state"])
+    sys.exit(0)
+
+if argv[:3] == ["issue", "close", "42"]:
+    data.setdefault("calls", []).append("close")
+    state.write_text(json.dumps(data))
+    sys.exit(0)
+
+if argv[:3] == ["issue", "comment", "42"]:
+    data.setdefault("calls", []).append("comment")
+    state.write_text(json.dumps(data))
+    sys.exit(0)
+
+sys.exit(0)
+'''
+
+
+def _read(rel: str) -> str:
+    path = COMMANDS / rel
+    assert path.is_file(), f"{rel} is missing; this check is stale"
+    return path.read_text(encoding="utf-8")
+
+
+def _flat(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _bash_blocks(rel: str) -> list[str]:
+    """Every fenced bash block a reader is instructed to run, verbatim.
+
+    Extracting a convenient substring around the code of interest is what let a
+    published fence defect through: merge.md had prose inside its opening ```bash
+    fence, so the block a user would actually copy was not valid shell at all. These
+    tests therefore take whole fences and check them as published.
+    """
+    text = _read(rel)
+    blocks = [
+        re.sub(r"^ {0,3}", "", block, flags=re.MULTILINE)
+        for block in re.findall(r"^[ \t]*```bash\n(.*?)^[ \t]*```", text, re.S | re.M)
+    ]
+    # Some published blocks are templates carrying <angle-bracket> placeholders; those
+    # are illustrations by construction and were never copy-runnable. Excluding them
+    # keeps this check about blocks a reader can actually execute, rather than
+    # asserting a convention this change did not introduce.
+    return [b for b in blocks if not re.search(r"<[a-z][a-z0-9 /._-]*>", b)]
+
+
+def _closure_block(rel: str) -> str:
+    blocks = [b for b in _bash_blocks(rel) if "ACCEPTANCE_COMPLETE" in b and "gh issue close" in b]
+    assert len(blocks) == 1, f"{rel}: expected one published closure block, found {len(blocks)}"
+    return blocks[0]
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
+def test_every_published_bash_block_is_valid_shell(rel: str) -> None:
+    """A document can publish something that is not runnable; this catches that."""
+    for index, block in enumerate(_bash_blocks(rel)):
+        result = subprocess.run(
+            ["bash", "-n"], input=block, capture_output=True, text=True
+        )
+        assert result.returncode == 0, (
+            f"{rel} block {index} is not valid shell as published:\n{result.stderr}"
+        )
+
+
+class TestCanonicalPolicy:
+    def test_the_three_dispositions_are_defined_once(self) -> None:
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
+
+        assert "Accounting for what was delivered" in text
+        for word in ("Demonstrated", "Revised", "Deferred"):
+            assert word in text
+
+    def test_a_revision_record_is_not_delivery_evidence(self) -> None:
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
+
+        assert "revised-but-unproven is still unresolved" in text
+
+    def test_silence_is_not_delivery(self) -> None:
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
+
+        assert "an item nobody mentions is unresolved, never delivered by default" in text
+
+    def test_a_small_change_needs_no_artifact_or_checkbox_gate(self) -> None:
+        """Criterion 5: the accounting must not become a mandatory form."""
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
+
+        assert "no required per-item line, no separate" in text
+
+    def test_transfer_needs_authority_and_a_destination(self) -> None:
+        text = _flat((ROOT / "docs/agents/issue-contract.md").read_text(encoding="utf-8"))
+
+        assert "durable destination" in text
+        assert 'writing the word "deferred" is none of those' in text
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
+def test_every_lifecycle_surface_routes_to_the_policy(rel: str) -> None:
+    """Routing only: the surface names the disposition and the canonical document."""
+    text = _flat(_read(rel))
+
+    assert "acceptance" in text.lower(), f"{rel} never mentions the accounting"
+    assert "issue-contract.md" in text, f"{rel} does not point at the canonical rule"
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
+def test_every_lifecycle_surface_names_the_non_closing_reference(rel: str) -> None:
+    text = _flat(_read(rel))
+
+    assert "Refs #N" in text, f"{rel} never offers a non-closing reference"
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES, ids=lambda r: r)
+def test_earlier_branch_commits_are_checked_for_closing_text(rel: str) -> None:
+    """Changing the PR body alone leaves closing text in the squash source."""
+    text = _flat(_read(rel))
+
+    assert "git log origin/main..HEAD" in text, (
+        f"{rel} does not tell anyone to check the branch commits, so a stale "
+        "'Closes #N' in an earlier commit still reaches the squash"
+    )
+
+
+@pytest.mark.parametrize("rel", ["flow/merge.md", "flow/auto.md"], ids=lambda r: r)
+class TestPublishedClosureShell:
+    """Execute the published closure block against a stub `gh`.
+
+    The decision is an explicit variable the agent sets from its own accounting -
+    there is no field parsed out of the report, so a quoted example, a duplicate
+    line or a truncated read cannot authorise a close.
+    """
+
+    def _run(self, rel: str, tmp_path: Path, decision: str | None) -> list[str]:
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        gh = bindir / "gh"
+        gh.write_text(GH_STUB, encoding="utf-8")
+        gh.chmod(0o755)
+        state = tmp_path / "state.json"
+        state.write_text(json.dumps({"issue_state": "OPEN", "calls": []}))
+
+        preamble = 'ISSUE_NUM=42\nPR_NUMBER=100\n'
+        if decision is not None:
+            preamble += f'export ACCEPTANCE_COMPLETE={decision!r}\n'
+        result = subprocess.run(
+            ["bash", "-c", preamble + _closure_block(rel)],
+            capture_output=True,
+            text=True,
+            env={"PATH": f"{bindir}:{os.environ['PATH']}", "GH_STUB_STATE": str(state)},
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(state.read_text())["calls"]
+
+    def test_a_complete_accounting_closes_the_issue(self, rel: str, tmp_path: Path) -> None:
+        assert self._run(rel, tmp_path, "yes") == ["close"]
+
+    def test_an_unset_decision_cannot_close(self, rel: str, tmp_path: Path) -> None:
+        """Missing is not complete: the absence of a deferral is not delivery."""
+        assert self._run(rel, tmp_path, None) == []
+
+    def test_an_empty_decision_cannot_close(self, rel: str, tmp_path: Path) -> None:
+        assert self._run(rel, tmp_path, "") == []
+
+    def test_an_unknown_value_cannot_close(self, rel: str, tmp_path: Path) -> None:
+        for value in ("no", "mostly", "complete", "YES "):
+            assert self._run(rel, tmp_path, value) == [], f"{value!r} closed the issue"
+
+
+def test_quality_gates_are_still_mandatory() -> None:
+    """Criterion 7: acceptance accounting adds to CI, it does not soften it."""
+    text = _read("flow/finish.md")
+
+    assert "FLOW_FINISH_GATE" in text or "make lint" in text
+    assert "evidence about" in _flat(text), (
+        "finish.md no longer distinguishes check evidence from acceptance evidence"
+    )
+
+
+def test_partial_delivery_is_not_blocked() -> None:
+    """The disposition changes what CLOSES, not what may merge."""
+    text = _flat(_read("flow/finish.md"))
+
+    assert "changes what CLOSES, not what may merge" in text

--- a/tests/test_acceptance_disposition.py
+++ b/tests/test_acceptance_disposition.py
@@ -211,11 +211,11 @@ class TestPublishedClosureShell:
         state = tmp_path / "state.json"
         state.write_text(json.dumps({"issue_state": "OPEN", "calls": []}))
 
-        preamble = 'ISSUE_NUM=42\nPR_NUMBER=100\n'
+        block = _closure_block(rel)
         if decision is not None:
-            preamble += f'export ACCEPTANCE_COMPLETE={decision!r}\n'
+            block = _inject_decision(block, decision)
         result = subprocess.run(
-            ["bash", "-c", preamble + _closure_block(rel)],
+            ["bash", "-c", 'ISSUE_NUM=42\nPR_NUMBER=100\n' + block],
             capture_output=True,
             text=True,
             env={"PATH": f"{bindir}:{os.environ['PATH']}", "GH_STUB_STATE": str(state)},
@@ -300,26 +300,31 @@ def _selection_block(rel: str) -> str:
     return blocks[0]
 
 
+def _inject_decision(block: str, decision: str) -> str:
+    """Set the decision at its DOCUMENTED assignment, changing nothing else.
+
+    Earlier versions of these tests executed the published block and then overwrote
+    its result with a handwritten copy of the same logic - so they passed on my
+    replacement rather than on what ships. Only the input is injected now; the
+    published source decides the outcome.
+    """
+    patched, count = re.subn(
+        r'^ACCEPTANCE_COMPLETE=""', f'ACCEPTANCE_COMPLETE={decision!r}', block, count=1, flags=re.M
+    )
+    assert count == 1, "the published block no longer resets ACCEPTANCE_COMPLETE"
+    return patched
+
+
 @pytest.mark.parametrize("rel", LIFECYCLE_SURFACES[:2] + LIFECYCLE_SURFACES[3:], ids=lambda r: r)
 def test_the_reference_selection_defaults_to_non_closing(rel: str) -> None:
-    """Executable selection, not an explanatory comment.
+    """Execute the PUBLISHED selection; inject only the decision value."""
+    block = _selection_block(rel)
 
-    The first attempt published a closing title with a note saying to choose
-    otherwise - and in finish.md that note was written as a backtick span, which is
-    command substitution in shell, not a comment. What publishes has to BE the
-    decision.
-    """
     for decision, expected in (("", "Refs"), ("no", "Refs"), ("mostly", "Refs"), ("yes", "Closes")):
-        script = (
-            f'ISSUE_NUM=42\n{_selection_block(rel)}\n'
-            f'ACCEPTANCE_COMPLETE={decision!r}\n'
-            'ISSUE_REF="Refs #${ISSUE_NUM}"\n'
-            'if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then ISSUE_REF="Closes #${ISSUE_NUM}"; fi\n'
-            'echo "$ISSUE_REF"'
-        )
+        script = "ISSUE_NUM=42\n" + _inject_decision(block, decision) + '\necho "$ISSUE_REF"'
         result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
         assert result.returncode == 0, result.stderr
-        assert result.stdout.strip().startswith(expected), (
+        assert result.stdout.strip() == f"{expected} #42", (
             f"{rel}: decision {decision!r} produced {result.stdout.strip()!r}"
         )
 
@@ -345,14 +350,41 @@ def test_the_acceptance_variable_is_reset_not_inherited(rel: str) -> None:
     )
 
 
-def test_pr_create_with_an_incomplete_judgement_publishes_no_closing_reference(
-    tmp_path: Path,
+def _all_bash_blocks(rel: str) -> list[str]:
+    """Every fenced bash block, placeholders included."""
+    text = _read(rel)
+    return [
+        re.sub(r"^ {0,3}", "", block, flags=re.MULTILINE)
+        for block in re.findall(r"^[ \t]*```bash\n(.*?)^[ \t]*```", text, re.S | re.M)
+    ]
+
+
+def _published_pr_create(rel: str) -> str:
+    """The `gh pr create` invocation exactly as the document publishes it.
+
+    Searched over ALL blocks: the syntax check filters out template blocks carrying
+    `<placeholders>`, and finish.md's create call is one of them - filtering here too
+    would have quietly skipped the very command under test.
+    """
+    for block in _all_bash_blocks(rel):
+        if "gh pr create" in block:
+            return block
+    raise AssertionError(f"{rel} publishes no gh pr create block")
+
+
+@pytest.mark.parametrize("rel", ["flow/finish.md", "flow/auto.md"], ids=lambda r: r)
+def test_the_published_create_path_publishes_no_closing_reference_when_incomplete(
+    rel: str, tmp_path: Path
 ) -> None:
-    """Bounded stub-gh run of the PUBLISHED create path, not just the close block."""
+    """Run the document's OWN selection and its OWN create command.
+
+    Nothing here re-implements either: if the shipped snippets reverted to an
+    unconditional closing reference, this fails.
+    """
     bindir = tmp_path / "bin"
-    bindir.mkdir()
+    bindir.mkdir(exist_ok=True)
     (bindir / "gh").write_text(
-        "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" >> \"$GH_CALLS\"\n", encoding="utf-8"
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$@" >> "$GH_CALLS"\n', encoding="utf-8"
     )
     (bindir / "gh").chmod(0o755)
     calls = tmp_path / "calls.txt"
@@ -360,11 +392,10 @@ def test_pr_create_with_an_incomplete_judgement_publishes_no_closing_reference(
     for decision, forbidden in (("", "Closes"), ("yes", "Refs")):
         calls.write_text("")
         script = (
-            'ISSUE_NUM=42\n'
-            f'ACCEPTANCE_COMPLETE={decision!r}\n'
-            'ISSUE_REF="Refs #${ISSUE_NUM}"\n'
-            'if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then ISSUE_REF="Closes #${ISSUE_NUM}"; fi\n'
-            'gh pr create --title "fix(x): thing (${ISSUE_REF})" --body "summary\n\n${ISSUE_REF}"'
+            "ISSUE_NUM=42\nISSUE_TITLE=thing\n"
+            + _inject_decision(_selection_block(rel), decision)
+            + "\n"
+            + _published_pr_create(rel)
         )
         result = subprocess.run(
             ["bash", "-c", script],
@@ -374,6 +405,36 @@ def test_pr_create_with_an_incomplete_judgement_publishes_no_closing_reference(
         )
         assert result.returncode == 0, result.stderr
         published = calls.read_text()
+        assert published.strip(), f"{rel}: the published create block invoked no gh"
         assert forbidden not in published, (
-            f"decision {decision!r} published {forbidden!r}: {published!r}"
+            f"{rel}: decision {decision!r} published {forbidden!r}:\n{published}"
         )
+
+
+@pytest.mark.parametrize("rel", ["flow/finish.md", "flow/auto.md"], ids=lambda r: r)
+def test_the_selection_precedes_every_use_of_the_reference(rel: str) -> None:
+    """Control data, not just prose: the variable must be set before it is read."""
+    text = _read(rel)
+    assignment = text.index('ISSUE_REF="Refs #${ISSUE_NUM}"')
+    first_use = text.index("${ISSUE_REF}")
+
+    assert assignment < first_use, (
+        f"{rel} uses ${{ISSUE_REF}} before the block that selects it"
+    )
+
+
+def test_merge_resets_the_decision_for_this_issue() -> None:
+    """/flow:merge runs standalone; an exported yes must not decide the next issue."""
+    block = _selection_or_close_block("flow/merge.md")
+
+    assert 'ACCEPTANCE_COMPLETE=""' in block
+    assert "${ACCEPTANCE_COMPLETE:-}" not in block, (
+        "flow/merge.md inherits the decision instead of resetting it"
+    )
+
+
+def _selection_or_close_block(rel: str) -> str:
+    for block in _all_bash_blocks(rel):
+        if "ACCEPTANCE_COMPLETE" in block:
+            return block
+    raise AssertionError(f"{rel} publishes no acceptance decision")

--- a/tests/test_acceptance_disposition.py
+++ b/tests/test_acceptance_disposition.py
@@ -292,3 +292,88 @@ def test_no_surface_narrows_the_closing_review_to_one_spelling(rel: str) -> None
     assert "grep -in 'closes #'" not in _read(rel), (
         f"{rel} greps for one closing spelling instead of reviewing the text"
     )
+
+
+def _selection_block(rel: str) -> str:
+    blocks = [b for b in _bash_blocks(rel) if "ISSUE_REF=" in b]
+    assert blocks, f"{rel} publishes no reference-selection block"
+    return blocks[0]
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES[:2] + LIFECYCLE_SURFACES[3:], ids=lambda r: r)
+def test_the_reference_selection_defaults_to_non_closing(rel: str) -> None:
+    """Executable selection, not an explanatory comment.
+
+    The first attempt published a closing title with a note saying to choose
+    otherwise - and in finish.md that note was written as a backtick span, which is
+    command substitution in shell, not a comment. What publishes has to BE the
+    decision.
+    """
+    for decision, expected in (("", "Refs"), ("no", "Refs"), ("mostly", "Refs"), ("yes", "Closes")):
+        script = (
+            f'ISSUE_NUM=42\n{_selection_block(rel)}\n'
+            f'ACCEPTANCE_COMPLETE={decision!r}\n'
+            'ISSUE_REF="Refs #${ISSUE_NUM}"\n'
+            'if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then ISSUE_REF="Closes #${ISSUE_NUM}"; fi\n'
+            'echo "$ISSUE_REF"'
+        )
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().startswith(expected), (
+            f"{rel}: decision {decision!r} produced {result.stdout.strip()!r}"
+        )
+
+
+@pytest.mark.parametrize("rel", ["flow/finish.md", "flow/auto.md"], ids=lambda r: r)
+def test_the_published_pr_create_uses_the_selected_reference(rel: str) -> None:
+    """The PR-create path itself must be non-closing on an incomplete judgement."""
+    text = _read(rel)
+
+    assert "${ISSUE_REF}" in text
+    assert "Closes #ISSUE_NUM" not in text, (
+        f"{rel} still publishes an unconditional closing reference in its PR command"
+    )
+
+
+@pytest.mark.parametrize("rel", LIFECYCLE_SURFACES[:2] + LIFECYCLE_SURFACES[3:], ids=lambda r: r)
+def test_the_acceptance_variable_is_reset_not_inherited(rel: str) -> None:
+    """A `yes` left over from earlier work must not decide this issue."""
+    block = _selection_block(rel)
+
+    assert re.search(r'ACCEPTANCE_COMPLETE=""', block), (
+        f"{rel} does not reset the judgement for this issue"
+    )
+
+
+def test_pr_create_with_an_incomplete_judgement_publishes_no_closing_reference(
+    tmp_path: Path,
+) -> None:
+    """Bounded stub-gh run of the PUBLISHED create path, not just the close block."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "gh").write_text(
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" >> \"$GH_CALLS\"\n", encoding="utf-8"
+    )
+    (bindir / "gh").chmod(0o755)
+    calls = tmp_path / "calls.txt"
+
+    for decision, forbidden in (("", "Closes"), ("yes", "Refs")):
+        calls.write_text("")
+        script = (
+            'ISSUE_NUM=42\n'
+            f'ACCEPTANCE_COMPLETE={decision!r}\n'
+            'ISSUE_REF="Refs #${ISSUE_NUM}"\n'
+            'if [[ "$ACCEPTANCE_COMPLETE" == "yes" ]]; then ISSUE_REF="Closes #${ISSUE_NUM}"; fi\n'
+            'gh pr create --title "fix(x): thing (${ISSUE_REF})" --body "summary\n\n${ISSUE_REF}"'
+        )
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            env={"PATH": f"{bindir}:{os.environ['PATH']}", "GH_CALLS": str(calls)},
+        )
+        assert result.returncode == 0, result.stderr
+        published = calls.read_text()
+        assert forbidden not in published, (
+            f"decision {decision!r} published {forbidden!r}: {published!r}"
+        )


### PR DESCRIPTION
A green suite answers "did the checks pass", never "did we build what was promised".
This adds that second answer to the completion report, and makes issue closure follow
it.

## What ships

**Canonical policy** - `docs/agents/issue-contract.md` gains "Accounting for what was
delivered": three dispositions (Demonstrated / Revised / Deferred), each with what it
claims and what it needs; evidence is *reassessed* against the current agreed
behaviour after a revision rather than discarded by rule; an item nobody mentions is
unresolved, never delivered by default; a small change discharges the whole accounting
in a couple of sentences of ordinary prose, with no required per-item line, artifact,
schema or checkbox gate; transfer or withdrawal resolves the original only with
recorded authority and a durable destination; and "lint and tests pass" is named as
evidence about checks, not about behaviour.

**Lifecycle** - `flow/finish`, `flow/auto`, `flow/merge` and the three delegated
drivers (`codex`, `qwen`, `gemma`) route to that policy and act on it. The accounting
happens *before* the commands it governs. The reference the run publishes is selected
from it - non-closing by default, closing only on an explicit complete judgement - and
that one selected reference feeds the commit message, the PR title and the PR body
alike. `flow/merge` reviews the effective merge sources before the first mutation that
could close the issue, and resets the decision because it can run standalone.

The accounting is ordinary prose. There is no field to fill in and nothing parses the
report; the decision is an explicit execution variable the agent sets, and unset,
empty or unrecognised cannot close.

## Acceptance accounting

All seven criteria are accepted **at the bounded scope of the evidence below**. Four
kinds of evidence, and each says something different:

| Evidence | What it establishes | What it does not |
|---|---|---|
| **Canonical-policy and routing checks** (phrase-presence assertions over `issue-contract.md`; every lifecycle surface names the accounting, points at the canonical document, offers `Refs #N`, and reviews the branch commits) | The policy is written, says these specific things, and all six surfaces route to it | Nothing about what an agent then does |
| **Published-shell execution** (`TestPublishedClosureShell` extracts the real fenced shell from `flow/merge` and `flow/auto` and runs it against a stub `gh`) | The shipped command *as published* closes on a complete judgement, and does not close when the decision is unset, empty or unknown | Nothing about the judgement's quality |
| **Source mutations** (replacing the selection block with an unconditional closing reference; changing the PR title source) | The tests read the shipped document rather than re-implementing its logic - both mutations were detected, independently reproduced by the reviewer | Coverage beyond those two paths |
| **Five bounded model decisions** + **manual source review** (mine and the reviewer's) | Agents given supplied facts and the rule extracted at run time produced correct dispositions and cited specific behavioural evidence; review covers revision authority, current-evidence framing and retained quality requirements | Reliability - five runs, one model, one runtime |

| # | Criterion | Which evidence carries it |
|---|---|---|
| 1 | Every material item demonstrated / revised / deferred | policy text (`test_the_three_dispositions_are_defined_once`, `test_silence_is_not_delivery`); all five samples reached one of the three states |
| 2 | Demonstrated items cite specific behavioural evidence | the disposition table's "not the suite as a whole" requirement - **source review, not an assertion**; the samples' own bodies cite named tests |
| 3 | Revised items carry reason + agreement; deferred stays visibly incomplete | policy text (`test_a_revision_record_is_not_delivery_evidence`, `test_transfer_needs_authority_and_a_destination`); samples s2 and s3 |
| 4 | Evidence assessed against the current agreed behaviour | policy text (`test_revised_evidence_is_reassessed_rather_than_voided`); sample s5 refused stale evidence for a superseded promise |
| 5 | A small change satisfies it in a few sentences, no artifact | policy text (`test_a_small_change_needs_no_artifact_or_checkbox_gate`) and `test_no_surface_requires_a_machine_field` across all six surfaces |
| 6 | Automated checks distinguished from judgement | the "evidence about checks" wording in `flow/finish` (`test_quality_gates_are_still_mandatory`) - source review for the substance |
| 7 | CI stays in force; unresolved acceptance is not concealed | same test for the gate's survival; `test_partial_delivery_is_not_blocked` for the published statement that the disposition changes what CLOSES, not what may merge; **published-shell execution** for the behaviour itself |

Several of the cited tests are phrase-presence checks on a document. They are listed
as exactly that: they detect a surface silently dropping the policy, which is the
propagation failure this family of changes keeps hitting. They are not behavioural
proof, and none of this establishes that every future agent will account for every
promise - only that the rule is published, routed everywhere, executable where it
decides a reference, and followed by agents in five observed cases.

## Observed behaviour

Five bounded report decisions were run as delegated-Codex samples against the
accounting rule extracted **at run time** from `flow/finish.md`, with the expected
outcome never in the prompt: a fully demonstrated case (closing reference published),
an agreed revision, an explicit deferral, a silently unmet criterion, and stale
evidence for a superseded promise - the last four all published the non-closing
reference. The agreed-revision case was *stricter* than I expected: the revision had
also promised documentation and only the error path had evidence, so the agent
refused to close. That is the behaviour the policy wants.

This repository's own `guard_incidental_close_keywords` from `gh-pr-merge.sh` was then
run for real against all five bodies with the guard's opt-out explicitly off: the
positive control is refused with exit 7 and a diagnostic, and all five samples are
clean. An earlier version of that harness reported the control as exit 1 and called it
a pass; that 1 came from `set -u` on an unset variable, not from the guard refusing,
so the harness was rebuilt to make a control that passes for the wrong reason
impossible. Both results are retained in the evidence bundle.

## Validation scope

- 71 focused tests (`tests/test_acceptance_disposition.py`) plus 24 from #859 - green
  on this head.
- `make skills-check` and the codex mirror drift check - green on this head.
- `git diff --check` over the whole branch range - clean.
- The full 3004-test suite and the finish gate were run and passed at `499a711`. The
  commits since are an editorial repair to two damaged sentences, three
  whitespace-only lines, and regenerated mirrors; per the reviewer's direction no
  further full suite was run for wording alone. **Required PR CI on this exact head is
  the gate.**

## Residual

The five sample transcripts, runner and guard harness are an out-of-repo evidence
bundle. A source/prompt pin and a portable reproduction are transferred to **#861** by
reviewer direction. Five runs of one model on one runtime, with scenarios authored by
the implementer - observed behaviour, not a reliability claim.

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQUjuiK5LmADM7ejk1FJ5
