### PR TITLE
feat(flow): route a supplemental finding to the nit store at close (Refs #865)

### DIFF
--- a/.claude/commands/codex/code_review.md
+++ b/.claude/commands/codex/code_review.md
@@ -135,15 +135,33 @@ change to fix it, and do not drop it. Record it.
 Resolve the repository's nit store:
 
 ```bash
-case "$(basename "$(git rev-parse --show-toplevel)")" in
+# Key on the REMOTE, never the directory name. This step always runs from a
+# per-issue worktree (`.../claude-power-pack-issue-865`), so a basename test
+# falls through every time and the explicit mapping below never fires - leaving
+# a full-text search as the only path, which is the opposite of the intent.
+REPO=$(basename -s .git "$(git remote get-url origin 2>/dev/null)")
+[ -n "$REPO" ] || REPO=$(gh repo view --json name -q .name 2>/dev/null)
+
+case "$REPO" in
     kyle)              NIT_STORE=1004 ;;
     claude-power-pack) NIT_STORE=864 ;;
     codex-power-pack)  NIT_STORE=227 ;;
     *) NIT_STORE=$(gh issue list --search "Nit Store" --state open \
                      --json number --jq '.[0].number' 2>/dev/null) ;;
 esac
+
+# Never post into an empty number. A finding silently posted nowhere is the
+# exact failure this step exists to prevent, so fail loudly instead.
+if [ -z "$NIT_STORE" ]; then
+    echo "No nit store for '${REPO:-unknown}' - file the finding as a normal issue." >&2
+    exit 1
+fi
 gh issue comment "$NIT_STORE" --body "<one finding>"
 ```
+
+`--search` is full text, not an exact title match, so it can select any open
+issue merely mentioning the phrase. It is the last resort, not the normal path;
+if it is what resolved the number, say so in the closing report.
 
 If the repository has no nit store, file the finding as a normal issue instead.
 

--- a/.claude/commands/codex/code_review.md
+++ b/.claude/commands/codex/code_review.md
@@ -125,6 +125,43 @@ is the caller's decision (`/flow:auto_codex` Step 5 does exactly that).
 If `CODEX_EXIT` is non-zero, report the failure honestly and do not fabricate
 findings; a calling workflow treats it like the exit-3 unavailable case.
 
+### Step 5: Route Deferred Findings to the Nit Store
+
+A finding you triaged **defer** - real, but out of scope for this branch - is a
+supplemental finding. This command does not fix it, and the triage line is not a
+record: it scrolls out of the caller's context and is gone. Do not widen the
+change to fix it, and do not drop it. Record it.
+
+Resolve the repository's nit store:
+
+```bash
+case "$(basename "$(git rev-parse --show-toplevel)")" in
+    kyle)              NIT_STORE=1004 ;;
+    claude-power-pack) NIT_STORE=864 ;;
+    codex-power-pack)  NIT_STORE=227 ;;
+    *) NIT_STORE=$(gh issue list --search "Nit Store" --state open \
+                     --json number --jq '.[0].number' 2>/dev/null) ;;
+esac
+gh issue comment "$NIT_STORE" --body "<one finding>"
+```
+
+If the repository has no nit store, file the finding as a normal issue instead.
+
+- **One finding per comment.** State the file and line (or the command), what is
+  wrong, why it matters, and which issue or PR you were reviewing when you found
+  it. The comment is the whole record; it is read later without your context.
+- **Attribute it.** The finding is Codex's; say so in the comment, exactly as the
+  relay above does. A later reader weighs a cross-model finding differently from
+  your own.
+- **The store is an inbox, not a backlog.** A comment is a disposition, not a fix.
+- **It is not a place to hide a defect that warrants its own ticket now.** A live
+  correctness, security, or data-loss finding gets its own issue, whatever its
+  scope - `defer` is a scope judgement, not a severity one.
+- **Name what you stored, with the comment link, in your closing report.**
+
+A review with nothing deferred stores nothing. That is an ordinary outcome, not a
+gap to fill.
+
 ## Notes
 
 - Uses the user's **Codex account** (real quota/billing per call). One review

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -332,6 +332,42 @@ ${ISSUE_REF}"
 - Body: Summary of changes + test plan + `${ISSUE_REF}`
 - Analyze all commits on the branch to draft the summary
 
+### Step 6b: Route Supplemental Findings to the Nit Store
+
+A supplemental finding is anything true and worth fixing that you discovered
+while doing something else: a defect noticed in passing, a rough edge found
+while closing this issue, a contract narrower than its callers assume. Do not
+widen this change to fix it, and do not drop it. Record it.
+
+Resolve the repository's nit store:
+
+```bash
+case "$(basename "$(git rev-parse --show-toplevel)")" in
+    kyle)              NIT_STORE=1004 ;;
+    claude-power-pack) NIT_STORE=864 ;;
+    codex-power-pack)  NIT_STORE=227 ;;
+    *) NIT_STORE=$(gh issue list --search "Nit Store" --state open \
+                     --json number --jq '.[0].number' 2>/dev/null) ;;
+esac
+gh issue comment "$NIT_STORE" --body "<one finding>"
+```
+
+If the repository has no nit store, file the finding as a normal issue instead.
+
+- **One finding per comment.** State the file and line (or the command), what is
+  wrong, why it matters, and which issue or PR you were working when you found
+  it. The comment is the whole record; it is read later without your context.
+- **The store is an inbox, not a backlog.** Comments are reviewed and aggregated
+  into real issues later, so a comment is a disposition, not a fix.
+- **It is not a place to hide a defect that warrants its own ticket now.** A live
+  correctness, security, or data-loss problem gets its own issue, and the closing
+  report says so.
+- **Name what you stored, with the comment link, in the Step 7 output.** A
+  finding recorded but never reported is indistinguishable from one dropped.
+
+Having nothing to store is an ordinary outcome. Do not manufacture a finding to
+fill this step.
+
 ### Step 7: Output
 
 ```
@@ -344,6 +380,10 @@ Branch pushed: issue-42-fix-login → origin
 
 PR created: https://github.com/owner/repo/pull/78
   Title: fix(auth): Resolve login redirect loop (Closes #42)
+
+Supplemental findings: 1 stored in the nit store (#864)
+  - scripts/deploy.sh:42 unquoted $PATH expansion
+    https://github.com/owner/repo/issues/864#issuecomment-123456789
 ```
 
 ## Error Handling

--- a/.claude/commands/flow/finish.md
+++ b/.claude/commands/flow/finish.md
@@ -342,15 +342,33 @@ widen this change to fix it, and do not drop it. Record it.
 Resolve the repository's nit store:
 
 ```bash
-case "$(basename "$(git rev-parse --show-toplevel)")" in
+# Key on the REMOTE, never the directory name. This step always runs from a
+# per-issue worktree (`.../claude-power-pack-issue-865`), so a basename test
+# falls through every time and the explicit mapping below never fires - leaving
+# a full-text search as the only path, which is the opposite of the intent.
+REPO=$(basename -s .git "$(git remote get-url origin 2>/dev/null)")
+[ -n "$REPO" ] || REPO=$(gh repo view --json name -q .name 2>/dev/null)
+
+case "$REPO" in
     kyle)              NIT_STORE=1004 ;;
     claude-power-pack) NIT_STORE=864 ;;
     codex-power-pack)  NIT_STORE=227 ;;
     *) NIT_STORE=$(gh issue list --search "Nit Store" --state open \
                      --json number --jq '.[0].number' 2>/dev/null) ;;
 esac
+
+# Never post into an empty number. A finding silently posted nowhere is the
+# exact failure this step exists to prevent, so fail loudly instead.
+if [ -z "$NIT_STORE" ]; then
+    echo "No nit store for '${REPO:-unknown}' - file the finding as a normal issue." >&2
+    exit 1
+fi
 gh issue comment "$NIT_STORE" --body "<one finding>"
 ```
+
+`--search` is full text, not an exact title match, so it can select any open
+issue merely mentioning the phrase. It is the last resort, not the normal path;
+if it is what resolved the number, say so in the closing report.
 
 If the repository has no nit store, file the finding as a normal issue instead.
 

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -344,15 +344,33 @@ widen this change to fix it, and do not drop it. Record it.
 Resolve the repository's nit store:
 
 ```bash
-case "$(basename "$(git rev-parse --show-toplevel)")" in
+# Key on the REMOTE, never the directory name. This step always runs from a
+# per-issue worktree (`.../claude-power-pack-issue-865`), so a basename test
+# falls through every time and the explicit mapping below never fires - leaving
+# a full-text search as the only path, which is the opposite of the intent.
+REPO=$(basename -s .git "$(git remote get-url origin 2>/dev/null)")
+[ -n "$REPO" ] || REPO=$(gh repo view --json name -q .name 2>/dev/null)
+
+case "$REPO" in
     kyle)              NIT_STORE=1004 ;;
     claude-power-pack) NIT_STORE=864 ;;
     codex-power-pack)  NIT_STORE=227 ;;
     *) NIT_STORE=$(gh issue list --search "Nit Store" --state open \
                      --json number --jq '.[0].number' 2>/dev/null) ;;
 esac
+
+# Never post into an empty number. A finding silently posted nowhere is the
+# exact failure this step exists to prevent, so fail loudly instead.
+if [ -z "$NIT_STORE" ]; then
+    echo "No nit store for '${REPO:-unknown}' - file the finding as a normal issue." >&2
+    exit 1
+fi
 gh issue comment "$NIT_STORE" --body "<one finding>"
 ```
+
+`--search` is full text, not an exact title match, so it can select any open
+issue merely mentioning the phrase. It is the last resort, not the normal path;
+if it is what resolved the number, say so in the closing report.
 
 If the repository has no nit store, file the finding as a normal issue instead.
 

--- a/codex/skills/flow-finish/reference.md
+++ b/codex/skills/flow-finish/reference.md
@@ -334,6 +334,42 @@ ${ISSUE_REF}"
 - Body: Summary of changes + test plan + `${ISSUE_REF}`
 - Analyze all commits on the branch to draft the summary
 
+### Step 6b: Route Supplemental Findings to the Nit Store
+
+A supplemental finding is anything true and worth fixing that you discovered
+while doing something else: a defect noticed in passing, a rough edge found
+while closing this issue, a contract narrower than its callers assume. Do not
+widen this change to fix it, and do not drop it. Record it.
+
+Resolve the repository's nit store:
+
+```bash
+case "$(basename "$(git rev-parse --show-toplevel)")" in
+    kyle)              NIT_STORE=1004 ;;
+    claude-power-pack) NIT_STORE=864 ;;
+    codex-power-pack)  NIT_STORE=227 ;;
+    *) NIT_STORE=$(gh issue list --search "Nit Store" --state open \
+                     --json number --jq '.[0].number' 2>/dev/null) ;;
+esac
+gh issue comment "$NIT_STORE" --body "<one finding>"
+```
+
+If the repository has no nit store, file the finding as a normal issue instead.
+
+- **One finding per comment.** State the file and line (or the command), what is
+  wrong, why it matters, and which issue or PR you were working when you found
+  it. The comment is the whole record; it is read later without your context.
+- **The store is an inbox, not a backlog.** Comments are reviewed and aggregated
+  into real issues later, so a comment is a disposition, not a fix.
+- **It is not a place to hide a defect that warrants its own ticket now.** A live
+  correctness, security, or data-loss problem gets its own issue, and the closing
+  report says so.
+- **Name what you stored, with the comment link, in the Step 7 output.** A
+  finding recorded but never reported is indistinguishable from one dropped.
+
+Having nothing to store is an ordinary outcome. Do not manufacture a finding to
+fill this step.
+
 ### Step 7: Output
 
 ```
@@ -346,6 +382,10 @@ Branch pushed: issue-42-fix-login → origin
 
 PR created: https://github.com/owner/repo/pull/78
   Title: fix(auth): Resolve login redirect loop (Closes #42)
+
+Supplemental findings: 1 stored in the nit store (#864)
+  - scripts/deploy.sh:42 unquoted $PATH expansion
+    https://github.com/owner/repo/issues/864#issuecomment-123456789
 ```
 
 ## Error Handling

--- a/tests/test_nit_store_routing.py
+++ b/tests/test_nit_store_routing.py
@@ -1,0 +1,155 @@
+"""Pin: the closing lifecycle surfaces route a supplemental finding to the nit store (issue #865).
+
+The nit stores exist (kyle #1004, claude-power-pack #864, codex-power-pack #227),
+but before #865 no command document told a worker to use one. A finding noticed
+while closing an issue had nowhere to go: too small to widen the change for, too
+real to drop, and by the time the PR merged it had scrolled out of context. It was
+dropped silently, which is the one outcome that leaves no trace to audit.
+
+**Why these two surfaces.** `flow/finish.md` is the closing step of every
+non-delegated run, and `codex/code_review.md` is where a cross-model review sorts
+findings into agree/disagree/defer - `defer` being a supplemental finding by
+definition, named and then discarded. Both are reached three ways: directly from
+`~/.claude/commands` (a symlink into this repo), through kyle's container mount
+(`DOCKER_TOOL_MOUNTS`, which delivers `commands` but no CLAUDE.md of any kind), and
+- for `flow/finish.md` only - through the generated `codex/skills/flow-finish`
+bundle. That last asymmetry is deliberate and load-bearing for the mirror test
+below: `make codex-skills` does not mirror the `codex` namespace, so
+`codex/code_review.md` has no generated copy to check.
+
+**These are prompt documents, so the document is the enforceable layer.** No code
+path reads them; a test can only establish that the instruction is present and
+reachable. It cannot establish that an agent obeys it. `test_probes_are_not_vacuous`
+is what keeps the first claim honest - it strips the section and requires every
+probe to fail, so a rename or a move cannot leave this file passing on prose that
+no longer says anything.
+
+Verified non-vacuous: stashed against the pre-change tree, all 30 tests here fail.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS = ROOT / ".claude" / "commands"
+
+#: Closing surfaces that must carry the routing step.
+SURFACES = (
+    COMMANDS / "flow" / "finish.md",
+    COMMANDS / "codex" / "code_review.md",
+)
+
+#: The generated bundle a codex-lane session reads instead of the command file.
+#: Only `flow` is mirrored; see the module docstring.
+MIRROR = ROOT / "codex" / "skills" / "flow-finish" / "reference.md"
+
+#: Each probe is (name, pattern). Every one must match every surface, and every
+#: one must FAIL on a document with the section removed - see the control below.
+PROBES = (
+    ("names the kyle store", re.compile(r"kyle\)\s*NIT_STORE=1004")),
+    ("names the CPP store", re.compile(r"claude-power-pack\)\s*NIT_STORE=864")),
+    ("names the CxPP store", re.compile(r"codex-power-pack\)\s*NIT_STORE=227")),
+    (
+        "falls back to a search",
+        re.compile(r'gh issue list --search "Nit Store" --state open'),
+    ),
+    (
+        "falls back to a normal issue",
+        re.compile(r"no nit store, file the finding as a normal issue"),
+    ),
+    ("one finding per comment", re.compile(r"One finding per comment")),
+    (
+        "records file and line, and the issue or PR",
+        re.compile(r"file and line \(or the command\).+which issue or PR", re.S),
+    ),
+    (
+        "read later without your context",
+        re.compile(r"read later without your context"),
+    ),
+    ("inbox, not a backlog", re.compile(r"inbox, not a backlog")),
+    ("a comment is a disposition", re.compile(r"disposition, not a fix")),
+    (
+        "a live defect still gets its own issue",
+        re.compile(r"correctness, security, or data-loss.+own issue", re.S),
+    ),
+    (
+        "names what was stored in the closing report",
+        re.compile(r"with the comment link", re.S),
+    ),
+    (
+        "nothing to store is an ordinary outcome",
+        re.compile(r"(ordinary outcome|stores nothing)"),
+    ),
+)
+
+
+def _section(text: str) -> str:
+    """The nit-store step only, so a probe cannot match unrelated prose elsewhere."""
+    match = re.search(
+        r"^###[^\n]*Nit Store[^\n]*$(.*?)(?=^### |\Z)", text, re.M | re.S
+    )
+    assert match, "no '### ... Nit Store' section found"
+    return match.group(0)
+
+
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+@pytest.mark.parametrize("name,pattern", PROBES, ids=lambda v: v if isinstance(v, str) else "")
+def test_surface_routes_supplemental_findings(surface: Path, name: str, pattern: re.Pattern) -> None:
+    assert surface.is_file(), f"{surface} is missing"
+    assert pattern.search(_section(surface.read_text())), (
+        f"{surface.relative_to(ROOT)} no longer {name}"
+    )
+
+
+def test_the_step_is_a_closing_step_in_finish() -> None:
+    """Placed after the PR exists, so the comment can name the PR it came from."""
+    text = (COMMANDS / "flow" / "finish.md").read_text()
+    create_pr = text.index("### Step 6: Create PR")
+    nit = text.index("### Step 6b: Route Supplemental Findings to the Nit Store")
+    output = text.index("### Step 7: Output")
+    assert create_pr < nit < output
+
+
+def test_finish_output_reports_what_was_stored() -> None:
+    """A finding recorded but not reported is indistinguishable from one dropped."""
+    text = (COMMANDS / "flow" / "finish.md").read_text()
+    output = text[text.index("### Step 7: Output") :]
+    assert "Supplemental findings:" in output
+    assert "#issuecomment-" in output, "the example must show a comment link"
+
+
+def test_generated_codex_bundle_carries_the_step() -> None:
+    """A codex-lane session reads the bundle, not the command file.
+
+    Guards the drift the issue's own note warns about: `make codex-skills` must
+    have been run after editing `flow/finish.md`, or this lane silently keeps the
+    old text.
+    """
+    assert MIRROR.is_file(), f"{MIRROR} is missing"
+    mirrored = _section(MIRROR.read_text())
+    for name, pattern in PROBES:
+        assert pattern.search(mirrored), f"generated bundle no longer {name} - run `make codex-skills`"
+
+
+def test_probes_are_not_vacuous() -> None:
+    """Positive control: with the section removed, every probe must fail.
+
+    Without this, renaming the heading or moving the block elsewhere could leave
+    the parametrized tests matching incidental prose - a green suite over an
+    instruction that is no longer there.
+    """
+    for surface in SURFACES:
+        text = surface.read_text()
+        stripped = re.sub(
+            r"^###[^\n]*Nit Store[^\n]*$.*?(?=^### |\Z)", "", text, flags=re.M | re.S
+        )
+        assert stripped != text, f"control removed nothing from {surface.name}"
+        survivors = [name for name, pattern in PROBES if pattern.search(stripped)]
+        assert not survivors, (
+            f"{surface.name}: probes match outside the nit-store section, so they "
+            f"prove nothing about it: {survivors}"
+        )

--- a/tests/test_nit_store_routing.py
+++ b/tests/test_nit_store_routing.py
@@ -24,12 +24,28 @@ is what keeps the first claim honest - it strips the section and requires every
 probe to fail, so a rename or a move cannot leave this file passing on prose that
 no longer says anything.
 
-Verified non-vacuous: stashed against the pre-change tree, all 30 tests here fail.
+**Two kinds of test live here, and they establish different things.** The
+structural probes prove the instruction is PRESENT and reachable in each surface
+and in the generated bundle. They cannot prove the shell it publishes works - and
+that gap was not hypothetical: the first version of this step resolved the nit
+store with `basename "$(git rev-parse --show-toplevel)"`, which never matches,
+because `/flow:finish` always runs from a per-issue worktree (`.../repo-issue-865`).
+All three named repositories fell through to the full-text search on every real
+invocation, and 30 green structural tests saw nothing. The executing tests below
+run the published block from a path with that suffix, which is the only path it
+ever has.
+
+Verified non-vacuous: stashed against the pre-change tree, all 30 structural tests
+here fail.
 """
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -153,3 +169,149 @@ def test_probes_are_not_vacuous() -> None:
             f"{surface.name}: probes match outside the nit-store section, so they "
             f"prove nothing about it: {survivors}"
         )
+
+
+# --------------------------------------------------------------------------
+# Executing tests: run the published resolver, do not merely read it.
+# --------------------------------------------------------------------------
+
+#: These run the block for real, so they need the binaries it calls (#577).
+requires_shell = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("git") is None,
+    reason="requires bash and git on PATH",
+)
+
+GH_STUB = r"""#!/usr/bin/env python3
+# Stub gh: records every call, answers from a JSON fixture.
+import json, os, sys
+from pathlib import Path
+
+state = Path(os.environ["GH_STUB_STATE"])
+data = json.loads(state.read_text())
+argv = sys.argv[1:]
+data.setdefault("calls", []).append(argv)
+state.write_text(json.dumps(data))
+
+if argv[:2] == ["repo", "view"]:
+    print(data.get("repo_view", ""), end="")
+elif argv[:2] == ["issue", "list"]:
+    print(data.get("issue_list", ""), end="")
+elif argv[:2] == ["issue", "comment"]:
+    pass
+else:
+    sys.exit(1)
+"""
+
+
+def _resolver_block(surface: Path) -> str:
+    """The first bash block of the nit-store section - the published resolver."""
+    section = _section(surface.read_text())
+    match = re.search(r"```bash\n(.*?)```", section, re.S)
+    assert match, f"no bash block in {surface.name}'s nit-store section"
+    return match.group(1)
+
+
+def _run_resolver(
+    tmp_path: Path,
+    surface: Path,
+    *,
+    origin: str | None,
+    repo_view: str = "",
+    issue_list: str = "",
+    dirname: str = "claude-power-pack-issue-865",
+) -> tuple[int, str, list[list[str]]]:
+    """Execute the published block from a per-issue worktree-shaped path."""
+    workdir = tmp_path / dirname
+    workdir.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=workdir, check=True)
+    if origin is not None:
+        subprocess.run(
+            ["git", "remote", "add", "origin", origin], cwd=workdir, check=True
+        )
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(GH_STUB)
+    gh.chmod(0o755)
+
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"repo_view": repo_view, "issue_list": issue_list}))
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "GH_STUB_STATE": str(state),
+    }
+    proc = subprocess.run(
+        ["bash", "-c", _resolver_block(surface) + '\necho "RESOLVED=$NIT_STORE"'],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = json.loads(state.read_text()).get("calls", [])
+    return proc.returncode, proc.stdout + proc.stderr, calls
+
+
+@requires_shell
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_resolver_matches_from_a_per_issue_worktree(tmp_path: Path, surface: Path) -> None:
+    """The real case: the directory is `<repo>-issue-NNN`, never `<repo>`.
+
+    This is the regression. Keying on the directory basename fell through here on
+    every single invocation, making the last-resort search the only live path.
+    """
+    code, output, calls = _run_resolver(
+        tmp_path,
+        surface,
+        origin="https://github.com/cooneycw/claude-power-pack.git",
+    )
+    assert code == 0, output
+    assert "RESOLVED=864" in output, output
+    assert not [c for c in calls if c[:2] == ["issue", "list"]], (
+        f"fell through to the search despite a known remote: {calls}"
+    )
+
+
+@requires_shell
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_resolver_handles_an_ssh_remote(tmp_path: Path, surface: Path) -> None:
+    code, output, _ = _run_resolver(
+        tmp_path, surface, origin="git@github.com:cooneycw/kyle.git"
+    )
+    assert code == 0, output
+    assert "RESOLVED=1004" in output, output
+
+
+@requires_shell
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_resolver_refuses_to_post_into_an_empty_number(tmp_path: Path, surface: Path) -> None:
+    """No remote, no `gh repo view`, no search hit - it must fail, not post nowhere.
+
+    `gh issue comment "" --body ...` is the silent-loss failure the whole feature
+    exists to prevent, so the guard is the load-bearing part of the block.
+    """
+    code, output, calls = _run_resolver(tmp_path, surface, origin=None)
+    assert code != 0, f"expected a loud failure, got 0:\n{output}"
+    assert not [c for c in calls if c[:2] == ["issue", "comment"]], (
+        f"posted a comment with no resolved nit store: {calls}"
+    )
+    assert "normal issue" in output, output
+
+
+@requires_shell
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_resolver_falls_back_to_the_search_for_an_unknown_repo(
+    tmp_path: Path, surface: Path
+) -> None:
+    code, output, calls = _run_resolver(
+        tmp_path,
+        surface,
+        origin="https://github.com/cooneycw/some-other-repo.git",
+        issue_list="4242\n",
+        dirname="some-other-repo-issue-7",
+    )
+    assert code == 0, output
+    assert "RESOLVED=4242" in output, output
+    assert [c for c in calls if c[:2] == ["issue", "list"]], calls


### PR DESCRIPTION
## Summary

The nit stores exist (kyle #1004, claude-power-pack #864, codex-power-pack #227) but no command document told a worker to use one. A finding noticed while closing an issue was too small to widen the change for, too real to drop, and gone from context by the time the PR merged — so it was dropped silently, the one outcome that leaves nothing to audit.

- **`.claude/commands/flow/finish.md`** — new **Step 6b**, placed after the PR exists so the comment can name the PR it came from. The Step 7 output block now reports what was stored, with its comment link.
- **`.claude/commands/codex/code_review.md`** — new **Step 5**, hooked on the `defer` triage bucket. A finding triaged "real, but out of scope" *is* a supplemental finding; the triage line named it and then let it scroll away. This surface also carries an attribution bullet the other does not need, because the finding is Codex's and a later reader weighs a cross-model finding differently from the author's own.
- **`codex/skills/flow-finish/reference.md`** — regenerated via `make codex-skills`.
- **`tests/test_nit_store_routing.py`** — new: 30 structural probes + 8 executing tests.

Both surfaces state that a live correctness, security, or data-loss defect still gets its own issue (`defer` is a scope judgement, not a severity one), and that having nothing to store is an ordinary outcome — so the step cannot pressure an agent into manufacturing a finding to fill it.

## The resolver defect, found in review (commit `9ca5ffc`)

The first version resolved the nit store with `basename "$(git rev-parse --show-toplevel)"`. **Both surfaces always run from a per-issue worktree** (`.../claude-power-pack-issue-865`), so the basename is never the repository name and all three explicit branches fell through on *every real invocation*.

It was not visibly broken, which is what made it bad: the full-text search fallback caught every case, so **the last resort was the only live path**. Two quiet consequences — `--search "Nit Store"` is full text, not an exact title match, so it can select any open issue merely mentioning the phrase; and when it returned nothing (no store, gh offline, rate limited) `NIT_STORE` was empty and the next line ran `gh issue comment "" --body ...`. The explicit branches were the safety net for exactly that, and they never fired.

Now keys on the **remote** (`git remote get-url origin`, falling back to `gh repo view`) — it asks *which repository is this* rather than *what is this folder called*, which is correct in a worktree, under any directory name, and after a rename. Plus a guard that refuses to post into an empty number and says so.

**The 30 structural tests did not see any of this.** They read the document; they never ran what it publishes. The four executing tests added run the published block under a stubbed `gh` from a directory carrying the `-issue-NNN` suffix — the only shape either surface ever runs in — and were verified to catch the original defect: restoring the basename resolver fails three of the four (the fourth is the unknown-repo fallback, which behaves the same either way).

Worth stating plainly: **CI was green over this defect.** Every gate in the repo ran and none was positioned to see it.

## A correction to the issue's reasoning

#865 argues the edit reaches the codex lane because `make codex-skills` mirrors both documents. **It does not mirror the `codex` namespace** — there is no `codex/skills/codex-code_review`, and the regeneration wrote exactly one file. The edit is still correct (`codex/code_review.md` reaches host sessions and kyle's container mount directly), but only the `flow/finish.md` half also reaches a generated bundle. Detail on [#865](https://github.com/cooneycw/claude-power-pack/issues/865#issuecomment-5648581351).

## Why the installed skills were not touched from this branch

The issue asks for `make codex-skills` + an install + a check that the installed copy carries the step. The install was verified against a **scratch `HOME`**, not the real `~/.codex/skills`.

That directory is read by other sessions running on this host right now. Installing from an unmerged branch would have had them executing prompt text that no one had reviewed — instructions delivered through the supply chain instead of through a diff, which is the one path that bypasses review entirely. The mechanism is verified (`--install` does place all five bullets into the installed `reference.md`); the host install runs post-merge from main, which is where reviewed text belongs.

## Test plan

- [x] `make lint` — passes
- [x] `make typecheck` — passes (208 source files)
- [x] `make test` — **3088 passed**
- [x] `make codex-skills-check` — 75 skills in sync
- [x] **Structural probes non-vacuous**: stashed against the pre-change tree, all 30 fail there. `test_probes_are_not_vacuous` strips the section and requires all 13 probes to fail, so a rename or a move cannot leave the suite green over prose that no longer says anything.
- [x] **Executing tests verified against the defect**: restoring the basename resolver fails 3 of 4.
- [x] Executing tests carry the #577 binary guard (`bash`, `git`).

## Acceptance accounting

`Refs #865`, not `Closes`. Four of the five material items are demonstrated above. The fifth — the issue's own note that *"landing the merge is not enough for the codex lane"* — is post-merge by construction: the host `~/.codex/skills` install and its verification happen from main after this merges. #865 closes then, with that evidence. (Confirmed live: the session that wrote this booted with its hook reporting `CPP install: 6 Codex skill(s) stale`.)

## Notes

Implemented in-session on `/flow:auto`, not `/codex:auto` as originally assigned: the `/codex:auto` execution fence (#735) forbids Codex from reading anything under `.claude/commands/**`, which is where this entire deliverable lives. Two consequences recorded in the nit store — the capability pre-flight returns `fit` for work the fence forbids ([comment](https://github.com/cooneycw/claude-power-pack/issues/864#issuecomment-5648550200)), and the repo→number mapping is now duplicated across the two documents ([comment](https://github.com/cooneycw/claude-power-pack/issues/864#issuecomment-5648626071)).

Refs #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yh3ybjhCBv6BDmyVZmKCq