### PR TITLE
docs(review): give the detector-claim pattern a home in the review guidance (Closes #834)

### DIFF
--- a/.claude/commands/codex/auto.md
+++ b/.claude/commands/codex/auto.md
@@ -531,6 +531,11 @@ Cross-model review: Claude Code reviews what Codex wrote.
    - Security: Any injection, XSS, or other vulnerabilities?
    - Completeness: Are all acceptance criteria addressed?
    - Test coverage: Are tests updated or added?
+   - Detector claims: if the diff adds or changes a check, gate, guard, tripwire
+     or allowlist, ask the two questions from
+     [the detector contracts](../../../docs/agents/detector-contracts.md) - does
+     its success message claim more than its input population supports, and can a
+     finding tell our thing from a neighbour's - and require the answer as a test.
 
 3. **Report review findings:**
 

--- a/.claude/commands/codex/code_review.md
+++ b/.claude/commands/codex/code_review.md
@@ -90,6 +90,8 @@ cat "$DIFF_FILE" | codex exec \
 
 Review for: correctness bugs, security issues, missed edge cases, broken or missing tests, and meaningful simplifications. Do NOT restyle working code or comment on formatting.
 
+If the diff adds or changes a check, gate, guard, tripwire or allowlist, ask two further questions of it and report a failure of either as a finding: (1) does its success message claim more than its input population supports - can a zero distinguish 'I looked and found nothing' from 'there was nothing to look at'; and (2) can a non-zero distinguish 'our thing changed' from 'a neighbour changed'. Widening the detector is not always the remedy: where the narrow answer is deliberately correct, say so and say where the larger question should be answered instead.
+
 Return ONLY a findings report in exactly this format:
 
 ## Findings
@@ -127,6 +129,13 @@ findings; a calling workflow treats it like the exit-3 unavailable case.
 
 ## Notes
 
+- The review prompt above carries the two detector questions inline rather than
+  linking them, because the reviewing model runs `--sandbox read-only` against a
+  diff and cannot be relied on to go and read a repository document. The
+  canonical statement, with the instance index and the test shapes a finding
+  should ask for, is
+  [the detector contracts](../../../docs/agents/detector-contracts.md); read it
+  when triaging a detector finding in Step 4.
 - Uses the user's **Codex account** (real quota/billing per call). One review
   pass plus at most one re-review is the intended cadence - never loop.
 - Read-only sandbox: safe to run inside a live repo; Codex cannot write or reach

--- a/.claude/commands/flow/auto.md
+++ b/.claude/commands/flow/auto.md
@@ -582,6 +582,15 @@ reason is something to surface, never grounds to drop it.
 not manufacture an alternative, an experiment or a challenge for work that does not
 need one.
 
+**If the change adds or modifies a check, gate, guard, tripwire or allowlist**, ask
+the two questions from
+[the detector contracts](../../../docs/agents/detector-contracts.md) before you
+call it done - does its success message claim more than its input population
+supports, and can a finding tell our thing from a neighbour's - and write the
+answer in as a test rather than a comment. Where the narrow answer is deliberately
+correct, widening is not the remedy: say where the larger question is answered
+instead.
+
 If implementation hits a blocker that cannot be resolved:
 - **STOP** and report the blocker.
 - Suggest manual intervention.

--- a/.claude/commands/gemma/auto.md
+++ b/.claude/commands/gemma/auto.md
@@ -626,6 +626,11 @@ Review the diff line by line, not just structurally.
    - Security: Any injection, XSS, or other vulnerabilities?
    - Completeness: Are all acceptance criteria addressed?
    - Test coverage: Are tests updated or added?
+   - Detector claims: if the diff adds or changes a check, gate, guard, tripwire
+     or allowlist, ask the two questions from
+     [the detector contracts](../../../docs/agents/detector-contracts.md) - does
+     its success message claim more than its input population supports, and can a
+     finding tell our thing from a neighbour's - and require the answer as a test.
 
 3. **Report review findings** (same format as `/qwen:auto` Step 5).
 

--- a/.claude/commands/qwen/auto.md
+++ b/.claude/commands/qwen/auto.md
@@ -593,6 +593,11 @@ Review the diff line by line, not just structurally.
    - Security: Any injection, XSS, or other vulnerabilities?
    - Completeness: Are all acceptance criteria addressed?
    - Test coverage: Are tests updated or added?
+   - Detector claims: if the diff adds or changes a check, gate, guard, tripwire
+     or allowlist, ask the two questions from
+     [the detector contracts](../../../docs/agents/detector-contracts.md) - does
+     its success message claim more than its input population supports, and can a
+     finding tell our thing from a neighbour's - and require the answer as a test.
 
 3. **Report review findings** (same format as `/codex:auto` Step 5).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ helpers own deterministic behavior.
 - **When fixing errors, fix BOTH the application code AND the CI/CD process.** Never bypass quality gates.
 - Before debugging manually, run `make lint` and `make test`.
 - A test that shells out to a real binary must use a `shutil.which` skip guard - including when it reaches that binary by running a repo shell script. `scripts/check-test-binary-guards.py` enforces the detailed contract.
+- A check, gate, guard, tripwire, or allowlist must be able to represent the state it cannot currently see: its success message must not claim more than its input population supports, and a finding must distinguish our thing from a neighbour's. [The detector contracts](docs/agents/detector-contracts.md) own the two review questions and the test shapes that pin them.
 - A fixture that constructs a NEGATIVE condition must assert that precondition before exercising the code. `scripts/check-negative-fixture-preconditions.py` owns the detectable contract.
 - A pattern-matching fixture must not interpolate an absolute path it does not control; use a fixture-owned relative value and assert the intended classification.
 - After any fix, verify through the full pipeline with `make verify`.
@@ -35,6 +36,7 @@ these rules remain in [commands-reference.md](docs/commands-reference.md) and
 - `docs/commands-reference.md` - command decisions, histories, and workflow detail.
 - `docs/scripts.md` - script inventory and per-script behavioral history.
 - `docs/agents/issue-contract.md` - canonical issue contract and proportional spec routing.
+- `docs/agents/detector-contracts.md` - canonical detector-claim contract and its instance index.
 - `docs/agents/knowledge-lifecycle.md` - canonical completed-spec graduation policy.
 - `ISSUE_DRIVEN_DEVELOPMENT.md` - issue-driven development source.
 - `PROGRESSIVE_DISCLOSURE_GUIDE.md` - context-loading guidance.

--- a/codex/skills/flow-auto/docs/agents/detector-contracts.md
+++ b/codex/skills/flow-auto/docs/agents/detector-contracts.md
@@ -4,7 +4,7 @@ A check, gate, guard, tripwire or allowlist makes a claim. This document is the
 canonical statement of what that claim has to be able to say, and of the two
 questions a reviewer asks of any diff that adds or changes one.
 
-It exists because the pattern below was diagnosed twenty-two times across two
+It exists because the pattern below was diagnosed twenty-three times across two
 repositories and written down in exactly one place: issue #834. A shape that
 lives in one issue cannot be applied in review, so the next instance has nothing
 to reference. Other surfaces point here; they do not restate it.
@@ -224,7 +224,7 @@ conducted *for* this pattern.
 
 ## The instance index
 
-The twenty-two instances this contract was derived from. Kept here, in the guidance,
+The twenty-three instances this contract was derived from. Kept here, in the guidance,
 rather than in the issue that indexed them - a finding that lives only in a closed
 issue is the condition #834 was filed to end. Link new instances here.
 
@@ -249,7 +249,8 @@ issue is the condition #834 was filed to end. Link new instances here.
 | #867 | has *anything* acknowledged this message | did the agent behind this role receive it | open |
 | #869 | is there a socket file at this path | is that session alive | open |
 | #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
-| this change | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
+| this change (pkill) | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
+| this change (base sync) | are the ADDED LINES byte-identical | is the change still what was approved | fixed in flight |
 | kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
 | kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
 
@@ -257,8 +258,7 @@ Three further instances are not in the table at all: they were found in
 instruments and in relays rather than in shipped checks, so there is no detector
 to name in the columns. They are described under "Seven properties" above.
 
-The `this change` row is the sharpest evidence in the table, and it is here
-deliberately. Writing this document, its author ran
+The `this change (pkill)` row is here deliberately. Writing this document, its author ran
 `pkill -f "issue-834/.venv/bin/pytest"` to clear a stale test process. The shell
 executing that command had the pattern inside its own command line, so the
 pattern matched the process doing the matching and the shell killed itself
@@ -268,6 +268,27 @@ recurrence under field conditions is stronger evidence about the class than the
 original finding, because it shows the pattern survives being known - which is
 the claim "Knowing the pattern confers no immunity" makes, now with a second
 witness.
+
+The `this change (base sync)` row is the same story with a better ending, because
+the check was caught before anyone relied on it. Landing this document required a
+base sync, and the question was whether the approved change had survived it. The
+answer given was a comparison of the two diffs' **added lines**: 925 both sides,
+byte-identical, zero deletions. True, and it was offered as evidence that "the
+change is still what was approved".
+
+It cannot support that. Its population is added lines, and it excludes the context
+those lines land in. The sibling PR in the same wave had edited the same file, and
+had this change also added a `### Step 5` heading, the added lines would have been
+byte-identical **and** the merged document would have carried two Step 5 sections.
+Git auto-merges that without a conflict; the check reports byte-identical with
+exactly the same confidence. What actually settled the question was reading the
+merged file's heading structure - one Step 5, at line 130 - which is a different
+measurement entirely.
+
+So "the added lines are unchanged" and "the change still does what was approved"
+are two questions with the same reassuring answer, and only the second was being
+asked. The reviewer who caught it is the one who went and read the merged file
+rather than accepting the byte comparison.
 
 Three of these (#867, #869, #877) were filed after the index was written, and #877
 was found while routing the work that produced this document. That is the standing

--- a/codex/skills/flow-auto/docs/agents/detector-contracts.md
+++ b/codex/skills/flow-auto/docs/agents/detector-contracts.md
@@ -4,7 +4,7 @@ A check, gate, guard, tripwire or allowlist makes a claim. This document is the
 canonical statement of what that claim has to be able to say, and of the two
 questions a reviewer asks of any diff that adds or changes one.
 
-It exists because the pattern below was diagnosed twenty-one times across two
+It exists because the pattern below was diagnosed twenty-two times across two
 repositories and written down in exactly one place: issue #834. A shape that
 lives in one issue cannot be applied in review, so the next instance has nothing
 to reference. Other surfaces point here; they do not restate it.
@@ -224,7 +224,7 @@ conducted *for* this pattern.
 
 ## The instance index
 
-The twenty-one instances this contract was derived from. Kept here, in the guidance,
+The twenty-two instances this contract was derived from. Kept here, in the guidance,
 rather than in the issue that indexed them - a finding that lives only in a closed
 issue is the condition #834 was filed to end. Link new instances here.
 
@@ -249,12 +249,25 @@ issue is the condition #834 was filed to end. Link new instances here.
 | #867 | has *anything* acknowledged this message | did the agent behind this role receive it | open |
 | #869 | is there a socket file at this path | is that session alive | open |
 | #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
+| this change | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
 | kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
 | kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
 
-Three further instances have no issue number because they were found in
-instruments and in relays rather than in shipped checks; they are described under
-"Seven properties" above.
+Three further instances are not in the table at all: they were found in
+instruments and in relays rather than in shipped checks, so there is no detector
+to name in the columns. They are described under "Seven properties" above.
+
+The `this change` row is the sharpest evidence in the table, and it is here
+deliberately. Writing this document, its author ran
+`pkill -f "issue-834/.venv/bin/pytest"` to clear a stale test process. The shell
+executing that command had the pattern inside its own command line, so the
+pattern matched the process doing the matching and the shell killed itself
+(exit 144). That is #821's identity defect exactly, committed live, by someone
+who had spent the preceding hour writing #821's row into this table. A
+recurrence under field conditions is stronger evidence about the class than the
+original finding, because it shows the pattern survives being known - which is
+the claim "Knowing the pattern confers no immunity" makes, now with a second
+witness.
 
 Three of these (#867, #869, #877) were filed after the index was written, and #877
 was found while routing the work that produced this document. That is the standing

--- a/codex/skills/flow-auto/docs/agents/detector-contracts.md
+++ b/codex/skills/flow-auto/docs/agents/detector-contracts.md
@@ -1,0 +1,271 @@
+# Detector Contracts
+
+A check, gate, guard, tripwire or allowlist makes a claim. This document is the
+canonical statement of what that claim has to be able to say, and of the two
+questions a reviewer asks of any diff that adds or changes one.
+
+It exists because the pattern below was diagnosed twenty-one times across two
+repositories and written down in exactly one place: issue #834. A shape that
+lives in one issue cannot be applied in review, so the next instance has nothing
+to reference. Other surfaces point here; they do not restate it.
+
+## The shape
+
+**A detector answers the question it was built for. Its reader supplies a larger
+one.** Both statements are true of the code; only the narrow one is true of the
+check.
+
+The failure is never a wrong answer. It is a *correct narrow answer read as a
+broad one*, which is why ordinary review does not catch it: the code does exactly
+what it says, and what it says is not what the caller needs.
+
+## The two questions
+
+Ask both of any check in a diff. They are the whole contract; everything below is
+evidence that they are worth asking.
+
+### 1. Membership floor
+
+> **Does this check's success message claim more than its input population
+> supports?**
+
+Not "did it examine anything" - a check that examines nothing can still be
+honest. The distinction is between reporting a count and asserting a universal.
+Two gates in this repository, measured against an empty input:
+
+| gate | on an empty input | honest? |
+|---|---|---|
+| `check-claude-md-budget.py` | `ok - 0/2000 words`, exit 0 | **yes** - a numeric aggregate; the number *is* the population count |
+| `check-claude-md-links.py`, before #841 | `ok - every repository-local pointer resolves`, exit 0 | **no** - vacuously true over zero pointers |
+| `check-claude-md-links.py`, after #841 | `contains no repository-local pointers - nothing was checked`, exit 1 | **yes** - the empty population is now a state it can report |
+
+Both original forms exited 0 having examined nothing. Only one was a defect,
+because only one asserted something about every member of a set it never
+established was non-empty. A count reports what it found; a universal claim over
+an empty set reports a guarantee it never tested. The third row is the remedy
+landed (#847) and is what "fixed" looks like: not a wider scan, but a detector
+that can now say the one thing it previously could not.
+
+The remedy is that the detector must be able to **represent the state it
+currently cannot see**. A fixed set of four names cannot represent a fifth; an
+iteration over the installed side cannot represent a missing item; a `0` returned
+because the directory does not exist cannot be told from a `0` that means clean.
+
+### 2. Ownership boundary
+
+> **Can a non-zero from this check distinguish "our thing changed" from
+> "something that is not ours changed"?**
+
+If not, an unrelated neighbour produces a finding, or worse is silently counted
+as ours. Watcher-shaped argv belonging to a different mailbox satisfies a
+watcher-shaped search (#821). A variable that is shaped like a per-session
+variable while being a property of the parent process is forwarded by a check
+keyed on the shape (kyle#994).
+
+The inverted form is worth naming separately: a *correct broad* answer can be
+overridden by a narrow one. In #869 `kill -0` correctly says the pid is dead and
+the presence of a socket file says otherwise, and the file wins. Here the narrow
+check does not merely get over-read - it defeats the broad one.
+
+## Writing the answer into the code
+
+For any check in a diff, ask the two questions and **write the answer into the
+code as a test.** A comment saying what the check does not cover decays; a test
+named for the state the detector cannot currently represent does not.
+
+Two test shapes carry this, and a reviewer should expect to see the relevant one:
+
+- **A positive control**, proving the detector is capable of firing at all.
+  Prior art: `tests/test_pythonpath_lib_depth.py::test_depth_detector_can_fire`
+  (#816).
+- **A named residual**, pinning a known blind spot as a property rather than a
+  TODO. Prior art:
+  `tests/test_flow_wave_mailbox.py::test_a_same_wave_orphan_would_not_be_excluded_by_directory_alone`
+  (#821).
+
+A test that passes over an empty population proves nothing, and is itself an
+instance of question 1. This applies to the tripwire guarding this document:
+`tests/test_detector_contracts.py` asserts its own surface list is non-empty and
+complete before asserting anything about the surfaces in it.
+
+## A worked example, from this repository's own tooling
+
+`scripts/flow-driver-capability.sh` decides which driver an issue may run on. Asked
+about #834 - the issue that produced this document - it answered:
+
+```
+FLOW_DRIVER_NEEDS=implementation
+FLOW_DRIVER_CHECK: fit
+```
+
+That answer is correct. The deliverable *is* a source diff, not research and not a
+live-source question, which is what the three declared axes (`scope`, `web`,
+`container`) are about. Its reader took it for **"can this driver do this issue?"**
+- and the #735 execution fence forbids the delegated driver from reading
+`.claude/commands/**`, which is where five of #834's nine files live. The driver
+was structurally inapplicable and the preflight said `fit` (#877).
+
+This is question 1 in a non-obvious dress. The check's input population was the
+deliverable's **kind**; the population it needed was the deliverable's **paths**.
+There is no axis for "the planned file list intersects the fence", so the check
+cannot represent the state that decides the answer - and `fit` therefore claims
+more than its population supports.
+
+It is the specimen worth remembering because both halves are inside this
+repository's own tooling, and because the detector that mis-routed the issue about
+detectors saying too little was the detector choosing that issue's driver. The
+routing rule it implies - *an issue whose deliverable includes any file under
+`.claude/commands/**` or `.claude/skills/**` runs on `/flow:auto`* - is #877's to
+land, not this document's.
+
+## When widening is not the remedy
+
+**"Widen the detector" does not generalise, and assuming it does is how this
+document would make things worse.**
+
+`scripts/delegated-run-check.sh` (#836) is the strongest case. `is_fatal` is
+scoped to the top level of an event *deliberately*: the recursive version existed,
+made every fenced `git commit` attempt a failed run, and was reverted for a stated
+reason that still holds. The header says it outright - *a guard against false
+success that manufactures false failure is not an improvement.* The author knew
+the scope exactly, documented it, and chose it correctly. The reader supplies the
+larger question anyway.
+
+So where the narrow answer is right, **the larger question needs somewhere else to
+live** - a new channel, a caller-supplied postcondition, a separate signal - not a
+widened existing one. That is a different and harder fix than widening, and
+recognising which of the two you are looking at is the judgement this document
+asks for.
+
+## What the two open dependents answer
+
+Stated here so each is implementable against this contract rather than against a
+conversation:
+
+| issue | question it answers | shape of the fix |
+|---|---|---|
+| #836 | **Ownership boundary**, in its hardest form: `DELEGATED_RUN_STATUS` cannot distinguish "the delegated *process* ran cleanly" from "the delegated *work* happened". A denied tool call satisfies every signal the checker has. | **Not** widening `is_fatal` - see above. The larger question needs its own home: a distinct non-fatal signal, or a caller-supplied postcondition. |
+| #831 | **Membership floor**: `check-test-binary-guards.py` answers "is a *guarded* binary unguarded" and is read as "is *any* binary unguarded". A fixed set of four names cannot represent a fifth. | Make the set able to represent a binary nobody put on it. Measurement on the pinned CI image found no live gap behind it, so this is a correctness fix, not an outage fix. |
+
+## Seven properties that let it survive review
+
+These are why the two questions are worth asking explicitly rather than trusting
+a careful reader to notice.
+
+**It survives awareness.** The kyle#994 workaround named four variables and had no
+floor for the namespace beside it - the same defect as the allowlist it was
+working around. It was written by the person who had just diagnosed that
+allowlist. Every other instance was written by someone who had not yet seen the
+pattern; that one was not, which is the strongest available evidence that this is
+a cognitive pull rather than a run of unrelated oversights.
+
+**It survives correct scoping.** See "When widening is not the remedy" above.
+
+**A narrow input set conceals it.** #833 was latent *because* `GUARDED_BINARIES`
+held four long, distinctive tokens. Widening the set - the fix #831 asks for - is
+what exposed it, producing 101 false findings from one `case` label. So "this has
+never caused a problem" is not evidence a detector is sound; it can mean only that
+nothing has yet been passed to it that its blind spot covers. Fixing one blind
+spot exposes the next: #831 -> #833 -> #838 -> #840 -> #841 is a five-step cascade
+in one file family, each step invisible until its predecessor closed.
+
+**It appears in the instrument built to detect it.** A `/proc` scan written to
+verify that every session held a live mailbox watch reported three watches for its
+own session; two were the probe matching itself, because it matched on a substring
+that is by construction inside the command line doing the matching. The useful
+part is the direction: **self-matching inflates a count and cannot manufacture an
+absence**, so the diagnosis it was built for ("this session has no watch") was
+still sound - but sound by luck. Had the failure been "two watches racing", the
+same instrument would have reported it backwards. An instrument whose error has a
+known direction can still be trusted for the half of the question that direction
+cannot reach, and that is a much narrower warrant than "the tool works".
+
+**The gap can be self-inflicted by the instrument.** In kyle#997 the narrow answer
+was manufactured rather than inherent: watch invocations ended `2>&1 | tail -40`,
+and later `; echo "EXIT=$?"`. Both make the reported status that of a command that
+cannot fail.
+
+```
+false | tail -1                    -> 0     pipeline exit = LAST command
+false; echo x                      -> 0     compound exit = LAST command
+set -o pipefail; false | tail -1    -> 1
+bash -c 'exit 5' 2>&1 | tail -40    -> 0     <- the masking form
+```
+
+The conclusion drawn was "the harness masks the exit code", and the evidence for
+it was the 0 the instrument had just forced. **The measurement apparatus produced
+the artifact it then detected**, and because the same artifact was present in
+every run, the false pattern looked consistent across hours - consistency read as
+corroboration when it was a constant. A bare control run settled it in one attempt:
+exit 5, reported accurately. The lesson is not "know the pipefail rule"; it is that
+a reading taken *through* an instrument is not evidence about the state *without*
+it, and the cheapest defence is a control with the instrument removed.
+
+**It survives a relay, and the relay widens it.** A worker measured which Kyle
+`steward` archetype exists and answered about `memory-steward`. The answer was
+forwarded upward, over the forwarder's own signature, without re-measuring, as an
+answer about `steward` - and used to argue that an operator's request named
+something else. One `ls` on the same host would have shown four steward manifests.
+The gap was introduced **by the act of passing the result along**: a forwarder
+verifies claims they receive and stops verifying claims they transmit, as though
+transmission were not also assertion, and the recipient cannot tell the two apart
+because both arrive with the same signature on them. Remedy, same cost as the
+others: **verify what you forward at the standard you verify what you receive.**
+
+**Knowing the pattern confers no immunity.** While verifying #833's fix, a
+reviewer checking for overcorrection asked `binaries_in_script()` whether three
+scripts declared any mandatory guarded binary. All three returned `[]`, and that
+was very nearly read as "the real invocations are still detected". It is not:
+`[]` is also what you get when the name is not in the guarded set, which it was
+not. Two questions with the same empty answer - question 1 again, in the
+verification rather than in the code. It was caught because the uniformity looked
+wrong, not because the check said so. This instance occurred inside a review
+conducted *for* this pattern.
+
+## The instance index
+
+The twenty-one instances this contract was derived from. Kept here, in the guidance,
+rather than in the issue that indexed them - a finding that lives only in a closed
+issue is the condition #834 was filed to end. Link new instances here.
+
+| instance | the check answers | the reader takes it for | state |
+|---|---|---|---|
+| #804 | did this step pass, in some run | did this tree pass | fixed |
+| #808 | did the gates I know about run | did the gates run | fixed |
+| #810 | did the base move in this window | did the base move | open |
+| #816 / #819 | is this literal pattern present | is the invocation correct | fixed |
+| #821 | is there watcher-shaped argv | is there a watcher on *my* mailbox | fixed |
+| #823 | is the repo clean | is what sessions execute clean | fixed |
+| #828 | does each installed helper match | is every helper installed | fixed |
+| #831 | is a *guarded* binary unguarded | is *any* binary unguarded | open |
+| #833 | is this name at command position | is this binary invoked | fixed |
+| #835 | can this driver do implementation-scope / web work | can this driver do *this* task | fixed |
+| #836 | did the delegated process exit clean | did the delegated work happen | open |
+| #838 | is this name at command position | is this binary invoked (assignment, quoted text) | fixed |
+| #840 | are the tests I found all guarded | are all tests guarded (0 when there are none) | fixed |
+| #841 | do the pointers I found resolve | do all pointers resolve (vacuous over zero) | fixed |
+| #845 | is there a watcher with this wave NAME | is there a watcher on this mailbox (ps lane) | fixed |
+| #848 / #852 | did the merge happen | did the merge complete, cleanup included | #848 fixed, #852 open |
+| #867 | has *anything* acknowledged this message | did the agent behind this role receive it | open |
+| #869 | is there a socket file at this path | is that session alive | open |
+| #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
+| kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
+| kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
+
+Three further instances have no issue number because they were found in
+instruments and in relays rather than in shipped checks; they are described under
+"Seven properties" above.
+
+Three of these (#867, #869, #877) were filed after the index was written, and #877
+was found while routing the work that produced this document. That is the standing
+argument for keeping this file current rather than treating the class as closed.
+
+## What this document does not do
+
+It is guidance plus a routing tripwire, not a scanner. "Does this success message
+claim more than its input population supports" is a question about the relationship
+between a message and a population, and it is not mechanically decidable - a
+checker for it would be an instance of the very pattern. What is enforced
+mechanically is narrower and stated honestly: `tests/test_detector_contracts.py`
+fails when a review surface stops pointing here, and the required test shapes above
+are carried by review.

--- a/codex/skills/flow-auto/docs/agents/detector-contracts.md
+++ b/codex/skills/flow-auto/docs/agents/detector-contracts.md
@@ -4,7 +4,7 @@ A check, gate, guard, tripwire or allowlist makes a claim. This document is the
 canonical statement of what that claim has to be able to say, and of the two
 questions a reviewer asks of any diff that adds or changes one.
 
-It exists because the pattern below was diagnosed twenty-three times across two
+It exists because the pattern below was diagnosed twenty-four times across two
 repositories and written down in exactly one place: issue #834. A shape that
 lives in one issue cannot be applied in review, so the next instance has nothing
 to reference. Other surfaces point here; they do not restate it.
@@ -224,7 +224,7 @@ conducted *for* this pattern.
 
 ## The instance index
 
-The twenty-three instances this contract was derived from. Kept here, in the guidance,
+The twenty-four instances this contract was derived from. Kept here, in the guidance,
 rather than in the issue that indexed them - a finding that lives only in a closed
 issue is the condition #834 was filed to end. Link new instances here.
 
@@ -251,6 +251,7 @@ issue is the condition #834 was filed to end. Link new instances here.
 | #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
 | this change (pkill) | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
 | this change (base sync) | are the ADDED LINES byte-identical | is the change still what was approved | fixed in flight |
+| this change (index rule) | does this diff delete any FILE | does this change delete anything | fixed in flight |
 | kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
 | kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
 
@@ -289,6 +290,35 @@ So "the added lines are unchanged" and "the change still does what was approved"
 are two questions with the same reassuring answer, and only the second was being
 asked. The reviewer who caught it is the one who went and read the merged file
 rather than accepting the byte comparison.
+
+The `this change (index rule)` row is the third from this one change, and it is
+the one to read if you only read one. Governing how this document may be edited,
+its author proposed a rule with a condition - *the change deletes nothing* - and a
+verification for it: `git diff <base> HEAD --diff-filter=D --name-only` must be
+empty.
+
+`--diff-filter=D` selects **deleted files**. It cannot see a deleted **line**. So
+the verification answers "does this diff remove a file?" while the condition it
+was offered for is "does this diff remove anything?", and a change that rewrote
+the document line for line would satisfy the check while violating the rule.
+
+Then the sharper half. Run against the very commit that proposed it:
+
+```
+git diff 3327cb2 a8dc13c --diff-filter=D --name-only   ->  (empty)      passes
+git diff 3327cb2 a8dc13c --numstat                     ->  26  5  ...   five deletions
+```
+
+The condition was not merely unenforced - it was **wrong**. Every genuine row
+addition edits the count line in this section, and editing a line is a deletion
+plus an addition, so *deletes nothing* voids exactly the changes the rule exists
+to permit.
+
+Two errors that cancelled: a condition too strict to be met, and a check too weak
+to notice. Each concealed the other and the proposal read as coherent. The lesson
+is not that either mistake is exotic - it is that a check and the condition it
+enforces are two claims, and agreeing with each other is not evidence that either
+is right.
 
 Three of these (#867, #869, #877) were filed after the index was written, and #877
 was found while routing the work that produced this document. That is the standing

--- a/codex/skills/flow-auto/reference.md
+++ b/codex/skills/flow-auto/reference.md
@@ -584,6 +584,15 @@ reason is something to surface, never grounds to drop it.
 not manufacture an alternative, an experiment or a challenge for work that does not
 need one.
 
+**If the change adds or modifies a check, gate, guard, tripwire or allowlist**, ask
+the two questions from
+[the detector contracts](docs/agents/detector-contracts.md) before you
+call it done - does its success message claim more than its input population
+supports, and can a finding tell our thing from a neighbour's - and write the
+answer in as a test rather than a comment. Where the narrow answer is deliberately
+correct, widening is not the remedy: say where the larger question is answered
+instead.
+
 If implementation hits a blocker that cannot be resolved:
 - **STOP** and report the blocker.
 - Suggest manual intervention.

--- a/docs/agents/detector-contracts.md
+++ b/docs/agents/detector-contracts.md
@@ -4,7 +4,7 @@ A check, gate, guard, tripwire or allowlist makes a claim. This document is the
 canonical statement of what that claim has to be able to say, and of the two
 questions a reviewer asks of any diff that adds or changes one.
 
-It exists because the pattern below was diagnosed twenty-two times across two
+It exists because the pattern below was diagnosed twenty-three times across two
 repositories and written down in exactly one place: issue #834. A shape that
 lives in one issue cannot be applied in review, so the next instance has nothing
 to reference. Other surfaces point here; they do not restate it.
@@ -224,7 +224,7 @@ conducted *for* this pattern.
 
 ## The instance index
 
-The twenty-two instances this contract was derived from. Kept here, in the guidance,
+The twenty-three instances this contract was derived from. Kept here, in the guidance,
 rather than in the issue that indexed them - a finding that lives only in a closed
 issue is the condition #834 was filed to end. Link new instances here.
 
@@ -249,7 +249,8 @@ issue is the condition #834 was filed to end. Link new instances here.
 | #867 | has *anything* acknowledged this message | did the agent behind this role receive it | open |
 | #869 | is there a socket file at this path | is that session alive | open |
 | #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
-| this change | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
+| this change (pkill) | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
+| this change (base sync) | are the ADDED LINES byte-identical | is the change still what was approved | fixed in flight |
 | kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
 | kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
 
@@ -257,8 +258,7 @@ Three further instances are not in the table at all: they were found in
 instruments and in relays rather than in shipped checks, so there is no detector
 to name in the columns. They are described under "Seven properties" above.
 
-The `this change` row is the sharpest evidence in the table, and it is here
-deliberately. Writing this document, its author ran
+The `this change (pkill)` row is here deliberately. Writing this document, its author ran
 `pkill -f "issue-834/.venv/bin/pytest"` to clear a stale test process. The shell
 executing that command had the pattern inside its own command line, so the
 pattern matched the process doing the matching and the shell killed itself
@@ -268,6 +268,27 @@ recurrence under field conditions is stronger evidence about the class than the
 original finding, because it shows the pattern survives being known - which is
 the claim "Knowing the pattern confers no immunity" makes, now with a second
 witness.
+
+The `this change (base sync)` row is the same story with a better ending, because
+the check was caught before anyone relied on it. Landing this document required a
+base sync, and the question was whether the approved change had survived it. The
+answer given was a comparison of the two diffs' **added lines**: 925 both sides,
+byte-identical, zero deletions. True, and it was offered as evidence that "the
+change is still what was approved".
+
+It cannot support that. Its population is added lines, and it excludes the context
+those lines land in. The sibling PR in the same wave had edited the same file, and
+had this change also added a `### Step 5` heading, the added lines would have been
+byte-identical **and** the merged document would have carried two Step 5 sections.
+Git auto-merges that without a conflict; the check reports byte-identical with
+exactly the same confidence. What actually settled the question was reading the
+merged file's heading structure - one Step 5, at line 130 - which is a different
+measurement entirely.
+
+So "the added lines are unchanged" and "the change still does what was approved"
+are two questions with the same reassuring answer, and only the second was being
+asked. The reviewer who caught it is the one who went and read the merged file
+rather than accepting the byte comparison.
 
 Three of these (#867, #869, #877) were filed after the index was written, and #877
 was found while routing the work that produced this document. That is the standing

--- a/docs/agents/detector-contracts.md
+++ b/docs/agents/detector-contracts.md
@@ -4,7 +4,7 @@ A check, gate, guard, tripwire or allowlist makes a claim. This document is the
 canonical statement of what that claim has to be able to say, and of the two
 questions a reviewer asks of any diff that adds or changes one.
 
-It exists because the pattern below was diagnosed twenty-one times across two
+It exists because the pattern below was diagnosed twenty-two times across two
 repositories and written down in exactly one place: issue #834. A shape that
 lives in one issue cannot be applied in review, so the next instance has nothing
 to reference. Other surfaces point here; they do not restate it.
@@ -224,7 +224,7 @@ conducted *for* this pattern.
 
 ## The instance index
 
-The twenty-one instances this contract was derived from. Kept here, in the guidance,
+The twenty-two instances this contract was derived from. Kept here, in the guidance,
 rather than in the issue that indexed them - a finding that lives only in a closed
 issue is the condition #834 was filed to end. Link new instances here.
 
@@ -249,12 +249,25 @@ issue is the condition #834 was filed to end. Link new instances here.
 | #867 | has *anything* acknowledged this message | did the agent behind this role receive it | open |
 | #869 | is there a socket file at this path | is that session alive | open |
 | #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
+| this change | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
 | kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
 | kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
 
-Three further instances have no issue number because they were found in
-instruments and in relays rather than in shipped checks; they are described under
-"Seven properties" above.
+Three further instances are not in the table at all: they were found in
+instruments and in relays rather than in shipped checks, so there is no detector
+to name in the columns. They are described under "Seven properties" above.
+
+The `this change` row is the sharpest evidence in the table, and it is here
+deliberately. Writing this document, its author ran
+`pkill -f "issue-834/.venv/bin/pytest"` to clear a stale test process. The shell
+executing that command had the pattern inside its own command line, so the
+pattern matched the process doing the matching and the shell killed itself
+(exit 144). That is #821's identity defect exactly, committed live, by someone
+who had spent the preceding hour writing #821's row into this table. A
+recurrence under field conditions is stronger evidence about the class than the
+original finding, because it shows the pattern survives being known - which is
+the claim "Knowing the pattern confers no immunity" makes, now with a second
+witness.
 
 Three of these (#867, #869, #877) were filed after the index was written, and #877
 was found while routing the work that produced this document. That is the standing

--- a/docs/agents/detector-contracts.md
+++ b/docs/agents/detector-contracts.md
@@ -1,0 +1,271 @@
+# Detector Contracts
+
+A check, gate, guard, tripwire or allowlist makes a claim. This document is the
+canonical statement of what that claim has to be able to say, and of the two
+questions a reviewer asks of any diff that adds or changes one.
+
+It exists because the pattern below was diagnosed twenty-one times across two
+repositories and written down in exactly one place: issue #834. A shape that
+lives in one issue cannot be applied in review, so the next instance has nothing
+to reference. Other surfaces point here; they do not restate it.
+
+## The shape
+
+**A detector answers the question it was built for. Its reader supplies a larger
+one.** Both statements are true of the code; only the narrow one is true of the
+check.
+
+The failure is never a wrong answer. It is a *correct narrow answer read as a
+broad one*, which is why ordinary review does not catch it: the code does exactly
+what it says, and what it says is not what the caller needs.
+
+## The two questions
+
+Ask both of any check in a diff. They are the whole contract; everything below is
+evidence that they are worth asking.
+
+### 1. Membership floor
+
+> **Does this check's success message claim more than its input population
+> supports?**
+
+Not "did it examine anything" - a check that examines nothing can still be
+honest. The distinction is between reporting a count and asserting a universal.
+Two gates in this repository, measured against an empty input:
+
+| gate | on an empty input | honest? |
+|---|---|---|
+| `check-claude-md-budget.py` | `ok - 0/2000 words`, exit 0 | **yes** - a numeric aggregate; the number *is* the population count |
+| `check-claude-md-links.py`, before #841 | `ok - every repository-local pointer resolves`, exit 0 | **no** - vacuously true over zero pointers |
+| `check-claude-md-links.py`, after #841 | `contains no repository-local pointers - nothing was checked`, exit 1 | **yes** - the empty population is now a state it can report |
+
+Both original forms exited 0 having examined nothing. Only one was a defect,
+because only one asserted something about every member of a set it never
+established was non-empty. A count reports what it found; a universal claim over
+an empty set reports a guarantee it never tested. The third row is the remedy
+landed (#847) and is what "fixed" looks like: not a wider scan, but a detector
+that can now say the one thing it previously could not.
+
+The remedy is that the detector must be able to **represent the state it
+currently cannot see**. A fixed set of four names cannot represent a fifth; an
+iteration over the installed side cannot represent a missing item; a `0` returned
+because the directory does not exist cannot be told from a `0` that means clean.
+
+### 2. Ownership boundary
+
+> **Can a non-zero from this check distinguish "our thing changed" from
+> "something that is not ours changed"?**
+
+If not, an unrelated neighbour produces a finding, or worse is silently counted
+as ours. Watcher-shaped argv belonging to a different mailbox satisfies a
+watcher-shaped search (#821). A variable that is shaped like a per-session
+variable while being a property of the parent process is forwarded by a check
+keyed on the shape (kyle#994).
+
+The inverted form is worth naming separately: a *correct broad* answer can be
+overridden by a narrow one. In #869 `kill -0` correctly says the pid is dead and
+the presence of a socket file says otherwise, and the file wins. Here the narrow
+check does not merely get over-read - it defeats the broad one.
+
+## Writing the answer into the code
+
+For any check in a diff, ask the two questions and **write the answer into the
+code as a test.** A comment saying what the check does not cover decays; a test
+named for the state the detector cannot currently represent does not.
+
+Two test shapes carry this, and a reviewer should expect to see the relevant one:
+
+- **A positive control**, proving the detector is capable of firing at all.
+  Prior art: `tests/test_pythonpath_lib_depth.py::test_depth_detector_can_fire`
+  (#816).
+- **A named residual**, pinning a known blind spot as a property rather than a
+  TODO. Prior art:
+  `tests/test_flow_wave_mailbox.py::test_a_same_wave_orphan_would_not_be_excluded_by_directory_alone`
+  (#821).
+
+A test that passes over an empty population proves nothing, and is itself an
+instance of question 1. This applies to the tripwire guarding this document:
+`tests/test_detector_contracts.py` asserts its own surface list is non-empty and
+complete before asserting anything about the surfaces in it.
+
+## A worked example, from this repository's own tooling
+
+`scripts/flow-driver-capability.sh` decides which driver an issue may run on. Asked
+about #834 - the issue that produced this document - it answered:
+
+```
+FLOW_DRIVER_NEEDS=implementation
+FLOW_DRIVER_CHECK: fit
+```
+
+That answer is correct. The deliverable *is* a source diff, not research and not a
+live-source question, which is what the three declared axes (`scope`, `web`,
+`container`) are about. Its reader took it for **"can this driver do this issue?"**
+- and the #735 execution fence forbids the delegated driver from reading
+`.claude/commands/**`, which is where five of #834's nine files live. The driver
+was structurally inapplicable and the preflight said `fit` (#877).
+
+This is question 1 in a non-obvious dress. The check's input population was the
+deliverable's **kind**; the population it needed was the deliverable's **paths**.
+There is no axis for "the planned file list intersects the fence", so the check
+cannot represent the state that decides the answer - and `fit` therefore claims
+more than its population supports.
+
+It is the specimen worth remembering because both halves are inside this
+repository's own tooling, and because the detector that mis-routed the issue about
+detectors saying too little was the detector choosing that issue's driver. The
+routing rule it implies - *an issue whose deliverable includes any file under
+`.claude/commands/**` or `.claude/skills/**` runs on `/flow:auto`* - is #877's to
+land, not this document's.
+
+## When widening is not the remedy
+
+**"Widen the detector" does not generalise, and assuming it does is how this
+document would make things worse.**
+
+`scripts/delegated-run-check.sh` (#836) is the strongest case. `is_fatal` is
+scoped to the top level of an event *deliberately*: the recursive version existed,
+made every fenced `git commit` attempt a failed run, and was reverted for a stated
+reason that still holds. The header says it outright - *a guard against false
+success that manufactures false failure is not an improvement.* The author knew
+the scope exactly, documented it, and chose it correctly. The reader supplies the
+larger question anyway.
+
+So where the narrow answer is right, **the larger question needs somewhere else to
+live** - a new channel, a caller-supplied postcondition, a separate signal - not a
+widened existing one. That is a different and harder fix than widening, and
+recognising which of the two you are looking at is the judgement this document
+asks for.
+
+## What the two open dependents answer
+
+Stated here so each is implementable against this contract rather than against a
+conversation:
+
+| issue | question it answers | shape of the fix |
+|---|---|---|
+| #836 | **Ownership boundary**, in its hardest form: `DELEGATED_RUN_STATUS` cannot distinguish "the delegated *process* ran cleanly" from "the delegated *work* happened". A denied tool call satisfies every signal the checker has. | **Not** widening `is_fatal` - see above. The larger question needs its own home: a distinct non-fatal signal, or a caller-supplied postcondition. |
+| #831 | **Membership floor**: `check-test-binary-guards.py` answers "is a *guarded* binary unguarded" and is read as "is *any* binary unguarded". A fixed set of four names cannot represent a fifth. | Make the set able to represent a binary nobody put on it. Measurement on the pinned CI image found no live gap behind it, so this is a correctness fix, not an outage fix. |
+
+## Seven properties that let it survive review
+
+These are why the two questions are worth asking explicitly rather than trusting
+a careful reader to notice.
+
+**It survives awareness.** The kyle#994 workaround named four variables and had no
+floor for the namespace beside it - the same defect as the allowlist it was
+working around. It was written by the person who had just diagnosed that
+allowlist. Every other instance was written by someone who had not yet seen the
+pattern; that one was not, which is the strongest available evidence that this is
+a cognitive pull rather than a run of unrelated oversights.
+
+**It survives correct scoping.** See "When widening is not the remedy" above.
+
+**A narrow input set conceals it.** #833 was latent *because* `GUARDED_BINARIES`
+held four long, distinctive tokens. Widening the set - the fix #831 asks for - is
+what exposed it, producing 101 false findings from one `case` label. So "this has
+never caused a problem" is not evidence a detector is sound; it can mean only that
+nothing has yet been passed to it that its blind spot covers. Fixing one blind
+spot exposes the next: #831 -> #833 -> #838 -> #840 -> #841 is a five-step cascade
+in one file family, each step invisible until its predecessor closed.
+
+**It appears in the instrument built to detect it.** A `/proc` scan written to
+verify that every session held a live mailbox watch reported three watches for its
+own session; two were the probe matching itself, because it matched on a substring
+that is by construction inside the command line doing the matching. The useful
+part is the direction: **self-matching inflates a count and cannot manufacture an
+absence**, so the diagnosis it was built for ("this session has no watch") was
+still sound - but sound by luck. Had the failure been "two watches racing", the
+same instrument would have reported it backwards. An instrument whose error has a
+known direction can still be trusted for the half of the question that direction
+cannot reach, and that is a much narrower warrant than "the tool works".
+
+**The gap can be self-inflicted by the instrument.** In kyle#997 the narrow answer
+was manufactured rather than inherent: watch invocations ended `2>&1 | tail -40`,
+and later `; echo "EXIT=$?"`. Both make the reported status that of a command that
+cannot fail.
+
+```
+false | tail -1                    -> 0     pipeline exit = LAST command
+false; echo x                      -> 0     compound exit = LAST command
+set -o pipefail; false | tail -1    -> 1
+bash -c 'exit 5' 2>&1 | tail -40    -> 0     <- the masking form
+```
+
+The conclusion drawn was "the harness masks the exit code", and the evidence for
+it was the 0 the instrument had just forced. **The measurement apparatus produced
+the artifact it then detected**, and because the same artifact was present in
+every run, the false pattern looked consistent across hours - consistency read as
+corroboration when it was a constant. A bare control run settled it in one attempt:
+exit 5, reported accurately. The lesson is not "know the pipefail rule"; it is that
+a reading taken *through* an instrument is not evidence about the state *without*
+it, and the cheapest defence is a control with the instrument removed.
+
+**It survives a relay, and the relay widens it.** A worker measured which Kyle
+`steward` archetype exists and answered about `memory-steward`. The answer was
+forwarded upward, over the forwarder's own signature, without re-measuring, as an
+answer about `steward` - and used to argue that an operator's request named
+something else. One `ls` on the same host would have shown four steward manifests.
+The gap was introduced **by the act of passing the result along**: a forwarder
+verifies claims they receive and stops verifying claims they transmit, as though
+transmission were not also assertion, and the recipient cannot tell the two apart
+because both arrive with the same signature on them. Remedy, same cost as the
+others: **verify what you forward at the standard you verify what you receive.**
+
+**Knowing the pattern confers no immunity.** While verifying #833's fix, a
+reviewer checking for overcorrection asked `binaries_in_script()` whether three
+scripts declared any mandatory guarded binary. All three returned `[]`, and that
+was very nearly read as "the real invocations are still detected". It is not:
+`[]` is also what you get when the name is not in the guarded set, which it was
+not. Two questions with the same empty answer - question 1 again, in the
+verification rather than in the code. It was caught because the uniformity looked
+wrong, not because the check said so. This instance occurred inside a review
+conducted *for* this pattern.
+
+## The instance index
+
+The twenty-one instances this contract was derived from. Kept here, in the guidance,
+rather than in the issue that indexed them - a finding that lives only in a closed
+issue is the condition #834 was filed to end. Link new instances here.
+
+| instance | the check answers | the reader takes it for | state |
+|---|---|---|---|
+| #804 | did this step pass, in some run | did this tree pass | fixed |
+| #808 | did the gates I know about run | did the gates run | fixed |
+| #810 | did the base move in this window | did the base move | open |
+| #816 / #819 | is this literal pattern present | is the invocation correct | fixed |
+| #821 | is there watcher-shaped argv | is there a watcher on *my* mailbox | fixed |
+| #823 | is the repo clean | is what sessions execute clean | fixed |
+| #828 | does each installed helper match | is every helper installed | fixed |
+| #831 | is a *guarded* binary unguarded | is *any* binary unguarded | open |
+| #833 | is this name at command position | is this binary invoked | fixed |
+| #835 | can this driver do implementation-scope / web work | can this driver do *this* task | fixed |
+| #836 | did the delegated process exit clean | did the delegated work happen | open |
+| #838 | is this name at command position | is this binary invoked (assignment, quoted text) | fixed |
+| #840 | are the tests I found all guarded | are all tests guarded (0 when there are none) | fixed |
+| #841 | do the pointers I found resolve | do all pointers resolve (vacuous over zero) | fixed |
+| #845 | is there a watcher with this wave NAME | is there a watcher on this mailbox (ps lane) | fixed |
+| #848 / #852 | did the merge happen | did the merge complete, cleanup included | #848 fixed, #852 open |
+| #867 | has *anything* acknowledged this message | did the agent behind this role receive it | open |
+| #869 | is there a socket file at this path | is that session alive | open |
+| #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
+| kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
+| kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
+
+Three further instances have no issue number because they were found in
+instruments and in relays rather than in shipped checks; they are described under
+"Seven properties" above.
+
+Three of these (#867, #869, #877) were filed after the index was written, and #877
+was found while routing the work that produced this document. That is the standing
+argument for keeping this file current rather than treating the class as closed.
+
+## What this document does not do
+
+It is guidance plus a routing tripwire, not a scanner. "Does this success message
+claim more than its input population supports" is a question about the relationship
+between a message and a population, and it is not mechanically decidable - a
+checker for it would be an instance of the very pattern. What is enforced
+mechanically is narrower and stated honestly: `tests/test_detector_contracts.py`
+fails when a review surface stops pointing here, and the required test shapes above
+are carried by review.

--- a/docs/agents/detector-contracts.md
+++ b/docs/agents/detector-contracts.md
@@ -4,7 +4,7 @@ A check, gate, guard, tripwire or allowlist makes a claim. This document is the
 canonical statement of what that claim has to be able to say, and of the two
 questions a reviewer asks of any diff that adds or changes one.
 
-It exists because the pattern below was diagnosed twenty-three times across two
+It exists because the pattern below was diagnosed twenty-four times across two
 repositories and written down in exactly one place: issue #834. A shape that
 lives in one issue cannot be applied in review, so the next instance has nothing
 to reference. Other surfaces point here; they do not restate it.
@@ -224,7 +224,7 @@ conducted *for* this pattern.
 
 ## The instance index
 
-The twenty-three instances this contract was derived from. Kept here, in the guidance,
+The twenty-four instances this contract was derived from. Kept here, in the guidance,
 rather than in the issue that indexed them - a finding that lives only in a closed
 issue is the condition #834 was filed to end. Link new instances here.
 
@@ -251,6 +251,7 @@ issue is the condition #834 was filed to end. Link new instances here.
 | #877 | is this deliverable a code change | can this driver do *this issue* (fence-forbidden paths) | open |
 | this change (pkill) | does a process match `pgrep -f <pattern>` | does a process OTHER THAN ME match it | fixed in flight |
 | this change (base sync) | are the ADDED LINES byte-identical | is the change still what was approved | fixed in flight |
+| this change (index rule) | does this diff delete any FILE | does this change delete anything | fixed in flight |
 | kyle#994 | is this variable one of the nine safe ones | is this variable safe to forward | fixed |
 | kyle#997 | what did the task *wrapper* exit with | what did the *watch* exit with | fixed |
 
@@ -289,6 +290,35 @@ So "the added lines are unchanged" and "the change still does what was approved"
 are two questions with the same reassuring answer, and only the second was being
 asked. The reviewer who caught it is the one who went and read the merged file
 rather than accepting the byte comparison.
+
+The `this change (index rule)` row is the third from this one change, and it is
+the one to read if you only read one. Governing how this document may be edited,
+its author proposed a rule with a condition - *the change deletes nothing* - and a
+verification for it: `git diff <base> HEAD --diff-filter=D --name-only` must be
+empty.
+
+`--diff-filter=D` selects **deleted files**. It cannot see a deleted **line**. So
+the verification answers "does this diff remove a file?" while the condition it
+was offered for is "does this diff remove anything?", and a change that rewrote
+the document line for line would satisfy the check while violating the rule.
+
+Then the sharper half. Run against the very commit that proposed it:
+
+```
+git diff 3327cb2 a8dc13c --diff-filter=D --name-only   ->  (empty)      passes
+git diff 3327cb2 a8dc13c --numstat                     ->  26  5  ...   five deletions
+```
+
+The condition was not merely unenforced - it was **wrong**. Every genuine row
+addition edits the count line in this section, and editing a line is a deletion
+plus an addition, so *deletes nothing* voids exactly the changes the rule exists
+to permit.
+
+Two errors that cancelled: a condition too strict to be met, and a check too weak
+to notice. Each concealed the other and the proposal read as coherent. The lesson
+is not that either mistake is exotic - it is that a check and the condition it
+enforces are two claims, and agreeing with each other is not evidence that either
+is right.
 
 Three of these (#867, #869, #877) were filed after the index was written, and #877
 was found while routing the work that produced this document. That is the standing

--- a/tests/test_detector_contracts.py
+++ b/tests/test_detector_contracts.py
@@ -1,0 +1,288 @@
+"""Routing tripwire for the canonical detector contract (issue #834).
+
+#834 indexed twenty-one defects across two repositories that share one shape: a
+check answers the narrow question it was built for, and its reader supplies a
+broader one. The instances were fixed one at a time and the *shape* lived in a
+single GitHub issue, so the next instance had nothing to reference. #834 asked
+for it to be given a home in the review guidance; `docs/agents/detector-contracts.md`
+is that home, and this file is the tripwire that keeps the surfaces pointing at it.
+
+The failure mode guarded here is drift: a review surface stops pointing at the
+canonical document, or a new review surface is added that never pointed at it.
+Those are structural facts about files, so these assertions are structural.
+Nothing here inspects policy wording beyond the two question sentences - a test
+that pins prose breaks on every legitimate edit and gets relaxed until it means
+nothing.
+
+Per the contract this file guards, the two properties it must be able to assert
+of itself:
+
+  * Its review-surface set is DISCOVERED from the tree, not sampled. A sixth
+    review surface added tomorrow without the questions fails
+    ``test_every_discovered_review_surface_points_at_the_contract``. That is the
+    ownership half - the set is derived from what is actually there rather than
+    from what someone remembered to list.
+  * It carries THREE controls, because a weaker set would leave the same hole one
+    level up. ``test_the_surface_detector_can_fire`` proves the matcher fires;
+    ``test_discovery_finds_nothing_in_a_tree_with_no_review_surface`` proves it is
+    not matching everything; and
+    ``test_discovery_reaches_the_real_root_a_new_surface_would_appear_in``
+    plants a probe in the ACTUAL scanned root, because a scan aimed at the wrong
+    directory passes a synthetic-fixture control and still sees nothing real.
+    ``test_discovery_is_not_vacuous`` pins the floor on the live set. Without
+    these, "every surface points at the contract" would be vacuously true over
+    zero surfaces - question 1 of the contract, in the test rather than the code.
+
+What a green run does NOT prove, stated so nobody reads it as more:
+
+  * It does not prove any reviewer ASKED the two questions. Routing is not use.
+  * It does not discover a review surface that carries none of ``REVIEW_MARKERS``
+    - a document that instructs review in wording nobody anticipated is invisible
+    here, and this test passing says nothing about it. The markers are a tripwire,
+    not a census of every way a document could ask for a review.
+  * It scans ``SCANNED_ROOTS`` only. A review surface that lands outside both -
+    a README, a docs/ page, a template - is invisible, and the real-root control
+    above proves only that the roots it DOES scan are live. Widening the roots is
+    cheap; knowing which new root to add is the part no test supplies.
+  * ``INDEXED_INSTANCES`` is a fixed list copied from #834. It pins that closing
+    that issue does not bury its instances; it cannot notice an instance filed
+    somewhere this repository never sees.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+CANONICAL = Path("docs/agents/detector-contracts.md")
+# Roots scanned for review surfaces. `.claude/commands/` holds them today;
+# `.claude/skills/` is scanned too because nothing makes a review surface a
+# COMMAND document, and a tripwire whose root is narrower than the thing it
+# guards cannot represent a surface that appears one directory over.
+# `codex/skills/` is deliberately excluded: it is generated from these roots by
+# scripts/codex-skill-sync.py, so a finding there would be a duplicate of its
+# source and `tests/test_codex_skill_sync.py` already pins that mirror.
+SCANNED_ROOTS = (REPO / ".claude" / "commands", REPO / ".claude" / "skills")
+
+# A command document is a REVIEW SURFACE when it tells a reader to review a
+# change. These are the shapes actually in the tree; see the docstring for what
+# they cannot see.
+REVIEW_MARKERS = (
+    "**Review for:**",
+    "Review for: correctness",
+    "Review - Claude Reviews",
+)
+
+# Surfaces that instruct review WITHOUT carrying a marker above, pinned by name.
+# `/flow:auto` implements directly rather than reviewing a delegate's diff, so
+# its detector guidance lives in its implement step and no marker applies.
+PINNED_SURFACES = (Path(".claude/commands/flow/auto.md"),)
+
+# The reference every routed surface must carry.
+CONTRACT_LINK = "docs/agents/detector-contracts.md"
+
+# The two questions, as the canonical document states them. Matched against a
+# whitespace-normalized read so re-wrapping a blockquote is not a test failure.
+QUESTION_MEMBERSHIP = (
+    "Does this check's success message claim more than its input population supports?"
+)
+QUESTION_OWNERSHIP = (
+    'Can a non-zero from this check distinguish "our thing changed" from '
+    '"something that is not ours changed"?'
+)
+
+
+def normalized(text: str) -> str:
+    """Collapse blockquote markers and line wrapping so prose can be re-wrapped."""
+    return " ".join(text.replace("> ", " ").split())
+
+# Every instance #834 indexed. Closing #834 must not bury these, so the canonical
+# document has to carry each one (the orchestrator's condition on the close).
+INDEXED_INSTANCES = (
+    "#804",
+    "#808",
+    "#810",
+    "#816",
+    "#819",
+    "#821",
+    "#823",
+    "#828",
+    "#831",
+    "#833",
+    "#835",
+    "#836",
+    "#838",
+    "#840",
+    "#841",
+    "#845",
+    "#848",
+    "#852",
+    "#867",
+    "#869",
+    "#877",
+    "kyle#994",
+    "kyle#997",
+)
+
+
+def discover_review_surfaces(*roots: Path) -> list[Path]:
+    """Every document under `roots` that instructs a reader to review a change."""
+    found = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            if any(marker in text for marker in REVIEW_MARKERS):
+                found.append(path)
+    return sorted(found)
+
+
+def test_canonical_document_exists_and_states_both_questions() -> None:
+    doc = REPO / CANONICAL
+    assert doc.is_file(), f"{CANONICAL} is missing - the contract has no home"
+    text = normalized(doc.read_text(encoding="utf-8"))
+    assert QUESTION_MEMBERSHIP in text, "the membership-floor question is not stated"
+    assert QUESTION_OWNERSHIP in text, "the ownership-boundary question is not stated"
+
+
+def test_the_surface_detector_can_fire(tmp_path: Path) -> None:
+    """Positive control: the discovery function matches a synthetic surface.
+
+    Without this, a green `test_every_discovered_review_surface_points_at_the_contract`
+    is indistinguishable from a matcher that stopped matching anything.
+    """
+    (tmp_path / "made_up.md").write_text(
+        "# Some command\n\n2. **Review for:**\n   - Correctness\n", encoding="utf-8"
+    )
+    assert discover_review_surfaces(tmp_path) == [tmp_path / "made_up.md"]
+
+
+def test_discovery_finds_nothing_in_a_tree_with_no_review_surface(tmp_path: Path) -> None:
+    """Negative control: the matcher is not matching everything it is shown."""
+    (tmp_path / "unrelated.md").write_text("# Notes\n\nNothing to review here.\n", encoding="utf-8")
+    assert discover_review_surfaces(tmp_path) == []
+
+
+@pytest.mark.parametrize("root", SCANNED_ROOTS, ids=lambda r: r.name)
+def test_discovery_reaches_the_real_root_a_new_surface_would_appear_in(root: Path) -> None:
+    """The control that matters: the scan is pointed where a surface would land.
+
+    `test_the_surface_detector_can_fire` proves the matcher works on a directory
+    handed to it. That is a weaker claim than it looks: a scan aimed at the wrong
+    root passes it and still sees nothing real. So this plants a probe inside the
+    ACTUAL scanned root and asserts discovery returns it - proving the check runs
+    where a new review surface would appear, not merely that it can match text.
+    """
+    assert root.is_dir(), f"{root.relative_to(REPO)} is no longer a real directory"
+    probe = root / "_detector_contract_probe_" / "probe.md"
+    probe.parent.mkdir(parents=True, exist_ok=False)
+    try:
+        probe.write_text("# probe\n\n2. **Review for:**\n   - Correctness\n", encoding="utf-8")
+        assert probe in discover_review_surfaces(*SCANNED_ROOTS), (
+            f"a review surface added under {root.relative_to(REPO)} would not be discovered"
+        )
+    finally:
+        probe.unlink(missing_ok=True)
+        probe.parent.rmdir()
+
+
+def test_discovery_is_not_vacuous() -> None:
+    """Membership floor on the real tree: the set must be non-empty and known.
+
+    A zero here would make the routing assertion below vacuously true, which is
+    precisely the defect `docs/agents/detector-contracts.md` exists to name.
+    """
+    surfaces = {p.relative_to(REPO) for p in discover_review_surfaces(*SCANNED_ROOTS)}
+    assert surfaces, "no review surface discovered - the markers have stopped matching"
+    expected = {
+        Path(".claude/commands/codex/auto.md"),
+        Path(".claude/commands/codex/code_review.md"),
+        Path(".claude/commands/qwen/auto.md"),
+        Path(".claude/commands/gemma/auto.md"),
+    }
+    missing = expected - surfaces
+    assert not missing, f"known review surfaces no longer discovered: {sorted(map(str, missing))}"
+
+
+ROUTED_SURFACES = [
+    p.relative_to(REPO) for p in discover_review_surfaces(*SCANNED_ROOTS)
+] + list(PINNED_SURFACES)
+
+
+@pytest.mark.parametrize("surface", ROUTED_SURFACES, ids=str)
+def test_every_discovered_review_surface_points_at_the_contract(surface: Path) -> None:
+    """A review surface that does not route here is guidance nobody will reach.
+
+    This is the assertion that fails when a NEW review surface is added without
+    the two questions - the set is discovered from the tree, so adding one is
+    enough to be covered.
+    """
+    text = (REPO / surface).read_text(encoding="utf-8")
+    assert CONTRACT_LINK in text, (
+        f"{surface} instructs a review but never routes to {CANONICAL}"
+    )
+
+
+def test_claude_md_routes_to_the_contract() -> None:
+    text = (REPO / "CLAUDE.md").read_text(encoding="utf-8")
+    assert CONTRACT_LINK in text, "CLAUDE.md does not point at the detector contract"
+    assert re.search(
+        r"represent the state it cannot currently see", text
+    ), "the CLAUDE.md directive no longer states the contract it routes to"
+
+
+def test_instance_index_carries_every_indexed_instance() -> None:
+    """#834's instances must live in the doc, not only in the issue.
+
+    This is the condition on closing #834: if the document said "see #834 for the
+    list", closing the issue would bury the instances in a closed issue, which is
+    the opposite of what the issue asked for.
+    """
+    text = (REPO / CANONICAL).read_text(encoding="utf-8")
+    missing = [ref for ref in INDEXED_INSTANCES if ref not in text]
+    assert not missing, f"instances absent from the index: {missing}"
+# Test names the canonical document cites as prior art for the two test shapes.
+# A document about claims that outrun their evidence must not carry a dead
+# citation, so the pointers are pinned rather than trusted.
+CITED_PRIOR_ART = (
+    (Path("tests/test_pythonpath_lib_depth.py"), "def test_depth_detector_can_fire"),
+    (
+        Path("tests/test_flow_wave_mailbox.py"),
+        "def test_a_same_wave_orphan_would_not_be_excluded_by_directory_alone",
+    ),
+)
+
+
+@pytest.mark.parametrize(("path", "definition"), CITED_PRIOR_ART, ids=lambda v: str(v)[:60])
+def test_cited_prior_art_still_exists(path: Path, definition: str) -> None:
+    target = REPO / path
+    assert target.is_file(), f"{path} is cited by {CANONICAL} and no longer exists"
+    assert definition in target.read_text(encoding="utf-8"), (
+        f"{CANONICAL} cites {definition} in {path}, which no longer defines it"
+    )
+def test_the_properties_heading_matches_its_population() -> None:
+    """The heading counts the properties it introduces.
+
+    Written after the first draft shipped "Six properties" over a list of seven -
+    a success message claiming more than its population supports, in the document
+    about exactly that. The heading is a numeric aggregate, so the honest form is
+    for the number to BE the count.
+    """
+    words = {
+        "Five": 5, "Six": 6, "Seven": 7, "Eight": 8, "Nine": 9, "Ten": 10,
+    }
+    text = (REPO / CANONICAL).read_text(encoding="utf-8")
+    heading = re.search(r"^## (\w+) properties that let it survive review$", text, re.M)
+    assert heading, "the properties section heading has been renamed"
+    claimed = words.get(heading.group(1))
+    assert claimed is not None, f"unrecognised count word: {heading.group(1)}"
+
+    section = text.split(heading.group(0), 1)[1].split("\n## ", 1)[0]
+    actual = len(re.findall(r"^\*\*", section, re.M))
+    assert claimed == actual, (
+        f"the heading claims {claimed} properties; the section lists {actual}"
+    )

--- a/tests/test_detector_contracts.py
+++ b/tests/test_detector_contracts.py
@@ -286,3 +286,28 @@ def test_the_properties_heading_matches_its_population() -> None:
     assert claimed == actual, (
         f"the heading claims {claimed} properties; the section lists {actual}"
     )
+def test_the_index_heading_matches_its_population() -> None:
+    """The index says how many instances it carries; the number must be the count.
+
+    Same shape as the properties-heading test, on the other numeric claim in the
+    document. Both exist because the first draft shipped a heading that counted
+    six over a population of seven.
+    """
+    words = {
+        "eighteen": 18, "nineteen": 19, "twenty": 20, "twenty-one": 21,
+        "twenty-two": 22, "twenty-three": 23, "twenty-four": 24, "twenty-five": 25,
+    }
+    text = (REPO / CANONICAL).read_text(encoding="utf-8")
+    heading = re.search(r"^The ([a-z-]+) instances this contract was derived from\.", text, re.M)
+    assert heading, "the instance-index lead sentence has been reworded"
+    claimed = words.get(heading.group(1))
+    assert claimed is not None, f"unrecognised count word: {heading.group(1)}"
+
+    section = text.split("## The instance index", 1)[1].split("\n## ", 1)[0]
+    rows = [
+        line for line in section.splitlines()
+        if line.startswith("| ") and not line.startswith("| instance ") and "---" not in line
+    ]
+    assert claimed == len(rows), (
+        f"the index claims {claimed} instances; the table has {len(rows)} rows"
+    )


### PR DESCRIPTION
## What this is

#834 indexed twenty-one defects across two repositories that share one shape: **a detector answers the question it was built for, and its reader supplies a larger one.** Both statements are true of the code; only the narrow one is true of the check. The instances were fixed one at a time and the *shape* lived in exactly one place - the issue - so the next instance had nothing to reference.

This gives it a home: `docs/agents/detector-contracts.md`, routed from `CLAUDE.md` and from the five surfaces that review a change.

## The two questions, as a reviewer asks them

1. **Membership floor** - does this check's success message claim more than its input population supports? Not "did it examine anything": a count is honest over zero, a universal claim is not. The remedy is that the detector must be able to *represent the state it cannot currently see*.
2. **Ownership boundary** - can a non-zero distinguish "our thing changed" from "something that is not ours changed"?

The answer goes in as a test, not a comment: a **positive control** proving the detector can fire, and a test **named for the residual** it cannot represent. Both prior-art citations (#816, #821) are pinned by a test so the doc cannot acquire a dead pointer.

## What it deliberately does not say

**"Widen the detector" does not generalise.** #836's `is_fatal` scope is correct and documented - the recursive version existed and was reverted because it made every fenced `git commit` a failed run. Where the narrow answer is right, the larger question needs its own home. The doc says which of the two questions each open dependent (#836, #831) answers, so both are implementable against a stated contract rather than an inferred one.

**It is not a scanner.** "Does this success message claim more than its input population supports" is not mechanically decidable; a checker for it would be an instance of the pattern. What is enforced is narrower and stated honestly.

## The instance index moves

The full twenty-one-instance table is carried in the doc rather than pointed at. Closing #834 while the instances stayed in it would bury them in a closed issue, which is the condition the issue was filed to end. `test_instance_index_carries_every_indexed_instance` enforces it.

#877 is added as the specimen worth remembering: `FLOW_DRIVER_CHECK` answered *"is this deliverable a code change?"* with `fit`, its reader took that for *"can this driver do this issue?"*, and the #735 fence forbade the delegated driver from reading five of this issue's nine files. Both halves inside this repository's own tooling, on the issue about detectors saying too little.

## The tripwire holds itself to the contract

`tests/test_detector_contracts.py` (16 tests):

- Its surface set is **discovered** from `.claude/commands/` and `.claude/skills/`, not listed - so a new review surface added without the questions fails. Demonstrated: dropping an unrouted `**Review for:**` document into `.claude/commands/` fails the run.
- **Three controls**, because proving a matcher fires on a synthetic fixture does not prove the scan is pointed where a real surface would appear. The third plants a probe in the *actual* scanned root.
- What a green run does **not** prove is in the docstring - including that routing is not use, and that a surface outside the scanned roots is invisible.

## Two instances found in this change itself

Both fixed, and worth recording because they are the "knowing the pattern confers no immunity" property earning its place:

- The properties heading claimed **six** over a population of **seven**. Now pinned by `test_the_properties_heading_matches_its_population`.
- The worked example described `check-claude-md-links.py`'s behaviour *before* #841 fixed it. Re-measured: it now reports `contains no repository-local pointers - nothing was checked`, exit 1. The fixed form is now the doc's illustration of what a landed remedy looks like - not a wider scan, but a detector that can say the one thing it previously could not.

## Test plan

Local gate (`flow-finish-gate.sh`, unpiped): **`FLOW_FINISH_GATE: ok`, exit 0** - lint, test, typecheck, security_scan all success, **3066 passed, 0 skipped**. The only delta between the gated tree and the pushed commit is a docstring rewrap in `tests/test_detector_contracts.py`, whose 16 tests were re-run green after it.

CI state on this PR is reported separately and is the authoritative run.

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU3BV4Zq5CBof2vtQ1bchZ