### PR TITLE
fix(registry): stop a dead session's leftover socket from proving it live (Closes #869)

### DIFF
--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -812,6 +812,16 @@ gets the same primary evidence and the asymmetry has no remaining cause.
 The socket file survives as CORROBORATION only, reported in
 `FLOW_WAVE_LIVENESS_BASIS` and never changing a verdict.
 
+**On a host with no `/proc`, the errno is read from `kill`'s message text.**
+That is prose, not a fact, and `strerror()` is translated: the lookup pins
+`LC_ALL=C` so the common case is deterministic, but a message this code does not
+recognise resolves to `unknown` rather than to a wrong answer. The corner is
+narrow - `/proc` is consulted first, so this runs only where there is none - and
+it degrades in the safe direction, since `unknown` refuses a takeover instead of
+inventing life. Stated here because a documented contract that silently depends
+on the operator's locale is the same species of unstated assumption #869 exists
+to remove.
+
 **`unknown` is a third state, not a polite `stale`.** A host that can neither
 read `/proc` nor classify `kill`'s errno has an UNENUMERABLE process table, and
 rounding that down to "dead" is the mistake the sibling mailbox refused when it

--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -695,7 +695,9 @@ re-brief for a worker whose compaction dropped more detail than expected.
   `brief=STALE` and summarized in a `BRIEF:` line - it is running on older
   rules until it re-registers, and re-registering is the whole fix.
 - Dead entries read `stale` and are kept, not deleted - a dead worker mid-issue
-  is information, and its worktree claim outlives it.
+  is information, and its worktree claim outlives it. A role whose liveness could
+  not be DETERMINED reads `unknown:<basis>` instead, which is a different fact
+  and is not taken over without `--force` (#869).
 - **Unregistered `flow-claim` locks are reconciled in (#687).** Registration is
   opt-in and orthogonal to `/flow:auto`, so a session doing ordinary
   single-issue work holds a real worktree lock while appearing nowhere on the
@@ -781,15 +783,43 @@ Run on leaving the wave. Sessions that die without releasing are caught by
 staleness detection; their entries persist as `stale`. Releasing a role owned by
 another LIVE session refuses without `--force`.
 
-**Liveness is two-factor only where sockets exist** (#675). The primary proof is
-the recorded pid, signalled on the recorded host. A live socket FILE is a
-SECOND, independent proof, covering a pid the helper cannot signal - but reading
-it means stat-ing a path, so it can only ever apply to a `uds:` address. On a
-transport that stamps something else there is no file to stat and liveness rests
-on the pid alone. That is a property of the design, not an oversight: sockets
-are what the second factor reads, so a transport without them has one factor.
-(#689 makes the scheme test explicit rather than relying on a prefix-strip that
-silently no-ops; it exposes the asymmetry, it does not remove it.)
+**Liveness is decided by the process table, on every transport** (#675, #689,
+#869). The proof is the recorded pid on the recorded host - but `kill -0` has
+TWO failure modes behind ONE return code, and they are opposite answers rather
+than degrees of one:
+
+| errno | meaning | verdict |
+|-------|---------|---------|
+| `ESRCH` | no such process | **gone**. Definite. |
+| `EPERM` | not permitted | the process **exists**; we merely may not signal it. Positive evidence of life. |
+
+`/proc/<pid>` is consulted first where it exists, because it answers directly:
+the kernel keeps an entry for every live process whoever owns it.
+
+This SERVES #675's purpose with a correct instrument rather than reversing it.
+#675 introduced a socket-file second factor to cover "a pid the helper cannot
+signal" - that is the EPERM row above, now answered by evidence about the
+process itself. What is retired is only the mechanism: a socket FILE could
+override a definite `ESRCH`, because the kernel does not unlink a unix socket
+when its owner dies, so a SIGKILLed session read `live` for as long as the file
+sat on disk. #675 never claimed that; it was a bug in the mechanism.
+
+**The #689 asymmetry is gone, not documented.** #689 recorded that only `uds:`
+addresses have a file to stat, so other transports got one factor - "a property
+of the design, not an oversight". Errno needs no socket, so every transport now
+gets the same primary evidence and the asymmetry has no remaining cause.
+
+The socket file survives as CORROBORATION only, reported in
+`FLOW_WAVE_LIVENESS_BASIS` and never changing a verdict.
+
+**`unknown` is a third state, not a polite `stale`.** A host that can neither
+read `/proc` nor classify `kill`'s errno has an UNENUMERABLE process table, and
+rounding that down to "dead" is the mistake the sibling mailbox refused when it
+moved off pid liveness (#814): never checked and checked-but-undecidable are
+different facts. A role whose owner reads `unknown` is **not** taken over
+without `--force` - only a PROVEN death frees a role, because not knowing an
+owner is gone is not the same as knowing it is. The refusal and the forced
+takeover both name the basis.
 
 ## Output contract
 
@@ -842,6 +872,8 @@ from "this call does not report policy":
 | `FLOW_WAVE_POLICY_DRIVER` / `_GATE` / `_LEDGER` / `_MERGE_AUTHORITY` / `_DEPLOY` / `_REPO` / `_TS` | free text as declared |
 | `FLOW_WAVE_BRIEFED_REV` | the rev THIS role was briefed on (`register` / `get`) |
 | `FLOW_WAVE_BRIEF` | `current` / `stale` / `none`. `stale` = the policy was amended after this role registered; re-register to take the re-brief |
+| `FLOW_WAVE_LIVENESS` | `live` / `stale` / `unknown` / `released` |
+| `FLOW_WAVE_LIVENESS_BASIS` (#869) | WHICH RULE decided the liveness, so a proven death is never read as an undecidable one: `pid-present`, `pid-gone`, `other-host`, `released`, `self`, or `pid-undeterminable-{socket-present,socket-absent,no-socket-proof,no-address}`. The socket-file terms record CORROBORATION of an already-undeterminable pid - they never promote it to `live` |
 
 Two lane-scoping lines (#800), so an unknowable overlap answer is never read as
 a clean one:

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -697,7 +697,9 @@ re-brief for a worker whose compaction dropped more detail than expected.
   `brief=STALE` and summarized in a `BRIEF:` line - it is running on older
   rules until it re-registers, and re-registering is the whole fix.
 - Dead entries read `stale` and are kept, not deleted - a dead worker mid-issue
-  is information, and its worktree claim outlives it.
+  is information, and its worktree claim outlives it. A role whose liveness could
+  not be DETERMINED reads `unknown:<basis>` instead, which is a different fact
+  and is not taken over without `--force` (#869).
 - **Unregistered `flow-claim` locks are reconciled in (#687).** Registration is
   opt-in and orthogonal to `/flow-auto`, so a session doing ordinary
   single-issue work holds a real worktree lock while appearing nowhere on the
@@ -783,15 +785,43 @@ Run on leaving the wave. Sessions that die without releasing are caught by
 staleness detection; their entries persist as `stale`. Releasing a role owned by
 another LIVE session refuses without `--force`.
 
-**Liveness is two-factor only where sockets exist** (#675). The primary proof is
-the recorded pid, signalled on the recorded host. A live socket FILE is a
-SECOND, independent proof, covering a pid the helper cannot signal - but reading
-it means stat-ing a path, so it can only ever apply to a `uds:` address. On a
-transport that stamps something else there is no file to stat and liveness rests
-on the pid alone. That is a property of the design, not an oversight: sockets
-are what the second factor reads, so a transport without them has one factor.
-(#689 makes the scheme test explicit rather than relying on a prefix-strip that
-silently no-ops; it exposes the asymmetry, it does not remove it.)
+**Liveness is decided by the process table, on every transport** (#675, #689,
+#869). The proof is the recorded pid on the recorded host - but `kill -0` has
+TWO failure modes behind ONE return code, and they are opposite answers rather
+than degrees of one:
+
+| errno | meaning | verdict |
+|-------|---------|---------|
+| `ESRCH` | no such process | **gone**. Definite. |
+| `EPERM` | not permitted | the process **exists**; we merely may not signal it. Positive evidence of life. |
+
+`/proc/<pid>` is consulted first where it exists, because it answers directly:
+the kernel keeps an entry for every live process whoever owns it.
+
+This SERVES #675's purpose with a correct instrument rather than reversing it.
+#675 introduced a socket-file second factor to cover "a pid the helper cannot
+signal" - that is the EPERM row above, now answered by evidence about the
+process itself. What is retired is only the mechanism: a socket FILE could
+override a definite `ESRCH`, because the kernel does not unlink a unix socket
+when its owner dies, so a SIGKILLed session read `live` for as long as the file
+sat on disk. #675 never claimed that; it was a bug in the mechanism.
+
+**The #689 asymmetry is gone, not documented.** #689 recorded that only `uds:`
+addresses have a file to stat, so other transports got one factor - "a property
+of the design, not an oversight". Errno needs no socket, so every transport now
+gets the same primary evidence and the asymmetry has no remaining cause.
+
+The socket file survives as CORROBORATION only, reported in
+`FLOW_WAVE_LIVENESS_BASIS` and never changing a verdict.
+
+**`unknown` is a third state, not a polite `stale`.** A host that can neither
+read `/proc` nor classify `kill`'s errno has an UNENUMERABLE process table, and
+rounding that down to "dead" is the mistake the sibling mailbox refused when it
+moved off pid liveness (#814): never checked and checked-but-undecidable are
+different facts. A role whose owner reads `unknown` is **not** taken over
+without `--force` - only a PROVEN death frees a role, because not knowing an
+owner is gone is not the same as knowing it is. The refusal and the forced
+takeover both name the basis.
 
 ## Output contract
 
@@ -844,6 +874,8 @@ from "this call does not report policy":
 | `FLOW_WAVE_POLICY_DRIVER` / `_GATE` / `_LEDGER` / `_MERGE_AUTHORITY` / `_DEPLOY` / `_REPO` / `_TS` | free text as declared |
 | `FLOW_WAVE_BRIEFED_REV` | the rev THIS role was briefed on (`register` / `get`) |
 | `FLOW_WAVE_BRIEF` | `current` / `stale` / `none`. `stale` = the policy was amended after this role registered; re-register to take the re-brief |
+| `FLOW_WAVE_LIVENESS` | `live` / `stale` / `unknown` / `released` |
+| `FLOW_WAVE_LIVENESS_BASIS` (#869) | WHICH RULE decided the liveness, so a proven death is never read as an undecidable one: `pid-present`, `pid-gone`, `other-host`, `released`, `self`, or `pid-undeterminable-{socket-present,socket-absent,no-socket-proof,no-address}`. The socket-file terms record CORROBORATION of an already-undeterminable pid - they never promote it to `live` |
 
 Two lane-scoping lines (#800), so an unknowable overlap answer is never read as
 a clean one:

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -814,6 +814,16 @@ gets the same primary evidence and the asymmetry has no remaining cause.
 The socket file survives as CORROBORATION only, reported in
 `FLOW_WAVE_LIVENESS_BASIS` and never changing a verdict.
 
+**On a host with no `/proc`, the errno is read from `kill`'s message text.**
+That is prose, not a fact, and `strerror()` is translated: the lookup pins
+`LC_ALL=C` so the common case is deterministic, but a message this code does not
+recognise resolves to `unknown` rather than to a wrong answer. The corner is
+narrow - `/proc` is consulted first, so this runs only where there is none - and
+it degrades in the safe direction, since `unknown` refuses a takeover instead of
+inventing life. Stated here because a documented contract that silently depends
+on the operator's locale is the same species of unstated assumption #869 exists
+to remove.
+
 **`unknown` is a third state, not a polite `stale`.** A host that can neither
 read `/proc` nor classify `kill`'s errno has an UNENUMERABLE process table, and
 rounding that down to "dead" is the mistake the sibling mailbox refused when it

--- a/codex/skills/flow-register/scripts/flow-wave-registry.sh
+++ b/codex/skills/flow-register/scripts/flow-wave-registry.sh
@@ -455,7 +455,16 @@ pid_state() {
   fi
 
   if kill -0 "$pid" 2>/dev/null; then echo alive; return; fi
-  err="$(kill -0 "$pid" 2>&1 >/dev/null)"
+  # LAST RESORT, and the only branch in this function that reads PROSE rather
+  # than a fact. There is no portable way to get an errno out of the `kill`
+  # builtin except its message, and that message is `strerror()`, which glibc
+  # TRANSLATES. `LC_ALL=C` pins it - a temporary assignment on a builtin does
+  # reach bash's own setlocale - but it cannot help if the message shape itself
+  # differs, so an unrecognised message falls to `unknown` rather than guessing.
+  # That is the safe direction: `unknown` refuses a takeover, it never invents
+  # life. Reachable only on a host with no /proc, since /proc is consulted
+  # first, and never in the tests, which pin the table.
+  err="$(LC_ALL=C kill -0 "$pid" 2>&1 >/dev/null)"
   case "$err" in
     *"o such process"*)                     echo gone ;;
     *"ot permitted"*|*"ermission denied"*)  echo alive ;;

--- a/codex/skills/flow-register/scripts/flow-wave-registry.sh
+++ b/codex/skills/flow-register/scripts/flow-wave-registry.sh
@@ -322,7 +322,12 @@
 #   FLOW_WAVE_SOCK_DIR      socket dir override (default /run/user/<uid>/cc-socks)
 #   FLOW_WAVE_NOW           override "now" as epoch seconds
 #   FLOW_WAVE_HOST          override this host's name
-#   FLOW_WAVE_LIVE_PIDS     ':'-separated pids treated as alive (bypasses kill -0)
+#   FLOW_WAVE_LIVE_PIDS     ':'-separated pids treated as alive; when set the
+#                           list is AUTHORITATIVE, so a pid absent from it reads
+#                           gone (bypasses the /proc + errno probe entirely)
+#   FLOW_WAVE_UNKNOWN_PIDS  ':'-separated pids whose liveness is undeterminable.
+#                           The only way to exercise that branch on a /proc host,
+#                           where the real probe can always decide (#869)
 #   FLOW_WAVE_MAILBOX_DIR   mailbox wave-root override, passed through to the
 #                           sibling helper so the two always co-locate (#778)
 #   FLOW_WAVE_SELF_PID      starting pid for the self-address ancestor walk
@@ -392,24 +397,77 @@ emit() {
   echo "FLOW_WAVE_PID=${E_PID:--}"
   echo "FLOW_WAVE_SESSION=${E_SESSION:--}"
   echo "FLOW_WAVE_LIVENESS=${E_LIVE:--}"
+  echo "FLOW_WAVE_LIVENESS_BASIS=${E_BASIS:--}"
   echo "FLOW_WAVE_VERIFIED=${E_VERIFIED:--}"
   echo "FLOW_WAVE_MISMATCH=${E_MISMATCH:--}"
   echo "FLOW_WAVE_BOOTSTRAP=${E_BOOTSTRAP:--}"
   echo "FLOW_WAVE: $1"
 }
 
+# pid_state PID -> alive | gone | unknown, for a pid on THIS host.
+#
+# `kill -0` has TWO failure modes behind ONE return code, and collapsing them is
+# what #869 fixes. They are not degrees of the same answer; they are opposite
+# answers:
+#   ESRCH  no such process   - the process is GONE. Definite.
+#   EPERM  not permitted     - the process EXISTS, we merely may not signal it.
+#                              This is POSITIVE evidence of life.
+# EPERM is precisely the case #675 introduced the socket-file fallback to rescue
+# ("covering a pid the helper cannot signal"). Reading the errno serves that
+# stated purpose with a correct instrument, so the fallback no longer has to
+# stand in for evidence that was available all along - and, unlike stat-ing a
+# socket path, it works on EVERY transport rather than only `uds:`.
+#
+# `/proc/<pid>` is consulted first where it exists because it answers directly
+# and without ambiguity: the kernel keeps an entry for every live process on the
+# host regardless of who owns it, so presence is existence and absence is death.
+#
+# `unknown` is a real third answer, not a polite `gone`: a host with no /proc
+# whose `kill` reports something we do not recognise has an UNENUMERABLE process
+# table, and rounding that down to "dead" is the mistake the sibling mailbox
+# refused when it moved off pid liveness (#814). Never checked and
+# checked-but-undecidable are different facts.
+pid_state() {
+  local pid="$1" err
+  [ -n "$pid" ] && [ "$pid" != "-" ] && [ "$pid" != "null" ] || { echo gone; return; }
+  case "$pid" in ''|*[!0-9]*) echo gone; return ;; esac
+
+  # Test hooks pin the process table so no test depends on a pid that happens
+  # to exist. FLOW_WAVE_UNKNOWN_PIDS is checked first: it is the narrower
+  # statement, and it is the only way to reach the undeterminable branch on a
+  # /proc host, where the real prober can never return `unknown`.
+  if [ -n "${FLOW_WAVE_UNKNOWN_PIDS:-}" ]; then
+    case ":$FLOW_WAVE_UNKNOWN_PIDS:" in *":$pid:"*) echo unknown; return ;; esac
+  fi
+  if [ -n "${FLOW_WAVE_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_WAVE_LIVE_PIDS:" in
+      *":$pid:"*) echo alive ;;
+      # The pinned list is AUTHORITATIVE when set, so absence from it is death,
+      # not undeterminability - otherwise every test would read `unknown`.
+      *) echo gone ;;
+    esac
+    return
+  fi
+
+  if [ -d /proc/self ]; then
+    if [ -d "/proc/$pid" ]; then echo alive; else echo gone; fi
+    return
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then echo alive; return; fi
+  err="$(kill -0 "$pid" 2>&1 >/dev/null)"
+  case "$err" in
+    *"o such process"*)                     echo gone ;;
+    *"ot permitted"*|*"ermission denied"*)  echo alive ;;
+    *)                                      echo unknown ;;
+  esac
+}
+
 # is_alive PID HOST -> 0 when the owning session still runs on THIS host.
 is_alive() {
   local pid="$1" host="$2"
-  [ -n "$pid" ] && [ "$pid" != "-" ] && [ "$pid" != "null" ] || return 1
   [ "$host" = "$SELF_HOST" ] || return 1
-  if [ -n "${FLOW_WAVE_LIVE_PIDS:-}" ]; then
-    case ":$FLOW_WAVE_LIVE_PIDS:" in
-      *":$pid:"*) return 0 ;;
-      *) return 1 ;;
-    esac
-  fi
-  kill -0 "$pid" 2>/dev/null
+  [ "$(pid_state "$pid")" = "alive" ]
 }
 
 # Best-effort self-address: walk this process's ancestors and match each pid
@@ -502,41 +560,78 @@ entry_json() { # entry_json WAVE ROLE -> the entry object or 'null'
   read_registry | jq -c --arg w "$1" --arg r "$2" '.[$w].roles[$r] // null'
 }
 
-# liveness_of ENTRY_JSON -> live | stale | released
-liveness_of() {
-  local e="$1" pid host sock released
+# _liveness_compute ENTRY_JSON -> "STATE BASIS"
+#
+# STATE is live | stale | unknown | released. BASIS names WHICH RULE decided it,
+# so a reader can tell a proven death from an undecidable one without inferring
+# it from the state alone (#869 acceptance: the two `kill -0` failure modes are
+# distinguishable, and the code says which one it saw).
+#
+# THE SOCKET FILE IS CORROBORATION, NEVER PROOF (#869). It used to be sufficient
+# on its own, and evaluated AFTER the pid had already been reported dead:
+#
+#     uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
+#
+# The kernel does not unlink a unix domain socket when its owner dies, so the
+# file outlives the process and the WEAKER evidence overrode the STRONGER one: a
+# SIGKILLed session kept reading `live` for as long as its socket sat on disk.
+#
+# What #675 actually asked for is preserved. Its words are that the socket file
+# is "a SECOND, independent proof, covering a pid the helper cannot signal" -
+# that is the EPERM case, and `pid_state` now answers it directly and correctly.
+# What is removed is only the socket's power to override a DEFINITE ESRCH, which
+# #675 never claimed and which was a bug in the mechanism rather than in the
+# intent. #689 then made the branch uds-only and recorded that transports
+# without sockets get one factor, "a property of the design, not an oversight".
+# That asymmetry is now GONE rather than documented: errno needs no socket, so
+# every transport gets the same primary evidence. The socket survives only in
+# the BASIS, where it corroborates an already-undeterminable pid and changes no
+# verdict.
+_liveness_compute() {
+  local e="$1" pid host sock released st
   released="$(printf '%s' "$e" | jq -r '.released // false')"
-  [ "$released" = "true" ] && { echo released; return; }
+  [ "$released" = "true" ] && { echo "released released"; return; }
   pid="$(printf '%s' "$e" | jq -r '.pid // "-"')"
   host="$(printf '%s' "$e" | jq -r '.host // "-"')"
   sock="$(printf '%s' "$e" | jq -r '.socket // "unknown"')"
-  if is_alive "$pid" "$host"; then echo live; return; fi
-  # A live socket file on this host also proves liveness (covers a pid the
-  # helper cannot signal but whose session socket clearly exists).
-  #
-  # This secondary proof is UDS-ONLY and now says so (#689). It used to strip a
-  # `uds:` prefix unconditionally and stat the remainder, which on any other
-  # transport - `bridge:session_01RLE...` - stripped nothing and tested whether a
-  # file literally named `bridge:session_...` existed. Always false, so the
-  # fallback was silently inert rather than absent, and register.md's two-factor
-  # staleness rule ("socket gone + pid dead") was one-factor on those transports.
-  #
-  # Deliberately EXPOSES the gap rather than closing it: whether another
-  # transport can offer its own secondary proof is a separate question (#676).
-  # On a non-uds address liveness rests on `kill -0` alone - the registry is
-  # host-local by construction, so that is sound today, but it is one mechanism
-  # and not two, and the code should state that instead of implying otherwise.
-  if [ "$host" = "$SELF_HOST" ] && [ "$sock" != "unknown" ]; then
-    case "$sock" in
-      uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
-      # Any other scheme: no socket-file proof exists. Fall through to stale on
-      # the strength of `kill -0` alone rather than running a test that cannot
-      # pass (#689).
-      *) : ;;
-    esac
-  fi
-  echo stale
+
+  # Unchanged, and deliberately so: the registry is host-local by construction,
+  # so an entry from another host has always read `stale` and every reader is
+  # built on that. It is arguably the same shape of defect as the one above - we
+  # cannot determine a remote pid's liveness either - but promoting it to
+  # `unknown` would change takeover semantics for every cross-host entry, which
+  # is a separate decision and out of scope here. The BASIS says which rule
+  # fired, so the two never look alike to a reader.
+  if [ "$host" != "$SELF_HOST" ]; then echo "stale other-host"; return; fi
+
+  st="$(pid_state "$pid")"
+  case "$st" in
+    alive) echo "live pid-present"; return ;;
+    # A leftover socket file is NOT evidence against a confirmed death, so it is
+    # not consulted on this branch at all.
+    gone)  echo "stale pid-gone"; return ;;
+  esac
+
+  # pid_state could not decide. Report the socket as corroboration - it raises
+  # confidence that something is still there, and it settles nothing.
+  case "$sock" in
+    unknown) echo "unknown pid-undeterminable-no-address" ;;
+    uds:*)
+      if [ -S "${sock#uds:}" ]; then
+        echo "unknown pid-undeterminable-socket-present"
+      else
+        echo "unknown pid-undeterminable-socket-absent"
+      fi
+      ;;
+    *) echo "unknown pid-undeterminable-no-socket-proof" ;;
+  esac
 }
+
+# liveness_of ENTRY_JSON -> live | stale | unknown | released
+liveness_of() { local r; r="$(_liveness_compute "$1")"; echo "${r%% *}"; }
+
+# liveness_basis_of ENTRY_JSON -> the rule that decided it
+liveness_basis_of() { local r; r="$(_liveness_compute "$1")"; echo "${r#* }"; }
 
 # cwd_is_shared_parent CWD REPO -> 0 when CWD looks like a shared projects
 # parent rather than a lane (#683).
@@ -1182,7 +1277,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 E_WAVE="$WAVE"; E_ROLE="$ROLE"; E_SOCKET=""; E_PID=""; E_SESSION=""
-E_LIVE=""; E_VERIFIED=""; E_MISMATCH=""; E_SOURCE=""; E_REASON=""; E_BOOTSTRAP=""
+E_LIVE=""; E_BASIS=""; E_VERIFIED=""; E_MISMATCH=""; E_SOURCE=""; E_REASON=""; E_BOOTSTRAP=""
 
 case "$VERB" in
   self-address)
@@ -1345,20 +1440,44 @@ case "$VERB" in
       CUR_PID="$(printf '%s' "$CUR" | jq -r '.pid // "-"')"
       CUR_SESSION="$(printf '%s' "$CUR" | jq -r '.session // "-"')"
       CUR_LIVE="$(liveness_of "$CUR")"
+      CUR_BASIS="$(liveness_basis_of "$CUR")"
       SAME_OWNER=0
       [ "$CUR_SESSION" != "-" ] && [ "$CUR_SESSION" = "$SELF_SESSION" ] && SAME_OWNER=1
       [ "$CUR_PID" = "$SELF_PID" ] && SAME_OWNER=1
-      if [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "live" ] && [ "$FORCE" -eq 0 ]; then
-        echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a LIVE session (pid $CUR_PID, session $CUR_SESSION)." >&2
+      # An ALLOW-LIST of states that release the role, never a deny-list of
+      # states that hold it (#869). `!= stale` would read a brand-new state as
+      # takeable, which is this issue's own defect - weaker evidence beating
+      # stronger - reproduced one layer up. Only a PROVEN death frees a role:
+      # `unknown` means we could not determine the owner is gone, and that is
+      # not the same as determining it is.
+      case "$CUR_LIVE" in
+        stale|released) HELD=0 ;;
+        *)              HELD=1 ;;
+      esac
+      if [ "$SAME_OWNER" -eq 0 ] && [ "$HELD" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+        if [ "$CUR_LIVE" = "live" ]; then
+          echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a LIVE session (pid $CUR_PID, session $CUR_SESSION)." >&2
+        else
+          echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a session whose liveness is UNDETERMINABLE (pid $CUR_PID, session $CUR_SESSION, basis $CUR_BASIS)." >&2
+          echo "  This host cannot enumerate its process table, so the owner is not known to be gone - which is not the same as knowing it is alive." >&2
+        fi
         echo "  Two sessions both believing they are '$ROLE' is the failure this command exists to prevent (#638)." >&2
         echo "  Pick another role, or re-run with --force if you are certain that session is gone." >&2
         E_SOCKET="$(printf '%s' "$CUR" | jq -r '.socket // "unknown"')"
-        E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"
+        E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"; E_BASIS="$CUR_BASIS"
         emit refused
         exit 1
       fi
-      [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "stale" ] &&
-        echo "flow-wave-registry: taking over stale role '$ROLE' (owner pid $CUR_PID is gone)." >&2
+      if [ "$SAME_OWNER" -eq 0 ]; then
+        case "$CUR_LIVE" in
+          stale)
+            echo "flow-wave-registry: taking over stale role '$ROLE' (owner pid $CUR_PID is gone)." >&2 ;;
+          unknown)
+            # Only reachable under --force, and the loudest line here: the
+            # operator is overriding an unanswered question, not a known death.
+            echo "flow-wave-registry: --force taking over role '$ROLE' whose owner (pid $CUR_PID) was NOT confirmed gone (basis $CUR_BASIS)." >&2 ;;
+        esac
+      fi
       # Trust model, the reverse direction (#638 gate condition 1 / #672): a
       # FAILED self-derivation must never downgrade a recorded address to
       # 'unknown'. You cannot address 'unknown', so any known address outranks
@@ -1535,7 +1654,7 @@ case "$VERB" in
     echo "FLOW_WAVE_BRIEFED_REV=$POL_REV"
     echo "FLOW_WAVE_BRIEF=$(brief_state "$POL_REV" "$POL_REV")"
     echo "FLOW_WAVE_LANE_SCOPED=$E_LANE_SCOPED"
-    E_SOCKET="$SOCK"; E_PID="$SELF_PID"; E_SESSION="$SELF_SESSION"; E_LIVE=live
+    E_SOCKET="$SOCK"; E_PID="$SELF_PID"; E_SESSION="$SELF_SESSION"; E_LIVE=live; E_BASIS=self
     E_VERIFIED="$KEEP_VERIFIED"; E_MISMATCH="$KEEP_MISMATCH"
     E_SOURCE="$SOCK_SOURCE"; E_REASON="$SOCK_REASON"
     emit "$VERDICT"
@@ -1552,6 +1671,7 @@ case "$VERB" in
     E_PID="$(printf '%s' "$CUR" | jq -r '.pid // "-"')"
     E_SESSION="$(printf '%s' "$CUR" | jq -r '.session // "-"')"
     E_LIVE="$(liveness_of "$CUR")"
+    E_BASIS="$(liveness_basis_of "$CUR")"
     E_VERIFIED="$(printf '%s' "$CUR" | jq -r '.verified // false')"
     E_MISMATCH="$(printf '%s' "$CUR" | jq -r '.address_mismatch // false')"
     # `get` is what a session runs to answer "where do I send to this role?".
@@ -1680,9 +1800,19 @@ case "$VERB" in
     [ "$CUR_SESSION" != "-" ] && [ "$CUR_SESSION" = "$SELF_SESSION" ] && SAME_OWNER=1
     [ "$CUR_PID" = "$SELF_PID" ] && SAME_OWNER=1
     CUR_LIVE="$(liveness_of "$CUR")"
-    if [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "live" ] && [ "$FORCE" -eq 0 ]; then
-      echo "flow-wave-registry: role '$ROLE' belongs to a LIVE session (pid $CUR_PID) - not releasing. Pass --force to override." >&2
-      E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"
+    CUR_BASIS="$(liveness_basis_of "$CUR")"
+    # Allow-list, for the same reason as `register` above (#869).
+    case "$CUR_LIVE" in
+      stale|released) HELD=0 ;;
+      *)              HELD=1 ;;
+    esac
+    if [ "$SAME_OWNER" -eq 0 ] && [ "$HELD" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+      if [ "$CUR_LIVE" = "live" ]; then
+        echo "flow-wave-registry: role '$ROLE' belongs to a LIVE session (pid $CUR_PID) - not releasing. Pass --force to override." >&2
+      else
+        echo "flow-wave-registry: role '$ROLE' belongs to a session whose liveness is UNDETERMINABLE (pid $CUR_PID, basis $CUR_BASIS) - not releasing. Pass --force to override." >&2
+      fi
+      E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"; E_BASIS="$CUR_BASIS"
       emit refused
       exit 1
     fi
@@ -1733,9 +1863,22 @@ case "$VERB" in
     # unconditionally - it holds no lane, so it has no scoping to lose.
     UNSCOPED=0
     UNSCOPED_ROLES=""
+    # Roles whose LIVENESS could not be determined (#869). Counted here for the
+    # same reason #800 counts unscoped lanes: an unknowable answer must never be
+    # read as a clean one. Every `= "live"` consumer below correctly SKIPS an
+    # `unknown` role - but skipping it means its lane is neither overlap-checked
+    # nor counted as unchecked, so a roster would otherwise report a clean
+    # verdict over a role nobody examined. This counter is that role's receipt.
+    UNDETERMINED=0
+    UNDETERMINED_ROLES=""
     for r in $ROLES; do
       e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
-      [ "$(liveness_of "$e")" = "live" ] || continue
+      LV_R="$(liveness_of "$e")"
+      if [ "$LV_R" = "unknown" ]; then
+        UNDETERMINED=$((UNDETERMINED + 1))
+        UNDETERMINED_ROLES="$UNDETERMINED_ROLES $r"
+      fi
+      [ "$LV_R" = "live" ] || continue
       [ "$r" = "orchestrator" ] && continue
       lane_unscoped \
         "$(printf '%s' "$e" | jq -r '.repo // ""')" \
@@ -1802,7 +1945,8 @@ $rp"
       for r in $ROLES; do
         e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
         lv="$(liveness_of "$e")"
-        OUT="$(printf '%s' "$OUT" | jq -c --arg r "$r" --argjson e "$e" --arg lv "$lv" '.[$r] = ($e + {liveness: $lv})')"
+        lb="$(liveness_basis_of "$e")"
+        OUT="$(printf '%s' "$OUT" | jq -c --arg r "$r" --argjson e "$e" --arg lv "$lv" --arg lb "$lb" '.[$r] = ($e + {liveness: $lv, liveness_basis: $lb})')"
         # `watch` and `mailbox` are computed keys like `liveness`, and appear
         # ONLY when this wave actually uses the mailbox lane (#778) - so a wave
         # that never touched it emits byte-identical JSON to pre-#778, the same
@@ -1859,6 +2003,7 @@ $rp"
       echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
       echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
       echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+      echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
       echo "FLOW_WAVE: listed"
       exit 0
     fi
@@ -1884,6 +2029,7 @@ EOF
       echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
       echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
       echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+      echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
       echo "FLOW_WAVE: listed"
       exit 0
     fi
@@ -1900,6 +2046,7 @@ EOF
     for r in $ROLES; do
       e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
       lv="$(liveness_of "$e")"
+      lb="$(liveness_basis_of "$e")"
       sock="$(printf '%s' "$e" | jq -r '.socket // "unknown"')"
       iss="$(printf '%s' "$e" | jq -r '.issue // "" | if . == "" then "-" else . end')"
       # `filled` is a verified state, not a lesser one (#674): the address was
@@ -1969,7 +2116,13 @@ EOF
         fi
         mailbox_never_read "$r" && extra="$extra ** NEVER READ **"
       fi
-      echo "  $r -> $sock [$lv, $ver] issue=$iss$extra"
+      # The basis is rendered ONLY for `unknown`, so a roster of ordinary live
+      # and stale roles is byte-identical to pre-#869 - the same promise #778
+      # and #699 made about their own additions. `unknown` is the one state a
+      # reader cannot act on without knowing WHY it could not be decided.
+      lvs="$lv"
+      [ "$lv" = "unknown" ] && lvs="$lv:$lb"
+      echo "  $r -> $sock [$lvs, $ver] issue=$iss$extra"
     done
     # Claim-derived rows (#687), rendered AFTER the roles and visibly not roles.
     # An orchestrator scanning the issue column now sees a lane held by a
@@ -2141,6 +2294,7 @@ EOF
     echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
     echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
     echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+    echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
     echo "FLOW_WAVE: listed"
     exit 0
     ;;

--- a/codex/skills/flow-wave/scripts/flow-wave-registry.sh
+++ b/codex/skills/flow-wave/scripts/flow-wave-registry.sh
@@ -455,7 +455,16 @@ pid_state() {
   fi
 
   if kill -0 "$pid" 2>/dev/null; then echo alive; return; fi
-  err="$(kill -0 "$pid" 2>&1 >/dev/null)"
+  # LAST RESORT, and the only branch in this function that reads PROSE rather
+  # than a fact. There is no portable way to get an errno out of the `kill`
+  # builtin except its message, and that message is `strerror()`, which glibc
+  # TRANSLATES. `LC_ALL=C` pins it - a temporary assignment on a builtin does
+  # reach bash's own setlocale - but it cannot help if the message shape itself
+  # differs, so an unrecognised message falls to `unknown` rather than guessing.
+  # That is the safe direction: `unknown` refuses a takeover, it never invents
+  # life. Reachable only on a host with no /proc, since /proc is consulted
+  # first, and never in the tests, which pin the table.
+  err="$(LC_ALL=C kill -0 "$pid" 2>&1 >/dev/null)"
   case "$err" in
     *"o such process"*)                     echo gone ;;
     *"ot permitted"*|*"ermission denied"*)  echo alive ;;

--- a/codex/skills/flow-wave/scripts/flow-wave-registry.sh
+++ b/codex/skills/flow-wave/scripts/flow-wave-registry.sh
@@ -322,7 +322,12 @@
 #   FLOW_WAVE_SOCK_DIR      socket dir override (default /run/user/<uid>/cc-socks)
 #   FLOW_WAVE_NOW           override "now" as epoch seconds
 #   FLOW_WAVE_HOST          override this host's name
-#   FLOW_WAVE_LIVE_PIDS     ':'-separated pids treated as alive (bypasses kill -0)
+#   FLOW_WAVE_LIVE_PIDS     ':'-separated pids treated as alive; when set the
+#                           list is AUTHORITATIVE, so a pid absent from it reads
+#                           gone (bypasses the /proc + errno probe entirely)
+#   FLOW_WAVE_UNKNOWN_PIDS  ':'-separated pids whose liveness is undeterminable.
+#                           The only way to exercise that branch on a /proc host,
+#                           where the real probe can always decide (#869)
 #   FLOW_WAVE_MAILBOX_DIR   mailbox wave-root override, passed through to the
 #                           sibling helper so the two always co-locate (#778)
 #   FLOW_WAVE_SELF_PID      starting pid for the self-address ancestor walk
@@ -392,24 +397,77 @@ emit() {
   echo "FLOW_WAVE_PID=${E_PID:--}"
   echo "FLOW_WAVE_SESSION=${E_SESSION:--}"
   echo "FLOW_WAVE_LIVENESS=${E_LIVE:--}"
+  echo "FLOW_WAVE_LIVENESS_BASIS=${E_BASIS:--}"
   echo "FLOW_WAVE_VERIFIED=${E_VERIFIED:--}"
   echo "FLOW_WAVE_MISMATCH=${E_MISMATCH:--}"
   echo "FLOW_WAVE_BOOTSTRAP=${E_BOOTSTRAP:--}"
   echo "FLOW_WAVE: $1"
 }
 
+# pid_state PID -> alive | gone | unknown, for a pid on THIS host.
+#
+# `kill -0` has TWO failure modes behind ONE return code, and collapsing them is
+# what #869 fixes. They are not degrees of the same answer; they are opposite
+# answers:
+#   ESRCH  no such process   - the process is GONE. Definite.
+#   EPERM  not permitted     - the process EXISTS, we merely may not signal it.
+#                              This is POSITIVE evidence of life.
+# EPERM is precisely the case #675 introduced the socket-file fallback to rescue
+# ("covering a pid the helper cannot signal"). Reading the errno serves that
+# stated purpose with a correct instrument, so the fallback no longer has to
+# stand in for evidence that was available all along - and, unlike stat-ing a
+# socket path, it works on EVERY transport rather than only `uds:`.
+#
+# `/proc/<pid>` is consulted first where it exists because it answers directly
+# and without ambiguity: the kernel keeps an entry for every live process on the
+# host regardless of who owns it, so presence is existence and absence is death.
+#
+# `unknown` is a real third answer, not a polite `gone`: a host with no /proc
+# whose `kill` reports something we do not recognise has an UNENUMERABLE process
+# table, and rounding that down to "dead" is the mistake the sibling mailbox
+# refused when it moved off pid liveness (#814). Never checked and
+# checked-but-undecidable are different facts.
+pid_state() {
+  local pid="$1" err
+  [ -n "$pid" ] && [ "$pid" != "-" ] && [ "$pid" != "null" ] || { echo gone; return; }
+  case "$pid" in ''|*[!0-9]*) echo gone; return ;; esac
+
+  # Test hooks pin the process table so no test depends on a pid that happens
+  # to exist. FLOW_WAVE_UNKNOWN_PIDS is checked first: it is the narrower
+  # statement, and it is the only way to reach the undeterminable branch on a
+  # /proc host, where the real prober can never return `unknown`.
+  if [ -n "${FLOW_WAVE_UNKNOWN_PIDS:-}" ]; then
+    case ":$FLOW_WAVE_UNKNOWN_PIDS:" in *":$pid:"*) echo unknown; return ;; esac
+  fi
+  if [ -n "${FLOW_WAVE_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_WAVE_LIVE_PIDS:" in
+      *":$pid:"*) echo alive ;;
+      # The pinned list is AUTHORITATIVE when set, so absence from it is death,
+      # not undeterminability - otherwise every test would read `unknown`.
+      *) echo gone ;;
+    esac
+    return
+  fi
+
+  if [ -d /proc/self ]; then
+    if [ -d "/proc/$pid" ]; then echo alive; else echo gone; fi
+    return
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then echo alive; return; fi
+  err="$(kill -0 "$pid" 2>&1 >/dev/null)"
+  case "$err" in
+    *"o such process"*)                     echo gone ;;
+    *"ot permitted"*|*"ermission denied"*)  echo alive ;;
+    *)                                      echo unknown ;;
+  esac
+}
+
 # is_alive PID HOST -> 0 when the owning session still runs on THIS host.
 is_alive() {
   local pid="$1" host="$2"
-  [ -n "$pid" ] && [ "$pid" != "-" ] && [ "$pid" != "null" ] || return 1
   [ "$host" = "$SELF_HOST" ] || return 1
-  if [ -n "${FLOW_WAVE_LIVE_PIDS:-}" ]; then
-    case ":$FLOW_WAVE_LIVE_PIDS:" in
-      *":$pid:"*) return 0 ;;
-      *) return 1 ;;
-    esac
-  fi
-  kill -0 "$pid" 2>/dev/null
+  [ "$(pid_state "$pid")" = "alive" ]
 }
 
 # Best-effort self-address: walk this process's ancestors and match each pid
@@ -502,41 +560,78 @@ entry_json() { # entry_json WAVE ROLE -> the entry object or 'null'
   read_registry | jq -c --arg w "$1" --arg r "$2" '.[$w].roles[$r] // null'
 }
 
-# liveness_of ENTRY_JSON -> live | stale | released
-liveness_of() {
-  local e="$1" pid host sock released
+# _liveness_compute ENTRY_JSON -> "STATE BASIS"
+#
+# STATE is live | stale | unknown | released. BASIS names WHICH RULE decided it,
+# so a reader can tell a proven death from an undecidable one without inferring
+# it from the state alone (#869 acceptance: the two `kill -0` failure modes are
+# distinguishable, and the code says which one it saw).
+#
+# THE SOCKET FILE IS CORROBORATION, NEVER PROOF (#869). It used to be sufficient
+# on its own, and evaluated AFTER the pid had already been reported dead:
+#
+#     uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
+#
+# The kernel does not unlink a unix domain socket when its owner dies, so the
+# file outlives the process and the WEAKER evidence overrode the STRONGER one: a
+# SIGKILLed session kept reading `live` for as long as its socket sat on disk.
+#
+# What #675 actually asked for is preserved. Its words are that the socket file
+# is "a SECOND, independent proof, covering a pid the helper cannot signal" -
+# that is the EPERM case, and `pid_state` now answers it directly and correctly.
+# What is removed is only the socket's power to override a DEFINITE ESRCH, which
+# #675 never claimed and which was a bug in the mechanism rather than in the
+# intent. #689 then made the branch uds-only and recorded that transports
+# without sockets get one factor, "a property of the design, not an oversight".
+# That asymmetry is now GONE rather than documented: errno needs no socket, so
+# every transport gets the same primary evidence. The socket survives only in
+# the BASIS, where it corroborates an already-undeterminable pid and changes no
+# verdict.
+_liveness_compute() {
+  local e="$1" pid host sock released st
   released="$(printf '%s' "$e" | jq -r '.released // false')"
-  [ "$released" = "true" ] && { echo released; return; }
+  [ "$released" = "true" ] && { echo "released released"; return; }
   pid="$(printf '%s' "$e" | jq -r '.pid // "-"')"
   host="$(printf '%s' "$e" | jq -r '.host // "-"')"
   sock="$(printf '%s' "$e" | jq -r '.socket // "unknown"')"
-  if is_alive "$pid" "$host"; then echo live; return; fi
-  # A live socket file on this host also proves liveness (covers a pid the
-  # helper cannot signal but whose session socket clearly exists).
-  #
-  # This secondary proof is UDS-ONLY and now says so (#689). It used to strip a
-  # `uds:` prefix unconditionally and stat the remainder, which on any other
-  # transport - `bridge:session_01RLE...` - stripped nothing and tested whether a
-  # file literally named `bridge:session_...` existed. Always false, so the
-  # fallback was silently inert rather than absent, and register.md's two-factor
-  # staleness rule ("socket gone + pid dead") was one-factor on those transports.
-  #
-  # Deliberately EXPOSES the gap rather than closing it: whether another
-  # transport can offer its own secondary proof is a separate question (#676).
-  # On a non-uds address liveness rests on `kill -0` alone - the registry is
-  # host-local by construction, so that is sound today, but it is one mechanism
-  # and not two, and the code should state that instead of implying otherwise.
-  if [ "$host" = "$SELF_HOST" ] && [ "$sock" != "unknown" ]; then
-    case "$sock" in
-      uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
-      # Any other scheme: no socket-file proof exists. Fall through to stale on
-      # the strength of `kill -0` alone rather than running a test that cannot
-      # pass (#689).
-      *) : ;;
-    esac
-  fi
-  echo stale
+
+  # Unchanged, and deliberately so: the registry is host-local by construction,
+  # so an entry from another host has always read `stale` and every reader is
+  # built on that. It is arguably the same shape of defect as the one above - we
+  # cannot determine a remote pid's liveness either - but promoting it to
+  # `unknown` would change takeover semantics for every cross-host entry, which
+  # is a separate decision and out of scope here. The BASIS says which rule
+  # fired, so the two never look alike to a reader.
+  if [ "$host" != "$SELF_HOST" ]; then echo "stale other-host"; return; fi
+
+  st="$(pid_state "$pid")"
+  case "$st" in
+    alive) echo "live pid-present"; return ;;
+    # A leftover socket file is NOT evidence against a confirmed death, so it is
+    # not consulted on this branch at all.
+    gone)  echo "stale pid-gone"; return ;;
+  esac
+
+  # pid_state could not decide. Report the socket as corroboration - it raises
+  # confidence that something is still there, and it settles nothing.
+  case "$sock" in
+    unknown) echo "unknown pid-undeterminable-no-address" ;;
+    uds:*)
+      if [ -S "${sock#uds:}" ]; then
+        echo "unknown pid-undeterminable-socket-present"
+      else
+        echo "unknown pid-undeterminable-socket-absent"
+      fi
+      ;;
+    *) echo "unknown pid-undeterminable-no-socket-proof" ;;
+  esac
 }
+
+# liveness_of ENTRY_JSON -> live | stale | unknown | released
+liveness_of() { local r; r="$(_liveness_compute "$1")"; echo "${r%% *}"; }
+
+# liveness_basis_of ENTRY_JSON -> the rule that decided it
+liveness_basis_of() { local r; r="$(_liveness_compute "$1")"; echo "${r#* }"; }
 
 # cwd_is_shared_parent CWD REPO -> 0 when CWD looks like a shared projects
 # parent rather than a lane (#683).
@@ -1182,7 +1277,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 E_WAVE="$WAVE"; E_ROLE="$ROLE"; E_SOCKET=""; E_PID=""; E_SESSION=""
-E_LIVE=""; E_VERIFIED=""; E_MISMATCH=""; E_SOURCE=""; E_REASON=""; E_BOOTSTRAP=""
+E_LIVE=""; E_BASIS=""; E_VERIFIED=""; E_MISMATCH=""; E_SOURCE=""; E_REASON=""; E_BOOTSTRAP=""
 
 case "$VERB" in
   self-address)
@@ -1345,20 +1440,44 @@ case "$VERB" in
       CUR_PID="$(printf '%s' "$CUR" | jq -r '.pid // "-"')"
       CUR_SESSION="$(printf '%s' "$CUR" | jq -r '.session // "-"')"
       CUR_LIVE="$(liveness_of "$CUR")"
+      CUR_BASIS="$(liveness_basis_of "$CUR")"
       SAME_OWNER=0
       [ "$CUR_SESSION" != "-" ] && [ "$CUR_SESSION" = "$SELF_SESSION" ] && SAME_OWNER=1
       [ "$CUR_PID" = "$SELF_PID" ] && SAME_OWNER=1
-      if [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "live" ] && [ "$FORCE" -eq 0 ]; then
-        echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a LIVE session (pid $CUR_PID, session $CUR_SESSION)." >&2
+      # An ALLOW-LIST of states that release the role, never a deny-list of
+      # states that hold it (#869). `!= stale` would read a brand-new state as
+      # takeable, which is this issue's own defect - weaker evidence beating
+      # stronger - reproduced one layer up. Only a PROVEN death frees a role:
+      # `unknown` means we could not determine the owner is gone, and that is
+      # not the same as determining it is.
+      case "$CUR_LIVE" in
+        stale|released) HELD=0 ;;
+        *)              HELD=1 ;;
+      esac
+      if [ "$SAME_OWNER" -eq 0 ] && [ "$HELD" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+        if [ "$CUR_LIVE" = "live" ]; then
+          echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a LIVE session (pid $CUR_PID, session $CUR_SESSION)." >&2
+        else
+          echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a session whose liveness is UNDETERMINABLE (pid $CUR_PID, session $CUR_SESSION, basis $CUR_BASIS)." >&2
+          echo "  This host cannot enumerate its process table, so the owner is not known to be gone - which is not the same as knowing it is alive." >&2
+        fi
         echo "  Two sessions both believing they are '$ROLE' is the failure this command exists to prevent (#638)." >&2
         echo "  Pick another role, or re-run with --force if you are certain that session is gone." >&2
         E_SOCKET="$(printf '%s' "$CUR" | jq -r '.socket // "unknown"')"
-        E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"
+        E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"; E_BASIS="$CUR_BASIS"
         emit refused
         exit 1
       fi
-      [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "stale" ] &&
-        echo "flow-wave-registry: taking over stale role '$ROLE' (owner pid $CUR_PID is gone)." >&2
+      if [ "$SAME_OWNER" -eq 0 ]; then
+        case "$CUR_LIVE" in
+          stale)
+            echo "flow-wave-registry: taking over stale role '$ROLE' (owner pid $CUR_PID is gone)." >&2 ;;
+          unknown)
+            # Only reachable under --force, and the loudest line here: the
+            # operator is overriding an unanswered question, not a known death.
+            echo "flow-wave-registry: --force taking over role '$ROLE' whose owner (pid $CUR_PID) was NOT confirmed gone (basis $CUR_BASIS)." >&2 ;;
+        esac
+      fi
       # Trust model, the reverse direction (#638 gate condition 1 / #672): a
       # FAILED self-derivation must never downgrade a recorded address to
       # 'unknown'. You cannot address 'unknown', so any known address outranks
@@ -1535,7 +1654,7 @@ case "$VERB" in
     echo "FLOW_WAVE_BRIEFED_REV=$POL_REV"
     echo "FLOW_WAVE_BRIEF=$(brief_state "$POL_REV" "$POL_REV")"
     echo "FLOW_WAVE_LANE_SCOPED=$E_LANE_SCOPED"
-    E_SOCKET="$SOCK"; E_PID="$SELF_PID"; E_SESSION="$SELF_SESSION"; E_LIVE=live
+    E_SOCKET="$SOCK"; E_PID="$SELF_PID"; E_SESSION="$SELF_SESSION"; E_LIVE=live; E_BASIS=self
     E_VERIFIED="$KEEP_VERIFIED"; E_MISMATCH="$KEEP_MISMATCH"
     E_SOURCE="$SOCK_SOURCE"; E_REASON="$SOCK_REASON"
     emit "$VERDICT"
@@ -1552,6 +1671,7 @@ case "$VERB" in
     E_PID="$(printf '%s' "$CUR" | jq -r '.pid // "-"')"
     E_SESSION="$(printf '%s' "$CUR" | jq -r '.session // "-"')"
     E_LIVE="$(liveness_of "$CUR")"
+    E_BASIS="$(liveness_basis_of "$CUR")"
     E_VERIFIED="$(printf '%s' "$CUR" | jq -r '.verified // false')"
     E_MISMATCH="$(printf '%s' "$CUR" | jq -r '.address_mismatch // false')"
     # `get` is what a session runs to answer "where do I send to this role?".
@@ -1680,9 +1800,19 @@ case "$VERB" in
     [ "$CUR_SESSION" != "-" ] && [ "$CUR_SESSION" = "$SELF_SESSION" ] && SAME_OWNER=1
     [ "$CUR_PID" = "$SELF_PID" ] && SAME_OWNER=1
     CUR_LIVE="$(liveness_of "$CUR")"
-    if [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "live" ] && [ "$FORCE" -eq 0 ]; then
-      echo "flow-wave-registry: role '$ROLE' belongs to a LIVE session (pid $CUR_PID) - not releasing. Pass --force to override." >&2
-      E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"
+    CUR_BASIS="$(liveness_basis_of "$CUR")"
+    # Allow-list, for the same reason as `register` above (#869).
+    case "$CUR_LIVE" in
+      stale|released) HELD=0 ;;
+      *)              HELD=1 ;;
+    esac
+    if [ "$SAME_OWNER" -eq 0 ] && [ "$HELD" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+      if [ "$CUR_LIVE" = "live" ]; then
+        echo "flow-wave-registry: role '$ROLE' belongs to a LIVE session (pid $CUR_PID) - not releasing. Pass --force to override." >&2
+      else
+        echo "flow-wave-registry: role '$ROLE' belongs to a session whose liveness is UNDETERMINABLE (pid $CUR_PID, basis $CUR_BASIS) - not releasing. Pass --force to override." >&2
+      fi
+      E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"; E_BASIS="$CUR_BASIS"
       emit refused
       exit 1
     fi
@@ -1733,9 +1863,22 @@ case "$VERB" in
     # unconditionally - it holds no lane, so it has no scoping to lose.
     UNSCOPED=0
     UNSCOPED_ROLES=""
+    # Roles whose LIVENESS could not be determined (#869). Counted here for the
+    # same reason #800 counts unscoped lanes: an unknowable answer must never be
+    # read as a clean one. Every `= "live"` consumer below correctly SKIPS an
+    # `unknown` role - but skipping it means its lane is neither overlap-checked
+    # nor counted as unchecked, so a roster would otherwise report a clean
+    # verdict over a role nobody examined. This counter is that role's receipt.
+    UNDETERMINED=0
+    UNDETERMINED_ROLES=""
     for r in $ROLES; do
       e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
-      [ "$(liveness_of "$e")" = "live" ] || continue
+      LV_R="$(liveness_of "$e")"
+      if [ "$LV_R" = "unknown" ]; then
+        UNDETERMINED=$((UNDETERMINED + 1))
+        UNDETERMINED_ROLES="$UNDETERMINED_ROLES $r"
+      fi
+      [ "$LV_R" = "live" ] || continue
       [ "$r" = "orchestrator" ] && continue
       lane_unscoped \
         "$(printf '%s' "$e" | jq -r '.repo // ""')" \
@@ -1802,7 +1945,8 @@ $rp"
       for r in $ROLES; do
         e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
         lv="$(liveness_of "$e")"
-        OUT="$(printf '%s' "$OUT" | jq -c --arg r "$r" --argjson e "$e" --arg lv "$lv" '.[$r] = ($e + {liveness: $lv})')"
+        lb="$(liveness_basis_of "$e")"
+        OUT="$(printf '%s' "$OUT" | jq -c --arg r "$r" --argjson e "$e" --arg lv "$lv" --arg lb "$lb" '.[$r] = ($e + {liveness: $lv, liveness_basis: $lb})')"
         # `watch` and `mailbox` are computed keys like `liveness`, and appear
         # ONLY when this wave actually uses the mailbox lane (#778) - so a wave
         # that never touched it emits byte-identical JSON to pre-#778, the same
@@ -1859,6 +2003,7 @@ $rp"
       echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
       echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
       echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+      echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
       echo "FLOW_WAVE: listed"
       exit 0
     fi
@@ -1884,6 +2029,7 @@ EOF
       echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
       echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
       echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+      echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
       echo "FLOW_WAVE: listed"
       exit 0
     fi
@@ -1900,6 +2046,7 @@ EOF
     for r in $ROLES; do
       e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
       lv="$(liveness_of "$e")"
+      lb="$(liveness_basis_of "$e")"
       sock="$(printf '%s' "$e" | jq -r '.socket // "unknown"')"
       iss="$(printf '%s' "$e" | jq -r '.issue // "" | if . == "" then "-" else . end')"
       # `filled` is a verified state, not a lesser one (#674): the address was
@@ -1969,7 +2116,13 @@ EOF
         fi
         mailbox_never_read "$r" && extra="$extra ** NEVER READ **"
       fi
-      echo "  $r -> $sock [$lv, $ver] issue=$iss$extra"
+      # The basis is rendered ONLY for `unknown`, so a roster of ordinary live
+      # and stale roles is byte-identical to pre-#869 - the same promise #778
+      # and #699 made about their own additions. `unknown` is the one state a
+      # reader cannot act on without knowing WHY it could not be decided.
+      lvs="$lv"
+      [ "$lv" = "unknown" ] && lvs="$lv:$lb"
+      echo "  $r -> $sock [$lvs, $ver] issue=$iss$extra"
     done
     # Claim-derived rows (#687), rendered AFTER the roles and visibly not roles.
     # An orchestrator scanning the issue column now sees a lane held by a
@@ -2141,6 +2294,7 @@ EOF
     echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
     echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
     echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+    echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
     echo "FLOW_WAVE: listed"
     exit 0
     ;;

--- a/scripts/flow-wave-registry.sh
+++ b/scripts/flow-wave-registry.sh
@@ -455,7 +455,16 @@ pid_state() {
   fi
 
   if kill -0 "$pid" 2>/dev/null; then echo alive; return; fi
-  err="$(kill -0 "$pid" 2>&1 >/dev/null)"
+  # LAST RESORT, and the only branch in this function that reads PROSE rather
+  # than a fact. There is no portable way to get an errno out of the `kill`
+  # builtin except its message, and that message is `strerror()`, which glibc
+  # TRANSLATES. `LC_ALL=C` pins it - a temporary assignment on a builtin does
+  # reach bash's own setlocale - but it cannot help if the message shape itself
+  # differs, so an unrecognised message falls to `unknown` rather than guessing.
+  # That is the safe direction: `unknown` refuses a takeover, it never invents
+  # life. Reachable only on a host with no /proc, since /proc is consulted
+  # first, and never in the tests, which pin the table.
+  err="$(LC_ALL=C kill -0 "$pid" 2>&1 >/dev/null)"
   case "$err" in
     *"o such process"*)                     echo gone ;;
     *"ot permitted"*|*"ermission denied"*)  echo alive ;;

--- a/scripts/flow-wave-registry.sh
+++ b/scripts/flow-wave-registry.sh
@@ -322,7 +322,12 @@
 #   FLOW_WAVE_SOCK_DIR      socket dir override (default /run/user/<uid>/cc-socks)
 #   FLOW_WAVE_NOW           override "now" as epoch seconds
 #   FLOW_WAVE_HOST          override this host's name
-#   FLOW_WAVE_LIVE_PIDS     ':'-separated pids treated as alive (bypasses kill -0)
+#   FLOW_WAVE_LIVE_PIDS     ':'-separated pids treated as alive; when set the
+#                           list is AUTHORITATIVE, so a pid absent from it reads
+#                           gone (bypasses the /proc + errno probe entirely)
+#   FLOW_WAVE_UNKNOWN_PIDS  ':'-separated pids whose liveness is undeterminable.
+#                           The only way to exercise that branch on a /proc host,
+#                           where the real probe can always decide (#869)
 #   FLOW_WAVE_MAILBOX_DIR   mailbox wave-root override, passed through to the
 #                           sibling helper so the two always co-locate (#778)
 #   FLOW_WAVE_SELF_PID      starting pid for the self-address ancestor walk
@@ -392,24 +397,77 @@ emit() {
   echo "FLOW_WAVE_PID=${E_PID:--}"
   echo "FLOW_WAVE_SESSION=${E_SESSION:--}"
   echo "FLOW_WAVE_LIVENESS=${E_LIVE:--}"
+  echo "FLOW_WAVE_LIVENESS_BASIS=${E_BASIS:--}"
   echo "FLOW_WAVE_VERIFIED=${E_VERIFIED:--}"
   echo "FLOW_WAVE_MISMATCH=${E_MISMATCH:--}"
   echo "FLOW_WAVE_BOOTSTRAP=${E_BOOTSTRAP:--}"
   echo "FLOW_WAVE: $1"
 }
 
+# pid_state PID -> alive | gone | unknown, for a pid on THIS host.
+#
+# `kill -0` has TWO failure modes behind ONE return code, and collapsing them is
+# what #869 fixes. They are not degrees of the same answer; they are opposite
+# answers:
+#   ESRCH  no such process   - the process is GONE. Definite.
+#   EPERM  not permitted     - the process EXISTS, we merely may not signal it.
+#                              This is POSITIVE evidence of life.
+# EPERM is precisely the case #675 introduced the socket-file fallback to rescue
+# ("covering a pid the helper cannot signal"). Reading the errno serves that
+# stated purpose with a correct instrument, so the fallback no longer has to
+# stand in for evidence that was available all along - and, unlike stat-ing a
+# socket path, it works on EVERY transport rather than only `uds:`.
+#
+# `/proc/<pid>` is consulted first where it exists because it answers directly
+# and without ambiguity: the kernel keeps an entry for every live process on the
+# host regardless of who owns it, so presence is existence and absence is death.
+#
+# `unknown` is a real third answer, not a polite `gone`: a host with no /proc
+# whose `kill` reports something we do not recognise has an UNENUMERABLE process
+# table, and rounding that down to "dead" is the mistake the sibling mailbox
+# refused when it moved off pid liveness (#814). Never checked and
+# checked-but-undecidable are different facts.
+pid_state() {
+  local pid="$1" err
+  [ -n "$pid" ] && [ "$pid" != "-" ] && [ "$pid" != "null" ] || { echo gone; return; }
+  case "$pid" in ''|*[!0-9]*) echo gone; return ;; esac
+
+  # Test hooks pin the process table so no test depends on a pid that happens
+  # to exist. FLOW_WAVE_UNKNOWN_PIDS is checked first: it is the narrower
+  # statement, and it is the only way to reach the undeterminable branch on a
+  # /proc host, where the real prober can never return `unknown`.
+  if [ -n "${FLOW_WAVE_UNKNOWN_PIDS:-}" ]; then
+    case ":$FLOW_WAVE_UNKNOWN_PIDS:" in *":$pid:"*) echo unknown; return ;; esac
+  fi
+  if [ -n "${FLOW_WAVE_LIVE_PIDS:-}" ]; then
+    case ":$FLOW_WAVE_LIVE_PIDS:" in
+      *":$pid:"*) echo alive ;;
+      # The pinned list is AUTHORITATIVE when set, so absence from it is death,
+      # not undeterminability - otherwise every test would read `unknown`.
+      *) echo gone ;;
+    esac
+    return
+  fi
+
+  if [ -d /proc/self ]; then
+    if [ -d "/proc/$pid" ]; then echo alive; else echo gone; fi
+    return
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then echo alive; return; fi
+  err="$(kill -0 "$pid" 2>&1 >/dev/null)"
+  case "$err" in
+    *"o such process"*)                     echo gone ;;
+    *"ot permitted"*|*"ermission denied"*)  echo alive ;;
+    *)                                      echo unknown ;;
+  esac
+}
+
 # is_alive PID HOST -> 0 when the owning session still runs on THIS host.
 is_alive() {
   local pid="$1" host="$2"
-  [ -n "$pid" ] && [ "$pid" != "-" ] && [ "$pid" != "null" ] || return 1
   [ "$host" = "$SELF_HOST" ] || return 1
-  if [ -n "${FLOW_WAVE_LIVE_PIDS:-}" ]; then
-    case ":$FLOW_WAVE_LIVE_PIDS:" in
-      *":$pid:"*) return 0 ;;
-      *) return 1 ;;
-    esac
-  fi
-  kill -0 "$pid" 2>/dev/null
+  [ "$(pid_state "$pid")" = "alive" ]
 }
 
 # Best-effort self-address: walk this process's ancestors and match each pid
@@ -502,41 +560,78 @@ entry_json() { # entry_json WAVE ROLE -> the entry object or 'null'
   read_registry | jq -c --arg w "$1" --arg r "$2" '.[$w].roles[$r] // null'
 }
 
-# liveness_of ENTRY_JSON -> live | stale | released
-liveness_of() {
-  local e="$1" pid host sock released
+# _liveness_compute ENTRY_JSON -> "STATE BASIS"
+#
+# STATE is live | stale | unknown | released. BASIS names WHICH RULE decided it,
+# so a reader can tell a proven death from an undecidable one without inferring
+# it from the state alone (#869 acceptance: the two `kill -0` failure modes are
+# distinguishable, and the code says which one it saw).
+#
+# THE SOCKET FILE IS CORROBORATION, NEVER PROOF (#869). It used to be sufficient
+# on its own, and evaluated AFTER the pid had already been reported dead:
+#
+#     uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
+#
+# The kernel does not unlink a unix domain socket when its owner dies, so the
+# file outlives the process and the WEAKER evidence overrode the STRONGER one: a
+# SIGKILLed session kept reading `live` for as long as its socket sat on disk.
+#
+# What #675 actually asked for is preserved. Its words are that the socket file
+# is "a SECOND, independent proof, covering a pid the helper cannot signal" -
+# that is the EPERM case, and `pid_state` now answers it directly and correctly.
+# What is removed is only the socket's power to override a DEFINITE ESRCH, which
+# #675 never claimed and which was a bug in the mechanism rather than in the
+# intent. #689 then made the branch uds-only and recorded that transports
+# without sockets get one factor, "a property of the design, not an oversight".
+# That asymmetry is now GONE rather than documented: errno needs no socket, so
+# every transport gets the same primary evidence. The socket survives only in
+# the BASIS, where it corroborates an already-undeterminable pid and changes no
+# verdict.
+_liveness_compute() {
+  local e="$1" pid host sock released st
   released="$(printf '%s' "$e" | jq -r '.released // false')"
-  [ "$released" = "true" ] && { echo released; return; }
+  [ "$released" = "true" ] && { echo "released released"; return; }
   pid="$(printf '%s' "$e" | jq -r '.pid // "-"')"
   host="$(printf '%s' "$e" | jq -r '.host // "-"')"
   sock="$(printf '%s' "$e" | jq -r '.socket // "unknown"')"
-  if is_alive "$pid" "$host"; then echo live; return; fi
-  # A live socket file on this host also proves liveness (covers a pid the
-  # helper cannot signal but whose session socket clearly exists).
-  #
-  # This secondary proof is UDS-ONLY and now says so (#689). It used to strip a
-  # `uds:` prefix unconditionally and stat the remainder, which on any other
-  # transport - `bridge:session_01RLE...` - stripped nothing and tested whether a
-  # file literally named `bridge:session_...` existed. Always false, so the
-  # fallback was silently inert rather than absent, and register.md's two-factor
-  # staleness rule ("socket gone + pid dead") was one-factor on those transports.
-  #
-  # Deliberately EXPOSES the gap rather than closing it: whether another
-  # transport can offer its own secondary proof is a separate question (#676).
-  # On a non-uds address liveness rests on `kill -0` alone - the registry is
-  # host-local by construction, so that is sound today, but it is one mechanism
-  # and not two, and the code should state that instead of implying otherwise.
-  if [ "$host" = "$SELF_HOST" ] && [ "$sock" != "unknown" ]; then
-    case "$sock" in
-      uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
-      # Any other scheme: no socket-file proof exists. Fall through to stale on
-      # the strength of `kill -0` alone rather than running a test that cannot
-      # pass (#689).
-      *) : ;;
-    esac
-  fi
-  echo stale
+
+  # Unchanged, and deliberately so: the registry is host-local by construction,
+  # so an entry from another host has always read `stale` and every reader is
+  # built on that. It is arguably the same shape of defect as the one above - we
+  # cannot determine a remote pid's liveness either - but promoting it to
+  # `unknown` would change takeover semantics for every cross-host entry, which
+  # is a separate decision and out of scope here. The BASIS says which rule
+  # fired, so the two never look alike to a reader.
+  if [ "$host" != "$SELF_HOST" ]; then echo "stale other-host"; return; fi
+
+  st="$(pid_state "$pid")"
+  case "$st" in
+    alive) echo "live pid-present"; return ;;
+    # A leftover socket file is NOT evidence against a confirmed death, so it is
+    # not consulted on this branch at all.
+    gone)  echo "stale pid-gone"; return ;;
+  esac
+
+  # pid_state could not decide. Report the socket as corroboration - it raises
+  # confidence that something is still there, and it settles nothing.
+  case "$sock" in
+    unknown) echo "unknown pid-undeterminable-no-address" ;;
+    uds:*)
+      if [ -S "${sock#uds:}" ]; then
+        echo "unknown pid-undeterminable-socket-present"
+      else
+        echo "unknown pid-undeterminable-socket-absent"
+      fi
+      ;;
+    *) echo "unknown pid-undeterminable-no-socket-proof" ;;
+  esac
 }
+
+# liveness_of ENTRY_JSON -> live | stale | unknown | released
+liveness_of() { local r; r="$(_liveness_compute "$1")"; echo "${r%% *}"; }
+
+# liveness_basis_of ENTRY_JSON -> the rule that decided it
+liveness_basis_of() { local r; r="$(_liveness_compute "$1")"; echo "${r#* }"; }
 
 # cwd_is_shared_parent CWD REPO -> 0 when CWD looks like a shared projects
 # parent rather than a lane (#683).
@@ -1182,7 +1277,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 E_WAVE="$WAVE"; E_ROLE="$ROLE"; E_SOCKET=""; E_PID=""; E_SESSION=""
-E_LIVE=""; E_VERIFIED=""; E_MISMATCH=""; E_SOURCE=""; E_REASON=""; E_BOOTSTRAP=""
+E_LIVE=""; E_BASIS=""; E_VERIFIED=""; E_MISMATCH=""; E_SOURCE=""; E_REASON=""; E_BOOTSTRAP=""
 
 case "$VERB" in
   self-address)
@@ -1345,20 +1440,44 @@ case "$VERB" in
       CUR_PID="$(printf '%s' "$CUR" | jq -r '.pid // "-"')"
       CUR_SESSION="$(printf '%s' "$CUR" | jq -r '.session // "-"')"
       CUR_LIVE="$(liveness_of "$CUR")"
+      CUR_BASIS="$(liveness_basis_of "$CUR")"
       SAME_OWNER=0
       [ "$CUR_SESSION" != "-" ] && [ "$CUR_SESSION" = "$SELF_SESSION" ] && SAME_OWNER=1
       [ "$CUR_PID" = "$SELF_PID" ] && SAME_OWNER=1
-      if [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "live" ] && [ "$FORCE" -eq 0 ]; then
-        echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a LIVE session (pid $CUR_PID, session $CUR_SESSION)." >&2
+      # An ALLOW-LIST of states that release the role, never a deny-list of
+      # states that hold it (#869). `!= stale` would read a brand-new state as
+      # takeable, which is this issue's own defect - weaker evidence beating
+      # stronger - reproduced one layer up. Only a PROVEN death frees a role:
+      # `unknown` means we could not determine the owner is gone, and that is
+      # not the same as determining it is.
+      case "$CUR_LIVE" in
+        stale|released) HELD=0 ;;
+        *)              HELD=1 ;;
+      esac
+      if [ "$SAME_OWNER" -eq 0 ] && [ "$HELD" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+        if [ "$CUR_LIVE" = "live" ]; then
+          echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a LIVE session (pid $CUR_PID, session $CUR_SESSION)." >&2
+        else
+          echo "flow-wave-registry: role '$ROLE' (wave '$WAVE') is held by a session whose liveness is UNDETERMINABLE (pid $CUR_PID, session $CUR_SESSION, basis $CUR_BASIS)." >&2
+          echo "  This host cannot enumerate its process table, so the owner is not known to be gone - which is not the same as knowing it is alive." >&2
+        fi
         echo "  Two sessions both believing they are '$ROLE' is the failure this command exists to prevent (#638)." >&2
         echo "  Pick another role, or re-run with --force if you are certain that session is gone." >&2
         E_SOCKET="$(printf '%s' "$CUR" | jq -r '.socket // "unknown"')"
-        E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"
+        E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"; E_BASIS="$CUR_BASIS"
         emit refused
         exit 1
       fi
-      [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "stale" ] &&
-        echo "flow-wave-registry: taking over stale role '$ROLE' (owner pid $CUR_PID is gone)." >&2
+      if [ "$SAME_OWNER" -eq 0 ]; then
+        case "$CUR_LIVE" in
+          stale)
+            echo "flow-wave-registry: taking over stale role '$ROLE' (owner pid $CUR_PID is gone)." >&2 ;;
+          unknown)
+            # Only reachable under --force, and the loudest line here: the
+            # operator is overriding an unanswered question, not a known death.
+            echo "flow-wave-registry: --force taking over role '$ROLE' whose owner (pid $CUR_PID) was NOT confirmed gone (basis $CUR_BASIS)." >&2 ;;
+        esac
+      fi
       # Trust model, the reverse direction (#638 gate condition 1 / #672): a
       # FAILED self-derivation must never downgrade a recorded address to
       # 'unknown'. You cannot address 'unknown', so any known address outranks
@@ -1535,7 +1654,7 @@ case "$VERB" in
     echo "FLOW_WAVE_BRIEFED_REV=$POL_REV"
     echo "FLOW_WAVE_BRIEF=$(brief_state "$POL_REV" "$POL_REV")"
     echo "FLOW_WAVE_LANE_SCOPED=$E_LANE_SCOPED"
-    E_SOCKET="$SOCK"; E_PID="$SELF_PID"; E_SESSION="$SELF_SESSION"; E_LIVE=live
+    E_SOCKET="$SOCK"; E_PID="$SELF_PID"; E_SESSION="$SELF_SESSION"; E_LIVE=live; E_BASIS=self
     E_VERIFIED="$KEEP_VERIFIED"; E_MISMATCH="$KEEP_MISMATCH"
     E_SOURCE="$SOCK_SOURCE"; E_REASON="$SOCK_REASON"
     emit "$VERDICT"
@@ -1552,6 +1671,7 @@ case "$VERB" in
     E_PID="$(printf '%s' "$CUR" | jq -r '.pid // "-"')"
     E_SESSION="$(printf '%s' "$CUR" | jq -r '.session // "-"')"
     E_LIVE="$(liveness_of "$CUR")"
+    E_BASIS="$(liveness_basis_of "$CUR")"
     E_VERIFIED="$(printf '%s' "$CUR" | jq -r '.verified // false')"
     E_MISMATCH="$(printf '%s' "$CUR" | jq -r '.address_mismatch // false')"
     # `get` is what a session runs to answer "where do I send to this role?".
@@ -1680,9 +1800,19 @@ case "$VERB" in
     [ "$CUR_SESSION" != "-" ] && [ "$CUR_SESSION" = "$SELF_SESSION" ] && SAME_OWNER=1
     [ "$CUR_PID" = "$SELF_PID" ] && SAME_OWNER=1
     CUR_LIVE="$(liveness_of "$CUR")"
-    if [ "$SAME_OWNER" -eq 0 ] && [ "$CUR_LIVE" = "live" ] && [ "$FORCE" -eq 0 ]; then
-      echo "flow-wave-registry: role '$ROLE' belongs to a LIVE session (pid $CUR_PID) - not releasing. Pass --force to override." >&2
-      E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"
+    CUR_BASIS="$(liveness_basis_of "$CUR")"
+    # Allow-list, for the same reason as `register` above (#869).
+    case "$CUR_LIVE" in
+      stale|released) HELD=0 ;;
+      *)              HELD=1 ;;
+    esac
+    if [ "$SAME_OWNER" -eq 0 ] && [ "$HELD" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+      if [ "$CUR_LIVE" = "live" ]; then
+        echo "flow-wave-registry: role '$ROLE' belongs to a LIVE session (pid $CUR_PID) - not releasing. Pass --force to override." >&2
+      else
+        echo "flow-wave-registry: role '$ROLE' belongs to a session whose liveness is UNDETERMINABLE (pid $CUR_PID, basis $CUR_BASIS) - not releasing. Pass --force to override." >&2
+      fi
+      E_PID="$CUR_PID"; E_SESSION="$CUR_SESSION"; E_LIVE="$CUR_LIVE"; E_BASIS="$CUR_BASIS"
       emit refused
       exit 1
     fi
@@ -1733,9 +1863,22 @@ case "$VERB" in
     # unconditionally - it holds no lane, so it has no scoping to lose.
     UNSCOPED=0
     UNSCOPED_ROLES=""
+    # Roles whose LIVENESS could not be determined (#869). Counted here for the
+    # same reason #800 counts unscoped lanes: an unknowable answer must never be
+    # read as a clean one. Every `= "live"` consumer below correctly SKIPS an
+    # `unknown` role - but skipping it means its lane is neither overlap-checked
+    # nor counted as unchecked, so a roster would otherwise report a clean
+    # verdict over a role nobody examined. This counter is that role's receipt.
+    UNDETERMINED=0
+    UNDETERMINED_ROLES=""
     for r in $ROLES; do
       e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
-      [ "$(liveness_of "$e")" = "live" ] || continue
+      LV_R="$(liveness_of "$e")"
+      if [ "$LV_R" = "unknown" ]; then
+        UNDETERMINED=$((UNDETERMINED + 1))
+        UNDETERMINED_ROLES="$UNDETERMINED_ROLES $r"
+      fi
+      [ "$LV_R" = "live" ] || continue
       [ "$r" = "orchestrator" ] && continue
       lane_unscoped \
         "$(printf '%s' "$e" | jq -r '.repo // ""')" \
@@ -1802,7 +1945,8 @@ $rp"
       for r in $ROLES; do
         e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
         lv="$(liveness_of "$e")"
-        OUT="$(printf '%s' "$OUT" | jq -c --arg r "$r" --argjson e "$e" --arg lv "$lv" '.[$r] = ($e + {liveness: $lv})')"
+        lb="$(liveness_basis_of "$e")"
+        OUT="$(printf '%s' "$OUT" | jq -c --arg r "$r" --argjson e "$e" --arg lv "$lv" --arg lb "$lb" '.[$r] = ($e + {liveness: $lv, liveness_basis: $lb})')"
         # `watch` and `mailbox` are computed keys like `liveness`, and appear
         # ONLY when this wave actually uses the mailbox lane (#778) - so a wave
         # that never touched it emits byte-identical JSON to pre-#778, the same
@@ -1859,6 +2003,7 @@ $rp"
       echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
       echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
       echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+      echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
       echo "FLOW_WAVE: listed"
       exit 0
     fi
@@ -1884,6 +2029,7 @@ EOF
       echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
       echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
       echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+      echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
       echo "FLOW_WAVE: listed"
       exit 0
     fi
@@ -1900,6 +2046,7 @@ EOF
     for r in $ROLES; do
       e="$(printf '%s' "$REG" | jq -c --arg w "$WAVE" --arg r "$r" '.[$w].roles[$r]')"
       lv="$(liveness_of "$e")"
+      lb="$(liveness_basis_of "$e")"
       sock="$(printf '%s' "$e" | jq -r '.socket // "unknown"')"
       iss="$(printf '%s' "$e" | jq -r '.issue // "" | if . == "" then "-" else . end')"
       # `filled` is a verified state, not a lesser one (#674): the address was
@@ -1969,7 +2116,13 @@ EOF
         fi
         mailbox_never_read "$r" && extra="$extra ** NEVER READ **"
       fi
-      echo "  $r -> $sock [$lv, $ver] issue=$iss$extra"
+      # The basis is rendered ONLY for `unknown`, so a roster of ordinary live
+      # and stale roles is byte-identical to pre-#869 - the same promise #778
+      # and #699 made about their own additions. `unknown` is the one state a
+      # reader cannot act on without knowing WHY it could not be decided.
+      lvs="$lv"
+      [ "$lv" = "unknown" ] && lvs="$lv:$lb"
+      echo "  $r -> $sock [$lvs, $ver] issue=$iss$extra"
     done
     # Claim-derived rows (#687), rendered AFTER the roles and visibly not roles.
     # An orchestrator scanning the issue column now sees a lane held by a
@@ -2141,6 +2294,7 @@ EOF
     echo "FLOW_WAVE_UNREAD=$UNREAD_TOTAL"
     echo "FLOW_WAVE_BOOTSTRAP=$BOOTSTRAP_STATE"
     echo "FLOW_WAVE_OVERLAP_UNSCOPED=$UNSCOPED"
+    echo "FLOW_WAVE_LIVENESS_UNDETERMINED=$UNDETERMINED"
     echo "FLOW_WAVE: listed"
     exit 0
     ;;

--- a/tests/test_flow_wave_registry.py
+++ b/tests/test_flow_wave_registry.py
@@ -30,9 +30,15 @@ Contract:
   ``orchestrator`` and any role with no issue claimed - and the exemption is
   ANNOUNCED, never silent; ``register`` advises when ``--cwd`` looks like a
   shared parent rather than a lane.
-- The socket-file liveness fallback is uds-only and says so (#689); on other
-  transports liveness rests on ``kill -0`` alone rather than on a test that
-  cannot pass.
+- A leftover socket file never resurrects a dead pid (#869). ``kill -0`` has two
+  failure modes behind one return code - ESRCH (gone) and EPERM (exists, not
+  ours) - and the registry now separates them, so the case #675 introduced the
+  socket fallback for (a pid the helper cannot signal) is answered by positive
+  evidence instead. ``liveness_of`` returns a third state, ``unknown``, for a
+  host whose process table cannot be enumerated at all; the socket file survives
+  only in ``FLOW_WAVE_LIVENESS_BASIS``, where it corroborates and decides
+  nothing. Supersedes the uds-only fallback of #689, whose one-factor asymmetry
+  on non-uds transports is gone rather than documented.
 - ``verified``/``address_filled``/``address_mismatch`` share ONE lifecycle
   (#691/#692): preserved together across a same-owner re-register at a
   byte-identical address, cleared together on a takeover or an address change.
@@ -102,6 +108,7 @@ def _run(
     pid: str = SELF_PID,
     session: str = SELF_SESSION,
     live: str = "",
+    unknown: str = "",
     now: str = "1700000000",
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
@@ -113,6 +120,7 @@ def _run(
             "FLOW_WAVE_SOCK_DIR": str(tmp / "socks"),
             "FLOW_WAVE_HOST": HOST,
             "FLOW_WAVE_LIVE_PIDS": live,
+            "FLOW_WAVE_UNKNOWN_PIDS": unknown,
             "FLOW_WAVE_NOW": now,
         }
     )
@@ -515,36 +523,245 @@ class TestLaneLessRolesExemptFromOverlap:
 
 
 @requires_tools
-class TestLivenessSecondaryProofIsUdsOnly:
-    """The socket-file fallback states its precondition (#689).
+class TestLeftoverSocketIsNotProofOfLife:
+    """A socket file corroborates; it never proves (#869).
 
-    It used to strip `uds:` unconditionally and stat the remainder, so on a
-    `bridge:` address it tested for a file literally named `bridge:session_...`
-    - always false, so the fallback was silently inert rather than absent.
-    Behaviour is preserved for uds; the non-uds gap becomes explicit.
+    The kernel does not unlink a unix domain socket when its owner dies, so the
+    file outlives the process. The old fallback consulted it AFTER the pid had
+    already been reported dead and returned `live` on the strength of it, which
+    made the WEAKER evidence override the STRONGER one: a SIGKILLed session read
+    `live` for as long as its socket sat on disk.
+
+    #675's stated purpose survives intact. It wanted to cover "a pid the helper
+    cannot signal" - the EPERM case - and that is now answered by classifying
+    `kill -0`'s two failure modes rather than by stat-ing a path. What is removed
+    is only the socket's power to override a definite ESRCH, which #675 never
+    claimed. #689's uds-only asymmetry is gone rather than documented, because
+    errno needs no socket and so works on every transport.
     """
 
-    def test_uds_socket_file_still_proves_liveness_for_a_dead_pid(self, tmp_path: Path) -> None:
+    def test_leftover_uds_socket_does_not_resurrect_a_dead_pid(self, tmp_path: Path) -> None:
+        """The exact defect: dead pid + socket file still on disk -> stale."""
         import socket as _socket
 
-        sock_path = tmp_path / "live.sock"
+        sock_path = tmp_path / "leftover.sock"
         s = _socket.socket(_socket.AF_UNIX)
         try:
             s.bind(str(sock_path))
         except OSError as exc:  # path too long for AF_UNIX on this box
             pytest.skip(f"cannot bind AF_UNIX socket here: {exc}")
         try:
+            assert sock_path.is_socket()  # the file the old branch trusted
             _run(tmp_path, "register", "1", "--socket", f"uds:{sock_path}", pid="999999")
-            p = _run(tmp_path, "list", live="none")
-            assert "[live," in p.stdout
+
+            dead = _run(tmp_path, "get", "1", live="none")
+            assert _detail(dead, "FLOW_WAVE_LIVENESS") == "stale"
+            assert _detail(dead, "FLOW_WAVE_LIVENESS_BASIS") == "pid-gone"
+
+            # Positive control: the SAME socket file, with the pid pinned alive,
+            # must read live - otherwise this test could pass on a registry that
+            # simply never returns `live` at all.
+            alive = _run(tmp_path, "get", "1", live="999999")
+            assert _detail(alive, "FLOW_WAVE_LIVENESS") == "live"
+            assert _detail(alive, "FLOW_WAVE_LIVENESS_BASIS") == "pid-present"
         finally:
             s.close()
 
-    def test_non_uds_address_reads_stale_without_consulting_a_file(self, tmp_path: Path) -> None:
+    @pytest.mark.skipif(not Path("/proc/self").is_dir(), reason="needs /proc")
+    def test_sigkilled_owner_reads_stale_against_the_real_process_table(
+        self, tmp_path: Path
+    ) -> None:
+        """The issue's own positive control, end to end, with no liveness hook.
+
+        `FLOW_WAVE_LIVE_PIDS` is left EMPTY so the real prober runs. A pinned
+        list would prove only that the hook works.
+        """
+        import signal
+
+        sock_path = tmp_path / "victim.sock"
+        code = (
+            "import socket,time;s=socket.socket(socket.AF_UNIX);"
+            f"s.bind({str(sock_path)!r});print('up',flush=True);time.sleep(300)"
+        )
+        proc = subprocess.Popen(["python3", "-c", code], stdout=subprocess.PIPE, text=True)
+        try:
+            assert proc.stdout is not None
+            if proc.stdout.readline().strip() != "up":
+                pytest.skip("helper could not bind an AF_UNIX socket here")
+            pid = str(proc.pid)
+            _run(tmp_path, "register", "1", "--socket", f"uds:{sock_path}", pid=pid)
+
+            # Bound, owner alive -> file exists, and the roster agrees.
+            assert _detail(_run(tmp_path, "get", "1", pid=pid), "FLOW_WAVE_LIVENESS") == "live"
+
+            proc.send_signal(signal.SIGKILL)
+            proc.wait(timeout=10)
+            deadline = time.monotonic() + 10
+            while Path(f"/proc/{pid}").exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert not Path(f"/proc/{pid}").exists(), "death not confirmed"
+
+            # SIGKILL owner, death confirmed -> file STILL on disk, still a socket.
+            assert sock_path.is_socket()
+
+            p = _run(tmp_path, "get", "1", pid=pid)
+            assert _detail(p, "FLOW_WAVE_LIVENESS") == "stale"
+            assert _detail(p, "FLOW_WAVE_LIVENESS_BASIS") == "pid-gone"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+
+    @pytest.mark.skipif(
+        not Path("/proc/1").is_dir() or os.geteuid() == 0,
+        reason="needs /proc and a non-root euid, so that pid 1 is unsignalable",
+    )
+    def test_a_pid_we_may_not_signal_still_reads_live(self, tmp_path: Path) -> None:
+        """#675's actual case, served by the better instrument.
+
+        pid 1 exists and a non-root user may not signal it, so `kill -0` fails
+        with EPERM exactly as it would for a session owned by another user. The
+        old code reached this only via a socket file; there is no socket here.
+        """
+        assert subprocess.run(["kill", "-0", "1"], capture_output=True).returncode != 0
+        _run(tmp_path, "register", "1", "--socket", "uds:/nonexistent/none.sock", pid="1")
+        p = _run(tmp_path, "get", "1", pid="1")
+        assert _detail(p, "FLOW_WAVE_LIVENESS") == "live"
+        assert _detail(p, "FLOW_WAVE_LIVENESS_BASIS") == "pid-present"
+
+    def test_non_uds_address_gets_the_same_primary_evidence(self, tmp_path: Path) -> None:
+        """#689's asymmetry is removed, not documented: errno needs no socket."""
         _run(tmp_path, "register", "1", "--socket", "bridge:session_01RLEabc", pid="999998")
-        p = _run(tmp_path, "list", live="none")
-        assert p.returncode == 0
-        assert "[stale," in p.stdout
+        dead = _run(tmp_path, "list", live="none")
+        assert dead.returncode == 0
+        assert "[stale," in dead.stdout
+        alive = _run(tmp_path, "get", "1", live="999998")
+        assert _detail(alive, "FLOW_WAVE_LIVENESS") == "live"
+
+
+@requires_tools
+class TestUndeterminableLivenessIsItsOwnState:
+    """`unknown` is a third answer, not a polite `stale` (#869).
+
+    A host that cannot enumerate its process table has not reported a death, and
+    rounding that down to one is the mistake the sibling mailbox refused when it
+    moved off pid liveness (#814). Never checked and checked-but-undecidable are
+    different facts.
+    """
+
+    def test_undeterminable_pid_reads_unknown_not_live(self, tmp_path: Path) -> None:
+        import socket as _socket
+
+        sock_path = tmp_path / "corroborating.sock"
+        s = _socket.socket(_socket.AF_UNIX)
+        try:
+            s.bind(str(sock_path))
+        except OSError as exc:
+            pytest.skip(f"cannot bind AF_UNIX socket here: {exc}")
+        try:
+            _run(tmp_path, "register", "1", "--socket", f"uds:{sock_path}", pid="999999")
+            p = _run(tmp_path, "get", "1", live="none", unknown="999999")
+            # Present socket + undeterminable pid is the case the OLD code
+            # called `live`. It corroborates, and it still decides nothing.
+            assert _detail(p, "FLOW_WAVE_LIVENESS") == "unknown"
+            assert _detail(p, "FLOW_WAVE_LIVENESS_BASIS") == "pid-undeterminable-socket-present"
+        finally:
+            s.close()
+
+    def test_basis_distinguishes_a_missing_socket_from_a_present_one(
+        self, tmp_path: Path
+    ) -> None:
+        _run(tmp_path, "register", "1", "--socket", "uds:/nonexistent/gone.sock", pid="999999")
+        p = _run(tmp_path, "get", "1", live="none", unknown="999999")
+        assert _detail(p, "FLOW_WAVE_LIVENESS") == "unknown"
+        assert _detail(p, "FLOW_WAVE_LIVENESS_BASIS") == "pid-undeterminable-socket-absent"
+
+    def test_unknown_owner_is_not_taken_over_without_force(self, tmp_path: Path) -> None:
+        """Only a PROVEN death frees a role - #638's guarantee, unchanged."""
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/x.sock",
+             pid=OTHER_PID, session=OTHER_SESSION)
+        p = _run(tmp_path, "register", "1", "--socket", "uds:/tmp/y.sock",
+                 live="none", unknown=OTHER_PID)
+        assert _verdict(p) == "refused"
+        assert p.returncode == 1
+        assert _detail(p, "FLOW_WAVE_LIVENESS") == "unknown"
+        assert "UNDETERMINABLE" in p.stderr
+
+    def test_force_takes_over_an_unknown_owner_and_says_it_was_not_confirmed(
+        self, tmp_path: Path
+    ) -> None:
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/x.sock",
+             pid=OTHER_PID, session=OTHER_SESSION)
+        p = _run(tmp_path, "register", "1", "--socket", "uds:/tmp/y.sock", "--force",
+                 live="none", unknown=OTHER_PID)
+        assert _verdict(p) == "registered"
+        assert "NOT confirmed gone" in p.stderr
+
+    def test_a_proven_dead_owner_is_still_taken_over_silently(self, tmp_path: Path) -> None:
+        """The `unknown` refusal must not wedge the ordinary stale takeover."""
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/x.sock",
+             pid=OTHER_PID, session=OTHER_SESSION)
+        p = _run(tmp_path, "register", "1", "--socket", "uds:/tmp/y.sock", live="none")
+        assert _verdict(p) == "registered"
+        assert "taking over stale role" in p.stderr
+
+    def test_release_refuses_an_unknown_owner(self, tmp_path: Path) -> None:
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/x.sock",
+             pid=OTHER_PID, session=OTHER_SESSION)
+        p = _run(tmp_path, "release", "1", live="none", unknown=OTHER_PID)
+        assert _verdict(p) == "refused"
+        assert p.returncode == 1
+
+    def test_unknown_is_rendered_with_its_basis_in_the_roster(self, tmp_path: Path) -> None:
+        _run(tmp_path, "register", "1", "--socket", "uds:/nonexistent/gone.sock", pid="999999")
+        p = _run(tmp_path, "list", live="none", unknown="999999")
+        assert "[unknown:pid-undeterminable-socket-absent," in p.stdout
+
+    def test_ordinary_roster_lines_are_unchanged(self, tmp_path: Path) -> None:
+        """Only `unknown` carries a basis, so a normal wave reads as before."""
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/x.sock")
+        live = _run(tmp_path, "list", live=SELF_PID)
+        assert "[live, " in live.stdout and "live:" not in live.stdout
+        stale = _run(tmp_path, "list", live="none")
+        assert "[stale, " in stale.stdout and "stale:" not in stale.stdout
+
+    def test_roster_counts_roles_whose_liveness_could_not_be_determined(
+        self, tmp_path: Path
+    ) -> None:
+        """The receipt for a role every `= live` consumer skips.
+
+        Skipping an `unknown` role is correct - but it leaves that role neither
+        overlap-checked nor counted as unchecked, so without this counter the
+        roster reports a clean verdict over a role nobody examined. Same reason
+        #800 emits `FLOW_WAVE_OVERLAP_UNSCOPED`.
+        """
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/a.sock",
+             pid="200", session="s-a")
+        _run(tmp_path, "register", "2", "--socket", "uds:/tmp/b.sock",
+             pid="300", session="s-b")
+        p = _run(tmp_path, "list", live="200", unknown="300")
+        assert _detail(p, "FLOW_WAVE_LIVENESS_UNDETERMINED") == "1"
+        # Emitted as a VALUE even when zero, so a consumer can tell "none" from
+        # "this call does not report it".
+        clean = _run(tmp_path, "list", live="200:300")
+        assert _detail(clean, "FLOW_WAVE_LIVENESS_UNDETERMINED") == "0"
+
+    def test_the_counter_is_reported_on_every_list_render_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Including --json and the empty roster - the #800 promise, kept."""
+        empty = _run(tmp_path, "list")
+        assert _detail(empty, "FLOW_WAVE_LIVENESS_UNDETERMINED") == "0"
+        _run(tmp_path, "register", "1", "--socket", "uds:/tmp/a.sock", pid="300")
+        js = _run(tmp_path, "list", "--json", live="none", unknown="300")
+        assert _detail(js, "FLOW_WAVE_LIVENESS_UNDETERMINED") == "1"
+
+    def test_list_json_carries_the_basis_beside_the_liveness(self, tmp_path: Path) -> None:
+        _run(tmp_path, "register", "1", "--socket", "uds:/nonexistent/gone.sock", pid="999999")
+        p = _run(tmp_path, "list", "--json", live="none", unknown="999999")
+        entry = _json_payload(p)["1"]
+        assert entry["liveness"] == "unknown"
+        assert entry["liveness_basis"] == "pid-undeterminable-socket-absent"
 
 
 @requires_tools

--- a/tests/test_flow_wave_registry.py
+++ b/tests/test_flow_wave_registry.py
@@ -623,7 +623,11 @@ class TestLeftoverSocketIsNotProofOfLife:
         with EPERM exactly as it would for a session owned by another user. The
         old code reached this only via a socket file; there is no socket here.
         """
-        assert subprocess.run(["kill", "-0", "1"], capture_output=True).returncode != 0
+        # Asserted through os.kill rather than a `kill` BINARY: this test's
+        # claim is about the errno, and a minimal container without procps
+        # would turn a missing binary into an ERROR rather than a skip.
+        with pytest.raises(PermissionError):
+            os.kill(1, 0)
         _run(tmp_path, "register", "1", "--socket", "uds:/nonexistent/none.sock", pid="1")
         p = _run(tmp_path, "get", "1", pid="1")
         assert _detail(p, "FLOW_WAVE_LIVENESS") == "live"


### PR DESCRIPTION
## The defect

`liveness_of` consulted the recorded `uds:` socket file **after** `kill -0` had already reported the pid dead, and returned `live` on the strength of it:

```sh
uds:*) [ -S "${sock#uds:}" ] && { echo live; return; } ;;
```

The kernel does not unlink a unix domain socket when its owner dies, so the file outlives the process and the **weaker** evidence overrode the **stronger** one. A SIGKILLed session read `live` in the roster for as long as its socket sat on disk.

## The fix, and why it is not a reversal of #675

The socket branch was standing in for evidence that was already available. `kill -0` has **two** failure modes behind **one** return code, and they are opposite answers rather than degrees of one:

| errno | meaning | verdict |
|-------|---------|---------|
| `ESRCH` | no such process | **gone**. Definite. |
| `EPERM` | not permitted | the process **exists**; we merely may not signal it. Positive evidence of life. |

`EPERM` is exactly the case #675 introduced the socket fallback for — its own words are that the socket file is "a SECOND, independent proof, **covering a pid the helper cannot signal**". So this serves #675's stated purpose with a correct instrument. What is retired is only the socket's power to override a definite `ESRCH`, which #675 never claimed and which was a bug in the mechanism, not in the intent.

`/proc/<pid>` is consulted first where it exists, because it answers directly for any owner.

**#689's asymmetry is removed rather than documented.** #689 recorded that only `uds:` addresses have a file to stat, so other transports got one factor — "a property of the design, not an oversight". Errno needs no socket, so every transport now gets the same primary evidence and the asymmetry has no remaining cause.

## `unknown` is a third state

A host that can neither read `/proc` nor classify `kill`'s errno has an **unenumerable** process table. Rounding that down to "dead" is the mistake the sibling mailbox refused in #814: never-checked and checked-but-undecidable are different facts.

A role in that state is **not** taken over without `--force` — only a proven death frees a role, because not knowing an owner is gone is not the same as knowing it is.

`FLOW_WAVE_LIVENESS_BASIS` names which rule decided every verdict. The socket file survives only there, as corroboration that changes no verdict.

## Consumer audit (every `liveness_of` call site)

A new third state flowing into unmodified call sites is the highest-risk part of this change. The failure mode is specific and quiet: any consumer testing `!= stale` rather than `== live` would read `unknown` as live — this issue's own defect, reproduced one layer up.

**14** call sites (not 13, as first reported). **Zero** test `!= stale`; the repo contains no such comparison anywhere.

| Line | Context | Comparison | Effect on `unknown` |
|---|---|---|---|
| 754 | `collect_unregistered_claims` | `== live` | skipped → its claim may show as unregistered (over-reports; advisory) |
| 1166 | `likely_wave` | `== live` | skipped → advisory degrades to silence |
| 1185 | `cross_wave_notes` | `== live` | skipped → note omitted (advisory) |
| 1403 | `policy` stale-brief scan | `== live` | skipped → not listed for re-brief (advisory) |
| 1442 | `register` takeover | **allow-list** | **refuses** without `--force` |
| 1673 | `get` | assigns `E_LIVE` | reported verbatim, with basis |
| 1802 | `release` | **allow-list** | **refuses** without `--force` |
| 1842 | `list` unaddressed count | `== live` | skipped (advisory) |
| 1868 | `list` unscoped count | `== live` | skipped — **see below** |
| 1889 | `list` mailbox deafness | `== live` | skipped (advisory) |
| 1934 | `list --json` | assigns `lv` | emitted verbatim + `liveness_basis` |
| 2033 | `list` text roster | assigns `lv` | rendered `[unknown:<basis>, …]` |
| 2165 | `list` overlap checks | `== live` | skipped — **see below** |
| 2249 | `list` stale-brief summary | `== live` | skipped (advisory) |

**One loose end this change opened, and closed.** Sites 1868 and 2165 mean an `unknown` role's lane is neither overlap-checked **nor** counted as unchecked — so the roster would report a clean verdict over a role nobody examined. `FLOW_WAVE_LIVENESS_UNDETERMINED` is now emitted on every `list` render path (including `0`, the empty roster, and `--json`), for the same reason #800 emits `FLOW_WAVE_OVERLAP_UNSCOPED`: an unknowable answer must never read as a clean one.

The audit is **static and dynamic**. A static operator sweep proves no consumer can misread the state; it does not prove the consumers were ever reached. Every verb above was also driven against a registry holding a real `unknown` entry (`list`, `list --json`, `get`, `policy show`, `release`, `register` takeover), with a control run pinning the same role alive to prove the checks fire rather than passing vacuously.

## Test plan

- `test_leftover_uds_socket_does_not_resurrect_a_dead_pid` — the exact defect; carries a positive control (same socket file, pid pinned alive → `live`) so it cannot pass on a registry that simply never returns `live`.
- `test_sigkilled_owner_reads_stale_against_the_real_process_table` — the issue's own positive control end to end, with **no liveness hook**: spawns a real process that binds a real socket, SIGKILLs it, confirms `/proc/<pid>` is gone and the socket file is still on disk, then asserts `stale`. A pinned list would prove only that the hook works.
- `test_a_pid_we_may_not_signal_still_reads_live` — pid 1 under a non-root euid: genuinely `EPERM`, no socket involved. #675's case, served by the better instrument.
- `unknown` state: rendering, basis (`socket-present` vs `socket-absent`), refusal of takeover and release, `--force` override naming that the owner was not confirmed gone, `--json`, and the new counter.
- `test_ordinary_roster_lines_are_unchanged` — only `unknown` carries a basis, so a normal wave's roster is byte-identical to before.

Vendored `codex/skills/**` copies regenerated via `scripts/codex-skill-sync.py --write`, never hand-edited.

## Acceptance

| Item | Disposition |
|---|---|
| Dead pid + remaining socket does not render `live` | Demonstrated — dedicated test, plus the SIGKILL end-to-end test |
| The two `kill -0` failure modes are distinguishable | Demonstrated — `pid_state` classifies them; `FLOW_WAVE_LIVENESS_BASIS` reports which fired; pid-1 test covers EPERM |
| A test covers SIGKILL-then-stale-socket directly | Demonstrated — `test_sigkilled_owner_reads_stale_against_the_real_process_table` |

## Deliberately out of scope

- **Recycled pids.** The issue's "Related" note: `kill -0` on a recycled pid reports the original session alive, which the mailbox rejected in #814 and moved to a lifetime `flock` for. Not carried across here; the position is stated in the code comment and recorded in the nit store (#864).
- **Cross-host entries** still read `stale` rather than `unknown`. Arguably the same shape of defect — a remote pid's liveness is equally undeterminable — but promoting it would change takeover semantics for every cross-host entry. The basis line (`other-host`) keeps the two distinguishable to a reader. Recorded in #864.

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdGcy6opnQ7PxDB8eVGXs6