### PR TITLE
fix(flow): stamp every delivery-lane claim with the harness version (Refs #870)

### DIFF
--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -499,8 +499,11 @@ that is a new measurement and it belongs in this table with its own stamp.
 **Delivery preference order. Follow it in order; do not skip to the end.**
 
 1. **Direct session messaging** (`SendMessage` to the `ListAgents` name) -
-   available in both directions on 2.1.266; the August one-directional
-   restriction is retired. It is a FAST PATH, not a record: nothing is stored,
+   routes between independent sessions on 2.1.266, measured
+   worker->orchestrator 2026-09-12. The reverse is no longer believed blocked
+   (the v2.1.224 expiry, and the current contract) but was NOT re-measured;
+   ceasing to believe a direction is blocked is not the same as establishing it
+   works. It is a FAST PATH, not a record: nothing is stored,
    there is no receipt, and a message delivered to a session that never acts on
    it leaves no trace either end can audit. Use it to make something already
    written arrive sooner.
@@ -546,12 +549,16 @@ procedure mandates the vulnerable shape.
 
 **What was observed here, and why it does not settle the question.** On
 2.1.266, 2026-09-12, a worker->orchestrator send was delivered to a receiver
-holding a watch in exactly that vulnerable shape. The watch survived: alive on
-`pgrep` after delivery, and it later exited **0** - the normal mail-arrived
-exit, where a reaped task reports killed with no exit code.
+holding a watch in exactly that vulnerable shape. The watch survived, and the
+evidence is its **exit code 0** on mail arrival: a task that exits 0 having
+delivered its payload cannot have been reaped, whenever the kill window fell. A
+liveness check taken at delivery time was also run and is deliberately NOT
+recorded - the 2.1.258 report puts the kill 0-13s after the TURN ends, so a
+process alive during the turn samples the wrong window and implies a rigour it
+does not have.
 
 That is one observation and it does NOT generalize, for three separate reasons,
-each of which alone would be enough:
+of which the first and third are each sufficient alone:
 
 1. **This host is not in the default configuration.** It sets
    `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (in the environment and in
@@ -559,10 +566,13 @@ each of which alone would be enough:
    sessions booted. If the kill path runs through background-shell pressure
    reaping, the mechanism is disabled here and survival is a property of this
    host rather than of 2.1.266.
-2. **The upstream discriminator was not controlled for.** The second report
-   puts the kill at turn end, not delivery, and only when the task is the
-   session's sole live background task. Neither condition was established for
-   the receiver.
+2. **The upstream discriminator was not deliberately controlled for.** The
+   second report puts the kill at turn end, not delivery, and only when the task
+   is the session's sole live background task. The receiver reports that its
+   watch WAS its sole live background task, so that condition held - but it held
+   by circumstance rather than by design, which is weaker evidence than an
+   experiment and is recorded as such. This reason alone would not disqualify
+   the observation; 1 and 3 do.
 3. **It may simply be fixed.** The same reporter stopped reproducing at 2.1.263,
    and this host runs 2.1.266.
 

--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -458,24 +458,152 @@ with a reserved word, `send --no-lexicon` is the per-message escape.
 ### The delivery lane - mailbox + wake (issue #676)
 
 Everything above is the ADDRESS BOOK: who a role is, where it lives, whether
-the address can be trusted. None of it delivers anything, and on 2026-08-11
-that gap cost ~2 hours - the harness rejected every orchestrator->worker
-`SendMessage` (it routes only to subagents the calling session spawned), so a
-fully-written assignment sat undelivered while both sessions correctly stood
-by. The only transport that moved a message was the user typing a pointer into
-the worker's terminal by hand.
+the address can be trusted. None of it delivers anything.
+
+**Every claim in this section carries the harness version it was established
+on, next to the claim.** That is not housekeeping. The order this section used
+to give rested on a single incident of 2026-08-11, written as a property of
+"the harness" with no version anywhere near it: the harness rejected every
+orchestrator->worker `SendMessage`, reportedly routing only to subagents the
+calling session spawned, and an assignment sat undelivered ~2h while both
+sessions correctly stood by. Cross-session messaging between independent
+sessions then shipped in **v2.1.224**, and the premise expired without anything
+in the text able to say so (issue #870). An unversioned claim about harness
+behaviour is the defect that produced this section; do not add one.
+
+**Established on 2.1.266, 2026-09-12** (`claude --version`), on this host:
+
+| Claim | How established |
+|---|---|
+| A cross-session message ENQUEUES and drains at the receiver's next tool round | installed tool contract, read 2026-09-12 |
+| The address is any peer name from `ListAgents` - "subagent, another local Claude session" - with no spawn relationship required | installed tool contract, read 2026-09-12 |
+| `ListAgents` resolves independent sessions on this machine, by name, including their tmux pane | run 2026-09-12 |
+| worker->orchestrator `SendMessage` between two independent sessions RESOLVED and DELIVERED | **measured** 2026-09-12, `success=true`, target reported as "another Claude session on this machine" |
+
+The first two are CONTRACT facts - what the installed harness documents about
+itself - and they are labelled that way because they are not measurements. They
+contradict the August premise directly (enqueue is not reject; any listed peer
+is not only-my-subagents), which is enough to retire it, and is NOT enough to
+tell you what a send does in the field. The fourth row is the field check, and
+it is the one that actually retires the premise. Keep the two kinds apart when
+you update this: replacing an expired reading with a fresher reading repeats the
+mistake at a later date.
+
+The August claim was DIRECTIONAL - worker->orchestrator reliable,
+orchestrator->worker not - and only one direction was re-measured here. Nothing
+in the contract, in the upstream thread, or in the original incident describes
+an asymmetric routing mechanism, so the directional framing is dropped rather
+than re-asserted for the untested direction. If you find a direction that fails,
+that is a new measurement and it belongs in this table with its own stamp.
 
 **Delivery preference order. Follow it in order; do not skip to the end.**
 
-1. **Direct session messaging** (`SendMessage` to the registry address) - use
-   it wherever the harness supports it. Worker->orchestrator has been reliable
-   in the field; orchestrator->worker has not.
-2. **Mailbox + watch** - the host-local lane below. This is the fallback for
-   every direction the harness cannot route, and it is a REAL lane: it wakes
-   the counterpart.
+1. **Direct session messaging** (`SendMessage` to the `ListAgents` name) -
+   available in both directions on 2.1.266; the August one-directional
+   restriction is retired. It is a FAST PATH, not a record: nothing is stored,
+   there is no receipt, and a message delivered to a session that never acts on
+   it leaves no trace either end can audit. Use it to make something already
+   written arrive sooner.
+2. **Mailbox + watch** - the host-local lane below, and the DURABLE one. It
+   holds a record, survives the receiver being dead at send time, and gives an
+   explicit ack. Lane 1 going first does not demote it: anything that must
+   still be true in an hour belongs here, and for the container boundary below
+   this is the only lane that exists at all.
 3. **User relay** - the DOCUMENTED LAST RESORT. On 2026-08-11 it was the first
    resort, which is the bug. Reaching for a human means lanes 1 and 2 both
    failed, and that is worth saying out loud rather than doing quietly.
+
+**The container boundary, stated here because it decides lane 1.** Native
+session discovery is filesystem-based, so a containerised session and a host
+session cannot see each other at all - not a permissions failure and not
+something a setting fixes: there is no path between them. Two sessions inside
+one container can. If either end is containerised, lane 1 does not exist and
+the mailbox is not a fallback but the only transport. Check before routing, not
+after silence.
+
+**A hazard on lane 1 whose status is version-dependent - read the stamps.**
+Cross-session message delivery has been observed to kill the receiver's
+in-flight *harness background Bash tasks* (upstream
+anthropics/claude-code#91139, open; thread read 2026-09-12). Two independent
+reports, and they do not describe the same trigger:
+
+| Report | Harness | Finding |
+|---|---|---|
+| original | 2.1.252, macOS | six kill events across four sessions in ~90 min; only harness-TRACKED tasks die, `nohup`-detached survive |
+| second | 2.1.258, Linux | sharper discriminator: the kill lands at the END OF THE TURN the message started, not at delivery, and only when that task is the session's ONLY live background task or subagent; a `setsid` grandchild survives every time |
+| same reporter | 2.1.263, Linux | no longer reproducing |
+
+**The `setsid` exemption does not cover the common case in this fleet.**
+`/kyle:boot` instructs every Kyle session to arm its mailbox watch *as the
+background call itself*, and explicitly forbids appending `&`, because a
+detached watch leaves the harness recording the task complete and nothing
+re-invokes the session when mail lands (boot skill, line 146, read 2026-09-12).
+So a session booted that way has its ONLY wake mechanism in precisely the object
+the original report describes as dying - and a deafened session looks identical
+to a quiet one from outside. Anyone reading the upstream issue and concluding
+the fleet is covered by the `setsid` exemption has it backwards: the boot
+procedure mandates the vulnerable shape.
+
+**What was observed here, and why it does not settle the question.** On
+2.1.266, 2026-09-12, a worker->orchestrator send was delivered to a receiver
+holding a watch in exactly that vulnerable shape. The watch survived: alive on
+`pgrep` after delivery, and it later exited **0** - the normal mail-arrived
+exit, where a reaped task reports killed with no exit code.
+
+That is one observation and it does NOT generalize, for three separate reasons,
+each of which alone would be enough:
+
+1. **This host is not in the default configuration.** It sets
+   `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (in the environment and in
+   `~/.claude/settings.json`), which was already there before any of these
+   sessions booted. If the kill path runs through background-shell pressure
+   reaping, the mechanism is disabled here and survival is a property of this
+   host rather than of 2.1.266.
+2. **The upstream discriminator was not controlled for.** The second report
+   puts the kill at turn end, not delivery, and only when the task is the
+   session's sole live background task. Neither condition was established for
+   the receiver.
+3. **It may simply be fixed.** The same reporter stopped reproducing at 2.1.263,
+   and this host runs 2.1.266.
+
+**So: routing generalizes, no-kill does not.** That lane 1 resolves and delivers
+between independent sessions is a property of the harness and retires the August
+premise. That it does not deafen the receiver is, on the evidence available
+here, **not measurable on this host** - the most plausible mechanism is disabled
+in this configuration. Recording it as "safe on 2.1.266" would be the exact
+defect this section exists to correct, one version later.
+
+Practical consequence meanwhile: prefer `supervise` where it is available;
+after receiving a cross-session message, assume your watch may be gone and
+re-arm rather than checking; and do not increase lane 1 traffic to a session
+whose wake mechanism you have not confirmed.
+
+**Two settings decide whether lane 1 works, and neither is set on this host**
+(read 2026-09-12; `~/.claude/settings.json` carries no `crossSessionInbound`,
+no `isolatePeerMachines`, no `dialogExpiry`).
+
+- **`crossSessionInbound`** - unset, so delivery falls to a default computed
+  from both sessions' permission classes. Kyle spawns sessions with
+  `--dangerously-skip-permissions`, so fleet-internal traffic is bypass-to-
+  bypass and delivers today. A message from a *prompting* sender - an
+  interactive terminal not in bypass, a session on another surface - is held for
+  an approval dialog nobody is watching and dropped after `dialogExpiry`
+  (five minutes by default). **Recommended: `accept`.** It removes a working
+  lane's dependence on both ends happening to land in the same permission class,
+  which is a property no one declared and nothing checks.
+- **`isolatePeerMachines`** - unset, so a send beyond this machine leaves
+  without approval. Same-machine messages never touch Anthropic servers;
+  cross-machine and cloud ones do. `ListAgents` on this host resolves 43 peers,
+  most of them Remote Control sessions on other machines, so the set of
+  addresses a typo can reach is large and mostly off-box.
+  **Recommended: `true`**, making an off-box send a deliberate act rather than
+  the default outcome of picking the wrong name from a long list.
+
+These are recommendations recorded for a human to apply, deliberately not
+applied by any session. `~/.claude/settings.json` is host state shared by every
+session on the machine: a value written there takes effect for all of them, is
+not reviewable as a diff, and does not arrive through the change that reviewed
+the reasoning. The artifact is fine; the delivery path is what bypasses review.
 
 **The lane.** Beside the registry, same lifetime, same host-local scope
 (`$XDG_RUNTIME_DIR/cc-flow-wave/<wave>/`), one audited helper invoked BARE

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -161,11 +161,26 @@ so read that line before treating a quiet roster as a clear one.
 ## Setup: the delivery lane (consume #676, do not reimplement)
 
 The roster says WHERE a worker is. It does not deliver, and on 2026-08-11 that
-was the whole failure: the harness rejected every orchestrator->worker
-`SendMessage` (it routes only to subagents the calling session spawned), so a
-written assignment sat undelivered ~2h while both sessions correctly stood by.
-Follow the delivery preference order in `register.md` - `SendMessage` first,
-then the mailbox, and a human relay only as a named last resort.
+gap cost ~2h: a written assignment sat undelivered while both sessions correctly
+stood by, and the incident was written up as the harness rejecting every
+orchestrator->worker `SendMessage`. **That premise expired in v2.1.224 and the
+text did not know.** On 2.1.266 a send between two independent sessions resolves
+and delivers, measured 2026-09-12; the one-directional restriction is retired,
+and the directional framing with it, since nothing describes an asymmetric
+routing mechanism (issue #870).
+
+Follow the delivery preference order in `register.md`, which now carries a
+harness version against every claim: `SendMessage` as a FAST PATH, the mailbox
+as the DURABLE record, and a human relay only as a named last resort. Two things
+there decide whether lane 1 is available to you at all, and both are stated with
+their evidence rather than repeated here - the container boundary (a
+containerised session and a host session cannot see each other, so lane 1 does
+not exist for that pair), and a background-task hazard whose status is
+version-dependent.
+
+The lesson of 2026-08-11 is not the routing verdict, which expired. It is that
+this document stated a harness behaviour with no version attached, so nothing
+could tell the next reader it had gone stale. Stamp what you write here.
 
 **Arm supervision over the inbox at setup, before the first assignment
 (issues #676, #814).** One call covers every `inbox-*.md` in the wave, so a

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -460,24 +460,152 @@ with a reserved word, `send --no-lexicon` is the per-message escape.
 ### The delivery lane - mailbox + wake (issue #676)
 
 Everything above is the ADDRESS BOOK: who a role is, where it lives, whether
-the address can be trusted. None of it delivers anything, and on 2026-08-11
-that gap cost ~2 hours - the harness rejected every orchestrator->worker
-`SendMessage` (it routes only to subagents the calling session spawned), so a
-fully-written assignment sat undelivered while both sessions correctly stood
-by. The only transport that moved a message was the user typing a pointer into
-the worker's terminal by hand.
+the address can be trusted. None of it delivers anything.
+
+**Every claim in this section carries the harness version it was established
+on, next to the claim.** That is not housekeeping. The order this section used
+to give rested on a single incident of 2026-08-11, written as a property of
+"the harness" with no version anywhere near it: the harness rejected every
+orchestrator->worker `SendMessage`, reportedly routing only to subagents the
+calling session spawned, and an assignment sat undelivered ~2h while both
+sessions correctly stood by. Cross-session messaging between independent
+sessions then shipped in **v2.1.224**, and the premise expired without anything
+in the text able to say so (issue #870). An unversioned claim about harness
+behaviour is the defect that produced this section; do not add one.
+
+**Established on 2.1.266, 2026-09-12** (`claude --version`), on this host:
+
+| Claim | How established |
+|---|---|
+| A cross-session message ENQUEUES and drains at the receiver's next tool round | installed tool contract, read 2026-09-12 |
+| The address is any peer name from `ListAgents` - "subagent, another local Claude session" - with no spawn relationship required | installed tool contract, read 2026-09-12 |
+| `ListAgents` resolves independent sessions on this machine, by name, including their tmux pane | run 2026-09-12 |
+| worker->orchestrator `SendMessage` between two independent sessions RESOLVED and DELIVERED | **measured** 2026-09-12, `success=true`, target reported as "another Claude session on this machine" |
+
+The first two are CONTRACT facts - what the installed harness documents about
+itself - and they are labelled that way because they are not measurements. They
+contradict the August premise directly (enqueue is not reject; any listed peer
+is not only-my-subagents), which is enough to retire it, and is NOT enough to
+tell you what a send does in the field. The fourth row is the field check, and
+it is the one that actually retires the premise. Keep the two kinds apart when
+you update this: replacing an expired reading with a fresher reading repeats the
+mistake at a later date.
+
+The August claim was DIRECTIONAL - worker->orchestrator reliable,
+orchestrator->worker not - and only one direction was re-measured here. Nothing
+in the contract, in the upstream thread, or in the original incident describes
+an asymmetric routing mechanism, so the directional framing is dropped rather
+than re-asserted for the untested direction. If you find a direction that fails,
+that is a new measurement and it belongs in this table with its own stamp.
 
 **Delivery preference order. Follow it in order; do not skip to the end.**
 
-1. **Direct session messaging** (`SendMessage` to the registry address) - use
-   it wherever the harness supports it. Worker->orchestrator has been reliable
-   in the field; orchestrator->worker has not.
-2. **Mailbox + watch** - the host-local lane below. This is the fallback for
-   every direction the harness cannot route, and it is a REAL lane: it wakes
-   the counterpart.
+1. **Direct session messaging** (`SendMessage` to the `ListAgents` name) -
+   available in both directions on 2.1.266; the August one-directional
+   restriction is retired. It is a FAST PATH, not a record: nothing is stored,
+   there is no receipt, and a message delivered to a session that never acts on
+   it leaves no trace either end can audit. Use it to make something already
+   written arrive sooner.
+2. **Mailbox + watch** - the host-local lane below, and the DURABLE one. It
+   holds a record, survives the receiver being dead at send time, and gives an
+   explicit ack. Lane 1 going first does not demote it: anything that must
+   still be true in an hour belongs here, and for the container boundary below
+   this is the only lane that exists at all.
 3. **User relay** - the DOCUMENTED LAST RESORT. On 2026-08-11 it was the first
    resort, which is the bug. Reaching for a human means lanes 1 and 2 both
    failed, and that is worth saying out loud rather than doing quietly.
+
+**The container boundary, stated here because it decides lane 1.** Native
+session discovery is filesystem-based, so a containerised session and a host
+session cannot see each other at all - not a permissions failure and not
+something a setting fixes: there is no path between them. Two sessions inside
+one container can. If either end is containerised, lane 1 does not exist and
+the mailbox is not a fallback but the only transport. Check before routing, not
+after silence.
+
+**A hazard on lane 1 whose status is version-dependent - read the stamps.**
+Cross-session message delivery has been observed to kill the receiver's
+in-flight *harness background Bash tasks* (upstream
+anthropics/claude-code#91139, open; thread read 2026-09-12). Two independent
+reports, and they do not describe the same trigger:
+
+| Report | Harness | Finding |
+|---|---|---|
+| original | 2.1.252, macOS | six kill events across four sessions in ~90 min; only harness-TRACKED tasks die, `nohup`-detached survive |
+| second | 2.1.258, Linux | sharper discriminator: the kill lands at the END OF THE TURN the message started, not at delivery, and only when that task is the session's ONLY live background task or subagent; a `setsid` grandchild survives every time |
+| same reporter | 2.1.263, Linux | no longer reproducing |
+
+**The `setsid` exemption does not cover the common case in this fleet.**
+`/kyle:boot` instructs every Kyle session to arm its mailbox watch *as the
+background call itself*, and explicitly forbids appending `&`, because a
+detached watch leaves the harness recording the task complete and nothing
+re-invokes the session when mail lands (boot skill, line 146, read 2026-09-12).
+So a session booted that way has its ONLY wake mechanism in precisely the object
+the original report describes as dying - and a deafened session looks identical
+to a quiet one from outside. Anyone reading the upstream issue and concluding
+the fleet is covered by the `setsid` exemption has it backwards: the boot
+procedure mandates the vulnerable shape.
+
+**What was observed here, and why it does not settle the question.** On
+2.1.266, 2026-09-12, a worker->orchestrator send was delivered to a receiver
+holding a watch in exactly that vulnerable shape. The watch survived: alive on
+`pgrep` after delivery, and it later exited **0** - the normal mail-arrived
+exit, where a reaped task reports killed with no exit code.
+
+That is one observation and it does NOT generalize, for three separate reasons,
+each of which alone would be enough:
+
+1. **This host is not in the default configuration.** It sets
+   `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (in the environment and in
+   `~/.claude/settings.json`), which was already there before any of these
+   sessions booted. If the kill path runs through background-shell pressure
+   reaping, the mechanism is disabled here and survival is a property of this
+   host rather than of 2.1.266.
+2. **The upstream discriminator was not controlled for.** The second report
+   puts the kill at turn end, not delivery, and only when the task is the
+   session's sole live background task. Neither condition was established for
+   the receiver.
+3. **It may simply be fixed.** The same reporter stopped reproducing at 2.1.263,
+   and this host runs 2.1.266.
+
+**So: routing generalizes, no-kill does not.** That lane 1 resolves and delivers
+between independent sessions is a property of the harness and retires the August
+premise. That it does not deafen the receiver is, on the evidence available
+here, **not measurable on this host** - the most plausible mechanism is disabled
+in this configuration. Recording it as "safe on 2.1.266" would be the exact
+defect this section exists to correct, one version later.
+
+Practical consequence meanwhile: prefer `supervise` where it is available;
+after receiving a cross-session message, assume your watch may be gone and
+re-arm rather than checking; and do not increase lane 1 traffic to a session
+whose wake mechanism you have not confirmed.
+
+**Two settings decide whether lane 1 works, and neither is set on this host**
+(read 2026-09-12; `~/.claude/settings.json` carries no `crossSessionInbound`,
+no `isolatePeerMachines`, no `dialogExpiry`).
+
+- **`crossSessionInbound`** - unset, so delivery falls to a default computed
+  from both sessions' permission classes. Kyle spawns sessions with
+  `--dangerously-skip-permissions`, so fleet-internal traffic is bypass-to-
+  bypass and delivers today. A message from a *prompting* sender - an
+  interactive terminal not in bypass, a session on another surface - is held for
+  an approval dialog nobody is watching and dropped after `dialogExpiry`
+  (five minutes by default). **Recommended: `accept`.** It removes a working
+  lane's dependence on both ends happening to land in the same permission class,
+  which is a property no one declared and nothing checks.
+- **`isolatePeerMachines`** - unset, so a send beyond this machine leaves
+  without approval. Same-machine messages never touch Anthropic servers;
+  cross-machine and cloud ones do. `ListAgents` on this host resolves 43 peers,
+  most of them Remote Control sessions on other machines, so the set of
+  addresses a typo can reach is large and mostly off-box.
+  **Recommended: `true`**, making an off-box send a deliberate act rather than
+  the default outcome of picking the wrong name from a long list.
+
+These are recommendations recorded for a human to apply, deliberately not
+applied by any session. `~/.claude/settings.json` is host state shared by every
+session on the machine: a value written there takes effect for all of them, is
+not reviewable as a diff, and does not arrive through the change that reviewed
+the reasoning. The artifact is fine; the delivery path is what bypasses review.
 
 **The lane.** Beside the registry, same lifetime, same host-local scope
 (`$XDG_RUNTIME_DIR/cc-flow-wave/<wave>/`), one audited helper invoked BARE

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -501,8 +501,11 @@ that is a new measurement and it belongs in this table with its own stamp.
 **Delivery preference order. Follow it in order; do not skip to the end.**
 
 1. **Direct session messaging** (`SendMessage` to the `ListAgents` name) -
-   available in both directions on 2.1.266; the August one-directional
-   restriction is retired. It is a FAST PATH, not a record: nothing is stored,
+   routes between independent sessions on 2.1.266, measured
+   worker->orchestrator 2026-09-12. The reverse is no longer believed blocked
+   (the v2.1.224 expiry, and the current contract) but was NOT re-measured;
+   ceasing to believe a direction is blocked is not the same as establishing it
+   works. It is a FAST PATH, not a record: nothing is stored,
    there is no receipt, and a message delivered to a session that never acts on
    it leaves no trace either end can audit. Use it to make something already
    written arrive sooner.
@@ -548,12 +551,16 @@ procedure mandates the vulnerable shape.
 
 **What was observed here, and why it does not settle the question.** On
 2.1.266, 2026-09-12, a worker->orchestrator send was delivered to a receiver
-holding a watch in exactly that vulnerable shape. The watch survived: alive on
-`pgrep` after delivery, and it later exited **0** - the normal mail-arrived
-exit, where a reaped task reports killed with no exit code.
+holding a watch in exactly that vulnerable shape. The watch survived, and the
+evidence is its **exit code 0** on mail arrival: a task that exits 0 having
+delivered its payload cannot have been reaped, whenever the kill window fell. A
+liveness check taken at delivery time was also run and is deliberately NOT
+recorded - the 2.1.258 report puts the kill 0-13s after the TURN ends, so a
+process alive during the turn samples the wrong window and implies a rigour it
+does not have.
 
 That is one observation and it does NOT generalize, for three separate reasons,
-each of which alone would be enough:
+of which the first and third are each sufficient alone:
 
 1. **This host is not in the default configuration.** It sets
    `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (in the environment and in
@@ -561,10 +568,13 @@ each of which alone would be enough:
    sessions booted. If the kill path runs through background-shell pressure
    reaping, the mechanism is disabled here and survival is a property of this
    host rather than of 2.1.266.
-2. **The upstream discriminator was not controlled for.** The second report
-   puts the kill at turn end, not delivery, and only when the task is the
-   session's sole live background task. Neither condition was established for
-   the receiver.
+2. **The upstream discriminator was not deliberately controlled for.** The
+   second report puts the kill at turn end, not delivery, and only when the task
+   is the session's sole live background task. The receiver reports that its
+   watch WAS its sole live background task, so that condition held - but it held
+   by circumstance rather than by design, which is weaker evidence than an
+   experiment and is recorded as such. This reason alone would not disqualify
+   the observation; 1 and 3 do.
 3. **It may simply be fixed.** The same reporter stopped reproducing at 2.1.263,
    and this host runs 2.1.266.
 

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -163,11 +163,26 @@ so read that line before treating a quiet roster as a clear one.
 ## Setup: the delivery lane (consume #676, do not reimplement)
 
 The roster says WHERE a worker is. It does not deliver, and on 2026-08-11 that
-was the whole failure: the harness rejected every orchestrator->worker
-`SendMessage` (it routes only to subagents the calling session spawned), so a
-written assignment sat undelivered ~2h while both sessions correctly stood by.
-Follow the delivery preference order in `register.md` - `SendMessage` first,
-then the mailbox, and a human relay only as a named last resort.
+gap cost ~2h: a written assignment sat undelivered while both sessions correctly
+stood by, and the incident was written up as the harness rejecting every
+orchestrator->worker `SendMessage`. **That premise expired in v2.1.224 and the
+text did not know.** On 2.1.266 a send between two independent sessions resolves
+and delivers, measured 2026-09-12; the one-directional restriction is retired,
+and the directional framing with it, since nothing describes an asymmetric
+routing mechanism (issue #870).
+
+Follow the delivery preference order in `register.md`, which now carries a
+harness version against every claim: `SendMessage` as a FAST PATH, the mailbox
+as the DURABLE record, and a human relay only as a named last resort. Two things
+there decide whether lane 1 is available to you at all, and both are stated with
+their evidence rather than repeated here - the container boundary (a
+containerised session and a host session cannot see each other, so lane 1 does
+not exist for that pair), and a background-task hazard whose status is
+version-dependent.
+
+The lesson of 2026-08-11 is not the routing verdict, which expired. It is that
+this document stated a harness behaviour with no version attached, so nothing
+could tell the next reader it had gone stale. Stamp what you write here.
 
 **Arm supervision over the inbox at setup, before the first assignment
 (issues #676, #814).** One call covers every `inbox-*.md` in the wave, so a

--- a/tests/test_delivery_lane_versioned.py
+++ b/tests/test_delivery_lane_versioned.py
@@ -157,3 +157,39 @@ def test_the_hazard_reports_are_each_stamped() -> None:
         f"expected several distinct harness versions beside the hazard reports, got {versions}"
     )
     assert "91139" in section, "the upstream issue is not cited"
+
+
+def test_the_guidance_does_not_claim_more_than_the_evidence_records() -> None:
+    """The lane list must not assert a direction the evidence section says was not measured.
+
+    This one is a regression, and of the worst kind: the first draft of this change
+    stated in its evidence section that "only one direction was re-measured here"
+    and, four paragraphs later in the numbered lane list, that `SendMessage` was
+    "available in both directions on 2.1.266". Same file, contradictory, and the
+    half an agent acts from is the lane list - nobody reads an evidence table before
+    sending a message.
+
+    The version stamp made it worse rather than better. A stamp asserts WHEN a fact
+    was established, so stamping a direction that was never exercised manufactures
+    provenance for the half that has none. That is not a milder form of #870's
+    defect; it is #870's defect, inside #870's own remedy.
+
+    The distinction that has to hold: retiring a one-directional RESTRICTION is
+    justified by the v2.1.224 expiry plus one measured direction - ceasing to
+    believe a negative is cheap. Claiming both directions WORK is a positive claim
+    about an unexercised path, and costs a measurement.
+    """
+    section = _delivery_section(REGISTER.read_text())
+    says_one = re.search(
+        r"only one direction was re-measured|was NOT re-measured", section, re.I
+    )
+    assert says_one, "the evidence section no longer records how many directions were measured"
+    claims_both = re.search(
+        r"available in both directions|works in both directions|both directions on \d",
+        section,
+        re.I,
+    )
+    assert not claims_both, (
+        "the lane guidance asserts both directions while the evidence section "
+        "records only one as measured - the claim must not outrun its evidence"
+    )

--- a/tests/test_delivery_lane_versioned.py
+++ b/tests/test_delivery_lane_versioned.py
@@ -1,0 +1,159 @@
+"""Pin: delivery-lane claims carry the harness version they were established on (issue #870).
+
+The preference order in `flow/register.md` rested on one incident of 2026-08-11,
+written as a property of "the harness" with no version attached: `SendMessage`
+reportedly routed only to subagents the calling session spawned, so
+orchestrator->worker was declared unreliable. Cross-session messaging between
+independent sessions shipped in v2.1.224. The premise expired, the text could not
+say so, and a wave kept routing around a restriction that no longer existed.
+
+**The defect was never the verdict - it was the missing stamp.** A re-measurement
+that does not carry its own version is the same artifact with a fresher date, and
+#871 is the evergreen re-check that has to trust whatever is written here. So what
+this file pins is the STAMP DISCIPLINE, not the current verdict: a version beside
+every harness claim, contract readings labelled separately from measurements, and
+the population caveats kept attached to the result they qualify.
+
+**What is deliberately NOT pinned.** Whether lane 1 is first, whether a send kills
+a background task, what `crossSessionInbound` should be - all of that is expected
+to change, and a test asserting today's answer would have to be edited by the same
+person who next re-measures, which is how a guard becomes a formality. The tests
+below fail when a claim loses its stamp, never when a claim changes.
+
+Verified non-vacuous: stashed against the pre-change tree, all 9 fail.
+
+One probe had to be tightened to get there. `test_the_expired_premise_is_not_asserted_bare`
+first accepted a bare `2026-08-11` near the claim as evidence it was marked
+historical - but the OLD text carried that date too, so the probe passed over the
+very defect it was written for. It now requires a word that actually says the
+claim is dead (`expired`, `retired`, `no longer`). The general trap: when a probe
+looks for context around a defect, check that the defect's own surroundings do not
+already supply it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS = ROOT / ".claude" / "commands"
+REGISTER = COMMANDS / "flow" / "register.md"
+WAVE = COMMANDS / "flow" / "wave.md"
+
+#: A harness version, as it must appear beside a claim: 2.1.224, 2.1.266, v2.1.224.
+VERSION = re.compile(r"\bv?2\.1\.\d{3}\b")
+
+#: The expired premise, in the exact shape both documents used to assert it.
+EXPIRED_PREMISE = re.compile(
+    r"routes only to subagents the calling session spawned", re.I
+)
+
+
+def _delivery_section(text: str) -> str:
+    match = re.search(
+        r"^#+[^\n]*(delivery lane|delivery preference)[^\n]*$(.*?)(?=^## |\Z)",
+        text,
+        re.M | re.S | re.I,
+    )
+    assert match, "no delivery-lane section found"
+    return match.group(0)
+
+
+@pytest.mark.parametrize("surface", (REGISTER, WAVE), ids=lambda p: p.name)
+def test_the_expired_premise_is_not_asserted_bare(surface: Path) -> None:
+    """The August claim may be QUOTED as history; it may not stand as current fact.
+
+    Both documents stated it flatly, in the present tense, as a property of the
+    harness. Wherever it still appears it must sit next to a word marking it as
+    past - that is what stops a reader acting on it.
+    """
+    text = surface.read_text()
+    for match in EXPIRED_PREMISE.finditer(text):
+        window = text[max(0, match.start() - 700) : match.end() + 700]
+        assert re.search(r"expired|retired|no longer|was written up", window, re.I), (
+            f"{surface.name}: the 2026-08-11 premise appears with nothing marking "
+            "it as expired"
+        )
+
+
+@pytest.mark.parametrize("surface", (REGISTER, WAVE), ids=lambda p: p.name)
+def test_the_delivery_section_carries_a_harness_version(surface: Path) -> None:
+    section = _delivery_section(surface.read_text())
+    assert VERSION.search(section), (
+        f"{surface.name}: the delivery section states harness behaviour with no "
+        "version anywhere in it - the #870 defect exactly"
+    )
+
+
+def test_register_separates_contract_readings_from_measurements() -> None:
+    """A reading of the docs and a field result are different kinds of evidence.
+
+    Collapsing them is how an expired reading gets replaced by a fresher reading
+    and the document looks re-verified when nothing was run.
+    """
+    section = _delivery_section(REGISTER.read_text())
+    assert re.search(r"contract", section, re.I), "contract facts are not labelled"
+    assert re.search(r"\bmeasured\b", section, re.I), "no measurement is labelled"
+    assert re.search(
+        r"installed tool contract|CONTRACT facts", section
+    ), "the source of the contract claims is not named"
+
+
+def test_register_states_the_container_boundary_where_the_lanes_are_chosen() -> None:
+    """#870's constraint: a session in a container must not be routed into lane 1.
+
+    It has to be stated where the choice is made. A reader picking a lane does not
+    go looking for a caveat in another document.
+    """
+    section = _delivery_section(REGISTER.read_text())
+    assert re.search(r"contain(er|erised)", section, re.I), (
+        "the container boundary is not stated in the delivery section"
+    )
+    assert re.search(r"cannot see each other|no path between them", section, re.I), (
+        "the container boundary is mentioned without saying lane 1 cannot exist"
+    )
+
+
+def test_register_gives_both_settings_a_value_and_a_reason() -> None:
+    """#870 acceptance: chosen values with a recorded reason, not absence."""
+    section = _delivery_section(REGISTER.read_text())
+    for setting in ("crossSessionInbound", "isolatePeerMachines"):
+        assert setting in section, f"{setting} is not discussed"
+        window = section[section.index(setting) : section.index(setting) + 900]
+        assert re.search(r"Recommended:", window), (
+            f"{setting} has no recommended value"
+        )
+
+
+def test_the_no_kill_observation_keeps_its_population_caveat() -> None:
+    """The confound must travel with the result, not sit in a footnote.
+
+    This host disables the background-shell pressure reaper, so a surviving task
+    may be a property of the configuration rather than of the harness version. A
+    reader who takes the observation without the caveat concludes lane 1 is safe
+    everywhere, which is not what was established.
+    """
+    section = _delivery_section(REGISTER.read_text())
+    assert "CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP" in section, (
+        "the confound is not named where the observation is made"
+    )
+    assert re.search(r"does not generalize|not measurable on this host", section, re.I), (
+        "the no-kill observation is stated without its population limit"
+    )
+
+
+def test_the_hazard_reports_are_each_stamped() -> None:
+    """Three upstream data points on three harness versions, one of them a non-repro.
+
+    Without the stamps they average into "there is a hazard", which is both weaker
+    and less true than what the thread actually says.
+    """
+    section = _delivery_section(REGISTER.read_text())
+    versions = set(VERSION.findall(section))
+    assert len(versions) >= 3, (
+        f"expected several distinct harness versions beside the hazard reports, got {versions}"
+    )
+    assert "91139" in section, "the upstream issue is not cited"


### PR DESCRIPTION
## Summary

The delivery preference order rested on one incident of 2026-08-11, written as a property of *"the harness"* with no version anywhere near it: `SendMessage` reportedly routed only to subagents the calling session spawned, so orchestrator→worker was declared unreliable and waves routed around it. Cross-session messaging between independent sessions shipped in **v2.1.224**. The premise expired, nothing in the text could say so, and it stayed authoritative for a month.

**The defect was never the verdict — it was the missing stamp**, so that is what this fixes: a harness version beside every claim, contract readings labelled apart from measurements, and population caveats attached to the results they qualify.

## What was measured, and what was only read

| Claim | How established |
|---|---|
| A cross-session message enqueues and drains at the receiver's next tool round | installed tool contract, read 2026-09-12 |
| The address is any `ListAgents` peer, no spawn relationship required | installed tool contract, read 2026-09-12 |
| A send between two independent sessions **resolves and delivers** | **measured** on 2.1.266, 2026-09-12 |

The contract readings contradict the August premise on their own — enqueue is not reject, any listed peer is not only-my-subagents — but they are documentation, and #870 is about a claim that outlived its evidence. Replacing an expired reading with a fresher reading is the failure mode, not the fix. The measured row is what actually retires the premise.

**Only one direction was tested.** Nothing in the contract, the upstream thread, or the original incident describes an asymmetric routing mechanism, so the directional framing is dropped rather than re-asserted for the untested half.

## Lane 1 is a fast path, not a better mailbox

It stays first, re-described: it stores nothing, returns no receipt, and leaves no trace either end can audit. The mailbox is the durable lane — and for a containerised session it is the *only* lane, since native session discovery is filesystem-based and a container and a host cannot see each other at all. That boundary now sits where the lane is chosen, because a reader picking a lane does not go hunting for a caveat in another document.

## The hazard, split by version rather than averaged

| Report | Harness | Finding |
|---|---|---|
| original | 2.1.252, macOS | six kill events across four sessions in ~90 min; only harness-tracked tasks die |
| second | 2.1.258, Linux | kill lands at **turn end**, not delivery, and only when the task is the session's **sole** live background task; `setsid` grandchild survives |
| same reporter | 2.1.263, Linux | no longer reproducing |

A watch here survived delivery on 2.1.266 — and **that observation is recorded as not generalizing**, for three independent reasons: this host sets `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (present before any of these sessions booted), the upstream discriminator was not controlled for, and the hazard may simply be fixed. Writing it as "safe on 2.1.266" would repeat this section's own defect one version later.

Also recorded: **the `setsid` exemption does not cover this fleet.** `/kyle:boot` arms the mailbox watch *as* the background call and explicitly forbids `&`, so every session booted that way has its only wake mechanism in exactly the object the original report describes as dying. Anyone citing the exemption here has it backwards.

## Settings

`crossSessionInbound` → recommended `accept`; `isolatePeerMachines` → recommended `true`. Both with reasons recorded in the repo, and both deliberately **not** written to `~/.claude/settings.json` by any session: that file is host state shared by every session on this machine, a write there is not reviewable as a diff, and it does not arrive through the change that reviewed the reasoning.

## Test plan

- [x] `make lint`, `make typecheck` (209 files), `make codex-skills-check`
- [x] `make test` — **3097 passed**
- [x] **Non-vacuity**: stashed against the pre-change tree, all 9 tests in the new file fail.
- [x] One probe had to be **tightened** to reach that: it first accepted a bare `2026-08-11` near the claim as evidence the claim was marked historical — but the old text carried that date too, so it passed over the very defect it was written for. Recorded in the module docstring, because the trap is general: when a probe looks for context around a defect, check the defect's own surroundings do not already supply it.

The test pins the **stamp discipline, not the verdict** — it fails when a claim loses its version, its label or its caveat, and never when a claim changes. Otherwise the next person to re-measure is also the person who has to edit the guard, which is how a guard becomes a formality.

## Process note

Implemented on `/flow:auto`. `/codex:auto` could not take this one and would have said so honestly: re-measuring live harness behaviour is `research` against a live source, two of the three things its capability contract already declares out of scope. Worth contrasting with #865, which passed that same pre-flight **wrongly** — together they sharpen CPP#877 from *"the pre-flight has no axis for this"* to *"the pre-flight has the right axes for some of it and the wrong verdict for the rest"*.

Refs #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yh3ybjhCBv6BDmyVZmKCq