### PR TITLE
fix(mailbox): stop supervise acknowledging mail on an agent's behalf (Closes #867, Closes #873)

### DIFF
--- a/.claude/commands/flow/register.md
+++ b/.claude/commands/flow/register.md
@@ -285,10 +285,18 @@ and is wiped by the OS at reboot - exactly when every session's address dies too
    master session - waiting unheard, caught only because a DIFFERENT session
    noticed the silence from outside. `supervise` makes "a listener for this
    role exists" independent of any agent remembering anything: it re-arms
-   `watch --consume` in a detached loop, on its own, until this role is
+   `watch --peek` in a detached loop, on its own, until this role is
    released or the wave ends. **It does not, and cannot, guarantee the
    harness tells YOU** - no script can force that; see `route=` below for how
    that residual gap is made visible instead of silently assumed away.
+
+   **The supervisor never acknowledges your mail (#867, #873).** It surfaces
+   into its own log and raises a daemon-local watermark; the ack set stays
+   yours alone. That is what keeps `unread`, `route=`, and `** NEVER READ **`
+   measuring what they claim to - until it was fixed, the prescribed listener
+   silenced all three, and a worker that had received nothing rendered as a
+   healthy row. **So mail waiting for you stays visibly waiting.** Reading it
+   is still your job, and `ack` is still the only thing that clears it.
 
    A live supervisor already holding this role refuses a second one (exit 4,
    `duplicate`); check

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -183,9 +183,11 @@ ruling already made - and while designing #814 itself, an orchestrator went
 deaf for 25 minutes after a forgotten re-arm, missing seven messages
 including three from its own master, caught only because that master noticed
 the silence from outside. `supervise` detaches a daemon that keeps re-arming
-`watch --consume` on its own until this role is released or the wave ends -
+`watch --peek` on its own until this role is released or the wave ends -
 it removes the step that kept getting dropped, it does not merely warn about
-it. It still cannot force the harness to tell THIS session when mail
+it. It never ACKNOWLEDGES (#867, #873): a daemon printing into a log is not a
+recipient, and while it consumed, every deafness tell on this page read clean
+over a worker that had seen nothing. It still cannot force the harness to tell THIS session when mail
 arrives; see `route=` below for how that residual gap stays visible instead
 of assumed away. A live supervisor already holding this role refuses a
 second one (exit 4, `duplicate`); check

--- a/.claude/commands/flow/wave.md
+++ b/.claude/commands/flow/wave.md
@@ -263,9 +263,22 @@ assuming: `flow-wave-mailbox.sh list --wave <WAVE>` shows each box's rev,
 acked and unread count (issue #815 - `acked` replaced `cursor`: it is the
 count of revs that box's reader has explicitly acknowledged, not a read
 position), so an assignment a worker has NOT acknowledged is visible as a
-nonzero `UNREAD` instead of being invisible until someone asks. A worker with
-unread mail and no progress is a worker whose watch is not armed - fix that
-rather than relaying by hand.
+nonzero `UNREAD` instead of being invisible until someone asks.
+
+**A worker with unread mail and no progress now has TWO possible causes, and
+they need different fixes (#867, #873).** This used to read "a worker whose
+watch is not armed", which was a sound inference only because an armed
+supervisor CONSUMED - so unread mail implied nothing was listening. The
+supervisor no longer acknowledges, so unread mail is the ordinary resting
+state of anything the worker has not yet acked, and a nonzero `UNREAD` is no
+longer evidence about the watch at all. Read the two columns instead:
+
+- `watch=DEAD`/`ABSENT`/`stale` - nothing is listening. Get a supervisor
+  armed; that is the old diagnosis and it still applies when the column says so.
+- `watch=armed` **and** `route=UNCONFIRMED` - something is polling and
+  surfacing, and the agent behind it still has not acknowledged anything. That
+  is #814's residual gap showing, not a dead watch, and arming another watcher
+  will not touch it. Ask the worker directly.
 
 ## Setup: the transition lexicon (consume #701, do not reimplement)
 

--- a/codex/skills/flow-register/reference.md
+++ b/codex/skills/flow-register/reference.md
@@ -287,10 +287,18 @@ and is wiped by the OS at reboot - exactly when every session's address dies too
    master session - waiting unheard, caught only because a DIFFERENT session
    noticed the silence from outside. `supervise` makes "a listener for this
    role exists" independent of any agent remembering anything: it re-arms
-   `watch --consume` in a detached loop, on its own, until this role is
+   `watch --peek` in a detached loop, on its own, until this role is
    released or the wave ends. **It does not, and cannot, guarantee the
    harness tells YOU** - no script can force that; see `route=` below for how
    that residual gap is made visible instead of silently assumed away.
+
+   **The supervisor never acknowledges your mail (#867, #873).** It surfaces
+   into its own log and raises a daemon-local watermark; the ack set stays
+   yours alone. That is what keeps `unread`, `route=`, and `** NEVER READ **`
+   measuring what they claim to - until it was fixed, the prescribed listener
+   silenced all three, and a worker that had received nothing rendered as a
+   healthy row. **So mail waiting for you stays visibly waiting.** Reading it
+   is still your job, and `ack` is still the only thing that clears it.
 
    A live supervisor already holding this role refuses a second one (exit 4,
    `duplicate`); check

--- a/codex/skills/flow-register/scripts/flow-wave-mailbox.sh
+++ b/codex/skills/flow-register/scripts/flow-wave-mailbox.sh
@@ -128,9 +128,11 @@
 #          has to remember to re-arm `watch` after every wake. The invocation
 #          itself returns promptly with a `FLOW_MAILBOX: supervising` verdict
 #          (or `duplicate`, exit 4, if one already runs); the DAEMON it detaches
-#          is what persists, repeatedly arming `watch --consume` for <role>
-#          until role release or the wave ends. See SUPERVISION below for what
-#          this does and, as importantly, does not promise.
+#          is what persists, repeatedly arming `watch --peek` for <role> until
+#          role release or the wave ends. It never ACKNOWLEDGES: a detached
+#          daemon is not a recipient, and a receipt it writes is a lie about
+#          an agent (#867, #873). See SUPERVISION below for what this does
+#          and, as importantly, does not promise.
 #   list   Box inventory for the wave: box, reader, rev, acked, unread, mtime,
 #          plus the WATCH state, live WATCHERS count, and ROUTE readiness
 #          (#814 - see ROUTE READINESS below) of every role known to read here
@@ -198,10 +200,25 @@
 # one mechanism this whole lane depends on would be defeated. Instead the
 # `supervise` INVOCATION forks a daemon and returns immediately with its own
 # verdict line, like every other verb; the daemon repeatedly shells out to
-# `watch --role <role> --wave <wave> --consume`, letting EACH inner watch
-# still exit and still be the harness's notification trigger for whichever
-# session is separately listening for it - `supervise` guarantees a listener
-# always EXISTS, it is not a replacement for arming one.
+# `watch --role <role> --wave <wave> --peek --surfaced-state <file>`, letting
+# EACH inner watch still exit - `supervise` guarantees a listener always
+# EXISTS, it is not a replacement for arming one.
+#
+# `--peek`, emphatically not `--consume` (issues #867, #873). The daemon used
+# to consume, which acknowledged every message it printed while sending that
+# print to a log. Mail was therefore recorded as RECEIVED by a process that is
+# not the recipient, and all four of the tells an orchestrator is told to steer
+# by went quiet at once: `UNREAD` returned to 0 seconds after every send,
+# `route` read `confirmed`, the `watch=armed route=UNCONFIRMED` combination
+# became unreachable, and `** NEVER READ **` could not fire. Measured on a live
+# wave: 7 of 7 assignments acked, 0 delivered, for most of a working session,
+# with the roster agreeing throughout (#873).
+#
+# That is worse than having no receipts, because a wrong receipt removes the
+# reason to check. It also inverted the one separation #814 was careful to
+# build: `route_state` reads ack evidence precisely so it fails INDEPENDENTLY
+# of `watch`'s process check - and the polling process became the source of the
+# ack evidence, so one instrument manufactured the other's.
 #
 # Single ownership without inheriting #821. The obvious guard - record the
 # daemon's PID, check it with `kill -0` - reintroduces #821 one layer up:
@@ -917,6 +934,96 @@ boxes_for_role() {
   return 0
 }
 
+# --- The supervisor's SURFACED watermark (issues #867, #873) ------------------
+#
+# A supervisor must never acknowledge. An ack is a receipt, and #815 separated
+# surfacing from receiving precisely so that one event could not stand in for
+# the other; `supervise` re-joined them by arming `watch --consume`, so a
+# detached daemon printing to a log recorded mail as RECEIVED by an agent that
+# had not seen it. Measured on a live wave: 7 of 7 assignments acked, 0
+# delivered (#873).
+#
+# So the daemon peeks. The obvious version of that spins - with `--peek`
+# nothing moves, so the next arm re-fires on the same mail immediately - and
+# the fix is a watermark that is the daemon's OWN, recording what it has
+# SURFACED rather than what anybody has received.
+#
+# Three properties make this safe where the ack set would not be:
+#
+#   1. `route_state`, `unread`, and `** NEVER READ **` never consult it. They
+#      read the ack set, which only an agent's explicit `ack` writes. So the
+#      four deafness tells keep measuring what they claim to measure, which is
+#      the whole of #867's acceptance.
+#   2. It is PER BOX, not per role. Revs are allocated per box, so one global
+#      high-water mark for a role reading several boxes (the orchestrator) would
+#      silence a lower rev arriving later in a different box.
+#   3. Losing it is harmless in the safe direction: an absent or torn file reads
+#      as 0, which re-surfaces mail rather than hiding it. The failure mode is a
+#      duplicate log line, never a silent drop.
+surfaced_file() { echo "$WAVE_DIR/.supervise-$1.surfaced"; }
+
+# The rev this supervisor has already surfaced for one box (0 when unknown).
+surfaced_rev_for() {
+  local sfile="$1" base="$2"
+  [ -s "$sfile" ] || { echo 0; return; }
+  awk -v b="$base" '$1 == b { r = $2 + 0 } END { print r + 0 }' "$sfile"
+}
+
+# Record that everything up to REV in BASE has been surfaced. Same lock and
+# same write-to-temp-then-rename as ack_add, so a reader never sees a half file.
+surfaced_set() {
+  local sfile="$1" base="$2" rev="$3"
+  (
+    flock -w 10 9 || { echo "flow-wave-mailbox: could not lock $WAVE_DIR" >&2; exit 3; }
+    tmp="$(mktemp "$WAVE_DIR/.msurf.XXXXXX")" || exit 3
+    {
+      [ -s "$sfile" ] && awk -v b="$base" '$1 != b' "$sfile"
+      echo "$base $rev"
+    } | sort -u > "$tmp"
+    mv -f "$tmp" "$sfile" || { rm -f "$tmp"; exit 3; }
+  ) 9>"$LOCK_FILE"
+}
+
+# Count unacked revs ABOVE this supervisor's watermark, across a role's boxes.
+# Unacked AND above - both halves matter. Above-only would re-surface mail the
+# agent has since acknowledged; unacked-only is the spin.
+unread_above_for_role() {
+  local role="$1" sfile="$2" total=0 b base w n
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    base="$(basename "$b")"
+    w="$(surfaced_rev_for "$sfile" "$base")"
+    n="$(unacked_revs_in "$b" | awk -v w="$w" '$1 + 0 > w' | grep -c '^[0-9]' || true)"
+    total=$((total + n))
+  done <<EOF
+$(boxes_for_role "$role")
+EOF
+  echo "$total"
+}
+
+# Print what is above the watermark and raise it. NEVER touches the ack set -
+# that is the property #867 and #873 both name as binding, and the reason this
+# is a separate function rather than another flag on drain_role: there is no
+# code path from here to ack_add to get wrong later.
+drain_role_surfaced() {
+  local role="$1" sfile="$2" b base w body top
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    base="$(basename "$b")"
+    w="$(surfaced_rev_for "$sfile" "$base")"
+    body="$(extract_since "$b" "$w")"
+    if [ -n "$body" ]; then
+      echo "=== $base (surfaced, NOT acknowledged) ==="
+      echo "$body"
+    fi
+    top="$(max_rev "$b")"
+    [ "$top" -gt "$w" ] && surfaced_set "$sfile" "$base" "$top"
+  done <<EOF
+$(boxes_for_role "$role")
+EOF
+  return 0
+}
+
 # Total unread across every box a role reads.
 unread_for_role() {
   local total=0 b n
@@ -1308,6 +1415,7 @@ esac
 
 WAVE="default"; ROLE=""; A_TO=""; A_FROM=""; A_BODY=""; A_BODY_FILE=""; A_OUT=""
 REPLACE=0; PEEK=0; CONSUME=0; ALL=0; JSON_OUT=0; NO_LEXICON=0; STATUS=0
+SURFACED_STATE=""
 TIMEOUT="$WATCH_TIMEOUT_DEFAULT"; INTERVAL="$WATCH_INTERVAL_DEFAULT"
 A_BOX=""; A_REVS=""; ALL_UNACKED=0
 
@@ -1335,6 +1443,7 @@ while [ "$#" -gt 0 ]; do
     --no-lexicon) NO_LEXICON=1 ;;
     --peek) PEEK=1 ;;
     --consume) CONSUME=1 ;;
+    --surfaced-state) SURFACED_STATE="${2:-}"; shift ;;
     --status) STATUS=1 ;;
     --all) ALL=1 ;;
     --json) JSON_OUT=1 ;;
@@ -1593,6 +1702,13 @@ case "$VERB" in
     if [ "$PEEK" -eq 1 ] && [ "$CONSUME" -eq 1 ]; then
       usage_fail "watch: --peek and --consume are mutually exclusive"
     fi
+    # --surfaced-state is the supervisor lane (#867/#873). It is refused with
+    # --consume rather than ignored: the two express opposite intentions about
+    # who may acknowledge, and silently honouring one while accepting the other
+    # is how the defect being fixed here got in.
+    if [ -n "$SURFACED_STATE" ] && [ "$PEEK" -eq 0 ]; then
+      usage_fail "watch: --surfaced-state requires --peek (it exists so a watcher can wake on new mail WITHOUT acknowledging it - #867)"
+    fi
     if [ "$PEEK" -eq 0 ] && [ "$CONSUME" -eq 0 ]; then
       usage_fail "watch requires an explicit --peek or --consume (issue #792) - silent default consumption has marked mail read that was never shown. Use --consume to arm-then-read (mail is marked read on wake), or --peek to read-then-arm (mail is NOT consumed, so re-arming immediately would spin-fire on it)."
     fi
@@ -1615,7 +1731,11 @@ case "$VERB" in
       # Stamp BEFORE the check, so an arm that fires on its very first poll -
       # mail already waiting - still leaves the trace #778 exists to leave.
       watch_stamp "$ROLE"
-      UNREAD="$(unread_for_role "$ROLE")"
+      if [ -n "$SURFACED_STATE" ]; then
+        UNREAD="$(unread_above_for_role "$ROLE" "$SURFACED_STATE")"
+      else
+        UNREAD="$(unread_for_role "$ROLE")"
+      fi
       if [ "$UNREAD" -gt 0 ]; then
         # #792 item 2: this fired on the very first poll, i.e. the mail was
         # already unread the instant this watch armed - not a fresh wake.
@@ -1623,7 +1743,11 @@ case "$VERB" in
         if [ "$FIRST_POLL" -eq 1 ]; then
           echo "flow-wave-mailbox: NOTE - mail was already unread when this watch armed; this is not a fresh wake (issue #792)."
         fi
-        drain_role "$ROLE" "$PEEK" 0
+        if [ -n "$SURFACED_STATE" ]; then
+          drain_role_surfaced "$ROLE" "$SURFACED_STATE"
+        else
+          drain_role "$ROLE" "$PEEK" 0
+        fi
         E_ROLE="$ROLE"; E_UNREAD="$UNREAD"
         emit mail
         exit 0
@@ -1788,6 +1912,10 @@ EOF
     BACKOFF_BASE="${FLOW_WAVE_SUPERVISE_BACKOFF_BASE:-2}"
     BACKOFF_CAP="${FLOW_WAVE_SUPERVISE_BACKOFF_CAP:-60}"
     BACKOFF=0
+    # This daemon's own record of what it has SURFACED (#867/#873) - never a
+    # receipt, and never read by anything that reports on deafness. It exists
+    # only so a non-consuming watch does not re-fire on the same mail forever.
+    SUP_SURFACED="$(surfaced_file "$ROLE")"
 
     # Structured, sanitized evidence ONLY - a timestamp and a short event
     # description (event kind, exit code, backoff seconds). NEVER message
@@ -1828,17 +1956,24 @@ EOF
         fi
       fi
 
-      bash "$0" watch --role "$ROLE" --wave "$WAVE" --consume \
+      # --peek, never --consume (#867, #873). A detached daemon printing to a
+      # log is not a recipient, so it must not write the receipt. The watermark
+      # below is what keeps a non-consuming watch from re-firing on the same
+      # mail forever; it is the daemon's own record of what it SURFACED and
+      # nothing that reports on deafness ever reads it.
+      bash "$0" watch --role "$ROLE" --wave "$WAVE" --peek \
+        --surfaced-state "$SUP_SURFACED" \
         --timeout "$TIMEOUT" --interval "$INTERVAL" >/dev/null 2>&1
       INNER_RC=$?
 
       case "$INNER_RC" in
         0)
-          # Delivered and acknowledged (the daemon uses --consume - the
-          # named legacy convenience, matching the file's own default
-          # elsewhere; the delivered CONTENT is safely durable in the box
-          # already, the daemon does not need to relay it anywhere new).
-          log_event "delivered rc=0"
+          # SURFACED, not delivered and not acknowledged. The old wording here
+          # said "delivered rc=0", which meant only that the inner watch exited
+          # zero - i.e. that a print succeeded - and an orchestrator reading
+          # this log took it for evidence a model had read something (#873).
+          # It is not, it never was, and the log now says which fact it holds.
+          log_event "surfaced rc=0 (NOT acknowledged - mail stays unread until the agent acks it)"
           BACKOFF=0
           ;;
         5)

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -265,9 +265,22 @@ assuming: `flow-wave-mailbox.sh list --wave <WAVE>` shows each box's rev,
 acked and unread count (issue #815 - `acked` replaced `cursor`: it is the
 count of revs that box's reader has explicitly acknowledged, not a read
 position), so an assignment a worker has NOT acknowledged is visible as a
-nonzero `UNREAD` instead of being invisible until someone asks. A worker with
-unread mail and no progress is a worker whose watch is not armed - fix that
-rather than relaying by hand.
+nonzero `UNREAD` instead of being invisible until someone asks.
+
+**A worker with unread mail and no progress now has TWO possible causes, and
+they need different fixes (#867, #873).** This used to read "a worker whose
+watch is not armed", which was a sound inference only because an armed
+supervisor CONSUMED - so unread mail implied nothing was listening. The
+supervisor no longer acknowledges, so unread mail is the ordinary resting
+state of anything the worker has not yet acked, and a nonzero `UNREAD` is no
+longer evidence about the watch at all. Read the two columns instead:
+
+- `watch=DEAD`/`ABSENT`/`stale` - nothing is listening. Get a supervisor
+  armed; that is the old diagnosis and it still applies when the column says so.
+- `watch=armed` **and** `route=UNCONFIRMED` - something is polling and
+  surfacing, and the agent behind it still has not acknowledged anything. That
+  is #814's residual gap showing, not a dead watch, and arming another watcher
+  will not touch it. Ask the worker directly.
 
 ## Setup: the transition lexicon (consume #701, do not reimplement)
 

--- a/codex/skills/flow-wave/reference.md
+++ b/codex/skills/flow-wave/reference.md
@@ -185,9 +185,11 @@ ruling already made - and while designing #814 itself, an orchestrator went
 deaf for 25 minutes after a forgotten re-arm, missing seven messages
 including three from its own master, caught only because that master noticed
 the silence from outside. `supervise` detaches a daemon that keeps re-arming
-`watch --consume` on its own until this role is released or the wave ends -
+`watch --peek` on its own until this role is released or the wave ends -
 it removes the step that kept getting dropped, it does not merely warn about
-it. It still cannot force the harness to tell THIS session when mail
+it. It never ACKNOWLEDGES (#867, #873): a daemon printing into a log is not a
+recipient, and while it consumed, every deafness tell on this page read clean
+over a worker that had seen nothing. It still cannot force the harness to tell THIS session when mail
 arrives; see `route=` below for how that residual gap stays visible instead
 of assumed away. A live supervisor already holding this role refuses a
 second one (exit 4, `duplicate`); check

--- a/codex/skills/flow-wave/scripts/flow-wave-mailbox.sh
+++ b/codex/skills/flow-wave/scripts/flow-wave-mailbox.sh
@@ -128,9 +128,11 @@
 #          has to remember to re-arm `watch` after every wake. The invocation
 #          itself returns promptly with a `FLOW_MAILBOX: supervising` verdict
 #          (or `duplicate`, exit 4, if one already runs); the DAEMON it detaches
-#          is what persists, repeatedly arming `watch --consume` for <role>
-#          until role release or the wave ends. See SUPERVISION below for what
-#          this does and, as importantly, does not promise.
+#          is what persists, repeatedly arming `watch --peek` for <role> until
+#          role release or the wave ends. It never ACKNOWLEDGES: a detached
+#          daemon is not a recipient, and a receipt it writes is a lie about
+#          an agent (#867, #873). See SUPERVISION below for what this does
+#          and, as importantly, does not promise.
 #   list   Box inventory for the wave: box, reader, rev, acked, unread, mtime,
 #          plus the WATCH state, live WATCHERS count, and ROUTE readiness
 #          (#814 - see ROUTE READINESS below) of every role known to read here
@@ -198,10 +200,25 @@
 # one mechanism this whole lane depends on would be defeated. Instead the
 # `supervise` INVOCATION forks a daemon and returns immediately with its own
 # verdict line, like every other verb; the daemon repeatedly shells out to
-# `watch --role <role> --wave <wave> --consume`, letting EACH inner watch
-# still exit and still be the harness's notification trigger for whichever
-# session is separately listening for it - `supervise` guarantees a listener
-# always EXISTS, it is not a replacement for arming one.
+# `watch --role <role> --wave <wave> --peek --surfaced-state <file>`, letting
+# EACH inner watch still exit - `supervise` guarantees a listener always
+# EXISTS, it is not a replacement for arming one.
+#
+# `--peek`, emphatically not `--consume` (issues #867, #873). The daemon used
+# to consume, which acknowledged every message it printed while sending that
+# print to a log. Mail was therefore recorded as RECEIVED by a process that is
+# not the recipient, and all four of the tells an orchestrator is told to steer
+# by went quiet at once: `UNREAD` returned to 0 seconds after every send,
+# `route` read `confirmed`, the `watch=armed route=UNCONFIRMED` combination
+# became unreachable, and `** NEVER READ **` could not fire. Measured on a live
+# wave: 7 of 7 assignments acked, 0 delivered, for most of a working session,
+# with the roster agreeing throughout (#873).
+#
+# That is worse than having no receipts, because a wrong receipt removes the
+# reason to check. It also inverted the one separation #814 was careful to
+# build: `route_state` reads ack evidence precisely so it fails INDEPENDENTLY
+# of `watch`'s process check - and the polling process became the source of the
+# ack evidence, so one instrument manufactured the other's.
 #
 # Single ownership without inheriting #821. The obvious guard - record the
 # daemon's PID, check it with `kill -0` - reintroduces #821 one layer up:
@@ -917,6 +934,96 @@ boxes_for_role() {
   return 0
 }
 
+# --- The supervisor's SURFACED watermark (issues #867, #873) ------------------
+#
+# A supervisor must never acknowledge. An ack is a receipt, and #815 separated
+# surfacing from receiving precisely so that one event could not stand in for
+# the other; `supervise` re-joined them by arming `watch --consume`, so a
+# detached daemon printing to a log recorded mail as RECEIVED by an agent that
+# had not seen it. Measured on a live wave: 7 of 7 assignments acked, 0
+# delivered (#873).
+#
+# So the daemon peeks. The obvious version of that spins - with `--peek`
+# nothing moves, so the next arm re-fires on the same mail immediately - and
+# the fix is a watermark that is the daemon's OWN, recording what it has
+# SURFACED rather than what anybody has received.
+#
+# Three properties make this safe where the ack set would not be:
+#
+#   1. `route_state`, `unread`, and `** NEVER READ **` never consult it. They
+#      read the ack set, which only an agent's explicit `ack` writes. So the
+#      four deafness tells keep measuring what they claim to measure, which is
+#      the whole of #867's acceptance.
+#   2. It is PER BOX, not per role. Revs are allocated per box, so one global
+#      high-water mark for a role reading several boxes (the orchestrator) would
+#      silence a lower rev arriving later in a different box.
+#   3. Losing it is harmless in the safe direction: an absent or torn file reads
+#      as 0, which re-surfaces mail rather than hiding it. The failure mode is a
+#      duplicate log line, never a silent drop.
+surfaced_file() { echo "$WAVE_DIR/.supervise-$1.surfaced"; }
+
+# The rev this supervisor has already surfaced for one box (0 when unknown).
+surfaced_rev_for() {
+  local sfile="$1" base="$2"
+  [ -s "$sfile" ] || { echo 0; return; }
+  awk -v b="$base" '$1 == b { r = $2 + 0 } END { print r + 0 }' "$sfile"
+}
+
+# Record that everything up to REV in BASE has been surfaced. Same lock and
+# same write-to-temp-then-rename as ack_add, so a reader never sees a half file.
+surfaced_set() {
+  local sfile="$1" base="$2" rev="$3"
+  (
+    flock -w 10 9 || { echo "flow-wave-mailbox: could not lock $WAVE_DIR" >&2; exit 3; }
+    tmp="$(mktemp "$WAVE_DIR/.msurf.XXXXXX")" || exit 3
+    {
+      [ -s "$sfile" ] && awk -v b="$base" '$1 != b' "$sfile"
+      echo "$base $rev"
+    } | sort -u > "$tmp"
+    mv -f "$tmp" "$sfile" || { rm -f "$tmp"; exit 3; }
+  ) 9>"$LOCK_FILE"
+}
+
+# Count unacked revs ABOVE this supervisor's watermark, across a role's boxes.
+# Unacked AND above - both halves matter. Above-only would re-surface mail the
+# agent has since acknowledged; unacked-only is the spin.
+unread_above_for_role() {
+  local role="$1" sfile="$2" total=0 b base w n
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    base="$(basename "$b")"
+    w="$(surfaced_rev_for "$sfile" "$base")"
+    n="$(unacked_revs_in "$b" | awk -v w="$w" '$1 + 0 > w' | grep -c '^[0-9]' || true)"
+    total=$((total + n))
+  done <<EOF
+$(boxes_for_role "$role")
+EOF
+  echo "$total"
+}
+
+# Print what is above the watermark and raise it. NEVER touches the ack set -
+# that is the property #867 and #873 both name as binding, and the reason this
+# is a separate function rather than another flag on drain_role: there is no
+# code path from here to ack_add to get wrong later.
+drain_role_surfaced() {
+  local role="$1" sfile="$2" b base w body top
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    base="$(basename "$b")"
+    w="$(surfaced_rev_for "$sfile" "$base")"
+    body="$(extract_since "$b" "$w")"
+    if [ -n "$body" ]; then
+      echo "=== $base (surfaced, NOT acknowledged) ==="
+      echo "$body"
+    fi
+    top="$(max_rev "$b")"
+    [ "$top" -gt "$w" ] && surfaced_set "$sfile" "$base" "$top"
+  done <<EOF
+$(boxes_for_role "$role")
+EOF
+  return 0
+}
+
 # Total unread across every box a role reads.
 unread_for_role() {
   local total=0 b n
@@ -1308,6 +1415,7 @@ esac
 
 WAVE="default"; ROLE=""; A_TO=""; A_FROM=""; A_BODY=""; A_BODY_FILE=""; A_OUT=""
 REPLACE=0; PEEK=0; CONSUME=0; ALL=0; JSON_OUT=0; NO_LEXICON=0; STATUS=0
+SURFACED_STATE=""
 TIMEOUT="$WATCH_TIMEOUT_DEFAULT"; INTERVAL="$WATCH_INTERVAL_DEFAULT"
 A_BOX=""; A_REVS=""; ALL_UNACKED=0
 
@@ -1335,6 +1443,7 @@ while [ "$#" -gt 0 ]; do
     --no-lexicon) NO_LEXICON=1 ;;
     --peek) PEEK=1 ;;
     --consume) CONSUME=1 ;;
+    --surfaced-state) SURFACED_STATE="${2:-}"; shift ;;
     --status) STATUS=1 ;;
     --all) ALL=1 ;;
     --json) JSON_OUT=1 ;;
@@ -1593,6 +1702,13 @@ case "$VERB" in
     if [ "$PEEK" -eq 1 ] && [ "$CONSUME" -eq 1 ]; then
       usage_fail "watch: --peek and --consume are mutually exclusive"
     fi
+    # --surfaced-state is the supervisor lane (#867/#873). It is refused with
+    # --consume rather than ignored: the two express opposite intentions about
+    # who may acknowledge, and silently honouring one while accepting the other
+    # is how the defect being fixed here got in.
+    if [ -n "$SURFACED_STATE" ] && [ "$PEEK" -eq 0 ]; then
+      usage_fail "watch: --surfaced-state requires --peek (it exists so a watcher can wake on new mail WITHOUT acknowledging it - #867)"
+    fi
     if [ "$PEEK" -eq 0 ] && [ "$CONSUME" -eq 0 ]; then
       usage_fail "watch requires an explicit --peek or --consume (issue #792) - silent default consumption has marked mail read that was never shown. Use --consume to arm-then-read (mail is marked read on wake), or --peek to read-then-arm (mail is NOT consumed, so re-arming immediately would spin-fire on it)."
     fi
@@ -1615,7 +1731,11 @@ case "$VERB" in
       # Stamp BEFORE the check, so an arm that fires on its very first poll -
       # mail already waiting - still leaves the trace #778 exists to leave.
       watch_stamp "$ROLE"
-      UNREAD="$(unread_for_role "$ROLE")"
+      if [ -n "$SURFACED_STATE" ]; then
+        UNREAD="$(unread_above_for_role "$ROLE" "$SURFACED_STATE")"
+      else
+        UNREAD="$(unread_for_role "$ROLE")"
+      fi
       if [ "$UNREAD" -gt 0 ]; then
         # #792 item 2: this fired on the very first poll, i.e. the mail was
         # already unread the instant this watch armed - not a fresh wake.
@@ -1623,7 +1743,11 @@ case "$VERB" in
         if [ "$FIRST_POLL" -eq 1 ]; then
           echo "flow-wave-mailbox: NOTE - mail was already unread when this watch armed; this is not a fresh wake (issue #792)."
         fi
-        drain_role "$ROLE" "$PEEK" 0
+        if [ -n "$SURFACED_STATE" ]; then
+          drain_role_surfaced "$ROLE" "$SURFACED_STATE"
+        else
+          drain_role "$ROLE" "$PEEK" 0
+        fi
         E_ROLE="$ROLE"; E_UNREAD="$UNREAD"
         emit mail
         exit 0
@@ -1788,6 +1912,10 @@ EOF
     BACKOFF_BASE="${FLOW_WAVE_SUPERVISE_BACKOFF_BASE:-2}"
     BACKOFF_CAP="${FLOW_WAVE_SUPERVISE_BACKOFF_CAP:-60}"
     BACKOFF=0
+    # This daemon's own record of what it has SURFACED (#867/#873) - never a
+    # receipt, and never read by anything that reports on deafness. It exists
+    # only so a non-consuming watch does not re-fire on the same mail forever.
+    SUP_SURFACED="$(surfaced_file "$ROLE")"
 
     # Structured, sanitized evidence ONLY - a timestamp and a short event
     # description (event kind, exit code, backoff seconds). NEVER message
@@ -1828,17 +1956,24 @@ EOF
         fi
       fi
 
-      bash "$0" watch --role "$ROLE" --wave "$WAVE" --consume \
+      # --peek, never --consume (#867, #873). A detached daemon printing to a
+      # log is not a recipient, so it must not write the receipt. The watermark
+      # below is what keeps a non-consuming watch from re-firing on the same
+      # mail forever; it is the daemon's own record of what it SURFACED and
+      # nothing that reports on deafness ever reads it.
+      bash "$0" watch --role "$ROLE" --wave "$WAVE" --peek \
+        --surfaced-state "$SUP_SURFACED" \
         --timeout "$TIMEOUT" --interval "$INTERVAL" >/dev/null 2>&1
       INNER_RC=$?
 
       case "$INNER_RC" in
         0)
-          # Delivered and acknowledged (the daemon uses --consume - the
-          # named legacy convenience, matching the file's own default
-          # elsewhere; the delivered CONTENT is safely durable in the box
-          # already, the daemon does not need to relay it anywhere new).
-          log_event "delivered rc=0"
+          # SURFACED, not delivered and not acknowledged. The old wording here
+          # said "delivered rc=0", which meant only that the inner watch exited
+          # zero - i.e. that a print succeeded - and an orchestrator reading
+          # this log took it for evidence a model had read something (#873).
+          # It is not, it never was, and the log now says which fact it holds.
+          log_event "surfaced rc=0 (NOT acknowledged - mail stays unread until the agent acks it)"
           BACKOFF=0
           ;;
         5)

--- a/scripts/flow-wave-mailbox.sh
+++ b/scripts/flow-wave-mailbox.sh
@@ -128,9 +128,11 @@
 #          has to remember to re-arm `watch` after every wake. The invocation
 #          itself returns promptly with a `FLOW_MAILBOX: supervising` verdict
 #          (or `duplicate`, exit 4, if one already runs); the DAEMON it detaches
-#          is what persists, repeatedly arming `watch --consume` for <role>
-#          until role release or the wave ends. See SUPERVISION below for what
-#          this does and, as importantly, does not promise.
+#          is what persists, repeatedly arming `watch --peek` for <role> until
+#          role release or the wave ends. It never ACKNOWLEDGES: a detached
+#          daemon is not a recipient, and a receipt it writes is a lie about
+#          an agent (#867, #873). See SUPERVISION below for what this does
+#          and, as importantly, does not promise.
 #   list   Box inventory for the wave: box, reader, rev, acked, unread, mtime,
 #          plus the WATCH state, live WATCHERS count, and ROUTE readiness
 #          (#814 - see ROUTE READINESS below) of every role known to read here
@@ -198,10 +200,25 @@
 # one mechanism this whole lane depends on would be defeated. Instead the
 # `supervise` INVOCATION forks a daemon and returns immediately with its own
 # verdict line, like every other verb; the daemon repeatedly shells out to
-# `watch --role <role> --wave <wave> --consume`, letting EACH inner watch
-# still exit and still be the harness's notification trigger for whichever
-# session is separately listening for it - `supervise` guarantees a listener
-# always EXISTS, it is not a replacement for arming one.
+# `watch --role <role> --wave <wave> --peek --surfaced-state <file>`, letting
+# EACH inner watch still exit - `supervise` guarantees a listener always
+# EXISTS, it is not a replacement for arming one.
+#
+# `--peek`, emphatically not `--consume` (issues #867, #873). The daemon used
+# to consume, which acknowledged every message it printed while sending that
+# print to a log. Mail was therefore recorded as RECEIVED by a process that is
+# not the recipient, and all four of the tells an orchestrator is told to steer
+# by went quiet at once: `UNREAD` returned to 0 seconds after every send,
+# `route` read `confirmed`, the `watch=armed route=UNCONFIRMED` combination
+# became unreachable, and `** NEVER READ **` could not fire. Measured on a live
+# wave: 7 of 7 assignments acked, 0 delivered, for most of a working session,
+# with the roster agreeing throughout (#873).
+#
+# That is worse than having no receipts, because a wrong receipt removes the
+# reason to check. It also inverted the one separation #814 was careful to
+# build: `route_state` reads ack evidence precisely so it fails INDEPENDENTLY
+# of `watch`'s process check - and the polling process became the source of the
+# ack evidence, so one instrument manufactured the other's.
 #
 # Single ownership without inheriting #821. The obvious guard - record the
 # daemon's PID, check it with `kill -0` - reintroduces #821 one layer up:
@@ -917,6 +934,96 @@ boxes_for_role() {
   return 0
 }
 
+# --- The supervisor's SURFACED watermark (issues #867, #873) ------------------
+#
+# A supervisor must never acknowledge. An ack is a receipt, and #815 separated
+# surfacing from receiving precisely so that one event could not stand in for
+# the other; `supervise` re-joined them by arming `watch --consume`, so a
+# detached daemon printing to a log recorded mail as RECEIVED by an agent that
+# had not seen it. Measured on a live wave: 7 of 7 assignments acked, 0
+# delivered (#873).
+#
+# So the daemon peeks. The obvious version of that spins - with `--peek`
+# nothing moves, so the next arm re-fires on the same mail immediately - and
+# the fix is a watermark that is the daemon's OWN, recording what it has
+# SURFACED rather than what anybody has received.
+#
+# Three properties make this safe where the ack set would not be:
+#
+#   1. `route_state`, `unread`, and `** NEVER READ **` never consult it. They
+#      read the ack set, which only an agent's explicit `ack` writes. So the
+#      four deafness tells keep measuring what they claim to measure, which is
+#      the whole of #867's acceptance.
+#   2. It is PER BOX, not per role. Revs are allocated per box, so one global
+#      high-water mark for a role reading several boxes (the orchestrator) would
+#      silence a lower rev arriving later in a different box.
+#   3. Losing it is harmless in the safe direction: an absent or torn file reads
+#      as 0, which re-surfaces mail rather than hiding it. The failure mode is a
+#      duplicate log line, never a silent drop.
+surfaced_file() { echo "$WAVE_DIR/.supervise-$1.surfaced"; }
+
+# The rev this supervisor has already surfaced for one box (0 when unknown).
+surfaced_rev_for() {
+  local sfile="$1" base="$2"
+  [ -s "$sfile" ] || { echo 0; return; }
+  awk -v b="$base" '$1 == b { r = $2 + 0 } END { print r + 0 }' "$sfile"
+}
+
+# Record that everything up to REV in BASE has been surfaced. Same lock and
+# same write-to-temp-then-rename as ack_add, so a reader never sees a half file.
+surfaced_set() {
+  local sfile="$1" base="$2" rev="$3"
+  (
+    flock -w 10 9 || { echo "flow-wave-mailbox: could not lock $WAVE_DIR" >&2; exit 3; }
+    tmp="$(mktemp "$WAVE_DIR/.msurf.XXXXXX")" || exit 3
+    {
+      [ -s "$sfile" ] && awk -v b="$base" '$1 != b' "$sfile"
+      echo "$base $rev"
+    } | sort -u > "$tmp"
+    mv -f "$tmp" "$sfile" || { rm -f "$tmp"; exit 3; }
+  ) 9>"$LOCK_FILE"
+}
+
+# Count unacked revs ABOVE this supervisor's watermark, across a role's boxes.
+# Unacked AND above - both halves matter. Above-only would re-surface mail the
+# agent has since acknowledged; unacked-only is the spin.
+unread_above_for_role() {
+  local role="$1" sfile="$2" total=0 b base w n
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    base="$(basename "$b")"
+    w="$(surfaced_rev_for "$sfile" "$base")"
+    n="$(unacked_revs_in "$b" | awk -v w="$w" '$1 + 0 > w' | grep -c '^[0-9]' || true)"
+    total=$((total + n))
+  done <<EOF
+$(boxes_for_role "$role")
+EOF
+  echo "$total"
+}
+
+# Print what is above the watermark and raise it. NEVER touches the ack set -
+# that is the property #867 and #873 both name as binding, and the reason this
+# is a separate function rather than another flag on drain_role: there is no
+# code path from here to ack_add to get wrong later.
+drain_role_surfaced() {
+  local role="$1" sfile="$2" b base w body top
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    base="$(basename "$b")"
+    w="$(surfaced_rev_for "$sfile" "$base")"
+    body="$(extract_since "$b" "$w")"
+    if [ -n "$body" ]; then
+      echo "=== $base (surfaced, NOT acknowledged) ==="
+      echo "$body"
+    fi
+    top="$(max_rev "$b")"
+    [ "$top" -gt "$w" ] && surfaced_set "$sfile" "$base" "$top"
+  done <<EOF
+$(boxes_for_role "$role")
+EOF
+  return 0
+}
+
 # Total unread across every box a role reads.
 unread_for_role() {
   local total=0 b n
@@ -1308,6 +1415,7 @@ esac
 
 WAVE="default"; ROLE=""; A_TO=""; A_FROM=""; A_BODY=""; A_BODY_FILE=""; A_OUT=""
 REPLACE=0; PEEK=0; CONSUME=0; ALL=0; JSON_OUT=0; NO_LEXICON=0; STATUS=0
+SURFACED_STATE=""
 TIMEOUT="$WATCH_TIMEOUT_DEFAULT"; INTERVAL="$WATCH_INTERVAL_DEFAULT"
 A_BOX=""; A_REVS=""; ALL_UNACKED=0
 
@@ -1335,6 +1443,7 @@ while [ "$#" -gt 0 ]; do
     --no-lexicon) NO_LEXICON=1 ;;
     --peek) PEEK=1 ;;
     --consume) CONSUME=1 ;;
+    --surfaced-state) SURFACED_STATE="${2:-}"; shift ;;
     --status) STATUS=1 ;;
     --all) ALL=1 ;;
     --json) JSON_OUT=1 ;;
@@ -1593,6 +1702,13 @@ case "$VERB" in
     if [ "$PEEK" -eq 1 ] && [ "$CONSUME" -eq 1 ]; then
       usage_fail "watch: --peek and --consume are mutually exclusive"
     fi
+    # --surfaced-state is the supervisor lane (#867/#873). It is refused with
+    # --consume rather than ignored: the two express opposite intentions about
+    # who may acknowledge, and silently honouring one while accepting the other
+    # is how the defect being fixed here got in.
+    if [ -n "$SURFACED_STATE" ] && [ "$PEEK" -eq 0 ]; then
+      usage_fail "watch: --surfaced-state requires --peek (it exists so a watcher can wake on new mail WITHOUT acknowledging it - #867)"
+    fi
     if [ "$PEEK" -eq 0 ] && [ "$CONSUME" -eq 0 ]; then
       usage_fail "watch requires an explicit --peek or --consume (issue #792) - silent default consumption has marked mail read that was never shown. Use --consume to arm-then-read (mail is marked read on wake), or --peek to read-then-arm (mail is NOT consumed, so re-arming immediately would spin-fire on it)."
     fi
@@ -1615,7 +1731,11 @@ case "$VERB" in
       # Stamp BEFORE the check, so an arm that fires on its very first poll -
       # mail already waiting - still leaves the trace #778 exists to leave.
       watch_stamp "$ROLE"
-      UNREAD="$(unread_for_role "$ROLE")"
+      if [ -n "$SURFACED_STATE" ]; then
+        UNREAD="$(unread_above_for_role "$ROLE" "$SURFACED_STATE")"
+      else
+        UNREAD="$(unread_for_role "$ROLE")"
+      fi
       if [ "$UNREAD" -gt 0 ]; then
         # #792 item 2: this fired on the very first poll, i.e. the mail was
         # already unread the instant this watch armed - not a fresh wake.
@@ -1623,7 +1743,11 @@ case "$VERB" in
         if [ "$FIRST_POLL" -eq 1 ]; then
           echo "flow-wave-mailbox: NOTE - mail was already unread when this watch armed; this is not a fresh wake (issue #792)."
         fi
-        drain_role "$ROLE" "$PEEK" 0
+        if [ -n "$SURFACED_STATE" ]; then
+          drain_role_surfaced "$ROLE" "$SURFACED_STATE"
+        else
+          drain_role "$ROLE" "$PEEK" 0
+        fi
         E_ROLE="$ROLE"; E_UNREAD="$UNREAD"
         emit mail
         exit 0
@@ -1788,6 +1912,10 @@ EOF
     BACKOFF_BASE="${FLOW_WAVE_SUPERVISE_BACKOFF_BASE:-2}"
     BACKOFF_CAP="${FLOW_WAVE_SUPERVISE_BACKOFF_CAP:-60}"
     BACKOFF=0
+    # This daemon's own record of what it has SURFACED (#867/#873) - never a
+    # receipt, and never read by anything that reports on deafness. It exists
+    # only so a non-consuming watch does not re-fire on the same mail forever.
+    SUP_SURFACED="$(surfaced_file "$ROLE")"
 
     # Structured, sanitized evidence ONLY - a timestamp and a short event
     # description (event kind, exit code, backoff seconds). NEVER message
@@ -1828,17 +1956,24 @@ EOF
         fi
       fi
 
-      bash "$0" watch --role "$ROLE" --wave "$WAVE" --consume \
+      # --peek, never --consume (#867, #873). A detached daemon printing to a
+      # log is not a recipient, so it must not write the receipt. The watermark
+      # below is what keeps a non-consuming watch from re-firing on the same
+      # mail forever; it is the daemon's own record of what it SURFACED and
+      # nothing that reports on deafness ever reads it.
+      bash "$0" watch --role "$ROLE" --wave "$WAVE" --peek \
+        --surfaced-state "$SUP_SURFACED" \
         --timeout "$TIMEOUT" --interval "$INTERVAL" >/dev/null 2>&1
       INNER_RC=$?
 
       case "$INNER_RC" in
         0)
-          # Delivered and acknowledged (the daemon uses --consume - the
-          # named legacy convenience, matching the file's own default
-          # elsewhere; the delivered CONTENT is safely durable in the box
-          # already, the daemon does not need to relay it anywhere new).
-          log_event "delivered rc=0"
+          # SURFACED, not delivered and not acknowledged. The old wording here
+          # said "delivered rc=0", which meant only that the inner watch exited
+          # zero - i.e. that a print succeeded - and an orchestrator reading
+          # this log took it for evidence a model had read something (#873).
+          # It is not, it never was, and the log now says which fact it holds.
+          log_event "surfaced rc=0 (NOT acknowledged - mail stays unread until the agent acks it)"
           BACKOFF=0
           ;;
         5)

--- a/tests/test_flow_wave_mailbox.py
+++ b/tests/test_flow_wave_mailbox.py
@@ -1798,21 +1798,29 @@ class TestSupervise:
         finally:
             self._kill_daemon(_daemon_pid(tmp_path, WAVE, "1"))
 
-    def test_a_delivered_message_is_acknowledged_without_any_conversational_rearm(
+    def test_a_message_is_surfaced_without_any_conversational_rearm(
         self, tmp_path: Path
     ) -> None:
-        """The acceptance property, minus the live-harness half that only a
-        real fleet exercise can prove (see the PR's explicit non-promises):
-        once `supervise` is armed, a message sent afterward is received and
-        acknowledged with NO further command issued by this test."""
+        """#814's acceptance property, restated after #867/#873 removed the
+        half of it that was never true.
+
+        What `supervise` guarantees is that a LISTENER keeps existing with no
+        further command from this test - that half stands and is what this
+        asserts. The old name and body claimed the message was "acknowledged",
+        which was the defect: the daemon wrote a receipt on behalf of an agent
+        that had received nothing, and every deafness tell went quiet with it.
+        Renamed rather than merely re-bodied, because a name that states the
+        wrong contract is read long before the body is."""
         self._launch(tmp_path)
         pid = _daemon_pid(tmp_path, WAVE, "1")
         try:
             _send(tmp_path, "1", "assignment issue 814")
             assert _wait_for(
-                lambda: _detail(_run(tmp_path, "list", "--wave", WAVE), "FLOW_MAILBOX_UNREAD") == "0",
-                timeout=10,
-            ), "supervise never acknowledged the delivered message"
+                lambda: "surfaced" in _supervise_log(tmp_path, WAVE, "1").read_text(),
+                timeout=20,
+            ), "supervise never surfaced the message"
+            # And it stays the agent's to receive.
+            assert _detail(_run(tmp_path, "list", "--wave", WAVE), "FLOW_MAILBOX_UNREAD") == "1"
         finally:
             self._kill_daemon(pid)
 
@@ -1870,13 +1878,21 @@ class TestSupervise:
         try:
             secret_body = "SECRET-PAYLOAD-MUST-NOT-LEAK-INTO-THE-LOG"
             _send(tmp_path, "1", secret_body)
+            # Wait on the SURFACED marker, not on unread reaching 0 - the
+            # daemon no longer consumes (#867/#873), so the old wait condition
+            # would never be met and the body assertion below - the actual
+            # point of this test - would never be reached.
             assert _wait_for(
-                lambda: _detail(_run(tmp_path, "list", "--wave", WAVE), "FLOW_MAILBOX_UNREAD") == "0",
-                timeout=10,
+                lambda: "surfaced" in _supervise_log(tmp_path, WAVE, "1").read_text(),
+                timeout=20,
             )
             log_text = _supervise_log(tmp_path, WAVE, "1").read_text()
+            # Still the binding claim, and it matters MORE now: the surfacing
+            # drain prints bodies to the inner watch's stdout, which the daemon
+            # discards. This is what pins that discard.
             assert secret_body not in log_text
-            assert "delivered rc=0" in log_text
+            assert "surfaced rc=0" in log_text
+            assert "NOT acknowledged" in log_text
         finally:
             self._kill_daemon(pid)
 
@@ -2228,3 +2244,191 @@ class TestPsFallbackWatcherIdentityAcrossDirectories:
         )
         assert _detail(proc, "FLOW_MAILBOX_WATCHER_COUNT") == "0"
         assert _detail(proc, "FLOW_MAILBOX_WATCH_STATE") in ("absent", "dead")
+
+
+def _ack_file(tmp: Path, wave: str, box: str) -> Path:
+    return tmp / "mb" / wave / f".ack-{box}"
+
+
+def _surfaced_file(tmp: Path, wave: str, role: str) -> Path:
+    return tmp / "mb" / wave / f".supervise-{role}.surfaced"
+
+
+@requires_bash
+class TestSupervisorNeverAcknowledges:
+    """The ack must not be producible by the watcher (issues #867, #873).
+
+    `supervise` armed `watch --consume`, so the daemon acknowledged every
+    message it printed - into a log, from a detached process that is not the
+    recipient. Measured on a live wave: 7 of 7 assignments acked, 0 delivered,
+    for most of a working session (#873).
+
+    The damage was not the delivery gap, which #814 documented as a residual.
+    It was that all four tells an orchestrator is told to steer by went quiet
+    at once, so a worker that had received nothing rendered as a healthy row -
+    and a wrong receipt is worse than no receipt, because it removes the reason
+    to check.
+
+    It also inverted the separation #814 built deliberately: `route_state`
+    reads ack evidence precisely so it fails INDEPENDENTLY of `watch`'s process
+    check. The polling process became the source of the ack evidence, so one
+    instrument manufactured the other's.
+    """
+
+    def _launch(self, tmp_path: Path, role: str = "1", timeout: str = "2",
+                interval: str = "1") -> None:
+        env = os.environ.copy()
+        env["FLOW_WAVE_MAILBOX_DIR"] = str(tmp_path / "mb")
+        subprocess.run(
+            ["bash", str(MAILBOX), "supervise", "--role", role, "--wave", WAVE,
+             "--timeout", timeout, "--interval", interval],
+            capture_output=True, text=True, env=env, check=False, timeout=30,
+        )
+
+    def _teardown(self, tmp_path: Path, role: str = "1") -> None:
+        pf = _supervise_pidfile(tmp_path, WAVE, role)
+        if pf.exists():
+            try:
+                pid = int(pf.read_text().strip())
+            except (ValueError, OSError):
+                return
+            if _pid_alive(pid):
+                os.kill(pid, signal.SIGTERM)
+                _wait_for(lambda: not _pid_alive(pid), timeout=10)
+
+    def test_supervised_mail_stays_unread_until_the_agent_acks(
+        self, tmp_path: Path
+    ) -> None:
+        """#867's probe, end to end. It used to end with `empty`."""
+        self._launch(tmp_path)
+        try:
+            _run(tmp_path, "send", "--to", "1", "--wave", WAVE, "--body", "ASSIGNMENT: take #999")
+            # Give the daemon several re-arm cycles to do its worst.
+            assert _wait_for(
+                lambda: "surfaced" in _supervise_log(tmp_path, WAVE, "1").read_text(),
+                timeout=20,
+            ), "the supervisor never surfaced the message"
+
+            listed = _run(tmp_path, "list", "--wave", WAVE)
+            assert _detail(listed, "FLOW_MAILBOX_UNREAD") == "1"
+
+            # The ack set is the agent's alone. Not merely empty of this rev -
+            # the supervisor had no reason to create the file at all.
+            assert not _ack_file(tmp_path, WAVE, "outbox-1.md").exists()
+
+            # And the content is still there for the agent to actually read.
+            peeked = _run(tmp_path, "read", "--role", "1", "--wave", WAVE, "--peek")
+            assert "ASSIGNMENT: take #999" in peeked.stdout
+        finally:
+            self._teardown(tmp_path)
+
+    def test_route_does_not_read_confirmed_on_a_supervisor_ack(
+        self, tmp_path: Path
+    ) -> None:
+        """`route=confirmed` is documented as positive evidence the route
+        works. Under the old daemon it was positive evidence that *something*
+        acknowledged, and #814 introduced the something."""
+        self._launch(tmp_path)
+        try:
+            _run(tmp_path, "send", "--to", "1", "--wave", WAVE, "--body", "hello")
+            assert _wait_for(
+                lambda: "surfaced" in _supervise_log(tmp_path, WAVE, "1").read_text(),
+                timeout=20,
+            )
+            listed = _run(tmp_path, "list", "--wave", WAVE)
+            assert "confirmed" not in listed.stdout
+
+            # Positive control: an AGENT ack does confirm it, so this test
+            # cannot pass on a route_state that never says `confirmed`.
+            _run(tmp_path, "ack", "--role", "1", "--wave", WAVE, "--revs", "1")
+            after = _run(tmp_path, "list", "--wave", WAVE)
+            assert "confirmed" in after.stdout
+        finally:
+            self._teardown(tmp_path)
+
+    def test_the_supervisor_does_not_spin_on_mail_it_has_surfaced(
+        self, tmp_path: Path
+    ) -> None:
+        """The failure mode #867 names in its own proposed approach: with
+        `--peek` nothing moves, so a naive daemon re-fires on the same mail
+        forever. The watermark is what makes peeking viable."""
+        self._launch(tmp_path, timeout="1", interval="1")
+        try:
+            _run(tmp_path, "send", "--to", "1", "--wave", WAVE, "--body", "one")
+            assert _wait_for(
+                lambda: "surfaced" in _supervise_log(tmp_path, WAVE, "1").read_text(),
+                timeout=20,
+            )
+            time.sleep(6)  # many re-arm cycles on the same unread message
+            surfaced = [
+                ln for ln in _supervise_log(tmp_path, WAVE, "1").read_text().splitlines()
+                if "surfaced" in ln
+            ]
+            assert len(surfaced) == 1, f"spun: {len(surfaced)} surfaces for one message"
+
+            # A HIGHER rev must still wake it - the watermark suppresses
+            # repeats, never new mail.
+            _run(tmp_path, "send", "--to", "1", "--wave", WAVE, "--body", "two")
+            assert _wait_for(
+                lambda: len([
+                    ln for ln in
+                    _supervise_log(tmp_path, WAVE, "1").read_text().splitlines()
+                    if "surfaced" in ln
+                ]) == 2,
+                timeout=20,
+            ), "a second message did not wake the supervisor"
+        finally:
+            self._teardown(tmp_path)
+
+    def test_the_watermark_is_daemon_local_and_never_the_ack_set(
+        self, tmp_path: Path
+    ) -> None:
+        """The two files must stay distinct. If the watermark were ever read
+        by the reporting side, this whole fix would be the original defect
+        wearing a different filename."""
+        self._launch(tmp_path)
+        try:
+            _run(tmp_path, "send", "--to", "1", "--wave", WAVE, "--body", "x")
+            assert _wait_for(_surfaced_file(tmp_path, WAVE, "1").exists, timeout=20)
+            assert _surfaced_file(tmp_path, WAVE, "1").read_text().strip() == "outbox-1.md 1"
+            assert not _ack_file(tmp_path, WAVE, "outbox-1.md").exists()
+            assert _detail(_run(tmp_path, "list", "--wave", WAVE), "FLOW_MAILBOX_UNREAD") == "1"
+        finally:
+            self._teardown(tmp_path)
+
+    def test_surfaced_state_requires_peek(self, tmp_path: Path) -> None:
+        """Refused, not ignored: the two flags express opposite intentions
+        about who may acknowledge."""
+        p = _run(tmp_path, "watch", "--role", "1", "--wave", WAVE, "--consume",
+                 "--surfaced-state", str(tmp_path / "s"), "--timeout", "0")
+        assert p.returncode == 2
+        assert "requires --peek" in p.stderr
+
+    def test_the_daemon_never_arms_a_consuming_watch(self) -> None:
+        """A structural guard on the regression path itself.
+
+        Every behavioural test above needs a running daemon and real timing.
+        This one reads the source, because the defect was a single word - the
+        daemon armed `--consume` - and it survived review, shipped, and ran a
+        whole live wave before anyone noticed. A one-word regression deserves a
+        check that cannot be flaky.
+
+        Asserted on the daemon's OWN invocation only: `--consume` remains a
+        valid, documented option for a caller who is genuinely the recipient.
+        """
+        src = MAILBOX.read_text()
+        start = src.index("__supervise_daemon)")
+        daemon = src[start:]
+        arm = [
+            ln for ln in daemon.splitlines()
+            if 'bash "$0" watch' in ln
+        ]
+        assert len(arm) == 1, f"expected exactly one inner-watch arm, found {len(arm)}"
+        block = daemon[daemon.index(arm[0]):]
+        block = block[: block.index("INNER_RC=")]
+        assert "--peek" in block, "the daemon must peek"
+        assert "--surfaced-state" in block, "peeking without a watermark spins (#867)"
+        assert "--consume" not in block, (
+            "the supervisor daemon must never acknowledge on an agent's behalf "
+            "(#867, #873) - an ack is a receipt, and a detached daemon is not a recipient"
+        )


### PR DESCRIPTION
Closes #867. Closes #873. One defect seen from two angles, so one change.

## The defect

`supervise` armed `watch --consume`, so the detached daemon **acknowledged every message it printed** — into a log, from a process that is not the recipient.

Measured on a live wave (#873): **7 of 7 assignments consumed and acked, 0 delivered**, across a whole working session. The orchestrator believed it had assigned work. The roster agreed with it. The worker was idle and correctly said so.

The delivery gap itself was a documented #814 residual. The damage was that all four tells an orchestrator is *told* to steer by went quiet at once:

| Where it is stated | Under the old `supervise` |
|---|---|
| `wave.md`: an unacknowledged assignment is visible as nonzero `UNREAD` | returned to 0 within seconds of every send |
| `wave.md`: "a worker with unread mail and no progress is a worker whose watch is not armed" | never fires; there is never unread mail |
| `wave.md:231`: "`watch=armed route=UNCONFIRMED` — that combination IS the signal" | unreachable; the daemon acks well inside the 900s bound |
| `register.md`: a loud `** NEVER READ **` | the daemon acknowledges, so the role has |

A wrong receipt is worse than no receipt, because it removes the reason to check.

It also **inverted the one separation #814 built deliberately**. `mailbox_route_state`'s own docstring: *"deliberately never combined with it: `watch` answers 'is a process polling' (#821-affected), `route` answers 'has anything been acknowledged since' (#821-immune)."* The polling process became the source of the ack evidence, so one instrument manufactured the other's.

## The fix

The daemon peeks. `--peek` alone **spins** — #867 names this in its own proposed approach: nothing moves, so the next arm re-fires on the same mail forever. A daemon-local **surfaced watermark** (`.supervise-<role>.surfaced`) fixes that.

Three properties keep the watermark from becoming the same defect under another filename:

1. **Nothing that reports deafness reads it.** `unread`, `route` and `** NEVER READ **` all still read the ack set, which only an agent's explicit `ack` writes.
2. **It is per box, not per role.** Revs are allocated per box, so one high-water mark for a role reading several boxes (the orchestrator) would silence a lower rev arriving later in a different box.
3. **Losing it is safe.** An absent or torn file reads as 0, which re-surfaces mail rather than hiding it. The failure mode is a duplicate log line, never a silent drop.

`drain_role_surfaced` is a separate function rather than another flag on `drain_role`, so there is **no code path from the supervisor to `ack_add`** to get wrong later.

The log said `delivered rc=0`, which meant only that a print exited zero. It now says `surfaced rc=0 (NOT acknowledged — mail stays unread until the agent acks it)`.

`watch --surfaced-state` is **refused** with `--consume` rather than ignored: the two express opposite intentions about who may acknowledge, and silently honouring one while accepting the other is how this got in.

## #867's probe, re-run against the fix

```
1. supervise --role w1                  -> FLOW_MAILBOX: supervising
2. agent arms its own watch             -> FLOW_MAILBOX: duplicate (exit 4)
3. send --to w1 "ASSIGNMENT: take #999" -> FLOW_MAILBOX: sent
4. list (after 6s)
     BOX            REV  ACKED  UNREAD
     outbox-w1.md     1      0       1     <- was 0
     ROLE  WATCH   WATCHERS
     w1    armed          1
     ROLE  ROUTE
     w1    pending                         <- was confirmed
5. agent: read --role w1 --peek         -> prints "ASSIGNMENT: take #999"   <- was `empty`
```

`.ack-outbox-w1.md` does not exist — the supervisor had no reason to create it.

The registry roster row #873 said no column could show now reads:

```
w1 -> uds:/tmp/x.sock [live] watch=armed route=pending unread=2 ** NEVER READ **
```

## Test plan

`TestSupervisorNeverAcknowledges`, plus revisions to two existing tests.

**Verified against the defect, not only against the fix.** With the daemon reverted to `--consume`, the three behavioural tests that target the defect fail, and so does the structural guard. A test that passes both ways proves nothing.

- `test_supervised_mail_stays_unread_until_the_agent_acks` — #867's probe end to end; asserts the ack file is never even created.
- `test_route_does_not_read_confirmed_on_a_supervisor_ack` — carries a positive control (an *agent* ack does confirm it), so it cannot pass on a `route_state` that never says `confirmed`.
- `test_the_supervisor_does_not_spin_on_mail_it_has_surfaced` — 1 surfaced line over many re-arm cycles on one message; then a second message must still wake it.
- `test_the_watermark_is_daemon_local_and_never_the_ack_set`.
- `test_surfaced_state_requires_peek`.
- `test_the_daemon_never_arms_a_consuming_watch` — **structural**, reads the source. The defect was a single word that survived review, shipped, and ran a live wave before anyone noticed; a one-word regression deserves a check that cannot be flaky. Scoped to the daemon's own invocation, since `--consume` remains valid for a caller who is genuinely the recipient.

**Two existing tests asserted the old contract and are renamed, not merely re-bodied** — a name that states the wrong contract is read long before the body is:

- `test_a_delivered_message_is_acknowledged_without_any_conversational_rearm` → `test_a_message_is_surfaced_without_any_conversational_rearm`. #814's real guarantee is that a *listener* keeps existing with no further command; that half stands. "Acknowledged" was the defect.
- `test_evidence_log_never_carries_a_message_body` kept its name and claim — that claim matters **more** now, since the surfacing drain prints bodies to the inner watch's stdout which the daemon discards. Only its *wait condition* changed: it waited on `UNREAD == 0`, which the fix makes unreachable, so the body assertion was never being reached.

## What this does not claim

`supervise` still cannot force the harness to tell a specific session that mail arrived — #814's stated residual, unchanged. What changes is that the residual is now **visible** rather than papered over by a receipt nobody earned. `route=confirmed` becomes what it always claimed to be: positive evidence that an agent acknowledged something.

The process model — `setsid` detachment, the lifetime `flock`, backoff, release-triggered shutdown — is untouched. #867 calls it "the strong half" and the two concerns are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdGcy6opnQ7PxDB8eVGXs6